### PR TITLE
refactor(auth): ログイン入力を JSON に一本化する

### DIFF
--- a/class/controller/SessionController.php
+++ b/class/controller/SessionController.php
@@ -42,8 +42,8 @@ class SessionController extends ControllerBase
      */
     public function loginPostRest(): array
     {
-        $user_id = (string)($this->REQUEST_JSON['user_id'] ?? filter_input(INPUT_POST, 'user_id') ?? '');
-        $user_pass = (string)($this->REQUEST_JSON['user_pass'] ?? filter_input(INPUT_POST, 'user_pass') ?? '');
+        $user_id = (string)($this->REQUEST_JSON['user_id'] ?? '');
+        $user_pass = (string)($this->REQUEST_JSON['user_pass'] ?? '');
         $userMapper = new Database\UserMapper();
         $user = $userMapper->findByCredentials($user_id, $user_pass);
         if ($user === null) {

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -127,7 +127,7 @@ abstract class ControllerBase
      *
      * @var array
      */
-    protected $REQUEST_JSON;
+    protected $REQUEST_JSON = [];
 
     /**
      * Json format at rest.


### PR DESCRIPTION
## Summary
- `SessionController::loginPostRest` から `INPUT_POST` fallback を削除しました。
- REST ログインは `REQUEST_JSON` の `user_id` / `user_pass` のみを認証入力として扱います。
- `REQUEST_JSON` を空配列で初期化し、JSON 入力境界として扱いやすくしました。

## Verification
- `php -l class/controller/SessionController.php`
- `php -l class/xion/ControllerBase.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- HTTP: JSON login succeeds with `admin` / `admin`
- HTTP: form-urlencoded login does not authenticate and subsequent TODO access returns `SESSION-CLOSED`
- Cursor lints: no errors

Closes #34

Made with [Cursor](https://cursor.com)