### PR TITLE
feat(ui): React ホームサンプルを追加する

### DIFF
--- a/class/controller/IndexController.php
+++ b/class/controller/IndexController.php
@@ -44,9 +44,10 @@ class IndexController extends ControllerBase
      */
     public function indexAction()
     {
-        $this->setTitle('Hello NeNe-PHP!!');
-        $this->VIEW->addJS('https://cdn.jsdelivr.net/npm/vue/dist/vue.js')
-            ->setString('t_contents', 'This framework is produced by AYANE International.');
+        $this->setTitle('NeNe - Simple Legacy PHP Framework');
+        $this->VIEW->addJS('https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js')
+            ->addJS('https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js')
+            ->setString('t_contents', 'A small legacy PHP framework for URL-based applications.');
         // $userMapper = new Database\UserMapper();
         // $user = $userMapper->find(1);
     }

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -18,6 +18,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 - Review PHP CS Fixer setup and document the exact formatting command.
 - Add an OpenAPI starter document for REST endpoints.
 - Document routing examples with real controllers.
+- Prepare documentation/sample pages for the home side menu: `Authentication`, `Routing Guide`, and `OpenAPI`.
 - Review security-sensitive request, session, template, and error handling.
 
 ## Backlog Candidates

--- a/htdocs/css/common.css
+++ b/htdocs/css/common.css
@@ -5,10 +5,11 @@
 
 
 body {
-    background-color: #05242c;
-    color: #222;
-    font-family: 'Nunito', sans-serif;
-    font-size: 1.4em;
+    background: #050505;
+    color: #f2f2ee;
+    font-family: 'IBM Plex Sans', 'IBM Plex Sans JP', 'Helvetica Neue', Arial, sans-serif;
+    font-size: 16px;
+    letter-spacing: 0.01em;
     margin: 0;
     padding: 0;
 }
