### PR TITLE
chore(docker): MySQL 初期化を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,7 @@ docker compose up --build
 
 Open `http://localhost:8080/`.
 
-To initialize the SQLite database:
-
-```sh
-docker compose run --rm app sh -lc "printf 'Y\n' | php cli/initSQLite.php"
-```
+Docker Compose starts MySQL 8.4 and initializes the development `users` and `todos` tables automatically. The default development login is `admin` / `admin`.
 
 ## Testing
 

--- a/class/db/Todo.php
+++ b/class/db/Todo.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 7.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Database;
+
+use Nene\Xion\DataModelBase as DataModelBase;
+
+/**
+ * TODO item model.
+ */
+class Todo extends DataModelBase
+{
+    /**
+     * Table schema
+     *
+     * @var array
+     */
+    protected static $schema = [
+        'id'           => parent::INTEGER,
+        'created_at'   => parent::DATETIME,
+        'updated_at'   => parent::DATETIME,
+        'user_id'      => parent::INTEGER,
+        'title'        => parent::STRING,
+        'is_completed' => parent::BOOLEAN,
+        'is_deleted'   => parent::BOOLEAN
+    ];
+
+    /**
+     * Validation conditions
+     *
+     * @var array
+     */
+    protected static $validation = [
+        'user_id'      => ['required' => true],
+        'title'        => ['required' => true, 'maxlength' => 255],
+        'is_completed' => ['required' => true, 'bool' => true],
+        'is_deleted'   => ['required' => true, 'bool' => true]
+    ];
+}

--- a/class/db/TodoMapper.php
+++ b/class/db/TodoMapper.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 7.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Database;
+
+use Nene\Xion\DataMapperBase as DataMapperBase;
+use PDOStatement;
+
+/**
+ * TODO item data mapper.
+ */
+class TodoMapper extends DataMapperBase
+{
+    protected const MODEL_CLASS = 'Nene\Database\Todo';
+    protected const TARGET_TABLE = 'todos';
+    protected const KEY_SID = 'id';
+
+    /**
+     * Find TODO items owned by a user.
+     *
+     * @param int $userId User primary key.
+     *
+     * @return PDOStatement Search results.
+     */
+    final public function findByUserId(int $userId): PDOStatement
+    {
+        $stmt = $this->DB->prepare('
+            SELECT * FROM ' . static::TARGET_TABLE . '
+            WHERE user_id = :user_id
+            AND is_deleted = 0
+            ORDER BY id ASC
+        ');
+        $stmt->bindValue(':user_id', $userId);
+        return $this->decorate($this->execute($stmt));
+    }
+}

--- a/class/xion/PdoConnection.php
+++ b/class/xion/PdoConnection.php
@@ -56,7 +56,11 @@ class PdoConnection
         try {
             switch (DB_TYPE) {
                 case 'MySQL':
-                    $this->connection = new PDO('mysql:host=' . DB_HOST . '; dbname=' . DB_NAME, DB_USER, DB_PASS);
+                    $this->connection = new PDO(
+                        'mysql:host=' . DB_HOST . ';port=' . DB_PORT . ';dbname=' . DB_NAME . ';charset=utf8mb4',
+                        DB_USER,
+                        DB_PASS
+                    );
                     $this->connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
                     $this->connection->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
                     break;
@@ -66,7 +70,6 @@ class PdoConnection
             }
         } catch (\PDOException $e) {
             die('Connection failed : ' . $e->getMessage());
-            exit();
         }
     }
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,16 @@ services:
   app:
     build:
       context: .
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      NENE_DB_TYPE: MySQL
+      NENE_DB_HOST: mysql
+      NENE_DB_PORT: 3306
+      NENE_DB_NAME: "${NENE_DB_NAME:-nene}"
+      NENE_DB_USER: "${NENE_DB_USER:-nene}"
+      NENE_DB_PASS: "${NENE_DB_PASS:-nene}"
     ports:
       - "${NENE_PORT:-8080}:80"
     volumes:
