### PR TITLE
AI向けプロジェクト資料と開発運用ドキュメントを整備する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent / AI Guide
+
+This file is the first document for AI agents and automation working on NeNe.
+
+## Read First
+
+- Project overview: `docs/project.md`
+- Contributor guide: `docs/CONTRIBUTING.md`
+- Workflow: `docs/workflow.md`
+- Coding standards: `docs/development/coding-standards.md`
+- Commit conventions: `docs/development/commit-conventions.md`
+- Roadmap: `docs/roadmap.md`
+- Current TODO: `docs/todo/current.md`
+- ADR index: `docs/adr/README.md`
+
+## Operating Rules
+
+- Work from GitHub Issues. If a code, documentation, or configuration change has no Issue, create one before editing.
+- Do not commit directly to `master`. Use a topic branch named like `type/issue-number-summary`.
+- Keep changes focused. Do not mix framework migration, feature work, dependency updates, and cosmetic cleanup in one PR.
+- Keep milestones, roadmap, TODO, and ADRs aligned with Issues and PRs.
+- Do not commit secrets, credentials, local `.env` files, generated logs, cache, or compiled templates.
+- Prefer explicit, typed, testable PHP over hidden behavior.
+- Preserve NeNe's small legacy framework character while gradually improving standards support.
+
+## Project Direction
+
+NeNe is a legacy, simple, lightweight PHP framework. It uses a front controller and URL segments to resolve controllers and action methods.
+
+- Follow PSR basics where practical.
+- Keep PHP, Composer packages, PHP CS Fixer, PHPDoc, security, and OpenAPI practices moving toward current stable standards.
+- Document architectural decisions in ADRs before making broad framework changes.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,37 @@
 # NeNe
- Simple WEB application framework
 
-## Desctiption
+Simple web application framework.
 
-## Usage
+NeNe is a legacy, simple, lightweight PHP framework. It uses a front controller and URL path segments to resolve controller classes and action methods.
 
-## Install
+## Documentation
 
-## Requirement
+- Project overview: `docs/project.md`
+- Documentation index: `docs/README.md`
+- Contributor guide: `docs/CONTRIBUTING.md`
+- Workflow: `docs/workflow.md`
+- Coding standards: `docs/development/coding-standards.md`
+- AI agent guide: `AGENTS.md`
 
-## Licence
+## Routing
 