@@ -20,8 +21,8 @@ hr {
 }
 
 .content {
-    background-color: #FBC02D;
-    padding: 8px 8px 64px;
+    min-height: calc(100vh - 72px);
+    padding: 0;
 }
 .hidden {
     display: none;
@@ -34,33 +35,23 @@ hr {
 
 /* ========== HEADER ========== */
 header {
-    background-color: #012;
-    color: #fb2;
-    text-align: center;
-}
-header h2 {
-    display: block;
-    margin: 0;
-    padding: 32px 0 0;
-    font-family: 'Poller One', cursive;
-}
-.site__header_sub-title {
-    font-size: 0.8rem;
-    margin: 0;
-    padding: 0 0 16px;
+    display: none;
 }
 
 
 
 /* ========== HEADER ========== */
 footer {
-    color: #44d1b2;
-    font-size: 1.1rem;
-    margin: 16px 0px 16px;
+    background: #050505;
+    color: #777;
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+    margin: 0;
+    padding: 24px;
     text-align: center;
 }
 footer a {
-    color: #44d1b2;
+    color: #aaa;
     text-decoration:  none;
 }
 

--- a/htdocs/css/index/index.css
+++ b/htdocs/css/index/index.css
@@ -1,58 +1,381 @@
 @charset "utf-8";
 
-/* ========== LOGIN PAGE ========== */
-.information {
-    font-size: 0.9rem;
-    font-weight: bold;
-    margin-top: 64px;
-    text-align: center;
+/* ========== DEVELOPERS PAGE ========== */
+.index_index .content {
+    background:
+        radial-gradient(circle at top left, rgba(103, 92, 255, 0.16), transparent 30rem),
+        radial-gradient(circle at top right, rgba(255, 255, 255, 0.06), transparent 24rem),
+        linear-gradient(180deg, #101010 0%, #050505 42%, #080808 100%);
 }
-.login__form_block {
-    background-color: #fff;
-    border-radius: 4px;
-    box-shadow: 0px 3px 8px rgba(0,0,0,0.25);
+
+.developers {
     box-sizing: border-box;
-    margin: 24px auto;
-    padding: 24px 16px 16px;
-    width: 360px;
-    max-width: 100%;
-}
-.loginform__submite-btn_block {
-    margin-top: 16px;
-}
-.login__form_block input {
-    background-color: #3D4C53;
-    border: 0;
-    color: white;
-    font-size: 1.3rem;
-    height: 3.6rem;
-    padding: 15px;
-}
-.login__form_block input:focus {
-    background-color: #26A69A;
-}
-.login__form_block input::placeholder {
-    color: #ccc;
+    margin: 0 auto;
+    max-width: 1200px;
+    min-height: calc(100vh - 72px);
+    padding: 24px 28px 72px;
 }
 
+.developers * {
+    box-sizing: border-box;
+}
 
-.loginform__submit {
-    background-color: #000;
+.developers__header {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 44px;
+}
+
+.developers__brand,
+.developers__nav a {
+    color: #f2f2ee;
+    text-decoration: none;
+}
+
+.developers__brand {
+    align-items: center;
+    display: inline-flex;
+    font-size: 0.88rem;
+    font-weight: 700;
+    gap: 10px;
+    letter-spacing: 0.035em;
+}
+
+.developers__brand-mark {
+    align-items: center;
+    background: #f2f2ee;
+    border-radius: 8px;
+    color: #050505;
+    display: inline-flex;
+    font-size: 0.82rem;
+    height: 26px;
+    justify-content: center;
+    width: 26px;
+}
+
+.developers__nav {
+    align-items: center;
+    display: flex;
+    gap: 22px;
+}
+
+.developers__nav a {
+    color: #9d9d95;
+    font-size: 0.82rem;
+    letter-spacing: 0.025em;
+}
+
+.developers__nav a:hover,
+.developers__sidebar-link:hover {
+    color: #f2f2ee;
+}
+
+.developers__layout {
+    display: grid;
+    gap: 56px;
+    grid-template-columns: 220px minmax(0, 1fr);
+}
+
+.developers__sidebar {
+    align-self: start;
+    border-right: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 4px 22px 0 0;
+    position: sticky;
+    top: 24px;
+}
+
+.developers__sidebar-title {
+    color: #73736d;
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.035em;
+    margin: 0 0 12px;
+}
+
+.developers__sidebar-link {
+    border-radius: 8px;
+    color: #a4a49d;
+    font-size: 0.9rem;
+    padding: 9px 10px;
+    text-decoration: none;
+}
+
+.developers__sidebar-link.is-active {
+    background: rgba(255, 255, 255, 0.06);
+    color: #f2f2ee;
+}
+
+.developers__main {
+    max-width: 840px;
+}
+
+.developers__hero {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 6px 0 48px;
+}
+
+.developers__eyebrow {
+    color: #8f82ff;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    margin: 0 0 14px;
+    text-transform: uppercase;
+}
+
+.developers__hero h1 {
+    color: #f6f6f1;
+    font-size: clamp(2.7rem, 5vw, 4.6rem);
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    line-height: 1.02;
+    margin: 0;
+}
+
+.developers__lead {
+    color: #b8b8ad;
+    font-size: 1.04rem;
+    letter-spacing: 0.01em;
+    line-height: 1.7;
+    margin: 18px 0 0;
+    max-width: 620px;
+}
+
+.developers__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 26px;
+}
+
+.button {
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 8px;
+    cursor: pointer;
+    display: inline-flex;
+    font: inherit;
+    font-size: 0.86rem;
+    font-weight: 600;
+    justify-content: center;
+    letter-spacing: 0.01em;
+    padding: 10px 14px;
+    text-decoration: none;
+}
+
+.button--primary {
+    background: #f2f2ee;
+    color: #050505;
+}
+
+.button--secondary {
+    background: rgba(255, 255, 255, 0.04);
+    color: #f2f2ee;
+}
+
+.developers__section {
+    padding-top: 38px;
+}
+
+.developers__section h2 {
+    color: #f2f2ee;
+    font-size: 1.35rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin: 0 0 18px;
+}
+
+.developers__cards {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.developers__card,
+.quick-start-card,
+.sample-card {
+    background: rgba(18, 18, 18, 0.78);
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    border-radius: 14px;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32);
+}
+
+.developers__card {
+    padding: 20px;
+}
+
+.developers__card h3 {
+    color: #f2f2ee;
+    font-size: 1rem;
+    letter-spacing: 0;
+    margin: 0 0 8px;
+}
+
+.developers__card p {
+    color: #aaa9a1;
+    font-size: 0.9rem;
+    letter-spacing: 0;
+    line-height: 1.55;
+    margin: 0;
+}
+
+.developers__section-heading {
+    align-items: center;
+    display: flex;
+    gap: 24px;
+    justify-content: space-between;
+    margin-bottom: 18px;
+}
+
+.developers__section-heading h2 {
+    margin-bottom: 0;
+}
+
+.developers__section-heading > p {
+    color: #8d8d86;
+    font-size: 0.9rem;
+    line-height: 1.55;
+    margin: 0;
+    max-width: 280px;
+}
+
+.sample-card {
+    padding: 22px;
+}
+
+.quick-start-card {
+    padding: 14px;
+}
+
+.quick-start-card pre {
+    background: #050505;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 10px;
+    color: #f2f2ee;
+    font-size: 0.88rem;
+    line-height: 1.8;
+    margin: 0;
+    overflow: auto;
+    padding: 18px;
+}
+
+.sample-form,
+.todo-panel__form {
+    display: grid;
+    gap: 14px;
+}
+
+.sample-form label,
+.sample-form span {
+    display: block;
+}
+
+.sample-form span {
+    color: #aaa9a1;
+    font-size: 0.82rem;
+    margin-bottom: 7px;
+}
+
+.sample-form input,
+.todo-panel__form input {
+    background: #0a0a0a;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 8px;
+    color: #f2f2ee;
+    font: inherit;
+    height: 42px;
+    letter-spacing: 0.005em;
+    padding: 0 12px;
+    width: 100%;
+}
+
+.sample-form input:focus,
+.todo-panel__form input:focus {
+    border-color: rgba(143, 130, 255, 0.72);
+    outline: none;
+}
+
+.todo-panel__form {
+    grid-template-columns: minmax(0, 1fr) auto;
+    margin-bottom: 18px;
+}
+
+.todo-list {
+    display: grid;
+    gap: 10px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.todo-list__item {
+    align-items: center;
+    background: #0a0a0a;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 10px;
+    color: #f2f2ee;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    padding: 12px;
+}
+
+.todo-list__item.is-completed span {
+    color: #7d7d77;
+    text-decoration: line-through;
+}
+
+.todo-list__check,
+.todo-list__remove {
+    background: transparent;
     border: 0;
-    color: #fff;
-    font-weight: bold;
-    background-size: 200% 100%;	
-    background-image: -webkit-linear-gradient(left, transparent 50%, rgba(251, 192, 45, 1) 50%);	
-    background-image: linear-gradient(to right, transparent 50%, rgba(251, 192, 45, 1) 50%);
-    -webkit-transition: background-position .3s cubic-bezier(0.19, 1, 0.22, 1) .1s, color .5s ease 0s, background-color .5s ease;
-    transition: background-position .3s cubic-bezier(0.19, 1, 0.22, 1) .1s, color .5s ease 0s, background-color .5s ease;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
 }
-.loginform__submit:hover:enabled {
-    background-color: #fbc02d;
-    background-position: -100% 100%;
-    color: black;
+
+.todo-list__check {
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 6px;
+    height: 22px;
+    line-height: 20px;
+    padding: 0;
+    width: 22px;
 }
-.loginform__submit:disabled {
-    cursor: default;
-    background-color: #ccc;
+
+.todo-list__remove {
+    color: #8f82ff;
+    font-size: 0.82rem;
+}
+
+@media (max-width: 760px) {
+    .developers {
+        padding: 20px 16px 48px;
+    }
+
+    .developers__header,
+    .developers__section-heading {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 18px;
+    }
+
+    .developers__layout,
+    .developers__cards {
+        grid-template-columns: 1fr;
+    }
+
+    .developers__sidebar {
+        border-right: 0;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        padding: 0 0 18px;
+        position: static;
+    }
+
+    .todo-panel__form {
+        grid-template-columns: 1fr;
+    }
 }

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -1,54 +1,268 @@
 document.addEventListener('DOMContentLoaded', function() {
-    window.app = new Vue({
-        el: '#app',
-        data: {
-            message: 'Hello NeNe!',
-            formUserId:     '',
-            formUserIdMsg:  '',
-            formUserPass:   '',
-            formUserPassMsg:'',
-            isConnect:      false,
+    const root = document.getElementById('app');
+    if (!root || !window.React || !window.ReactDOM) {
+        return;
+    }
+
+    const e = React.createElement;
+    const useState = React.useState;
+    const tagline = root.dataset.tagline || 'A small legacy PHP framework for URL-based applications.';
+
+    const guides = [
+        {
+            title: 'Routing',
+            text: 'Resolve controllers and actions from simple URL segments.'
         },
-        created() {
-            document.getElementById('app').classList.remove('hidden');
+        {
+            title: 'Templates',
+            text: 'Render small server pages with focused Smarty templates.'
         },
-        methods: {
-            onSubmit: function() {
-                console.log('submit!!');
-                console.log(this.formUserId);
-                if (this.formUserId.length == 0) {
-                    this.formUserIdMsg = 'USER ID is required.';
-                    return;
-                }
-                this.formUserIdMsg = '';
-                if (this.formUserPass.length == 0) {
-                    this.formUserPassMsg = 'PASSWORD is required.';
-                    return;
-                } else if (this.formUserPass.length > 64) {
-                    this.formUserPassMsg = 'Please enter a password within 64 characters.';
-                    return;
-                } else if (this.formUserPass.length < 5) {
-                    this.formUserPassMsg = 'Password must be at least 6 characters';
-                    return;
-                }
-                this.formUserPassMsg = '';
-                this.isConnect = true;
-                let params = new FormData();
-                params.append('user_id', this.formUserId);
-                params.append('user_pass', this.formUserPass);
-                fetch('/session/login', {
-                    method: 'POST',
-                    credentials:'same-origin',
-                    body: params
-                }).then(res => res.json())
-                    .then(response => {
-                        this.isConnect = false;
-                        console.log(response);
-                    }).catch(error => {
-                        this.isConnect = false;
-                        console.log(error);
-                    });
+        {
+            title: 'Modernization',
+            text: 'Add tests, OpenAPI, and safer conventions without losing the legacy shape.'
+        }
+    ];
+
+    const sidebarLinks = [
+        { href: '#getting-started', label: 'Getting Started' },
+        { href: '#quick-start', label: 'Quick Start' },
+        { href: '#sample-app', label: 'Authentication' },
+        { href: '#sample-app', label: 'Sample TODO' },
+        { href: '#getting-started', label: 'Routing Guide' },
+        { href: '#getting-started', label: 'OpenAPI' }
+    ];
+
+    function App() {
+        return e('div', { className: 'developers' },
+            e(SiteHeader),
+            e('div', { className: 'developers__layout' },
+                e(Sidebar),
+                e('main', { className: 'developers__main' },
+                    e(Hero),
+                    e(GuideGrid),
+                    e(QuickStart),
+                    e(SampleApp)
+                )
+            )
+        );
+    }
+
+    function SiteHeader() {
+        return e('header', { className: 'developers__header' },
+            e('a', { className: 'developers__brand', href: '/' },
+                e('span', { className: 'developers__brand-mark' }, 'N'),
+                e('span', null, 'Developers')
+            ),
+            e('nav', { className: 'developers__nav' },
+                e('a', { href: 'https://github.com/hideyukiMORI/NeNe' }, 'GitHub'),
+                e('a', { href: 'https://github.com/hideyukiMORI/NeNe/tree/main/docs' }, 'Docs'),
+                e('a', { href: 'https://github.com/hideyukiMORI/NeNe/issues' }, 'Issues')
+            )
+        );
+    }
+
+    function Sidebar() {
+        return e('aside', { className: 'developers__sidebar' },
+            e('p', { className: 'developers__sidebar-title' }, 'NeNe'),
+            sidebarLinks.map(function(link, index) {
+                return e('a', {
+                    className: index === 0 ? 'developers__sidebar-link is-active' : 'developers__sidebar-link',
+                    href: link.href,
+                    key: link.label
+                }, link.label);
+            })
+        );
+    }
+
+    function Hero() {
+        return e('section', { className: 'developers__hero' },
+            e('p', { className: 'developers__eyebrow' }, 'Legacy PHP Framework'),
+            e('h1', null, 'NeNe Developers'),
+            e('p', { className: 'developers__lead' }, tagline),
+            e('div', { className: 'developers__actions' },
+                e('a', { className: 'button button--primary', href: 'https://github.com/hideyukiMORI/NeNe' }, 'View repository'),
+                e('a', { className: 'button button--secondary', href: 'https://github.com/hideyukiMORI/NeNe/tree/main/docs' }, 'Read the docs')
+            )
+        );
+    }
+
+    function GuideGrid() {
+        return e('section', { className: 'developers__section', id: 'getting-started' },
+            e('h2', null, 'Getting Started'),
+            e('div', { className: 'developers__cards' },
+                guides.map(function(guide) {
+                    return e('article', { className: 'developers__card', key: guide.title },
+                        e('h3', null, guide.title),
+                        e('p', null, guide.text)
+                    );
+                })
+            )
+        );
+    }
+
+    function QuickStart() {
+        return e('section', { className: 'developers__section', id: 'quick-start' },
+            e('div', { className: 'developers__section-heading' },
+                e('div', null,
+                    e('p', { className: 'developers__eyebrow' }, 'Quick Start'),
+                    e('h2', null, 'Run NeNe locally')
+                ),
+                e('p', null, 'Clone the repository and start the Docker environment.')
+            ),
+            e('div', { className: 'quick-start-card' },
+                e('pre', null, e('code', null, 'git clone git@github.com:hideyukiMORI/NeNe.git\ncd NeNe\ndocker compose up --build'))
+            )
+        );
+    }
+
+    function SampleApp() {
+        const initialTodos = [
+            { id: 1, text: 'Read the routing guide', completed: true },
+            { id: 2, text: 'Create a controller action', completed: false }
+        ];
+        const state = useState(false);
+        const isSignedIn = state[0];
+        const setIsSignedIn = state[1];
+        const emailState = useState('demo@example.com');
+        const email = emailState[0];
+        const setEmail = emailState[1];
+        const taskState = useState('');
+        const task = taskState[0];
+        const setTask = taskState[1];
+        const todosState = useState(initialTodos);
+        const todos = todosState[0];
+        const setTodos = todosState[1];
+
+        function signIn(event) {
+            event.preventDefault();
+            if (email.trim()) {
+                setIsSignedIn(true);
             }
         }
-    });
+
+        function addTodo(event) {
+            event.preventDefault();
+            const text = task.trim();
+            if (!text) {
+                return;
+            }
+            setTodos(todos.concat({
+                id: Date.now(),
+                text: text,
+                completed: false
+            }));
+            setTask('');
+        }
+
+        function toggleTodo(id) {
+            setTodos(todos.map(function(todo) {
+                if (todo.id !== id) {
+                    return todo;
+                }
+                return {
+                    id: todo.id,
+                    text: todo.text,
+                    completed: !todo.completed
+                };
+            }));
+        }
+
+        function removeTodo(id) {
+            setTodos(todos.filter(function(todo) {
+                return todo.id !== id;
+            }));
+        }
+
+        return e('section', { className: 'developers__section developers__sample', id: 'sample-app' },
+            e('div', { className: 'developers__section-heading' },
+                e('div', null,
+                    e('p', { className: 'developers__eyebrow' }, 'Sample App'),
+                    e('h2', null, 'Sign in and manage TODOs')
+                ),
+                e('p', null, 'A tiny React sample running on the NeNe top page.')
+            ),
+            e('div', { className: 'sample-card' },
+                isSignedIn
+                    ? e(TodoPanel, {
+                        addTodo: addTodo,
+                        removeTodo: removeTodo,
+                        setTask: setTask,
+                        task: task,
+                        todos: todos,
+                        toggleTodo: toggleTodo
+                    })
+                    : e(LoginForm, {
+                        email: email,
+                        setEmail: setEmail,
+                        signIn: signIn
+                    })
+            )
+        );
+    }
+
+    function LoginForm(props) {
+        return e('form', { className: 'sample-form', onSubmit: props.signIn },
+            e('label', null,
+                e('span', null, 'Email'),
+                e('input', {
+                    type: 'email',
+                    value: props.email,
+                    onChange: function(event) {
+                        props.setEmail(event.target.value);
+                    },
+                    placeholder: 'demo@example.com'
+                })
+            ),
+            e('label', null,
+                e('span', null, 'Password'),
+                e('input', {
+                    type: 'password',
+                    defaultValue: 'password',
+                    placeholder: 'password'
+                })
+            ),
+            e('button', { className: 'button button--primary', type: 'submit' }, 'Sign in')
+        );
+    }
+
+    function TodoPanel(props) {
+        return e('div', { className: 'todo-panel' },
+            e('form', { className: 'todo-panel__form', onSubmit: props.addTodo },
+                e('input', {
+                    value: props.task,
+                    onChange: function(event) {
+                        props.setTask(event.target.value);
+                    },
+                    placeholder: 'Add a TODO'
+                }),
+                e('button', { className: 'button button--secondary', type: 'submit' }, 'Add')
+            ),
+            e('ul', { className: 'todo-list' },
+                props.todos.map(function(todo) {
+                    return e('li', {
+                        className: todo.completed ? 'todo-list__item is-completed' : 'todo-list__item',
+                        key: todo.id
+                    },
+                        e('button', {
+                            className: 'todo-list__check',
+                            type: 'button',
+                            onClick: function() {
+                                props.toggleTodo(todo.id);
+                            }
+                        }, todo.completed ? '✓' : ''),
+                        e('span', null, todo.text),
+                        e('button', {
+                            className: 'todo-list__remove',
+                            type: 'button',
+                            onClick: function() {
+                                props.removeTodo(todo.id);
+                            }
+                        }, 'Remove')
+                    );
+                })
+            )
+        );
+    }
+
+    ReactDOM.createRoot(root).render(e(App));
 });

--- a/view/source/head_01.tpl
+++ b/view/source/head_01.tpl
@@ -3,8 +3,7 @@
     <head>
         <title>{$t_title}</title>
         <meta charset="UTF-8">
-        <link href="https://fonts.googleapis.com/css?family=Nunito&display=swap" rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css?family=Poller+One&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">
 
         <link rel="shortcut icon" href="/favicon.ico" type="image/vnd.microsoft.icon">
         <link rel="icon" href="/favicon.ico" type="image/vnd.microsoft.icon">

--- a/view/source/index/index.tpl
+++ b/view/source/index/index.tpl
@@ -1,17 +1,5 @@
 {include file='head_01.tpl'}{include file='head_02.tpl'}
 
-
-
-                <p class="information">
-                    {$t_contents}
-                </p>
-
-                <div class="login__form_block">
-                    <div id="app" class="hidden">
-                        {include file='../components/loginform.tpl'}
-                    </div>
-                </div>
-
-
+                <div id="app" class="nene-home" data-tagline="{$t_contents|escape:'html'}"></div>
 
 {include file='footer.tpl'}


### PR DESCRIPTION
## Summary
- トップページを React ベースの開発者向けサンプルに差し替えました。
- Linear Developers 風の黒基調レイアウト、サイドメニュー、Quick start ブロックを追加しました。
- ログインフォーム後に簡易 TODO アプリを操作できるサンプルを追加し、未整備メニュー項目を TODO に追記しました。

## Verification
- `php -l class/controller/IndexController.php`
- `node --check htdocs/js/index/index.js`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- Browser check at `http://localhost:8080/`

Closes #19

Made with [Cursor](https://cursor.com)