### PR TITLE
main ブランチ移行をドキュメントへ反映する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This file is the first document for AI agents and automation working on NeNe.
 ## Operating Rules
 
 - Work from GitHub Issues. If a code, documentation, or configuration change has no Issue, create one before editing.
-- Do not commit directly to `master`. Use a topic branch named like `type/issue-number-summary`.
+- Do not commit directly to `main`. Use a topic branch named like `type/issue-number-summary`.
 - Keep changes focused. Do not mix framework migration, feature work, dependency updates, and cosmetic cleanup in one PR.
 - Keep milestones, roadmap, TODO, and ADRs aligned with Issues and PRs.
 - Do not commit secrets, credentials, local `.env` files, generated logs, cache, or compiled templates.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,7 @@ NeNe development is Issue driven. Every meaningful code, documentation, dependen
 ## Basic Flow
 
 1. Create or select a GitHub Issue.
-2. Create a branch from `master`.
+2. Create a branch from `main`.
 3. Make a focused change.
 4. Run the relevant checks.
 5. Commit with the repository commit convention.

--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -4,6 +4,21 @@ Use this directory to mirror important GitHub milestones when local context is u
 
 ## Suggested Milestones
 
+### legacy-framework-stabilization
+
+Goal: finish the foundation needed to keep NeNe useful as a legacy, simple, lightweight PHP framework.
+
+Completion criteria:
+
+- Keep the legacy structure intact.
+- Keep the URL-based routing convention intact.
+- Resolve known security issues.
+- Make clone-based installation simple, fast, and stable.
+- Finish dispatcher behavior needed to reproduce correct REST handling.
+- Complete OpenAPI introduction for public REST/API contracts.
+- Keep NeNe easy, simple, and lightweight.
+- Maintain onboarding and implementation support docs under `docs/`, including ADR guidance.
+
 ### docs-foundation
 
 Purpose: establish project documentation, AI guidance, workflow, roadmap, TODO, and ADR practice.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,17 @@
 
 This roadmap describes NeNe's current direction. Each item should become GitHub Issues before implementation.
 
+## 0. Legacy Framework Stabilization
+
+- Keep the legacy directory structure and URL-based routing rules.
+- Resolve known security issues.
+- Make clone-based setup simple, fast, and stable.
+- Add Docker-based local development.
+- Finish dispatcher behavior for correct REST handling.
+- Complete OpenAPI introduction.
+- Keep NeNe as an old-school, simple, lightweight framework.
+- Improve onboarding docs, ADRs, and implementation support.
+
 ## 1. Documentation Foundation
 
 - Add AI and contributor guidance.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #8: Rename default branch from `master` to `main`.
 - #6: Add project documentation, AI guide, coding standards, workflow, roadmap, TODO, milestones, and ADR foundation.
 
 ## Next
@@ -23,4 +24,3 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 - Improve PHPDoc accuracy across `class/xion/`.
 - Add focused tests around dispatcher routing.
 - Decide PHP minimum and target versions in an ADR.
-- Decide whether `master` should be renamed to `main`.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -6,7 +6,7 @@ NeNe uses an Issue driven workflow.
 
 1. Create or confirm a GitHub Issue.
 2. Assign a milestone when the work belongs to a planned release or theme.
-3. Create a topic branch from `master`.
+3. Create a topic branch from `main`.
 4. Implement only the Issue scope.
 5. Run checks and record the results in the PR.
 6. Commit using the commit convention.
@@ -31,6 +31,7 @@ Use milestones to group work by release, modernization stage, or maintenance the
 
 Examples:
 
+- `legacy-framework-stabilization`
 - `docs-foundation`
 - `php-modernization`
 - `security-hardening`


### PR DESCRIPTION
## Summary
- Closes #8
- 既定ブランチを `main` に移行したため、開発フローと AI 向け運用ルールの `master` 表記を更新しました。
- `legacy-framework-stabilization` マイルストーンのゴールを roadmap と milestones docs に反映しました。

## Test plan
- `ReadLints` で `AGENTS.md` と `docs/` に linter error がないことを確認
- `rg master` で古い運用表記が残っていないことを確認

Made with [Cursor](https://cursor.com)