-## Author
+NeNe routes URLs by convention:
+
+```text
+/{controller}/{action}
+```
+
+The dispatcher resolves the URL to:
+
+- `Nene\Controller\{Controller}Controller`
+- `{action}Action` for server-rendered pages
+- `{action}Rest` for JSON/API responses
+
+## Requirements
+
+- PHP 8.1 or later is currently used for maintenance.
+- Composer is required for dependency installation and autoloading.
+
+## License
+
+Proprietary.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing
+
+NeNe development is Issue driven. Every meaningful code, documentation, dependency, or configuration change should start from a GitHub Issue.
+
+## Basic Flow
+
+1. Create or select a GitHub Issue.
+2. Create a branch from `master`.
+3. Make a focused change.
+4. Run the relevant checks.
+5. Commit with the repository commit convention.
+6. Push and open a pull request.
+7. Merge after review or verification.
+8. Keep the Issue, milestone, TODO, roadmap, and ADRs aligned.
+
+## Branch Names
+
+Use:
+
+```text
+type/issue-number-summary
+```
+
+Examples:
+
+- `docs/6-project-guides`
+- `fix/12-routing-404`
+- `chore/15-dependency-upgrades`
+- `feat/20-openapi-export`
+
+## Scope Control
+
+Keep each PR small enough to review.
+
+Avoid mixing:
+
+- Framework architecture changes.
+- Dependency upgrades.
+- Security fixes.
+- Feature work.
+- Formatting-only cleanup.
+- Documentation rewrites.
+
+If a change uncovers a separate issue, create a follow-up Issue instead of expanding the PR.
+
+## Safety
+
+Do not commit:
+
+- Secrets, tokens, passwords, private keys, or credentials.
+- Local `.env` files.
+- Generated logs.
+- Composer `vendor/`.
+- Smarty compiled templates.
+- Temporary files, cache, or local tool output.
+
+## Documentation
+
+Update documentation when behavior, conventions, workflow, or architecture changes.
+
+Use ADRs for decisions that affect architecture, compatibility, framework direction, routing, API contracts, or long-term maintenance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# NeNe Documentation
+
+This directory contains project documentation for humans and AI agents.
+
+## Start Here
+
+- `project.md`: Project overview and routing convention.
+- `CONTRIBUTING.md`: Contribution rules.
+- `workflow.md`: Issue-driven workflow.
+- `development/coding-standards.md`: Coding standards.
+- `development/commit-conventions.md`: Commit message rules.
+- `roadmap.md`: Project direction.
+- `todo/current.md`: Current TODO summary.
+- `milestones/README.md`: Milestone management.
+- `adr/README.md`: Architecture decision records.
+- `api/README.md`: OpenAPI and API documentation policy.
+
+## Source of Truth
+
+GitHub Issues and PRs are the source of truth for active work.
+
+Docs provide durable project context and should be updated when conventions, workflow, or architecture change.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,28 @@
+# ADR 0001: Record Architecture Decisions
+
+## Status
+
+Accepted
+
+## Context
+
+NeNe is a legacy, lightweight PHP framework. The project is being prepared for AI-assisted and Issue-driven maintenance.
+
+Future changes may affect PHP compatibility, routing, dependency policy, security, OpenAPI contracts, and framework architecture. Those decisions should be visible and traceable.
+
+## Decision
+
+Use Architecture Decision Records in `docs/adr/`.
+
+Each ADR should describe:
+
+- Status.
+- Context.
+- Decision.
+- Consequences.
+
+## Consequences
+
+- Broad technical decisions become easier to review later.
+- AI agents have durable context for project direction.
+- Significant changes should include a new or updated ADR instead of relying only on PR comments.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,26 @@
+# Architecture Decision Records
+
+Use ADRs to record decisions that shape NeNe's architecture and long-term maintenance.
+
+## When to Add an ADR
+
+Create an ADR when a change affects:
+
+- Routing and controller conventions.
+- PHP version support.
+- Dependency policy.
+- Security posture.
+- OpenAPI or public API contracts.
+- Template, logging, database, or configuration architecture.
+- Compatibility with legacy applications.
+
+## Status Values
+
+- `Proposed`
+- `Accepted`
+- `Deprecated`
+- `Superseded`
+
+## Index
+
+- `0001-record-architecture-decisions.md`: Start recording architecture decisions.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,35 @@
+# API Documentation
+
+NeNe should use OpenAPI for public HTTP API contracts.
+
+## Policy
+
+- New public REST endpoints should be documented with OpenAPI.
+- Request parameters, request bodies, responses, and error formats should be explicit.
+- OpenAPI files should live under `docs/api/` unless an ADR changes the location.
+- API behavior should not rely only on controller implementation details.
+
+## Current State
+
+No OpenAPI contract is defined yet.
+
+## Starter Structure
+
+When API documentation begins, prefer:
+
+```text
+docs/api/openapi.yaml
+docs/api/schemas/
+```
+
+## REST Convention
+
+NeNe currently treats controller methods ending in `Rest` as REST/API handlers.
+
+Example:
+
+```text
+/session/login -> SessionController::loginRest()
+```
+
+OpenAPI paths should describe the URL and the request/response contract, not the internal method name.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,0 +1,77 @@
+# Coding Standards
+
+NeNe is a legacy PHP framework, but new work should move the codebase toward current stable PHP and common PHP standards.
+
+## PHP Compatibility
+
+- Support the latest stable PHP version as far as practical.
+- Keep compatibility decisions explicit in Issues and ADRs.
+- Avoid new code that depends on deprecated PHP behavior.
+- Prefer strict types for new PHP files.
+- Use typed parameters, return types, and properties when they improve clarity and do not break compatibility.
+
+## Composer Packages
+
+- Keep direct Composer dependencies on current stable versions where practical.
+- Remove unused packages instead of upgrading them.
+- Use `composer update vendor/package --with-dependencies` for targeted dependency work when possible.
+- Do not commit `vendor/`.
+- Run `composer validate --strict` after dependency or Composer metadata changes.
+- Run `composer install --dry-run` to confirm lock file consistency.
+
+## PSR and Style
+
+- Follow PSR-4 autoloading.
+- Follow PSR-12 coding style.
+- Use PHP CS Fixer as the primary formatter when formatting is needed.
+- Do not mix formatting-only changes into unrelated PRs.
+- Preserve the existing namespace layout unless an Issue and ADR approve a migration.
+
+## PHPDoc
+
+PHPDoc should be useful and accurate.
+
+- Document public and protected classes, methods, and properties.
+- Keep `@param`, `@return`, and `@throws` accurate.
+- Prefer native PHP types when possible, with PHPDoc used for richer array shapes or domain meaning.
+- Do not leave placeholder annotations such as `[type]`, `mixed` without context, or stale class names.
+- Update PHPDoc when changing method behavior or return values.
+
+## Security
+
+Security fixes should be small, focused, and prioritized.
+
+- Treat Dependabot alerts and known CVEs as high-priority maintenance work.
+- Validate and sanitize input at the boundary.
+- Escape output by default in templates.
+- Avoid exposing stack traces, secrets, or local paths in production responses.
+- Do not trust request headers or URL parameters.
+- Avoid dynamic class, method, file, or template resolution unless constrained by framework conventions.
+- Keep sessions, authentication, and authorization behavior explicit.
+- Never commit secrets or local environment files.
+
+## OpenAPI
+
+New public HTTP APIs should be documented with OpenAPI.
+
+- REST-style controller methods should have an OpenAPI contract before or alongside implementation.
+- Keep request and response schemas explicit.
+- Prefer JSON responses for API endpoints.
+- Keep OpenAPI files in `docs/api/` unless a future ADR chooses another location.
+
+## Testing and Static Analysis
+
+- At minimum, run PHP syntax checks for changed PHP files.
+- Use Composer validation for dependency and package metadata changes.
+- Use Phan where practical. If existing baseline issues block adoption, record the limitation in the PR and create follow-up Issues.
+- Add focused tests when adding behavior that can be tested without large framework setup.
+
+## Legacy Compatibility
+
+NeNe has legacy conventions and global configuration constants. Do not rewrite them opportunistically.
+
+When improving old code:
+
+- Keep behavior compatible unless the Issue explicitly asks for a breaking change.
+- Prefer small migrations over broad rewrites.
+- Use ADRs for compatibility policy changes.

