### PR TITLE
Docker でローカル開発環境を起動できるようにする

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,9 @@
-
-tags
+.git
 vendor
-view/compile
 log
+view/compile
 data/*.db
 data/*.sqlite
 data/*.sqlite3
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM php:8.4-apache
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip libsqlite3-dev \
+    && docker-php-ext-install pdo_mysql pdo_sqlite \
+    && a2enmod rewrite headers \
+    && sed -ri 's!/var/www/html!/var/www/html/htdocs!g' /etc/apache2/sites-available/000-default.conf \
+    && sed -ri 's!AllowOverride None!AllowOverride All!g' /etc/apache2/apache2.conf \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /var/www/html
+
+COPY composer.json composer.lock ./
+RUN composer install --no-interaction --prefer-dist --no-progress
+
+COPY . .
+RUN ./init.sh

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ NeNe is a legacy, simple, lightweight PHP framework. It uses a front controller 
 - Contributor guide: `docs/CONTRIBUTING.md`
 - Workflow: `docs/workflow.md`
 - Coding standards: `docs/development/coding-standards.md`
+- Docker development: `docs/development/docker.md`
 - AI agent guide: `AGENTS.md`
 
 ## Routing
@@ -31,6 +32,20 @@ The dispatcher resolves the URL to:
 
 - PHP 8.1 or later is currently used for maintenance.
 - Composer is required for dependency installation and autoloading.
+
+## Docker Quick Start
+
+```sh
+docker compose up --build
+```
+
+Open `http://localhost:8080/`.
+
+To initialize the SQLite database:
+
+```sh
+docker compose run --rm app sh -lc "printf 'Y\n' | php cli/initSQLite.php"
+```
 
 ## License
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,16 @@
+services:
+  app:
+    build:
+      context: .
+    ports:
+      - "${NENE_PORT:-8080}:80"
+    volumes:
+      - .:/var/www/html
+      - vendor:/var/www/html/vendor
+    command: >
+      sh -lc "composer install --no-interaction --prefer-dist
+      && ./init.sh
+      && apache2-foreground"
+
+volumes:
+  vendor:

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This directory contains project documentation for humans and AI agents.
 - `workflow.md`: Issue-driven workflow.
 - `development/coding-standards.md`: Coding standards.
 - `development/commit-conventions.md`: Commit message rules.
+- `development/docker.md`: Docker local development.
 - `roadmap.md`: Project direction.
 - `todo/current.md`: Current TODO summary.
 - `milestones/README.md`: Milestone management.

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -1,0 +1,58 @@
+# Docker Development
+
+NeNe can run locally with Docker Compose.
+
+## Requirements
+
+- Docker
+- Docker Compose v2
+
+## Start
+
+```sh
+docker compose up --build
+```
+
+Open:
+
+```text
+http://localhost:8080/
+```
+
+Use another port if needed:
+
+```sh
+NENE_PORT=8081 docker compose up --build
+```
+
+## Initialize SQLite
+
+The default configuration uses SQLite at `data/nene.db`.
+
+To create the database and default admin user:
+
+```sh
+docker compose run --rm app sh -lc "printf 'Y\n' | php cli/initSQLite.php"
+```
+
+Default development account:
+
+```text
+user: admin
+password: admin
+```
+
+Do not use this account in production.
+
+## Stop
+
+```sh
+docker compose down
+```
+
+## Notes
+
+- The Apache document root is `htdocs/`.
+- `mod_rewrite` is enabled so `htdocs/.htaccess` can route URLs to `index.php`.
+- Composer dependencies are stored in a Docker named volume named `vendor`.
+- Generated files under `log/`, `view/compile/`, and SQLite database files are ignored by Git.


### PR DESCRIPTION
## Summary
- Closes #9
- PHP 8.4 + Apache の Dockerfile と Docker Compose 構成を追加しました。
- `htdocs/` を Apache DocumentRoot にし、`mod_rewrite` で既存 `.htaccess` ルーティングを使えるようにしました。
- README と `docs/development/docker.md` に起動手順と SQLite 初期化手順を追加しました。

## Test plan
- `composer validate --strict`
- `ReadLints` で `README.md`、`docs/README.md`、`docs/development/docker.md`、`Dockerfile`、`compose.yaml` に error がないことを確認
- `docker compose config` はこの WSL 環境に Docker CLI が無いため未実行です。Docker Desktop の WSL integration 有効化後に実行してください。

## Notes
- Generated files under `log/`, `view/compile/`, and SQLite database files are ignored by Git.

Made with [Cursor](https://cursor.com)