### PR TITLE
refactor(error): エラーコード正本をサーバー側へ移す

### DIFF
--- a/class/xion/ErrorCode.php
+++ b/class/xion/ErrorCode.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 namespace Nene\Xion;
 
 /**
- * Share error code with javascript.
+ * Error code catalog.
  */
 class ErrorCode
 {
@@ -38,15 +38,12 @@ class ErrorCode
 
     /**
      * CONSTRUCTOR
-     * Convert from javascript format to json and define as array.
+     * Load the server-side error code catalog.
      */
     final private function __construct()
     {
-        $error_code_file    = file_get_contents(ERROR_CODE_PATH);
-        $error_json         = str_replace('var ERROR_CODE = ', '', $error_code_file);
-        $error_json         = substr($error_json, 0, -1);
-        $error_array        = json_decode($error_json, true);
-        $this->ERROR_CODE   = $error_array;
+        $errorCode = require ERROR_CODE_PATH;
+        $this->ERROR_CODE = is_array($errorCode) ? $errorCode : [];
     }
 
     /**

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'SESSION-CLOSED' => 'Session timeout. Please log in again.',
+    'LOGIN-FAILED' => 'Wrong user ID or user PASS',
+    'TODO-ID-REQUIRED' => 'TODO id is required.',
+    'TODO-NOT-FOUND' => 'TODO item was not found.',
+    'TODO-TITLE-REQUIRED' => 'TODO title is required.'
+];

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -62,7 +62,8 @@ REST endpoints should make accepted HTTP methods explicit.
 - Build REST payloads through `Nene\Xion\ApiResponse` instead of hand-writing response arrays in controllers.
 - Success payloads use `status: success` and `errorCode: ""`; failure payloads use `status: failure`, `errorCode`, and `errorMessage`.
 - Error codes must be stable uppercase kebab-case strings with a domain prefix, such as `LOGIN-FAILED` or `TODO-NOT-FOUND`.
-- Define error code messages in `htdocs/message/error_code.js`; controllers should reference codes, not inline messages.
+- Define error code messages in the server-side catalog at `config/error_codes.php`; controllers should reference codes, not inline messages.
+- Treat browser-visible error-code assets as exports or compatibility files, not the source of truth.
 
 ## OpenAPI
 

--- a/htdocs/message/error_code.js
+++ b/htdocs/message/error_code.js
@@ -1,7 +1,0 @@
-var ERROR_CODE = {
-    "SESSION-CLOSED" : "Session timeout. Please log in again.",
-    "LOGIN-FAILED" : "Wrong user ID or user PASS",
-    "TODO-ID-REQUIRED" : "TODO id is required.",
-    "TODO-NOT-FOUND" : "TODO item was not found.",
-    "TODO-TITLE-REQUIRED" : "TODO title is required."
-}

--- a/ini/xSystemIni.php
+++ b/ini/xSystemIni.php
@@ -58,7 +58,7 @@ const DB_IS_PHYSICAL_DELETE = true;                     // WHETHER TO DELETE PHY
 
 // OUTPUT
 const JSON_OUTPUT = true;                               // JSON OUTPUT
-const ERROR_CODE_PATH = DOCUMENT_ROOT . 'message/error_code.js'; // ERROR CODE PATH
+const ERROR_CODE_PATH = DIR_ROOT . 'config/error_codes.php'; // ERROR CODE CATALOG PATH
 
 // LOG
 const LOG_PATH = DIR_ROOT . 'log/';                     // LOGGING PATH

--- a/tests/Unit/Xion/ApiResponseTest.php
+++ b/tests/Unit/Xion/ApiResponseTest.php
@@ -12,7 +12,7 @@ final class ApiResponseTest extends TestCase
     protected function setUp(): void
     {
         if (!defined('ERROR_CODE_PATH')) {
-            define('ERROR_CODE_PATH', dirname(__DIR__, 3) . '/htdocs/message/error_code.js');
+            define('ERROR_CODE_PATH', dirname(__DIR__, 3) . '/config/error_codes.php');
         }
     }
 

--- a/tests/Unit/Xion/ErrorCodeTest.php
+++ b/tests/Unit/Xion/ErrorCodeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ErrorCode;
+use PHPUnit\Framework\TestCase;
+
+final class ErrorCodeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!defined('ERROR_CODE_PATH')) {
+            define('ERROR_CODE_PATH', dirname(__DIR__, 3) . '/config/error_codes.php');
+        }
+    }
+
+    public function testGetErrorTextReturnsCatalogMessage(): void
+    {
+        self::assertSame(
+            'Session timeout. Please log in again.',
+            ErrorCode::getInstance()->getErrorText('SESSION-CLOSED')
+        );
+    }
+
+    public function testGetErrorTextReturnsDeterministicFallbackForMissingCode(): void
+    {
+        self::assertSame(
+            'Error code [UNKNOWN-CODE] is not defined.',
+            ErrorCode::getInstance()->getErrorText('UNKNOWN-CODE')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `config/error_codes.php` を追加し、エラーコード定義の正本をサーバー側 PHP カタログへ移しました。
- `Nene\Xion\ErrorCode` が公開 JS ではなく PHP カタログを読むように変更しました。
- `htdocs/message/error_code.js` を削除し、coding standards とテストを新しい正本に合わせました。

## Verification
- `php -l config/error_codes.php`
- `php -l class/xion/ErrorCode.php`
- `php -l tests/Unit/Xion/ErrorCodeTest.php`
- `php -l tests/Unit/Xion/ApiResponseTest.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- HTTP: unauthenticated TODO returns `SESSION-CLOSED`
- HTTP: bad login returns `LOGIN-FAILED`
- HTTP: empty TODO title returns `TODO-TITLE-REQUIRED`
- Cursor lints: no errors

Closes #40

Made with [Cursor](https://cursor.com)