--- a/docs/development/commit-conventions.md
+++ b/docs/development/commit-conventions.md
@@ -1,0 +1,45 @@
+# Commit Conventions
+
+Use Conventional Commits.
+
+## Format
+
+```text
+type(scope): summary
+
+body
+```
+
+The `type` and optional `scope` should be short English identifiers. The summary and body may be Japanese when that is clearer for the project.
+
+## Types
+
+- `feat`: New feature.
+- `fix`: Bug fix.
+- `docs`: Documentation only.
+- `style`: Formatting only, no behavior change.
+- `refactor`: Code restructuring without feature or bug fix intent.
+- `test`: Tests.
+- `chore`: Maintenance, dependency updates, tooling.
+- `security`: Security-specific change.
+
+## Examples
+
+```text
+docs(project): AI向けプロジェクト資料を追加する
+```
+
+```text
+chore(deps): 依存パッケージを整理して最新化する
+```
+
+```text
+fix(router): 存在しないアクションの404処理を安定させる
+```
+
+## Guidelines
+
+- One commit should explain one coherent change.
+- Mention the Issue or PR in the body when useful.
+- Avoid vague messages such as `update` or `fix`.
+- Do not use commits to hide unrelated cleanup.

--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -1,0 +1,30 @@
+# Milestones
+
+Use this directory to mirror important GitHub milestones when local context is useful.
+
+## Suggested Milestones
+
+### docs-foundation
+
+Purpose: establish project documentation, AI guidance, workflow, roadmap, TODO, and ADR practice.
+
+### php-modernization
+
+Purpose: keep PHP and Composer dependencies current, improve PHPDoc and typing, and make formatting/static analysis repeatable.
+
+### security-hardening
+
+Purpose: reduce security risk through dependency updates, secure defaults, input/output review, and safer error handling.
+
+### openapi-contracts
+
+Purpose: document public REST endpoints with OpenAPI and keep API behavior explicit.
+
+## Maintenance Rule
+
+When a GitHub milestone becomes active, update this directory with:
+
+- Goal.
+- Scope.
+- Linked Issues.
+- Completion criteria.

