### PR TITLE
feat(auth): TODO サンプルをログインユーザーに紐づける

### DIFF
--- a/class/controller/SessionController.php
+++ b/class/controller/SessionController.php
@@ -43,12 +43,12 @@ class SessionController extends ControllerBase
      */
     public function loginRest(): array
     {
-        sleep(3);
-        $user_id     = filter_input(INPUT_POST, 'user_id');
-        $user_pass   = filter_input(INPUT_POST, 'user_pass');
+        $user_id = (string)($this->REQUEST_JSON['user_id'] ?? filter_input(INPUT_POST, 'user_id') ?? '');
+        $user_pass = (string)($this->REQUEST_JSON['user_pass'] ?? filter_input(INPUT_POST, 'user_pass') ?? '');
         $userMapper = new Database\UserMapper();
-        $count = $userMapper->checkLogin($user_id, $user_pass);
-        if ($count === 0) {
+        $user = $userMapper->findByCredentials($user_id, $user_pass);
+        if ($user === null) {
+            $this->logout();
             $errorCode = 'LOGIN-FAILED';
             return ([
                 'status'        => 'failure',
@@ -56,10 +56,16 @@ class SessionController extends ControllerBase
                 'errorMessage'  => $this->ERROR_CODE->getErrorText($errorCode)
             ]);
         }
+        $_SESSION['xion']['login_mode'] = 'login';
+        $_SESSION['xion']['user'] = [
+            'id'        => (int)$user['id'],
+            'user_id'   => (string)$user['user_id'],
+            'user_name' => (string)$user['user_name'],
+            'e_mail'    => (string)$user['e_mail']
+        ];
         return ([
             'status'    => 'success',
-            'user_id'   => $user_id,
-            'user_pass' => $user_pass,
+            'user'      => $_SESSION['xion']['user'],
             'errorCode' => ''
         ]);
     }

--- a/class/controller/TodoController.php
+++ b/class/controller/TodoController.php
@@ -25,18 +25,6 @@ use Nene\Xion\ControllerBase;
  */
 class TodoController extends ControllerBase
 {
-    private const DEMO_USER_ID = 1;
-
-    /**
-     * Processed before the controller method is executed.
-     *
-     * @return void
-     */
-    protected function preAction()
-    {
-        $this->SESSION_CHECK = false;
-    }
-
     /**
      * Get TODO items.
      *
@@ -44,10 +32,11 @@ class TodoController extends ControllerBase
      */
     public function indexGetRest(): array
     {
+        $userId = $this->getLoginUserId();
         $todoMapper = new Database\TodoMapper();
         return [
             'status' => 'success',
-            'todos' => $this->normalizeRows($todoMapper->findRowsByUserId(self::DEMO_USER_ID))
+            'todos' => $this->normalizeRows($todoMapper->findRowsByUserId($userId))
         ];
     }
 
@@ -58,6 +47,7 @@ class TodoController extends ControllerBase
      */
     public function indexPostRest(): array
     {
+        $userId = $this->getLoginUserId();
         $title = trim((string)($this->REQUEST_JSON['title'] ?? ''));
         if ($title === '') {
             header('HTTP/1.0 400 Bad Request');
@@ -70,7 +60,7 @@ class TodoController extends ControllerBase
         $todoMapper = new Database\TodoMapper();
         return [
             'status' => 'success',
-            'todo' => $this->normalizeRow($todoMapper->createForUser(self::DEMO_USER_ID, $title))
+            'todo' => $this->normalizeRow($todoMapper->createForUser($userId, $title))
         ];
     }
 
@@ -81,6 +71,7 @@ class TodoController extends ControllerBase
      */
     public function itemPutRest(): array
     {
+        $userId = $this->getLoginUserId();
         $id = $this->getTodoId();
         if ($id === null) {
             header('HTTP/1.0 400 Bad Request');
@@ -105,7 +96,7 @@ class TodoController extends ControllerBase
             ];
         }
         $todoMapper = new Database\TodoMapper();
-        $todo = $todoMapper->updateForUser(self::DEMO_USER_ID, $id, $title, $isCompleted);
+        $todo = $todoMapper->updateForUser($userId, $id, $title, $isCompleted);
         if ($todo === null) {
             header('HTTP/1.0 404 Not Found');
             return [
@@ -127,6 +118,7 @@ class TodoController extends ControllerBase
      */
     public function itemDeleteRest(): array
     {
+        $userId = $this->getLoginUserId();
         $id = $this->getTodoId();
         if ($id === null) {
             header('HTTP/1.0 400 Bad Request');
@@ -137,7 +129,7 @@ class TodoController extends ControllerBase
             ];
         }
         $todoMapper = new Database\TodoMapper();
-        if (!$todoMapper->deleteForUser(self::DEMO_USER_ID, $id)) {
+        if (!$todoMapper->deleteForUser($userId, $id)) {
             header('HTTP/1.0 404 Not Found');
             return [
                 'status' => 'failure',
@@ -163,6 +155,16 @@ class TodoController extends ControllerBase
             return null;
         }
         return (int)$id;
+    }
+
+    /**
+     * Get the current login user's primary key.
+     *
+     * @return int User primary key.
+     */
+    private function getLoginUserId(): int
+    {
+        return (int)$_SESSION['xion']['user']['id'];
     }
 
     /**

--- a/class/db/UserMapper.php
+++ b/class/db/UserMapper.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace Nene\Database;
 
 use Nene\Xion\DataMapperBase as DataMapperBase;
-use Nene\Database;
 use PDO;
 
 /**
@@ -60,5 +59,29 @@ class UserMapper extends DataMapperBase
         $stmt->bindParam(':user_id', $user_id, PDO::PARAM_STR);
         $stmt->bindParam(':user_pass', $user_pass, PDO::PARAM_STR);
         return (int)$this->execute($stmt)->fetchColumn();
+    }
+
+    /**
+     * Find an active user by credentials.
+     *
+     * @param string $user_id   User ID.
+     * @param string $user_pass User password.
+     *
+     * @return array<string,mixed>|null User row.
+     */
+    final public function findByCredentials(string $user_id, string $user_pass): ?array
+    {
+        $stmt = $this->DB->prepare('
+            SELECT id, user_id, user_name, e_mail
+            FROM ' . static::TARGET_TABLE . '
+            WHERE user_id = :user_id
+            AND user_pass = :user_pass
+            AND is_deleted = 0
+            LIMIT 1
+        ');
+        $stmt->bindValue(':user_id', $user_id, PDO::PARAM_STR);
+        $stmt->bindValue(':user_pass', $user_pass, PDO::PARAM_STR);
+        $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+        return is_array($row) ? $row : null;
     }
 }

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -347,7 +347,7 @@ abstract class ControllerBase
                 Func\Json::outputArrayToJson(
                     $return,
                     $this->OUTPUT_JSON_STYLE,
-                    filter_input(INPUT_GET, 'callback'),
+                    filter_input(INPUT_GET, 'callback') ?: '',
                     $this->SESSION_CHECK
                 );
             }

--- a/htdocs/css/index/index.css
+++ b/htdocs/css/index/index.css
@@ -279,6 +279,13 @@
     margin-bottom: 7px;
 }
 
+.sample-form__error {
+    color: #ff8f8f;
+    font-size: 0.88rem;
+    line-height: 1.55;
+    margin: 0;
+}
+
 .sample-form input,
 .todo-panel__form input {
     background: #0a0a0a;
@@ -303,10 +310,15 @@
     margin-bottom: 18px;
 }
 
+.todo-panel__user,
 .todo-panel__status {
     color: #8f82ff;
     font-size: 0.86rem;
     margin: 0 0 12px;
+}
+
+.todo-panel__user {
+    color: #aaa9a1;
 }
 
 .todo-list {

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -120,9 +120,12 @@ document.addEventListener('DOMContentLoaded', function() {
         const state = useState(false);
         const isSignedIn = state[0];
         const setIsSignedIn = state[1];
-        const emailState = useState('demo@example.com');
-        const email = emailState[0];
-        const setEmail = emailState[1];
+        const userIdState = useState('admin');
+        const userId = userIdState[0];
+        const setUserId = userIdState[1];
+        const passwordState = useState('admin');
+        const password = passwordState[0];
+        const setPassword = passwordState[1];
         const taskState = useState('');
         const task = taskState[0];
         const setTask = taskState[1];
@@ -132,6 +135,12 @@ document.addEventListener('DOMContentLoaded', function() {
         const statusState = useState('');
         const status = statusState[0];
         const setStatus = statusState[1];
+        const loginErrorState = useState('');
+        const loginError = loginErrorState[0];
+        const setLoginError = loginErrorState[1];
+        const userState = useState(null);
+        const user = userState[0];
+        const setUser = userState[1];
 
         useEffect(function() {
             if (isSignedIn) {
@@ -153,6 +162,9 @@ document.addEventListener('DOMContentLoaded', function() {
                                     ? body.Error.ErrorMessage
                                     : 'Request failed.'
                             );
+                        }
+                        if (body.Data && body.Data.status === 'failure') {
+                            throw new Error(body.Data.errorMessage || 'Request failed.');
                         }
                         return body.Data;
                     });
@@ -181,9 +193,23 @@ document.addEventListener('DOMContentLoaded', function() {
 
         function signIn(event) {
             event.preventDefault();
-            if (email.trim()) {
-                setIsSignedIn(true);
+            setLoginError('');
+            if (!userId.trim() || !password.trim()) {
+                setLoginError('ID and password are required.');
+                return;
             }
+            requestJson('/session/login', {
+                method: 'POST',
+                body: JSON.stringify({
+                    user_id: userId,
+                    user_pass: password
+                })
+            }).then(function(data) {
+                setUser(data.user);
+                setIsSignedIn(true);
+            }).catch(function(error) {
+                setLoginError(error.message);
+            });
         }
 
         function addTodo(event) {
@@ -258,12 +284,16 @@ document.addEventListener('DOMContentLoaded', function() {
                         task: task,
                         todos: todos,
                         status: status,
-                        toggleTodo: toggleTodo
+                        toggleTodo: toggleTodo,
+                        user: user
                     })
                     : e(LoginForm, {
-                        email: email,
-                        setEmail: setEmail,
-                        signIn: signIn
+                        loginError: loginError,
+                        password: password,
+                        setPassword: setPassword,
+                        setUserId: setUserId,
+                        signIn: signIn,
+                        userId: userId
                     })
             )
         );
@@ -271,23 +301,27 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function LoginForm(props) {
         return e('form', { className: 'sample-form', onSubmit: props.signIn },
+            props.loginError ? e('p', { className: 'sample-form__error' }, props.loginError) : null,
             e('label', null,
-                e('span', null, 'Email'),
+                e('span', null, 'User ID'),
                 e('input', {
-                    type: 'email',
-                    value: props.email,
+                    type: 'text',
+                    value: props.userId,
                     onChange: function(event) {
-                        props.setEmail(event.target.value);
+                        props.setUserId(event.target.value);
                     },
-                    placeholder: 'demo@example.com'
+                    placeholder: 'admin'
                 })
             ),
             e('label', null,
                 e('span', null, 'Password'),
                 e('input', {
                     type: 'password',
-                    defaultValue: 'password',
-                    placeholder: 'password'
+                    value: props.password,
+                    onChange: function(event) {
+                        props.setPassword(event.target.value);
+                    },
+                    placeholder: 'admin'
                 })
             ),
             e('button', { className: 'button button--primary', type: 'submit' }, 'Sign in')
@@ -296,6 +330,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function TodoPanel(props) {
         return e('div', { className: 'todo-panel' },
+            props.user ? e('p', { className: 'todo-panel__user' }, 'Signed in as ' + props.user.user_id) : null,
             props.status ? e('p', { className: 'todo-panel__status' }, props.status) : null,
             e('form', { className: 'todo-panel__form', onSubmit: props.addTodo },
                 e('input', {


### PR DESCRIPTION
## Summary
- ログインフォームの初期値を `admin` / `admin` にし、実際に `/session/login` を呼ぶようにしました。
- ログイン成功時に `users.id` を含むユーザー情報を session に保存し、TODO API がログインユーザーの TODO を操作するようにしました。
- ログイン失敗時のエラー表示と、未ログイン TODO API 呼び出しの既存 JSON callback 型エラーを修正しました。

## Verification
- `php -l class/controller/SessionController.php`
- `php -l class/controller/TodoController.php`
- `php -l class/db/UserMapper.php`
- `php -l class/xion/ControllerBase.php`
- `node --check htdocs/js/index/index.js`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- HTTP: 未ログイン `GET /todo/index` returns `SESSION-CLOSED`
- HTTP: login failure returns `LOGIN-FAILED`
- HTTP: `admin` / `admin` login success stores user id and can manage TODOs
- Browser: login failure message and successful TODO load verified

Closes #24

Made with [Cursor](https://cursor.com)