### PR TITLE
chore(rest): REST メソッド明示方針を追加する

### DIFF
--- a/class/controller/SessionController.php
+++ b/class/controller/SessionController.php
@@ -41,7 +41,7 @@ class SessionController extends ControllerBase
      *
      * @return array
      */
-    public function loginRest(): array
+    public function loginPostRest(): array
     {
         $user_id = (string)($this->REQUEST_JSON['user_id'] ?? filter_input(INPUT_POST, 'user_id') ?? '');
         $user_pass = (string)($this->REQUEST_JSON['user_pass'] ?? filter_input(INPUT_POST, 'user_pass') ?? '');

--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -87,8 +87,8 @@ class Dispatcher
     /**
      * Resolve the controller method for an action.
      *
-     * REST handlers may opt into HTTP-method dispatch with names like indexGetRest.
-     * The legacy indexRest convention remains supported as a fallback.
+     * REST handlers should opt into HTTP-method dispatch with names like indexGetRest.
+     * The legacy indexRest convention remains supported only as a compatibility fallback.
      *
      * @param object $controllerInstance Controller instance.
      * @param string $action             Action name.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -50,6 +50,15 @@ Security fixes should be small, focused, and prioritized.
 - Keep sessions, authentication, and authorization behavior explicit.
 - Never commit secrets or local environment files.
 
+## REST Controllers
+
+REST endpoints should make accepted HTTP methods explicit.
+
+- Prefer method-specific controller methods such as `indexGetRest`, `indexPostRest`, `itemPutRest`, and `itemDeleteRest`.
+- Avoid new `{action}Rest` handlers because they accept every HTTP method through the legacy dispatcher fallback.
+- Use `{action}Rest` only when there is a documented compatibility or framework-level reason to accept all methods.
+- Authentication and state-changing endpoints must use method-specific REST handlers.
+
 ## OpenAPI
 
 New public HTTP APIs should be documented with OpenAPI.

--- a/tests/Unit/Xion/DispatcherTest.php
+++ b/tests/Unit/Xion/DispatcherTest.php
@@ -31,7 +31,7 @@ final class DispatcherTest extends TestCase
         self::assertSame(['GET', 'POST'], $route['allowed']);
     }
 
-    public function testResolveActionRouteKeepsLegacyRestFallback(): void
+    public function testResolveActionRouteKeepsLegacyRestFallbackForCompatibility(): void
     {
         $controller = new class {
             public function loginRest(): array


### PR DESCRIPTION
## Summary
- `loginRest` を `loginPostRest` に変更し、ログイン API を `POST` 明示にしました。
- Dispatcher の legacy `{action}Rest` fallback を互換用としてコメントで明確化しました。
- 新規 REST 実装では HTTP メソッド明示を推奨し、理由のない `{action}Rest` を非推奨として docs に追記しました。

## Verification
- `php -l class/controller/SessionController.php`
- `php -l class/xion/Dispatcher.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- HTTP: `GET /session/login` returns `405` with `Allow: POST`
- HTTP: `POST /session/login` succeeds with `admin` / `admin`

Closes #28

Made with [Cursor](https://cursor.com)