### PR TITLE
refactor(auth): 認証セッションを AuthSession に集約する

### DIFF
--- a/class/controller/SessionController.php
+++ b/class/controller/SessionController.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 
 namespace Nene\Controller;
 
-use Nene\Model as Model;
 use Nene\Xion\ControllerBase;
 use Nene\Database as Database;
 
@@ -56,16 +55,10 @@ class SessionController extends ControllerBase
                 'errorMessage'  => $this->ERROR_CODE->getErrorText($errorCode)
             ]);
         }
-        $_SESSION['xion']['login_mode'] = 'login';
-        $_SESSION['xion']['user'] = [
-            'id'        => (int)$user['id'],
-            'user_id'   => (string)$user['user_id'],
-            'user_name' => (string)$user['user_name'],
-            'e_mail'    => (string)$user['e_mail']
-        ];
+        $loginUser = $this->AUTH_SESSION->login($user);
         return ([
             'status'    => 'success',
-            'user'      => $_SESSION['xion']['user'],
+            'user'      => $loginUser,
             'errorCode' => ''
         ]);
     }

--- a/class/controller/TodoController.php
+++ b/class/controller/TodoController.php
@@ -164,7 +164,7 @@ class TodoController extends ControllerBase
      */
     private function getLoginUserId(): int
     {
-        return (int)$_SESSION['xion']['user']['id'];
+        return (int)$this->AUTH_SESSION->userId();
     }
 
     /**

--- a/class/xion/AuthSession.php
+++ b/class/xion/AuthSession.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 7.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+/**
+ * Authentication session boundary.
+ */
+class AuthSession
+{
+    /**
+     * Instance to pass as a singleton.
+     *
+     * @var AuthSession
+     */
+    private static $instance;
+
+    /**
+     * CONSTRUCTOR.
+     */
+    final private function __construct()
+    {
+    }
+
+    /**
+     * GET INSTANCE.
+     *
+     * @return AuthSession
+     */
+    final public static function getInstance(): AuthSession
+    {
+        if (!isset(self::$instance)) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Store login user information.
+     *
+     * @param array<string,mixed> $user User row.
+     *
+     * @return array<string,mixed> Stored user information.
+     */
+    final public function login(array $user): array
+    {
+        $loginUser = [
+            'id'        => (int)$user['id'],
+            'user_id'   => (string)$user['user_id'],
+            'user_name' => (string)$user['user_name'],
+            'e_mail'    => (string)$user['e_mail']
+        ];
+        $_SESSION['xion']['login_mode'] = 'login';
+        $_SESSION['xion']['user'] = $loginUser;
+        return $loginUser;
+    }
+
+    /**
+     * Delete authentication session information.
+     *
+     * @return void
+     */
+    final public function logout(): void
+    {
+        unset($_SESSION['xion']);
+    }
+
+    /**
+     * Check whether the current session is logged in.
+     *
+     * @return boolean Login state.
+     */
+    final public function isLoggedIn(): bool
+    {
+        return ($_SESSION['xion']['login_mode'] ?? '') === 'login' && $this->user() !== null;
+    }
+
+    /**
+     * Get current login user information.
+     *
+     * @return array<string,mixed>|null Current user information.
+     */
+    final public function user(): ?array
+    {
+        $user = $_SESSION['xion']['user'] ?? null;
+        return is_array($user) ? $user : null;
+    }
+
+    /**
+     * Get current login user's primary key.
+     *
+     * @return integer|null Current user primary key.
+     */
+    final public function userId(): ?int
+    {
+        $user = $this->user();
+        if ($user === null || !isset($user['id'])) {
+            return null;
+        }
+        return (int)$user['id'];
+    }
+
+    /**
+     * Get current login user's public identifier.
+     *
+     * @return string Current user identifier.
+     */
+    final public function userIdentifier(): string
+    {
+        $user = $this->user();
+        return $user === null ? '' : (string)($user['user_id'] ?? '');
+    }
+
+    /**
+     * Copy inhibit.
+     *
+     * @return void
+     */
+    final public function __clone()
+    {
+        throw new \RuntimeException('Clone is not allowed against ' . get_class($this));
+    }
+}

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -116,6 +116,13 @@ abstract class ControllerBase
     protected $ERROR_CODE;
 
     /**
+     * Authentication session boundary.
+     *
+     * @var AuthSession
+     */
+    protected $AUTH_SESSION;
+
+    /**
      * Rest post
      *
      * @var array
@@ -155,6 +162,7 @@ abstract class ControllerBase
         $this->ACCESS_LOGGER    = Log::getInstance('access');
         $this->ERROR_LOGGER     = Log::getInstance('error');
         $this->ERROR_CODE       = Xion\ErrorCode::getInstance();
+        $this->AUTH_SESSION     = Xion\AuthSession::getInstance();
         $this->refController    = $_SESSION['global']['referer']['controller'] ?? '';
         $this->refAction        = $_SESSION['global']['referer']['action'] ?? '';
     }
@@ -330,7 +338,7 @@ abstract class ControllerBase
      */
     final protected function sessionCheck(): void
     {
-        if (($_SESSION['xion']['login_mode'] ?? '') !== 'login') {
+        if (!$this->AUTH_SESSION->isLoggedIn()) {
             $this->logout();
             if (APP_ACTION_MODE !== 'Rest') {
                 $this->location(LOGOUT_URI);
@@ -361,7 +369,7 @@ abstract class ControllerBase
      */
     final protected function logout(): void
     {
-        unset($_SESSION['xion']);
+        $this->AUTH_SESSION->logout();
     }
 
     /**

--- a/class/xion/ModelBase.php
+++ b/class/xion/ModelBase.php
@@ -51,6 +51,13 @@ abstract class ModelBase
     protected $ERROR_CODE;
 
     /**
+     * Authentication session boundary.
+     *
+     * @var AuthSession
+     */
+    protected $AUTH_SESSION;
+
+    /**
      * CONSTRUCTOR.
      */
     public function __construct()
@@ -62,6 +69,7 @@ abstract class ModelBase
             $this->LOGGER->debug('NEW : ' . $this->CLASS);
         }
         $this->ERROR_CODE = Xion\ErrorCode::getInstance();
+        $this->AUTH_SESSION = Xion\AuthSession::getInstance();
     }
 
     /**
@@ -71,11 +79,7 @@ abstract class ModelBase
      */
     final protected function checkLogin()
     {
-        $login = $_SESSION['xion']['login_mode'] ?? '';
-        if ($login != 'login') {
-            return false;
-        }
-        return true;
+        return $this->AUTH_SESSION->isLoggedIn();
     }
 
     /**
@@ -100,10 +104,8 @@ abstract class ModelBase
      */
     final protected function accessLog(string $API = '')
     {
-        $user_id = $_SESSION['xion']['user_id'] ?? '';
-
         $log = date('[Y-m-d H:i:s]') . ' ' .
-            $user_id . ' ' .
+            $this->AUTH_SESSION->userIdentifier() . ' ' .
             APP_CONTROLLER . '   ' .
             APP_ACTION . '   ' .
             $API . PHP_EOL;

--- a/tests/Unit/Xion/AuthSessionTest.php
+++ b/tests/Unit/Xion/AuthSessionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\AuthSession;
+use PHPUnit\Framework\TestCase;
+
+final class AuthSessionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    public function testLoginStoresNormalizedUserInformation(): void
+    {
+        $authSession = AuthSession::getInstance();
+
+        $user = $authSession->login([
+            'id' => '1',
+            'user_id' => 'admin',
+            'user_name' => 'Administrator',
+            'e_mail' => 'admin@example.com'
+        ]);
+
+        self::assertTrue($authSession->isLoggedIn());
+        self::assertSame(1, $authSession->userId());
+        self::assertSame('admin', $authSession->userIdentifier());
+        self::assertSame($user, $authSession->user());
+    }
+
+    public function testLogoutClearsAuthenticationSession(): void
+    {
+        $authSession = AuthSession::getInstance();
+        $authSession->login([
+            'id' => 1,
+            'user_id' => 'admin',
+            'user_name' => 'Administrator',
+            'e_mail' => 'admin@example.com'
+        ]);
+
+        $authSession->logout();
+
+        self::assertFalse($authSession->isLoggedIn());
+        self::assertNull($authSession->user());
+        self::assertNull($authSession->userId());
+        self::assertSame('', $authSession->userIdentifier());
+    }
+
+    public function testLoginModeWithoutUserIsNotLoggedIn(): void
+    {
+        $_SESSION['xion']['login_mode'] = 'login';
+
+        self::assertFalse(AuthSession::getInstance()->isLoggedIn());
+    }
+}


### PR DESCRIPTION
## Summary
- `AuthSession` singleton を追加し、認証セッションの保存/取得/ログアウト/ログイン判定を集約しました。
- `ControllerBase`、`SessionController`、`TodoController`、`ModelBase` の `$_SESSION['xion']` 直参照を `AuthSession` 経由に変更しました。
- `AuthSession` の単体テストを追加し、壊れたセッションをログイン扱いしないことも確認しています。

## Verification
- `php -l class/xion/AuthSession.php`
- `php -l class/xion/ControllerBase.php`
- `php -l class/controller/SessionController.php`
- `php -l class/controller/TodoController.php`
- `php -l class/xion/ModelBase.php`
- `php -l tests/Unit/Xion/AuthSessionTest.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- HTTP: unauthenticated TODO returns `SESSION-CLOSED`
- HTTP: failed login returns `LOGIN-FAILED`
- HTTP: `admin` / `admin` login, TODO fetch, logout, post-logout TODO denial
- Cursor lints: no errors

Closes #32

Made with [Cursor](https://cursor.com)