@@ -12,5 +22,24 @@ services:
       && ./init.sh
       && apache2-foreground"
 
+  mysql:
+    image: mysql:8.4
+    environment:
+      MYSQL_DATABASE: "${NENE_DB_NAME:-nene}"
+      MYSQL_USER: "${NENE_DB_USER:-nene}"
+      MYSQL_PASSWORD: "${NENE_DB_PASS:-nene}"
+      MYSQL_ROOT_PASSWORD: "${NENE_DB_ROOT_PASS:-root}"
+    ports:
+      - "${NENE_MYSQL_PORT:-3307}:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./docker/mysql/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u$${MYSQL_USER} -p$${MYSQL_PASSWORD} --silent"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
 volumes:
+  mysql-data:
   vendor:

--- a/docker/mysql/init/001_schema.sql
+++ b/docker/mysql/init/001_schema.sql
@@ -1,0 +1,53 @@
+CREATE TABLE IF NOT EXISTS users (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    user_id VARCHAR(64) NOT NULL,
+    user_pass VARCHAR(64) NOT NULL,
+    user_name VARCHAR(255) NOT NULL,
+    e_mail VARCHAR(255) NOT NULL,
+    is_deleted TINYINT(1) NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY users_user_id_unique (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS todos (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    user_id BIGINT UNSIGNED NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    is_completed TINYINT(1) NOT NULL DEFAULT 0,
+    is_deleted TINYINT(1) NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    KEY todos_user_id_index (user_id),
+    CONSTRAINT todos_user_id_foreign
+        FOREIGN KEY (user_id) REFERENCES users (id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO users (user_id, user_pass, user_name, e_mail, is_deleted)
+SELECT 'admin', 'admin', 'admin', 'admin@example.com', 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM users WHERE user_id = 'admin'
+);
+
+INSERT INTO todos (user_id, title, is_completed, is_deleted)
+SELECT users.id, 'Read the routing guide', 1, 0
+FROM users
+WHERE users.user_id = 'admin'
+AND NOT EXISTS (
+    SELECT 1 FROM todos
+    WHERE todos.user_id = users.id
+    AND todos.title = 'Read the routing guide'
+);
+
+INSERT INTO todos (user_id, title, is_completed, is_deleted)
+SELECT users.id, 'Create a controller action', 0, 0
+FROM users
+WHERE users.user_id = 'admin'
+AND NOT EXISTS (
+    SELECT 1 FROM todos
+    WHERE todos.user_id = users.id
+    AND todos.title = 'Create a controller action'
+);

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -25,15 +25,27 @@ Use another port if needed:
 NENE_PORT=8081 docker compose up --build
 ```
 
-## Initialize SQLite
+## MySQL Development Database
 
-The default configuration uses SQLite at `data/nene.db`.
+Docker Compose starts a MySQL 8.4 service for local development. The application container receives these database settings automatically:
 
-To create the database and default admin user:
-
-```sh
-docker compose run --rm app sh -lc "printf 'Y\n' | php cli/initSQLite.php"
+```text
+type: MySQL
+host: mysql
+port: 3306
+database: nene
+user: nene
+password: nene
 ```
+
+The first MySQL startup runs `docker/mysql/init/001_schema.sql`, which creates:
+
+- `users`
+- `todos`
+
+It also inserts the default development account and sample TODO rows.
+
+The MySQL container is exposed on host port `3307` by default to avoid colliding with a host MySQL server.
 
 Default development account:
 
@@ -43,6 +55,26 @@ password: admin
 ```
 
 Do not use this account in production.
+
+To expose MySQL on another host port:
+
+```sh
+NENE_MYSQL_PORT=3308 docker compose up --build
+```
+
+To change development credentials, set the Compose variables before startup:
+
+```sh
+NENE_DB_NAME=nene_local NENE_DB_USER=nene NENE_DB_PASS=nene docker compose up --build
+```
+
+## Optional SQLite Initialization
+
+The legacy SQLite initializer remains available for non-Docker or fallback usage:
+
+```sh
+docker compose run --rm app sh -lc "printf 'Y\n' | php cli/initSQLite.php"
+```
 
 ## Stop
 
@@ -55,4 +87,5 @@ docker compose down
 - The Apache document root is `htdocs/`.
 - `mod_rewrite` is enabled so `htdocs/.htaccess` can route URLs to `index.php`.
 - Composer dependencies are stored in a Docker named volume named `vendor`.
+- MySQL data is stored in a Docker named volume named `mysql-data`.
 - Generated files under `log/`, `view/compile/`, and SQLite database files are ignored by Git.

--- a/ini/xSystemIni.php
+++ b/ini/xSystemIni.php
@@ -39,13 +39,14 @@ const URI_IMG = 'https://' . OWN_DOMAIN;                // IMAGE DIR URI
 
 
 // DATABASE CONNECTION SETUP
-const DB_TYPE = 'SQLite3';                              // TYPE [MySQL|SQLite3]
-const DB_DIR = DIR_ROOT . 'data/';                      // DIRECTORY FOR SQLite3 DATABASE
-const DB_FILE = 'nene.db';                              // FILE NAME FOR SQLite3 DATABASE
-const DB_USER = 'root';                                 // USERNAME
-const DB_PASS = '';                                     // PASSWORD
-const DB_HOST = 'localhost';                            // HOSTNAME
-const DB_NAME = 'nene-php';                             // DATABASE NAME
+define('DB_TYPE', getenv('NENE_DB_TYPE') ?: 'SQLite3'); // TYPE [MySQL|SQLite3]
+define('DB_DIR', DIR_ROOT . 'data/');                   // DIRECTORY FOR SQLite3 DATABASE
+define('DB_FILE', getenv('NENE_DB_FILE') ?: 'nene.db'); // FILE NAME FOR SQLite3 DATABASE
+define('DB_USER', getenv('NENE_DB_USER') ?: 'root');    // USERNAME
+define('DB_PASS', getenv('NENE_DB_PASS') ?: '');        // PASSWORD
+define('DB_HOST', getenv('NENE_DB_HOST') ?: 'localhost'); // HOSTNAME
+define('DB_PORT', getenv('NENE_DB_PORT') ?: '3306');    // PORT
+define('DB_NAME', getenv('NENE_DB_NAME') ?: 'nene-php'); // DATABASE NAME
 
 // DATABASE
 const DB_COLUMN_TIMESTAMP = true;


### PR DESCRIPTION
## Summary
- Docker Compose に MySQL 8.4 service を追加し、app から MySQL に接続する環境変数を設定しました。
- 初回起動用 SQL で `users` / `todos` テーブルと開発用初期データを作成するようにしました。
- `Todo` model/mapper と Docker 開発ドキュメントを追加・更新しました。

## Verification
- `php -l ini/xSystemIni.php`
- `php -l class/xion/PdoConnection.php`
- `php -l class/db/Todo.php`
- `php -l class/db/TodoMapper.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- `docker compose config`
- `NENE_MYSQL_PORT=3307 docker compose up -d --build`
- `docker compose exec -T mysql mysql -unene -pnene nene -e "SHOW TABLES; SELECT COUNT(*) AS users_count FROM users; SELECT COUNT(*) AS todos_count FROM todos;"`
- `docker compose exec -T app php -r 'require "vendor/autoload.php"; Nene\\Xion\\Initialize::init(); $pdo = Nene\\Xion\\PdoConnection::getInstance(); echo "users=" . $pdo->query("SELECT COUNT(*) FROM users")->fetchColumn() . PHP_EOL; echo "todos=" . $pdo->query("SELECT COUNT(*) FROM todos")->fetchColumn() . PHP_EOL;'`
- HTTP check at `http://localhost:8080/`

Closes #21

Made with [Cursor](https://cursor.com)