### PR TITLE
chore(cleanup): 不要なコメントアウトと空行を整理する

### DIFF
--- a/class/controller/IndexController.php
+++ b/class/controller/IndexController.php
@@ -17,9 +17,7 @@ declare(strict_types=1);
 
 namespace Nene\Controller;
 
-use Nene\Model as Model;
 use Nene\Xion\ControllerBase;
-use Nene\Database as Database;
 
 /**
  * IndexController
@@ -48,7 +46,5 @@ class IndexController extends ControllerBase
         $this->VIEW->addJS('https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js')
             ->addJS('https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js')
             ->setString('t_contents', 'A small legacy PHP framework for URL-based applications.');
-        // $userMapper = new Database\UserMapper();
-        // $user = $userMapper->find(1);
     }
 }

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -18,8 +18,6 @@ declare(strict_types=1);
 namespace Nene\Xion;
 
 use Monolog\Logger;
-use Nene\Model          as Model;
-use Nene\Database       as Database;
 use Nene\Xion           as Xion;
 use Nene\Func           as Func;
 
@@ -351,26 +349,8 @@ abstract class ControllerBase
                     $this->SESSION_CHECK
                 );
             }
-        } else {
-            // $this->setUserInfo($_SESSION['xion']['user_id']);
         }
     }
-
-    /**
-     * setUserInfo
-     *
-     * Set login user account information.
-     *
-     * @param string $userId User ID.
-     *
-     * @return void
-     */
-    // final protected function setUserInfo(string $userId): void
-    // {
-    //     $userMapper = new Database\UserMapper();
-    //     $_SESSION['xion']['user_info'] = $userMapper->findByUserID($userId);
-    //     $_SESSION['xion']['login_mode'] = 'login';
-    // }
 
     /**
      * logout

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -65,7 +65,6 @@ abstract class DataMapperBase
     protected const TARGET_TABLE = '';
     protected const KEY_SID = 'id';
 
-
     /**
      * CONSTRUCTOR
      */
@@ -80,8 +79,6 @@ abstract class DataMapperBase
         }
         $this->ERROR_CODE = Xion\ErrorCode::getInstance();
     }
-
-
 
     /**
      * Get table columns.
@@ -107,8 +104,6 @@ abstract class DataMapperBase
         unset($column[$key_sid]);
         return $column;
     }
-
-
 
     /**
      * INSERT
@@ -165,8 +160,6 @@ abstract class DataMapperBase
         return $row->{static::KEY_SID};
     }
 
-
-
     /**
      * UPDATE
      *
@@ -209,8 +202,6 @@ abstract class DataMapperBase
         }
     }
 
-
-
     /**
      * DELETE
      * To do a logical delete, use the update method or add logic to this method.
@@ -243,8 +234,6 @@ abstract class DataMapperBase
         }
     }
 
-
-
     /**
      * FIND
      * Search primary key by specified value and return one row.
@@ -266,8 +255,6 @@ abstract class DataMapperBase
         return $stmt->fetch();
     }
 
-
-
     /**
      * Find all
      * Returns all rows from a database table.
@@ -287,8 +274,6 @@ abstract class DataMapperBase
         return $this->decorate($stmt);
     }
 
-
-
     /**
      * COUNT BY ID
      * Returns whether there is a primary key row with the specified value.
@@ -307,8 +292,6 @@ abstract class DataMapperBase
         return $this->execute($stmt)->fetchColumn();
     }
 
-
-
     /**
      * Count all
      * Returns the number of rows in a database table.
@@ -323,8 +306,6 @@ abstract class DataMapperBase
         ');
         return $stmt->fetchColumn();
     }
-
-
 
     /**
      * EXECUTE
@@ -345,8 +326,6 @@ abstract class DataMapperBase
         return $stmt;
     }
 
-
-
     /**
      * EXECUTE QUERY
      * Try to query execute stmt.
@@ -365,8 +344,6 @@ abstract class DataMapperBase
         }
         return $stmt;
     }
-
-
 
     /**
      * Get search array
@@ -387,8 +364,6 @@ abstract class DataMapperBase
         return $searchArray;
     }
 
-
-
     /**
      * DECORATE
      * Set fetch mode to convert to the specified class.
@@ -403,8 +378,6 @@ abstract class DataMapperBase
         return $stmt;
     }
 
-
-
     /**
      * ASSOCIATIVE ARRAY
      * Set fetch mode to convert to associative array.
@@ -418,8 +391,6 @@ abstract class DataMapperBase
         $stmt->setFetchMode(PDO::FETCH_ASSOC);
         return $stmt;
     }
-
-
 
     /**
      * JSON ERROR CODE

--- a/class/xion/Log.php
+++ b/class/xion/Log.php
@@ -69,10 +69,8 @@ class Log
         $this->errorLog = new Logger('Nene');
         $this->errorLog->pushHandler(new RotatingFileHandler(ERROR_LOG_PATH, 60, Level::Error));
         if (LOG_LEVEL == 'EMERGENCY') {
-            // $this->logger->pushHandler(new StreamHandler(APP_LOG_PATH, Logger::EMERGENCY));
             $this->informationLog->pushHandler(new RotatingFileHandler(APP_LOG_PATH, 100, Level::Emergency));
         } else {
-            // $this->logger->pushHandler(new StreamHandler(APP_LOG_PATH, Logger::INFO));
             $this->informationLog->pushHandler(new RotatingFileHandler(APP_LOG_PATH, 100, Level::Info));
         }
     }

--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -233,21 +233,6 @@ class View
     }
 
     /**
-     * Set value.
-     * Set the value in the template.
-     *
-     * @param string $p_target Target variable name in template file.
-     * @param mixed  $p_value  The value to set.
-     *
-     * @return View
-     */
-    // final public function setValue(string $p_target, mixed $p_value): View
-    // {
-    //     self::$instance->smarty->assign($p_target, $p_value);
-    //     return self::$instance;
-    // }
-
-    /**
      * Set values.
      * Set the array in the template.
      *

--- a/htdocs/css/common.css
+++ b/htdocs/css/common.css
@@ -2,8 +2,6 @@
 
 /* ========== BASIC ========== */
 
