### PR TITLE
feat(rest): HTTP メソッド別 TODO API を追加する

### DIFF
--- a/class/controller/TodoController.php
+++ b/class/controller/TodoController.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 7.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Controller;
+
+use Nene\Database as Database;
+use Nene\Xion\ControllerBase;
+
+/**
+ * TODO REST controller for the sample application.
+ */
+class TodoController extends ControllerBase
+{
+    private const DEMO_USER_ID = 1;
+
+    /**
+     * Processed before the controller method is executed.
+     *
+     * @return void
+     */
+    protected function preAction()
+    {
+        $this->SESSION_CHECK = false;
+    }
+
+    /**
+     * Get TODO items.
+     *
+     * @return array<string,mixed> TODO response.
+     */
+    public function indexGetRest(): array
+    {
+        $todoMapper = new Database\TodoMapper();
+        return [
+            'status' => 'success',
+            'todos' => $this->normalizeRows($todoMapper->findRowsByUserId(self::DEMO_USER_ID))
+        ];
+    }
+
+    /**
+     * Create a TODO item.
+     *
+     * @return array<string,mixed> TODO response.
+     */
+    public function indexPostRest(): array
+    {
+        $title = trim((string)($this->REQUEST_JSON['title'] ?? ''));
+        if ($title === '') {
+            header('HTTP/1.0 400 Bad Request');
+            return [
+                'status' => 'failure',
+                'errorCode' => 'TODO-TITLE-REQUIRED',
+                'errorMessage' => 'TODO title is required.'
+            ];
+        }
+        $todoMapper = new Database\TodoMapper();
+        return [
+            'status' => 'success',
+            'todo' => $this->normalizeRow($todoMapper->createForUser(self::DEMO_USER_ID, $title))
+        ];
+    }
+
+    /**
+     * Update a TODO item.
+     *
+     * @return array<string,mixed> TODO response.
+     */
+    public function itemPutRest(): array
+    {
+        $id = $this->getTodoId();
+        if ($id === null) {
+            header('HTTP/1.0 400 Bad Request');
+            return [
+                'status' => 'failure',
+                'errorCode' => 'TODO-ID-REQUIRED',
+                'errorMessage' => 'TODO id is required.'
+            ];
+        }
+        $title = array_key_exists('title', $this->REQUEST_JSON)
+            ? trim((string)$this->REQUEST_JSON['title'])
+            : null;
+        $isCompleted = array_key_exists('is_completed', $this->REQUEST_JSON)
+            ? filter_var($this->REQUEST_JSON['is_completed'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)
+            : null;
+        if ($title === '') {
+            header('HTTP/1.0 400 Bad Request');
+            return [
+                'status' => 'failure',
+                'errorCode' => 'TODO-TITLE-REQUIRED',
+                'errorMessage' => 'TODO title is required.'
+            ];
+        }
+        $todoMapper = new Database\TodoMapper();
+        $todo = $todoMapper->updateForUser(self::DEMO_USER_ID, $id, $title, $isCompleted);
+        if ($todo === null) {
+            header('HTTP/1.0 404 Not Found');
+            return [
+                'status' => 'failure',
+                'errorCode' => 'TODO-NOT-FOUND',
+                'errorMessage' => 'TODO item was not found.'
+            ];
+        }
+        return [
+            'status' => 'success',
+            'todo' => $this->normalizeRow($todo)
+        ];
+    }
+
+    /**
+     * Delete a TODO item.
+     *
+     * @return array<string,mixed> TODO response.
+     */
+    public function itemDeleteRest(): array
+    {
+        $id = $this->getTodoId();
+        if ($id === null) {
+            header('HTTP/1.0 400 Bad Request');
+            return [
+                'status' => 'failure',
+                'errorCode' => 'TODO-ID-REQUIRED',
+                'errorMessage' => 'TODO id is required.'
+            ];
+        }
+        $todoMapper = new Database\TodoMapper();
+        if (!$todoMapper->deleteForUser(self::DEMO_USER_ID, $id)) {
+            header('HTTP/1.0 404 Not Found');
+            return [
+                'status' => 'failure',
+                'errorCode' => 'TODO-NOT-FOUND',
+                'errorMessage' => 'TODO item was not found.'
+            ];
+        }
+        return [
+            'status' => 'success',
+            'id' => $id
+        ];
+    }
+
+    /**
+     * Get TODO id from URL parameters.
+     *
+     * @return int|null TODO id.
+     */
+    private function getTodoId(): ?int
+    {
+        $id = $this->request->getParam('id');
+        if ($id === null || !ctype_digit((string)$id)) {
+            return null;
+        }
+        return (int)$id;
+    }
+
+    /**
+     * Normalize TODO rows for JSON output.
+     *
+     * @param array<int,array<string,mixed>> $rows TODO rows.
+     *
+     * @return array<int,array<string,mixed>> Normalized TODO rows.
+     */
+    private function normalizeRows(array $rows): array
+    {
+        return array_map([$this, 'normalizeRow'], $rows);
+    }
+
+    /**
+     * Normalize a TODO row for JSON output.
+     *
+     * @param array<string,mixed> $row TODO row.
+     *
+     * @return array<string,mixed> Normalized TODO row.
+     */
+    private function normalizeRow(array $row): array
+    {
+        return [
+            'id' => (int)$row['id'],
+            'user_id' => (int)$row['user_id'],
+            'title' => (string)$row['title'],
+            'is_completed' => (bool)$row['is_completed'],
+            'created_at' => (string)$row['created_at'],
+            'updated_at' => (string)$row['updated_at']
+        ];
+    }
+}

--- a/class/db/TodoMapper.php
+++ b/class/db/TodoMapper.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Nene\Database;
 
 use Nene\Xion\DataMapperBase as DataMapperBase;
+use PDO;
 use PDOStatement;
 
 /**
@@ -46,5 +47,144 @@ class TodoMapper extends DataMapperBase
         ');
         $stmt->bindValue(':user_id', $userId);
         return $this->decorate($this->execute($stmt));
+    }
+
+    /**
+     * Find TODO rows owned by a user as arrays.
+     *
+     * @param int $userId User primary key.
+     *
+     * @return array<int,array<string,mixed>> TODO rows.
+     */
+    final public function findRowsByUserId(int $userId): array
+    {
+        $stmt = $this->DB->prepare('
+            SELECT id, user_id, title, is_completed, created_at, updated_at
+            FROM ' . static::TARGET_TABLE . '
+            WHERE user_id = :user_id
+            AND is_deleted = 0
+            ORDER BY id ASC
+        ');
+        $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        return $this->execute($stmt)->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Find one TODO row owned by a user.
+     *
+     * @param int $userId User primary key.
+     * @param int $id     TODO primary key.
+     *
+     * @return array<string,mixed>|null TODO row.
+     */
+    final public function findRowByUserIdAndId(int $userId, int $id): ?array
+    {
+        $stmt = $this->DB->prepare('
+            SELECT id, user_id, title, is_completed, created_at, updated_at
+            FROM ' . static::TARGET_TABLE . '
+            WHERE id = :id
+            AND user_id = :user_id
+            AND is_deleted = 0
+            LIMIT 1
+        ');
+        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+        return is_array($row) ? $row : null;
+    }
+
+    /**
+     * Create a TODO row.
+     *
+     * @param int    $userId User primary key.
+     * @param string $title  TODO title.
+     *
+     * @return array<string,mixed> Created TODO row.
+     */
+    final public function createForUser(int $userId, string $title): array
+    {
+        $stmt = $this->DB->prepare('
+            INSERT INTO ' . static::TARGET_TABLE . ' (
+                user_id,
+                title,
+                is_completed,
+                is_deleted
+            ) VALUES (
+                :user_id,
+                :title,
+                0,
+                0
+            )
+        ');
+        $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $stmt->bindValue(':title', $title, PDO::PARAM_STR);
+        $this->execute($stmt);
+        $row = $this->findRowByUserIdAndId($userId, (int)$this->DB->lastInsertId());
+        if ($row === null) {
+            throw new \RuntimeException('Created TODO row could not be loaded.');
+        }
+        return $row;
+    }
+
+    /**
+     * Update a TODO row.
+     *
+     * @param int         $userId      User primary key.
+     * @param int         $id          TODO primary key.
+     * @param string|null $title       TODO title.
+     * @param bool|null   $isCompleted Completed flag.
+     *
+     * @return array<string,mixed>|null Updated TODO row.
+     */
+    final public function updateForUser(int $userId, int $id, ?string $title, ?bool $isCompleted): ?array
+    {
+        $sets = [];
+        if ($title !== null) {
+            $sets[] = 'title = :title';
+        }
+        if ($isCompleted !== null) {
+            $sets[] = 'is_completed = :is_completed';
+        }
+        if ($sets === []) {
+            return $this->findRowByUserIdAndId($userId, $id);
+        }
+        $stmt = $this->DB->prepare(sprintf(
+            'UPDATE %s SET %s WHERE id = :id AND user_id = :user_id AND is_deleted = 0',
+            static::TARGET_TABLE,
+            implode(', ', $sets)
+        ));
+        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        if ($title !== null) {
+            $stmt->bindValue(':title', $title, PDO::PARAM_STR);
+        }
+        if ($isCompleted !== null) {
+            $stmt->bindValue(':is_completed', $isCompleted ? 1 : 0, PDO::PARAM_INT);
+        }
+        $this->execute($stmt);
+        return $this->findRowByUserIdAndId($userId, $id);
+    }
+
+    /**
+     * Mark a TODO row as deleted.
+     *
+     * @param int $userId User primary key.
+     * @param int $id     TODO primary key.
+     *
+     * @return bool True when a row was deleted.
+     */
+    final public function deleteForUser(int $userId, int $id): bool
+    {
+        $stmt = $this->DB->prepare('
+            UPDATE ' . static::TARGET_TABLE . '
+            SET is_deleted = 1
+            WHERE id = :id
+            AND user_id = :user_id
+            AND is_deleted = 0
+        ');
+        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $this->execute($stmt);
+        return $stmt->rowCount() > 0;
     }
 }

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -181,7 +181,7 @@ abstract class ControllerBase
                 ]
             );
         }
-        if (APP_ACTION_MODE == 'Rest' && $this->method == 'POST') {
+        if (APP_ACTION_MODE == 'Rest' && in_array($this->method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
             $this->REQUEST_JSON = Func\Json::inputPostJsonToArray();
         } elseif (APP_ACTION_MODE == 'Action') {
             $this->setTemplate();
@@ -192,7 +192,7 @@ abstract class ControllerBase
             $this->sessionCheck();
         }
 
-        $methodName = sprintf('%s' . APP_ACTION_MODE, APP_ACTION);
+        $methodName = defined('APP_ACTION_METHOD') ? APP_ACTION_METHOD : sprintf('%s' . APP_ACTION_MODE, APP_ACTION);
         $return = $this->$methodName();
 
         if (APP_ACTION_MODE == 'Rest') {

--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -39,7 +39,8 @@ class Dispatcher
      */
     final public function dispatch(): void
     {
-        $param = ltrim($_SERVER['REQUEST_URI'], '/');
+        $requestPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '';
+        $param = ltrim($requestPath, '/');
         $param = rtrim($param, '/');
         $params = [];
         if ($param != '') {
@@ -54,22 +55,135 @@ class Dispatcher
 
         /* ========== SET ACTION ========== */
         define('APP_ACTION', $action);
-        if (
-            method_exists($controllerInstance, $action . 'Action')
-            && method_exists($controllerInstance, $action . 'Rest')
-        ) {
-            echo $action . 'Action' . ' and ' . $action . 'Rest Duplicate';
-            exit();
-        } elseif (method_exists($controllerInstance, $action . 'Action')) {
-            define('APP_ACTION_MODE', 'Action');
-        } elseif (method_exists($controllerInstance, $action . 'Rest')) {
-            define('APP_ACTION_MODE', 'Rest');
-        } else {
+        $route = $this->resolveActionRoute(
+            $controllerInstance,
+            $action,
+            $_SERVER['REQUEST_METHOD'] ?? 'GET'
+        );
+        if ($route['status'] === 404) {
             header('HTTP/1.0 404 Not Found');
             echo file_get_contents(DIR_ROOT . '/404.html');
             exit;
+        } elseif ($route['status'] === 405) {
+            header('HTTP/1.0 405 Method Not Allowed');
+            header('Allow: ' . implode(', ', $route['allowed']));
+            echo json_encode([
+                'Result' => false,
+                'Error' => [
+                    'ErrorCode' => 'METHOD-NOT-ALLOWED',
+                    'ErrorMessage' => 'The HTTP method is not allowed for this endpoint.'
+                ]
+            ]);
+            exit;
+        } elseif ($route['status'] === 500) {
+            echo $action . 'Action' . ' and ' . $action . 'Rest Duplicate';
+            exit();
         }
+        define('APP_ACTION_MODE', $route['mode']);
+        define('APP_ACTION_METHOD', $route['method']);
         $controllerInstance->run();
+    }
+
+    /**
+     * Resolve the controller method for an action.
+     *
+     * REST handlers may opt into HTTP-method dispatch with names like indexGetRest.
+     * The legacy indexRest convention remains supported as a fallback.
+     *
+     * @param object $controllerInstance Controller instance.
+     * @param string $action             Action name.
+     * @param string $requestMethod      HTTP request method.
+     *
+     * @return array{status:int, mode:string, method:string, allowed:array<int,string>}
+     */
+    final public function resolveActionRoute(object $controllerInstance, string $action, string $requestMethod): array
+    {
+        $actionMethod = $action . 'Action';
+        $legacyRestMethod = $action . 'Rest';
+        $methodRestMethod = $action . $this->getRestMethodSuffix($requestMethod) . 'Rest';
+        $allowedMethods = $this->getAllowedRestMethods($controllerInstance, $action);
+
+        if (method_exists($controllerInstance, $methodRestMethod)) {
+            return [
+                'status' => 200,
+                'mode' => 'Rest',
+                'method' => $methodRestMethod,
+                'allowed' => $allowedMethods
+            ];
+        }
+        if (
+            method_exists($controllerInstance, $actionMethod)
+            && method_exists($controllerInstance, $legacyRestMethod)
+        ) {
+            return [
+                'status' => 500,
+                'mode' => '',
+                'method' => '',
+                'allowed' => $allowedMethods
+            ];
+        }
+        if (method_exists($controllerInstance, $actionMethod)) {
+            return [
+                'status' => 200,
+                'mode' => 'Action',
+                'method' => $actionMethod,
+                'allowed' => $allowedMethods
+            ];
+        }
+        if (method_exists($controllerInstance, $legacyRestMethod)) {
+            return [
+                'status' => 200,
+                'mode' => 'Rest',
+                'method' => $legacyRestMethod,
+                'allowed' => $allowedMethods
+            ];
+        }
+        if ($allowedMethods !== []) {
+            return [
+                'status' => 405,
+                'mode' => '',
+                'method' => '',
+                'allowed' => $allowedMethods
+            ];
+        }
+        return [
+            'status' => 404,
+            'mode' => '',
+            'method' => '',
+            'allowed' => []
+        ];
+    }
+
+    /**
+     * Get the REST method suffix for an HTTP method.
+     *
+     * @param string $requestMethod HTTP request method.
+     *
+     * @return string REST method suffix.
+     */
+    private function getRestMethodSuffix(string $requestMethod): string
+    {
+        return ucfirst(strtolower($requestMethod));
+    }
+
+    /**
+     * Get HTTP methods supported by method-specific REST handlers.
+     *
+     * @param object $controllerInstance Controller instance.
+     * @param string $action             Action name.
+     *
+     * @return array<int,string> Supported HTTP methods.
+     */
+    private function getAllowedRestMethods(object $controllerInstance, string $action): array
+    {
+        $allowedMethods = [];
+        foreach (get_class_methods($controllerInstance) as $methodName) {
+            if (preg_match('/^' . preg_quote($action, '/') . '(Get|Post|Put|Patch|Delete)Rest$/', $methodName, $matches)) {
+                $allowedMethods[] = strtoupper($matches[1]);
+            }
+        }
+        sort($allowedMethods);
+        return $allowedMethods;
     }
 
     /**

--- a/class/xion/UrlParameter.php
+++ b/class/xion/UrlParameter.php
@@ -38,13 +38,15 @@ class UrlParameter extends RequestVariables
      */
     final protected function setValues(): void
     {
-        $param = rtrim($_SERVER['REQUEST_URI'], '/');
+        $requestPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '';
+        $param = trim($requestPath, '/');
         $params = [];
         if ('' != $param) {
             $params = explode('/', $param);
         }
-        if (LAYERS_NUM + 3 < count($params)) {
-            foreach ($params as $param) {
+        if (LAYERS_NUM + 2 < count($params)) {
+            $urlParams = array_slice($params, LAYERS_NUM + 2);
+            foreach ($urlParams as $param) {
                 $split = explode('_', $param);
                 if (2 == count($split)) {
                     $key = $split[0];

--- a/htdocs/css/index/index.css
+++ b/htdocs/css/index/index.css
@@ -303,6 +303,12 @@
     margin-bottom: 18px;
 }
 
+.todo-panel__status {
+    color: #8f82ff;
+    font-size: 0.86rem;
+    margin: 0 0 12px;
+}
+
 .todo-list {
     display: grid;
     gap: 10px;

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     const e = React.createElement;
+    const useEffect = React.useEffect;
     const useState = React.useState;
     const tagline = root.dataset.tagline || 'A small legacy PHP framework for URL-based applications.';
 
@@ -116,10 +117,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function SampleApp() {
-        const initialTodos = [
-            { id: 1, text: 'Read the routing guide', completed: true },
-            { id: 2, text: 'Create a controller action', completed: false }
-        ];
         const state = useState(false);
         const isSignedIn = state[0];
         const setIsSignedIn = state[1];
@@ -129,9 +126,58 @@ document.addEventListener('DOMContentLoaded', function() {
         const taskState = useState('');
         const task = taskState[0];
         const setTask = taskState[1];
-        const todosState = useState(initialTodos);
+        const todosState = useState([]);
         const todos = todosState[0];
         const setTodos = todosState[1];
+        const statusState = useState('');
+        const status = statusState[0];
+        const setStatus = statusState[1];
+
+        useEffect(function() {
+            if (isSignedIn) {
+                loadTodos();
+            }
+        }, [isSignedIn]);
+
+        function requestJson(url, options) {
+            const requestOptions = options || {};
+            requestOptions.headers = Object.assign({
+                'Content-Type': 'application/json'
+            }, requestOptions.headers || {});
+            return fetch(url, requestOptions)
+                .then(function(response) {
+                    return response.json().then(function(body) {
+                        if (!response.ok || !body.Result) {
+                            throw new Error(
+                                body.Error
+                                    ? body.Error.ErrorMessage
+                                    : 'Request failed.'
+                            );
+                        }
+                        return body.Data;
+                    });
+                });
+        }
+
+        function normalizeTodo(todo) {
+            return {
+                id: todo.id,
+                text: todo.title,
+                completed: todo.is_completed
+            };
+        }
+
+        function loadTodos() {
+            setStatus('Loading TODOs...');
+            return requestJson('/todo/index')
+                .then(function(data) {
+                    setTodos(data.todos.map(normalizeTodo));
+                    setStatus('');
+                })
+                .catch(function(error) {
+                    setStatus(error.message);
+                });
+        }
 
         function signIn(event) {
             event.preventDefault();
@@ -146,31 +192,53 @@ document.addEventListener('DOMContentLoaded', function() {
             if (!text) {
                 return;
             }
-            setTodos(todos.concat({
-                id: Date.now(),
-                text: text,
-                completed: false
-            }));
-            setTask('');
+            setStatus('Creating TODO...');
+            requestJson('/todo/index', {
+                method: 'POST',
+                body: JSON.stringify({ title: text })
+            }).then(function(data) {
+                setTodos(todos.concat(normalizeTodo(data.todo)));
+                setTask('');
+                setStatus('');
+            }).catch(function(error) {
+                setStatus(error.message);
+            });
         }
 
         function toggleTodo(id) {
-            setTodos(todos.map(function(todo) {
-                if (todo.id !== id) {
-                    return todo;
-                }
-                return {
-                    id: todo.id,
-                    text: todo.text,
-                    completed: !todo.completed
-                };
-            }));
+            const target = todos.find(function(todo) {
+                return todo.id === id;
+            });
+            if (!target) {
+                return;
+            }
+            setStatus('Updating TODO...');
+            requestJson('/todo/item/id_' + id, {
+                method: 'PUT',
+                body: JSON.stringify({ is_completed: !target.completed })
+            }).then(function(data) {
+                const updatedTodo = normalizeTodo(data.todo);
+                setTodos(todos.map(function(todo) {
+                    return todo.id === id ? updatedTodo : todo;
+                }));
+                setStatus('');
+            }).catch(function(error) {
+                setStatus(error.message);
+            });
         }
 
         function removeTodo(id) {
-            setTodos(todos.filter(function(todo) {
-                return todo.id !== id;
-            }));
+            setStatus('Deleting TODO...');
+            requestJson('/todo/item/id_' + id, {
+                method: 'DELETE'
+            }).then(function() {
+                setTodos(todos.filter(function(todo) {
+                    return todo.id !== id;
+                }));
+                setStatus('');
+            }).catch(function(error) {
+                setStatus(error.message);
+            });
         }
 
         return e('section', { className: 'developers__section developers__sample', id: 'sample-app' },
@@ -189,6 +257,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         setTask: setTask,
                         task: task,
                         todos: todos,
+                        status: status,
                         toggleTodo: toggleTodo
                     })
                     : e(LoginForm, {
@@ -227,6 +296,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function TodoPanel(props) {
         return e('div', { className: 'todo-panel' },
+            props.status ? e('p', { className: 'todo-panel__status' }, props.status) : null,
             e('form', { className: 'todo-panel__form', onSubmit: props.addTodo },
                 e('input', {
                     value: props.task,

--- a/tests/Unit/Xion/DispatcherTest.php
+++ b/tests/Unit/Xion/DispatcherTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\Dispatcher;
+use PHPUnit\Framework\TestCase;
+
+final class DispatcherTest extends TestCase
+{
+    public function testResolveActionRoutePrefersHttpMethodRestHandler(): void
+    {
+        $controller = new class {
+            public function indexGetRest(): array
+            {
+                return [];
+            }
+
+            public function indexPostRest(): array
+            {
+                return [];
+            }
+        };
+
+        $route = (new Dispatcher())->resolveActionRoute($controller, 'index', 'GET');
+
+        self::assertSame(200, $route['status']);
+        self::assertSame('Rest', $route['mode']);
+        self::assertSame('indexGetRest', $route['method']);
+        self::assertSame(['GET', 'POST'], $route['allowed']);
+    }
+
+    public function testResolveActionRouteKeepsLegacyRestFallback(): void
+    {
+        $controller = new class {
+            public function loginRest(): array
+            {
+                return [];
+            }
+        };
+
+        $route = (new Dispatcher())->resolveActionRoute($controller, 'login', 'POST');
+
+        self::assertSame(200, $route['status']);
+        self::assertSame('Rest', $route['mode']);
+        self::assertSame('loginRest', $route['method']);
+    }
+
+    public function testResolveActionRouteReturnsMethodNotAllowedWhenOnlyOtherRestMethodsExist(): void
+    {
+        $controller = new class {
+            public function itemPutRest(): array
+            {
+                return [];
+            }
+
+            public function itemDeleteRest(): array
+            {
+                return [];
+            }
+        };
+
+        $route = (new Dispatcher())->resolveActionRoute($controller, 'item', 'GET');
+
+        self::assertSame(405, $route['status']);
+        self::assertSame(['DELETE', 'PUT'], $route['allowed']);
+    }
+}


### PR DESCRIPTION
## Summary
- Dispatcher に HTTP メソッド別 REST ハンドラ解決を追加し、既存の `{action}Rest` fallback は維持しました。
- `TodoController` と `TodoMapper` に TODO CRUD API を追加しました。
- React の TODO サンプルを REST API 経由で MySQL の `todos` を操作する形へ切り替えました。

## Verification
- `php -l class/xion/Dispatcher.php`
- `php -l class/xion/ControllerBase.php`
- `php -l class/xion/UrlParameter.php`
- `php -l class/controller/TodoController.php`
- `php -l class/db/TodoMapper.php`
- `node --check htdocs/js/index/index.js`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- HTTP `GET /todo/index`
- HTTP `POST /todo/index`
- HTTP `PUT /todo/item/id_{id}`
- HTTP `DELETE /todo/item/id_{id}`
- HTTP `GET /todo/item/id_{id}` returns 405
- Browser check at `http://localhost:8080/`

Closes #10

Made with [Cursor](https://cursor.com)