### PR TITLE
Docker 起動時の書き込み権限を整える

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip libsqlite3-dev \
     && docker-php-ext-install pdo_mysql pdo_sqlite \
     && a2enmod rewrite headers \
+    && echo "ServerName localhost" > /etc/apache2/conf-available/servername.conf \
+    && a2enconf servername \
     && sed -ri 's!/var/www/html!/var/www/html/htdocs!g' /etc/apache2/sites-available/000-default.conf \
     && sed -ri 's!AllowOverride None!AllowOverride All!g' /etc/apache2/apache2.conf \
     && rm -rf /var/lib/apt/lists/*

--- a/class/xion/Request.php
+++ b/class/xion/Request.php
@@ -70,7 +70,7 @@ class Request
      *
      * @return mixed
      */
-    final public function getPost(string $key = null)
+    final public function getPost(?string $key = null)
     {
         if ($key == null) {
             return $this->post->get();
@@ -89,7 +89,7 @@ class Request
      *
      * @return mixed
      */
-    public function getQuery(string $key = null)
+    public function getQuery(?string $key = null)
     {
         if ($key == null) {
             return $this->query->get();
@@ -108,7 +108,7 @@ class Request
      *
      * @return mixed
      */
-    public function getParam(string $key = null)
+    public function getParam(?string $key = null)
     {
         if ($key == null) {
             return $this->param->get();

--- a/class/xion/RequestVariables.php
+++ b/class/xion/RequestVariables.php
@@ -52,11 +52,11 @@ abstract class RequestVariables
     /**
      * Get value.
      *
-     * @param string $key Parameter name.
+     * @param string|null $key Parameter name.
      *
      * @return mixed value [string or array]
      */
-    public function get(string $key = null)
+    public function get(?string $key = null)
     {
         $ret = null;
         if ($key == null) {

--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+mkdir -p ./data 2>/dev/null
 mkdir -p ./view/config 2>/dev/null
 mkdir -p ./view/compile 2>/dev/null
 mkdir -p ./log 2>/dev/null
-chmod 755 ./view/compile
+
+if id www-data >/dev/null 2>&1; then
+    chown -R www-data:www-data ./data ./view/compile ./log
+fi
+
+chmod 775 ./data ./view/compile ./log


### PR DESCRIPTION
## Summary
- Closes #9
- Docker Compose 起動時に `data/`、`view/compile/`、`log/` の作成と権限調整を行うようにしました。
- Apache の `ServerName` 警告を Docker image 内で抑制しました。
- PHP 8.4 で初回表示時に出ていた nullable 型 deprecation を修正しました。

## Test plan
- `docker compose down && docker compose build && docker compose up -d`
- `curl -i http://localhost:8080/`
- HTTP 200 OK、`Fatal error` なし、`Deprecated` なしを確認
- `sh -n init.sh`
- `php -l class/xion/Request.php`
- `php -l class/xion/RequestVariables.php`
- `composer validate --strict`

Made with [Cursor](https://cursor.com)