### PR TITLE
feat(auth): TODO サンプルにログアウトを追加する

### DIFF
--- a/class/controller/SessionController.php
+++ b/class/controller/SessionController.php
@@ -69,4 +69,18 @@ class SessionController extends ControllerBase
             'errorCode' => ''
         ]);
     }
+
+    /**
+     * LOGOUT
+     *
+     * @return array<string,string> Logout response.
+     */
+    public function logoutPostRest(): array
+    {
+        $this->logout();
+        return [
+            'status' => 'success',
+            'errorCode' => ''
+        ];
+    }
 }

--- a/htdocs/css/index/index.css
+++ b/htdocs/css/index/index.css
@@ -310,6 +310,14 @@
     margin-bottom: 18px;
 }
 
+.todo-panel__session {
+    align-items: center;
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+    margin-bottom: 12px;
+}
+
 .todo-panel__user,
 .todo-panel__status {
     color: #8f82ff;
@@ -319,6 +327,17 @@
 
 .todo-panel__user {
     color: #aaa9a1;
+    margin-bottom: 0;
+}
+
+.todo-panel__logout {
+    background: transparent;
+    border: 0;
+    color: #8f82ff;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.82rem;
+    padding: 0;
 }
 
 .todo-list {

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -267,6 +267,21 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         }
 
+        function signOut() {
+            setStatus('Signing out...');
+            requestJson('/session/logout', {
+                method: 'POST'
+            }).then(function() {
+                setTodos([]);
+                setTask('');
+                setStatus('');
+                setUser(null);
+                setIsSignedIn(false);
+            }).catch(function(error) {
+                setStatus(error.message);
+            });
+        }
+
         return e('section', { className: 'developers__section developers__sample', id: 'sample-app' },
             e('div', { className: 'developers__section-heading' },
                 e('div', null,
@@ -281,6 +296,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         addTodo: addTodo,
                         removeTodo: removeTodo,
                         setTask: setTask,
+                        signOut: signOut,
                         task: task,
                         todos: todos,
                         status: status,
@@ -330,7 +346,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function TodoPanel(props) {
         return e('div', { className: 'todo-panel' },
-            props.user ? e('p', { className: 'todo-panel__user' }, 'Signed in as ' + props.user.user_id) : null,
+            e('div', { className: 'todo-panel__session' },
+                props.user ? e('p', { className: 'todo-panel__user' }, 'Signed in as ' + props.user.user_id) : null,
+                e('button', {
+                    className: 'todo-panel__logout',
+                    type: 'button',
+                    onClick: props.signOut
+                }, 'Sign out')
+            ),
             props.status ? e('p', { className: 'todo-panel__status' }, props.status) : null,
             e('form', { className: 'todo-panel__form', onSubmit: props.addTodo },
                 e('input', {


### PR DESCRIPTION
## Summary
- `/session/logout` REST API を追加しました。
- TODO サンプルに `Sign out` ボタンを追加し、ログアウト時にユーザー/TODO/入力状態をリセットします。
- ログインから TODO 操作、ログアウトまでサンプルが完結するようにしました。

## Verification
- `php -l class/controller/SessionController.php`
- `node --check htdocs/js/index/index.js`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- HTTP: login -> TODO fetch -> logout -> post-logout TODO access returns `SESSION-CLOSED`
- Browser: sign in, `Sign out` button, return to login form

Closes #26

Made with [Cursor](https://cursor.com)