### PR TITLE
docs(php): PHP 8.4 ターゲット表記に統一する

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The dispatcher resolves the URL to:
 
 ## Requirements
 
-- PHP 8.1 or later is currently used for maintenance.
+- The Docker development target is PHP 8.4.
 - Composer is required for dependency installation and autoloading.
 
 ## Docker Quick Start

--- a/class/controller/IndexController.php
+++ b/class/controller/IndexController.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/controller/SessionController.php
+++ b/class/controller/SessionController.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/controller/TodoController.php
+++ b/class/controller/TodoController.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/db/Todo.php
+++ b/class/db/Todo.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/db/TodoMapper.php
+++ b/class/db/TodoMapper.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/db/User.php
+++ b/class/db/User.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/db/UserMapper.php
+++ b/class/db/UserMapper.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/func/Json.php
+++ b/class/func/Json.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/func/Text.php
+++ b/class/func/Text.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/AuthSession.php
+++ b/class/xion/AuthSession.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/DataModelBase.php
+++ b/class/xion/DataModelBase.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/ErrorCode.php
+++ b/class/xion/ErrorCode.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/Initialize.php
+++ b/class/xion/Initialize.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/Log.php
+++ b/class/xion/Log.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/ModelBase.php
+++ b/class/xion/ModelBase.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/PdoConnection.php
+++ b/class/xion/PdoConnection.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/Post.php
+++ b/class/xion/Post.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/QueryString.php
+++ b/class/xion/QueryString.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/Request.php
+++ b/class/xion/Request.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/RequestVariables.php
+++ b/class/xion/RequestVariables.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/UrlParameter.php
+++ b/class/xion/UrlParameter.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -4,6 +4,7 @@ NeNe is a legacy PHP framework, but new work should move the codebase toward cur
 
 ## PHP Compatibility
 
+- Treat PHP 8.4 in the Docker application container as the current development target.
 - Support the latest stable PHP version as far as practical.
 - Keep compatibility decisions explicit in Issues and ADRs.
 - Avoid new code that depends on deprecated PHP behavior.

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -7,6 +7,8 @@ NeNe can run locally with Docker Compose.
 - Docker
 - Docker Compose v2
 
+The application container uses PHP 8.4 as the Docker development target.
+
 ## Start
 
 ```sh

--- a/ini/xSiteIni.php
+++ b/ini/xSiteIni.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>

--- a/ini/xSystemIni.php
+++ b/ini/xSystemIni.php
@@ -4,7 +4,7 @@
  * AYANE : ayane.co.jp
  * powered by NENE.
  *
- * PHP Version >= 7.4
+ * PHP Version >= 8.4
  *
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>


### PR DESCRIPTION
## Summary
- PHPDoc ヘッダの `PHP Version >= 7.4` を `PHP Version >= 8.4` に統一しました。
- README の古い `PHP 8.1 or later` 表記を Docker development target PHP 8.4 に更新しました。
- Docker/coding standards docs にアプリコンテナの PHP 8.4 ターゲットを明記しました。

## Verification
- No remaining `PHP Version >= 7.4`, `PHP 8.1`, or `8.1 or later` matches
- `php -l` for all non-vendor PHP files: OK (40 files)
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- Cursor lints: no errors

Closes #36

Made with [Cursor](https://cursor.com)