--- a/docs/project.md
+++ b/docs/project.md
@@ -1,0 +1,54 @@
+# NeNe Project Overview
+
+NeNe is a legacy, simple, lightweight PHP web application framework.
+
+The project should remain small and understandable. New work should improve maintainability, security, and standards compatibility without turning NeNe into a large full-stack framework.
+
+## Current Shape
+
+- PHP application framework with a front controller entry point at `htdocs/index.php`.
+- Composer autoload maps application namespaces under `class/`.
+- `Nene\Xion\Dispatcher` parses URL path segments and dispatches a controller method.
+- `Nene\Xion\ControllerBase` coordinates request handling, sessions, templates, JSON responses, and common view values.
+- Smarty is used for server-rendered templates.
+- Monolog is used for logging.
+
+## Routing Convention
+
+NeNe routes by URL path segments.
+
+Given a URL like:
+
+```text
+/{controller}/{action}
+```
+
+the dispatcher resolves:
+
+- Controller class: `Nene\Controller\{Controller}Controller`
+- HTML action method: `{action}Action`
+- JSON/API method: `{action}Rest`
+
+If both `{action}Action` and `{action}Rest` exist, the route is treated as invalid. If neither exists, NeNe returns 404.
+
+Examples:
+
+- `/` resolves to `IndexController::indexAction()` or `IndexController::indexRest()`.
+- `/session/login` resolves to `SessionController::loginAction()` or `SessionController::loginRest()`.
+
+## Direction
+
+NeNe should evolve as:
+
+- A legacy-compatible but modernizing PHP framework.
+- PSR-aware, especially for autoloading, coding style, HTTP/API boundaries, and logging.
+- Composer-based, with packages kept on current stable versions where practical.
+- Security-conscious by default.
+- API-first where new external contracts are introduced, with OpenAPI used to describe public HTTP APIs.
+
+## Non-Goals
+
+- Do not add large framework dependencies without an Issue and ADR.
+- Do not introduce a new routing architecture casually.
+- Do not hide behavior behind heavy magic or implicit global state beyond what already exists.
+- Do not mix broad modernization with unrelated feature changes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,34 @@
+# Roadmap
+
+This roadmap describes NeNe's current direction. Each item should become GitHub Issues before implementation.
+
+## 1. Documentation Foundation
+
+- Add AI and contributor guidance.
+- Document routing, controller conventions, and current architecture.
+- Establish coding standards, workflow, roadmap, TODO, milestone, and ADR practices.
+
+## 2. PHP Modernization
+
+- Keep Composer dependencies current and remove unused packages.
+- Gradually improve PHPDoc and native type declarations.
+- Make PHP CS Fixer and PSR-12 usage repeatable.
+- Establish a static analysis baseline for Phan.
+
+## 3. Security Hardening
+
+- Triage Dependabot alerts quickly.
+- Review request input handling, output escaping, session handling, and error responses.
+- Document secure defaults for controllers, REST responses, templates, and logs.
+
+## 4. OpenAPI and API Contracts
+
+- Define where OpenAPI files live.
+- Document REST method conventions.
+- Add OpenAPI contracts for public JSON endpoints.
+
+## 5. Framework Architecture
+
+- Document current routing and lifecycle.
+- Decide which legacy conventions should remain stable.
+- Use ADRs before major changes to routing, configuration, dependency policy, or API boundaries.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,0 +1,26 @@
+# Current TODO
+
+This file summarizes short-term work for humans and AI agents. GitHub Issues remain the source of truth for actionable work.
+
+## Active
+
+- None.
+
+## Recently Completed
+
+- #6: Add project documentation, AI guide, coding standards, workflow, roadmap, TODO, milestones, and ADR foundation.
+
+## Next
+
+- Create a Phan baseline or configuration so static analysis can become repeatable.
+- Review PHP CS Fixer setup and document the exact formatting command.
+- Add an OpenAPI starter document for REST endpoints.
+- Document routing examples with real controllers.
+- Review security-sensitive request, session, template, and error handling.
+
+## Backlog Candidates
+
+- Improve PHPDoc accuracy across `class/xion/`.
+- Add focused tests around dispatcher routing.
+- Decide PHP minimum and target versions in an ADR.
+- Decide whether `master` should be renamed to `main`.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,64 @@
+# Development Workflow
+
+NeNe uses an Issue driven workflow.
+
+## Required Flow
+
+1. Create or confirm a GitHub Issue.
+2. Assign a milestone when the work belongs to a planned release or theme.
+3. Create a topic branch from `master`.
+4. Implement only the Issue scope.
+5. Run checks and record the results in the PR.
+6. Commit using the commit convention.
+7. Push and open a PR.
+8. Reference the Issue from the PR body.
+9. Merge after review or verification.
+10. Close or update the Issue.
+
+## Pull Request Requirements
+
+Each PR should include:
+
+- Purpose.
+- Summary of changes.
+- Verification results.
+- Related Issue, preferably with `Closes #number`.
+- Notes about known limitations or follow-up work.
+
+## Milestones
+
+Use milestones to group work by release, modernization stage, or maintenance theme.
+
+Examples:
+
+- `docs-foundation`
+- `php-modernization`
+- `security-hardening`
+- `openapi-contracts`
+
+Keep `docs/milestones/` aligned with GitHub milestones when a milestone becomes important enough to track locally.
+
+## TODO Management
+
+Use `docs/todo/current.md` for short-term work visible to humans and AI agents.
+
+The TODO file should not replace GitHub Issues. It should summarize active or next work and link to Issues where possible.
+
+## Roadmap Management
+
+Use `docs/roadmap.md` for medium-term direction.
+
+The roadmap should describe intent and sequencing. Implementation details belong in Issues, PRs, and ADRs.
+
+## ADR Management
+
+Use `docs/adr/` for architectural decisions.
+
+Create an ADR when a change:
+
+- Alters routing, controller conventions, or API behavior.
+- Adds or removes major dependencies.
+- Changes compatibility policy.
+- Introduces OpenAPI contracts.
+- Changes security posture.
+- Affects long-term framework direction.


### PR DESCRIPTION
## Summary
- Closes #6
- `AGENTS.md` と `docs/` を追加し、AI と開発者向けの入口を整備しました。
- NeNe の概要、URL ルーティング作法、コード規約、Issue ベースワークフローを明文化しました。
- ロードマップ、TODO、マイルストーン、ADR、OpenAPI 方針の管理場所を追加しました。

## Test plan
- Markdown / documentation-only change
- `ReadLints` で `README.md`、`AGENTS.md`、`docs/` に linter error がないことを確認
- `git diff --cached --stat` で追加ファイルと README の導線を確認


Made with [Cursor](https://cursor.com)