-
-
 body {
     background: #050505;
     color: #f2f2ee;
@@ -31,16 +29,12 @@ hr {
     color: red;
 }
 
-
-
 /* ========== HEADER ========== */
 header {
     display: none;
 }
 
-
-
-/* ========== HEADER ========== */
+/* ========== FOOTER ========== */
 footer {
     background: #050505;
     color: #777;
@@ -54,9 +48,6 @@ footer a {
     color: #aaa;
     text-decoration:  none;
 }
-
-
-
 
 /* ========== FORM ========== */
 form input,
@@ -107,13 +98,4 @@ form button:hover {
     color: white;
     cursor: pointer;
 }
-
-
-
-
-
-
-
-
-
 

--- a/htdocs/css/components/common.css
+++ b/htdocs/css/components/common.css
@@ -3,10 +3,6 @@
 /* ========== COMPONENTS ==========*/
 /* loginform */
 
-
-
-
-
 /* ========== LOADING SPINNER ==========*/
 .c__spinner {
     height: 30px;

--- a/ini/xSystemIni.php
+++ b/ini/xSystemIni.php
@@ -36,8 +36,6 @@ const URI_CSS = URI_ROOT . 'css/';                      // CSS URI
 const URI_JS = URI_ROOT . 'js/';                        // JS URI
 const URI_IMG = 'https://' . OWN_DOMAIN;                // IMAGE DIR URI
 
-
-
 // DATABASE CONNECTION SETUP
 define('DB_TYPE', getenv('NENE_DB_TYPE') ?: 'SQLite3'); // TYPE [MySQL|SQLite3]
 define('DB_DIR', DIR_ROOT . 'data/');                   // DIRECTORY FOR SQLite3 DATABASE
@@ -57,8 +55,6 @@ const DB_AUTO_UPDATED_STAMP = true;                     // WHETHER TO SET THE UP
 // WORKAROUND WHEN THE COLUMN NAME STARTS WITH A NUMBER FOR SOME REASON.
 const DB_NUM_PREFIX = 'numPrefix_';
 const DB_IS_PHYSICAL_DELETE = true;                     // WHETHER TO DELETE PHYSICALLY
-
-
 
 // OUTPUT
 const JSON_OUTPUT = true;                               // JSON OUTPUT

--- a/view/source/common.tpl
+++ b/view/source/common.tpl
@@ -1,15 +1,9 @@
 {include file='head_01.tpl'}{include file='head_02.tpl'}
 
-
-
                 <p class="information">
                     This API is managed by Ayane International.
                 </p>
 
-
-
                 <p>{$t_contents}</p>
-
-
 
 {include file='footer.tpl'}

--- a/view/source/footer.tpl
+++ b/view/source/footer.tpl
@@ -1,15 +1,11 @@
             </div>
         </div>
 
-
-
         <footer>
             <small class="copyright">&copy; {if strlen($t_copyright) > 0}<a href="{$t_copyright_url}" target="_blank" rel="noopener noreferrer">{$t_copyright}</a>{else}{$t_copyright}{/if}</small>
         </footer>
 {foreach from=$t_js item=js}        <script type="text/javascript" src="{$js}"></script>
 {/foreach}
-
-
 
     </body>
 </html>


### PR DESCRIPTION
## Summary
- 古いコメントアウト済みコードを削除しました。
- 可読性に寄与しない 3 行以上の連続空行を整理しました。
- ついでに CSS セクションコメントの誤記を `FOOTER` に直しました。

## Verification
- `php -l class/controller/IndexController.php`
- `php -l class/xion/ControllerBase.php`
- `php -l class/xion/DataMapperBase.php`
- `php -l class/xion/Log.php`
- `php -l class/xion/View.php`
- `php -l ini/xSystemIni.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- Cursor lints: no errors

Closes #30

Made with [Cursor](https://cursor.com)