### PR TITLE
refactor(api): REST レスポンス生成を共通化する

### DIFF
--- a/class/controller/SessionController.php
+++ b/class/controller/SessionController.php
@@ -48,19 +48,10 @@ class SessionController extends ControllerBase
         $user = $userMapper->findByCredentials($user_id, $user_pass);
         if ($user === null) {
             $this->logout();
-            $errorCode = 'LOGIN-FAILED';
-            return ([
-                'status'        => 'failure',
-                'errorCode'     => $errorCode,
-                'errorMessage'  => $this->ERROR_CODE->getErrorText($errorCode)
-            ]);
+            return $this->API_RESPONSE->failure('LOGIN-FAILED');
         }
         $loginUser = $this->AUTH_SESSION->login($user);
-        return ([
-            'status'    => 'success',
-            'user'      => $loginUser,
-            'errorCode' => ''
-        ]);
+        return $this->API_RESPONSE->success(['user' => $loginUser]);
     }
 
     /**
@@ -71,9 +62,6 @@ class SessionController extends ControllerBase
     public function logoutPostRest(): array
     {
         $this->logout();
-        return [
-            'status' => 'success',
-            'errorCode' => ''
-        ];
+        return $this->API_RESPONSE->success();
     }
 }

--- a/class/controller/TodoController.php
+++ b/class/controller/TodoController.php
@@ -34,10 +34,9 @@ class TodoController extends ControllerBase
     {
         $userId = $this->getLoginUserId();
         $todoMapper = new Database\TodoMapper();
-        return [
-            'status' => 'success',
+        return $this->API_RESPONSE->success([
             'todos' => $this->normalizeRows($todoMapper->findRowsByUserId($userId))
-        ];
+        ]);
     }
 
     /**
@@ -51,17 +50,12 @@ class TodoController extends ControllerBase
         $title = trim((string)($this->REQUEST_JSON['title'] ?? ''));
         if ($title === '') {
             header('HTTP/1.0 400 Bad Request');
-            return [
-                'status' => 'failure',
-                'errorCode' => 'TODO-TITLE-REQUIRED',
-                'errorMessage' => 'TODO title is required.'
-            ];
+            return $this->API_RESPONSE->failure('TODO-TITLE-REQUIRED');
         }
         $todoMapper = new Database\TodoMapper();
-        return [
-            'status' => 'success',
+        return $this->API_RESPONSE->success([
             'todo' => $this->normalizeRow($todoMapper->createForUser($userId, $title))
-        ];
+        ]);
     }
 
     /**
@@ -75,11 +69,7 @@ class TodoController extends ControllerBase
         $id = $this->getTodoId();
         if ($id === null) {
             header('HTTP/1.0 400 Bad Request');
-            return [
-                'status' => 'failure',
-                'errorCode' => 'TODO-ID-REQUIRED',
-                'errorMessage' => 'TODO id is required.'
-            ];
+            return $this->API_RESPONSE->failure('TODO-ID-REQUIRED');
         }
         $title = array_key_exists('title', $this->REQUEST_JSON)
             ? trim((string)$this->REQUEST_JSON['title'])
@@ -89,26 +79,17 @@ class TodoController extends ControllerBase
             : null;
         if ($title === '') {
             header('HTTP/1.0 400 Bad Request');
-            return [
-                'status' => 'failure',
-                'errorCode' => 'TODO-TITLE-REQUIRED',
-                'errorMessage' => 'TODO title is required.'
-            ];
+            return $this->API_RESPONSE->failure('TODO-TITLE-REQUIRED');
         }
         $todoMapper = new Database\TodoMapper();
         $todo = $todoMapper->updateForUser($userId, $id, $title, $isCompleted);
         if ($todo === null) {
             header('HTTP/1.0 404 Not Found');
-            return [
-                'status' => 'failure',
-                'errorCode' => 'TODO-NOT-FOUND',
-                'errorMessage' => 'TODO item was not found.'
-            ];
+            return $this->API_RESPONSE->failure('TODO-NOT-FOUND');
         }
-        return [
-            'status' => 'success',
+        return $this->API_RESPONSE->success([
             'todo' => $this->normalizeRow($todo)
-        ];
+        ]);
     }
 
     /**
@@ -122,25 +103,16 @@ class TodoController extends ControllerBase
         $id = $this->getTodoId();
         if ($id === null) {
             header('HTTP/1.0 400 Bad Request');
-            return [
-                'status' => 'failure',
-                'errorCode' => 'TODO-ID-REQUIRED',
-                'errorMessage' => 'TODO id is required.'
-            ];
+            return $this->API_RESPONSE->failure('TODO-ID-REQUIRED');
         }
         $todoMapper = new Database\TodoMapper();
         if (!$todoMapper->deleteForUser($userId, $id)) {
             header('HTTP/1.0 404 Not Found');
-            return [
-                'status' => 'failure',
-                'errorCode' => 'TODO-NOT-FOUND',
-                'errorMessage' => 'TODO item was not found.'
-            ];
+            return $this->API_RESPONSE->failure('TODO-NOT-FOUND');
         }
-        return [
-            'status' => 'success',
+        return $this->API_RESPONSE->success([
             'id' => $id
-        ];
+        ]);
     }
 
     /**

--- a/class/xion/ApiResponse.php
+++ b/class/xion/ApiResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+/**
+ * Builds REST response payloads.
+ */
+class ApiResponse
+{
+    /**
+     * Shared error code registry.
+     *
+     * @var ErrorCode
+     */
+    private $errorCode;
+
+    /**
+     * CONSTRUCTOR.
+     */
+    public function __construct()
+    {
+        $this->errorCode = ErrorCode::getInstance();
+    }
+
+    /**
+     * Build a success response.
+     *
+     * @param array<string,mixed> $data Response data.
+     *
+     * @return array<string,mixed> API response.
+     */
+    public function success(array $data = []): array
+    {
+        return array_merge([
+            'status' => 'success',
+            'errorCode' => ''
+        ], $data);
+    }
+
+    /**
+     * Build a failure response.
+     *
+     * @param string $errorCode Error code.
+     *
+     * @return array<string,string> API response.
+     */
+    public function failure(string $errorCode): array
+    {
+        return [
+            'status' => 'failure',
+            'errorCode' => $errorCode,
+            'errorMessage' => $this->errorCode->getErrorText($errorCode)
+        ];
+    }
+}

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -123,6 +123,13 @@ abstract class ControllerBase
     protected $AUTH_SESSION;
 
     /**
+     * REST response factory.
+     *
+     * @var ApiResponse
+     */
+    protected $API_RESPONSE;
+
+    /**
      * Rest post
      *
      * @var array
@@ -163,6 +170,7 @@ abstract class ControllerBase
         $this->ERROR_LOGGER     = Log::getInstance('error');
         $this->ERROR_CODE       = Xion\ErrorCode::getInstance();
         $this->AUTH_SESSION     = Xion\AuthSession::getInstance();
+        $this->API_RESPONSE     = new Xion\ApiResponse();
         $this->refController    = $_SESSION['global']['referer']['controller'] ?? '';
         $this->refAction        = $_SESSION['global']['referer']['action'] ?? '';
     }
@@ -343,15 +351,8 @@ abstract class ControllerBase
             if (APP_ACTION_MODE !== 'Rest') {
                 $this->location(LOGOUT_URI);
             } else {
-                $errorCode = 'SESSION-CLOSED';
-                $errorMessage = $this->ERROR_CODE->getErrorText($errorCode);
-                $return = [
-                    'status'        => 'failure',
-                    'errorCode'     => $errorCode,
-                    'errorMessage'  => $errorMessage
-                ];
                 Func\Json::outputArrayToJson(
-                    $return,
+                    $this->API_RESPONSE->failure('SESSION-CLOSED'),
                     $this->OUTPUT_JSON_STYLE,
                     filter_input(INPUT_GET, 'callback') ?: '',
                     $this->SESSION_CHECK

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -59,6 +59,10 @@ REST endpoints should make accepted HTTP methods explicit.
 - Avoid new `{action}Rest` handlers because they accept every HTTP method through the legacy dispatcher fallback.
 - Use `{action}Rest` only when there is a documented compatibility or framework-level reason to accept all methods.
 - Authentication and state-changing endpoints must use method-specific REST handlers.
+- Build REST payloads through `Nene\Xion\ApiResponse` instead of hand-writing response arrays in controllers.
+- Success payloads use `status: success` and `errorCode: ""`; failure payloads use `status: failure`, `errorCode`, and `errorMessage`.
+- Error codes must be stable uppercase kebab-case strings with a domain prefix, such as `LOGIN-FAILED` or `TODO-NOT-FOUND`.
+- Define error code messages in `htdocs/message/error_code.js`; controllers should reference codes, not inline messages.
 
 ## OpenAPI
 

--- a/htdocs/message/error_code.js
+++ b/htdocs/message/error_code.js
@@ -1,4 +1,7 @@
 var ERROR_CODE = {
     "SESSION-CLOSED" : "Session timeout. Please log in again.",
-    "LOGIN-FAILED" : "Wrong user ID or user PASS"
+    "LOGIN-FAILED" : "Wrong user ID or user PASS",
+    "TODO-ID-REQUIRED" : "TODO id is required.",
+    "TODO-NOT-FOUND" : "TODO item was not found.",
+    "TODO-TITLE-REQUIRED" : "TODO title is required."
 }

--- a/tests/Unit/Xion/ApiResponseTest.php
+++ b/tests/Unit/Xion/ApiResponseTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ApiResponse;
+use PHPUnit\Framework\TestCase;
+
+final class ApiResponseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!defined('ERROR_CODE_PATH')) {
+            define('ERROR_CODE_PATH', dirname(__DIR__, 3) . '/htdocs/message/error_code.js');
+        }
+    }
+
+    public function testSuccessBuildsStableResponseShape(): void
+    {
+        $response = (new ApiResponse())->success(['user' => ['user_id' => 'admin']]);
+
+        self::assertSame('success', $response['status']);
+        self::assertSame('', $response['errorCode']);
+        self::assertSame(['user_id' => 'admin'], $response['user']);
+    }
+
+    public function testFailureBuildsStableResponseShapeFromErrorCode(): void
+    {
+        $response = (new ApiResponse())->failure('LOGIN-FAILED');
+
+        self::assertSame([
+            'status' => 'failure',
+            'errorCode' => 'LOGIN-FAILED',
+            'errorMessage' => 'Wrong user ID or user PASS'
+        ], $response);
+    }
+}


### PR DESCRIPTION
## Summary
- `Nene\Xion\ApiResponse` を追加し、REST payload の `success` / `failure` 生成を共通化しました。
- `SessionController`、`TodoController`、未ログイン REST 応答を `ApiResponse` 経由に変更しました。
- TODO 系エラーメッセージを `htdocs/message/error_code.js` に集約し、エラーコード管理ルールを coding standards に追記しました。

## Verification
- `php -l class/xion/ApiResponse.php`
- `php -l class/xion/ControllerBase.php`
- `php -l class/controller/SessionController.php`
- `php -l class/controller/TodoController.php`
- `php -l tests/Unit/Xion/ApiResponseTest.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- HTTP: unauthenticated TODO returns `SESSION-CLOSED`
- HTTP: failed login returns `LOGIN-FAILED`
- HTTP: `admin` / `admin` login succeeds
- HTTP: empty TODO title returns `TODO-TITLE-REQUIRED`
- HTTP: logout returns success
- Cursor lints: no errors

Closes #38

Made with [Cursor](https://cursor.com)