### PR TITLE
refactor(route): ルート情報を RouteContext に集約する

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -130,6 +130,13 @@ abstract class ControllerBase
     protected $API_RESPONSE;
 
     /**
+     * Current route context.
+     *
+     * @var RouteContext
+     */
+    protected $ROUTE_CONTEXT;
+
+    /**
      * Rest post
      *
      * @var array
@@ -171,6 +178,7 @@ abstract class ControllerBase
         $this->ERROR_CODE       = Xion\ErrorCode::getInstance();
         $this->AUTH_SESSION     = Xion\AuthSession::getInstance();
         $this->API_RESPONSE     = new Xion\ApiResponse();
+        $this->ROUTE_CONTEXT    = Xion\RouteContext::getInstance();
         $this->refController    = $_SESSION['global']['referer']['controller'] ?? '';
         $this->refAction        = $_SESSION['global']['referer']['action'] ?? '';
     }
@@ -184,20 +192,22 @@ abstract class ControllerBase
      */
     final public function run()
     {
-        if (APP_CONTROLLER != 'debug') {
-            $_SESSION['global']['referer']['controller']    = APP_CONTROLLER;
-            $_SESSION['global']['referer']['action']        = APP_ACTION;
+        $controller = $this->ROUTE_CONTEXT->controller();
+        $action = $this->ROUTE_CONTEXT->action();
+        if ($controller != 'debug') {
+            $_SESSION['global']['referer']['controller']    = $controller;
+            $_SESSION['global']['referer']['action']        = $action;
             $this->ACCESS_LOGGER->info(
-                'ACCESS : ' . APP_CONTROLLER . '::' . APP_ACTION,
+                'ACCESS : ' . $controller . '::' . $action,
                 [
                     $_SERVER['HTTP_USER_AGENT'] ?? '',
                     $_SERVER['HTTP_REFERER'] ?? ''
                 ]
             );
         }
-        if (APP_ACTION_MODE == 'Rest' && in_array($this->method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
+        if ($this->ROUTE_CONTEXT->isRest() && in_array($this->method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
             $this->REQUEST_JSON = Func\Json::inputPostJsonToArray();
-        } elseif (APP_ACTION_MODE == 'Action') {
+        } elseif ($this->ROUTE_CONTEXT->isAction()) {
             $this->setTemplate();
         }
         $this->preAction();
@@ -206,10 +216,10 @@ abstract class ControllerBase
             $this->sessionCheck();
         }
 
-        $methodName = defined('APP_ACTION_METHOD') ? APP_ACTION_METHOD : sprintf('%s' . APP_ACTION_MODE, APP_ACTION);
+        $methodName = $this->ROUTE_CONTEXT->method();
         $return = $this->$methodName();
 
-        if (APP_ACTION_MODE == 'Rest') {
+        if ($this->ROUTE_CONTEXT->isRest()) {
             Func\Json::outputArrayToJson(
                 $return,
                 $this->OUTPUT_JSON_STYLE,
@@ -226,9 +236,9 @@ abstract class ControllerBase
                 ->setString('t_copyright_url', COPYRIGHT_URL)
                 ->setString('t_root', URI_ROOT)
                 ->setString('t_appVersion', VERSION)
-                ->setString('t_controller', APP_CONTROLLER)
-                ->setString('t_action', APP_ACTION)
-                ->setString('t_controller_action', APP_CONTROLLER . '_' . APP_ACTION)
+                ->setString('t_controller', $controller)
+                ->setString('t_action', $action)
+                ->setString('t_controller_action', $controller . '_' . $action)
                 ->setInteger('t_debugMode', DEBUG_MODE)
                 ->setString('t_login_mode', $this->SESSION_CHECK ? '1' : '0')
                 ->execute();
@@ -281,15 +291,17 @@ abstract class ControllerBase
      */
     final protected function setTemplate(): void
     {
+        $controller = $this->ROUTE_CONTEXT->controller();
+        $action = $this->ROUTE_CONTEXT->action();
         $template = 'common';
-        if (file_exists(sprintf('%s/%s.tpl', DIR_SMARTY_TEMPLATE, APP_CONTROLLER))) {
-            $template = APP_CONTROLLER;
+        if (file_exists(sprintf('%s/%s.tpl', DIR_SMARTY_TEMPLATE, $controller))) {
+            $template = $controller;
         }
-        if (file_exists(sprintf('%s/%s.tpl', DIR_SMARTY_TEMPLATE, APP_CONTROLLER . '/' . $template))) {
-            $template = APP_CONTROLLER . '/' . $template;
+        if (file_exists(sprintf('%s/%s.tpl', DIR_SMARTY_TEMPLATE, $controller . '/' . $template))) {
+            $template = $controller . '/' . $template;
         }
-        if (file_exists(sprintf('%s/%s.tpl', DIR_SMARTY_TEMPLATE, APP_CONTROLLER . '/' . APP_ACTION))) {
-            $template = APP_CONTROLLER . '/' . APP_ACTION;
+        if (file_exists(sprintf('%s/%s.tpl', DIR_SMARTY_TEMPLATE, $controller . '/' . $action))) {
+            $template = $controller . '/' . $action;
         }
         $this->VIEW->setTemplate($template . '.tpl');
     }
@@ -304,14 +316,16 @@ abstract class ControllerBase
      */
     final protected function setCSS(): void
     {
-        if (file_exists(sprintf('%scss/%s.css', DOCUMENT_ROOT, APP_CONTROLLER))) {
-            $this->VIEW->addCSS(APP_CONTROLLER);
+        $controller = $this->ROUTE_CONTEXT->controller();
+        $action = $this->ROUTE_CONTEXT->action();
+        if (file_exists(sprintf('%scss/%s.css', DOCUMENT_ROOT, $controller))) {
+            $this->VIEW->addCSS($controller);
         }
-        if (file_exists(sprintf('%scss/%s/common.css', DOCUMENT_ROOT, APP_CONTROLLER))) {
-            $this->VIEW->addCSS(APP_CONTROLLER . '/common');
+        if (file_exists(sprintf('%scss/%s/common.css', DOCUMENT_ROOT, $controller))) {
+            $this->VIEW->addCSS($controller . '/common');
         }
-        if (file_exists(sprintf('%scss/%s/%s.css', DOCUMENT_ROOT, APP_CONTROLLER, APP_ACTION))) {
-            $this->VIEW->addCSS(APP_CONTROLLER . '/' . APP_ACTION);
+        if (file_exists(sprintf('%scss/%s/%s.css', DOCUMENT_ROOT, $controller, $action))) {
+            $this->VIEW->addCSS($controller . '/' . $action);
         }
     }
 
@@ -325,14 +339,16 @@ abstract class ControllerBase
      */
     final protected function setJS(): void
     {
-        if (file_exists(sprintf('%sjs/%s.js', DOCUMENT_ROOT, APP_CONTROLLER))) {
-            $this->VIEW->addJS(APP_CONTROLLER);
+        $controller = $this->ROUTE_CONTEXT->controller();
+        $action = $this->ROUTE_CONTEXT->action();
+        if (file_exists(sprintf('%sjs/%s.js', DOCUMENT_ROOT, $controller))) {
+            $this->VIEW->addJS($controller);
         }
-        if (file_exists(sprintf('%sjs/%s/common.js', DOCUMENT_ROOT, APP_CONTROLLER))) {
-            $this->VIEW->addJS(APP_CONTROLLER . '/common');
+        if (file_exists(sprintf('%sjs/%s/common.js', DOCUMENT_ROOT, $controller))) {
+            $this->VIEW->addJS($controller . '/common');
         }
-        if (file_exists(sprintf('%sjs/%s/%s.js', DOCUMENT_ROOT, APP_CONTROLLER, APP_ACTION))) {
-            $this->VIEW->addJS(APP_CONTROLLER . '/' . APP_ACTION);
+        if (file_exists(sprintf('%sjs/%s/%s.js', DOCUMENT_ROOT, $controller, $action))) {
+            $this->VIEW->addJS($controller . '/' . $action);
         }
     }
 
@@ -348,7 +364,7 @@ abstract class ControllerBase
     {
         if (!$this->AUTH_SESSION->isLoggedIn()) {
             $this->logout();
-            if (APP_ACTION_MODE !== 'Rest') {
+            if (!$this->ROUTE_CONTEXT->isRest()) {
                 $this->location(LOGOUT_URI);
             } else {
                 Func\Json::outputArrayToJson(

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -74,7 +74,8 @@ abstract class DataMapperBase
         $this->LOGGER = Log::getInstance();
         $classPathArray = explode('\\', get_class($this));
         $this->CLASS = 'Database\\' . end($classPathArray);
-        if (APP_CONTROLLER != 'debug' && APP_CONTROLLER != 'stub') {
+        $controller = RouteContext::getInstance()->controller();
+        if ($controller != 'debug' && $controller != 'stub') {
             $this->LOGGER->debug('NEW : ' . $this->CLASS);
         }
         $this->ERROR_CODE = Xion\ErrorCode::getInstance();

--- a/class/xion/DataModelBase.php
+++ b/class/xion/DataModelBase.php
@@ -85,7 +85,8 @@ abstract class DataModelBase
         $this->LOGGER = Log::getInstance();
         $classPathArray = explode('\\', get_class($this));
         $this->CLASS = 'Database\\' . end($classPathArray);
-        if (APP_CONTROLLER != 'debug' && APP_CONTROLLER != 'stub') {
+        $controller = RouteContext::getInstance()->controller();
+        if ($controller != 'debug' && $controller != 'stub') {
             $this->LOGGER->debug('NEW : ' . $this->CLASS);
         }
         $this->ERROR_CODE = Xion\ErrorCode::getInstance();

--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -49,12 +49,8 @@ class Dispatcher
         $controller = (LAYERS_NUM < count($params)) ? $params[LAYERS_NUM] : 'index';
         $action = ((LAYERS_NUM + 1) < count($params)) ? $params[LAYERS_NUM + 1] : 'index';
 
-        /* ========== SET CONTROLLER ========== */
-        define('APP_CONTROLLER', $controller);
         $controllerInstance = $this->getControllerInstance($controller);
 
-        /* ========== SET ACTION ========== */
-        define('APP_ACTION', $action);
         $route = $this->resolveActionRoute(
             $controllerInstance,
             $action,
@@ -79,8 +75,7 @@ class Dispatcher
             echo $action . 'Action' . ' and ' . $action . 'Rest Duplicate';
             exit();
         }
-        define('APP_ACTION_MODE', $route['mode']);
-        define('APP_ACTION_METHOD', $route['method']);
+        RouteContext::getInstance()->set($controller, $action, $route['mode'], $route['method']);
         $controllerInstance->run();
     }
 
@@ -194,11 +189,11 @@ class Dispatcher
      *
      * @return ControllerBase $ControllerBase Controller alias specified by argument.
      */
-    private function getControllerInstance(string $controller)
+    private function getControllerInstance(string $controller): ControllerBase
     {
         $className = ucfirst(strtolower($controller)) . 'Controller';
         $className = '\\Nene\\Controller\\' . $className;
-        if (false == class_exists($className)) {
+        if (!class_exists($className)) {
             header('HTTP/1.0 404 Not Found');
             echo file_get_contents(DIR_ROOT . '/404.html');
             exit;

--- a/class/xion/ModelBase.php
+++ b/class/xion/ModelBase.php
@@ -65,7 +65,9 @@ abstract class ModelBase
         $this->LOGGER = Log::getInstance('information');
         $classPathArray = explode('\\', get_class($this));
         $this->CLASS = 'Model\\' . end($classPathArray);
-        if (APP_CONTROLLER != 'debug' && APP_CONTROLLER != 'stub') {
+        $routeContext = Xion\RouteContext::getInstance();
+        $controller = $routeContext->controller();
+        if ($controller != 'debug' && $controller != 'stub') {
             $this->LOGGER->debug('NEW : ' . $this->CLASS);
         }
         $this->ERROR_CODE = Xion\ErrorCode::getInstance();
@@ -106,8 +108,8 @@ abstract class ModelBase
     {
         $log = date('[Y-m-d H:i:s]') . ' ' .
             $this->AUTH_SESSION->userIdentifier() . ' ' .
-            APP_CONTROLLER . '   ' .
-            APP_ACTION . '   ' .
+            Xion\RouteContext::getInstance()->controller() . '   ' .
+            Xion\RouteContext::getInstance()->action() . '   ' .
             $API . PHP_EOL;
         file_put_contents(ACCESS_LOG_PATH, $log, FILE_APPEND);
     }

--- a/class/xion/RouteContext.php
+++ b/class/xion/RouteContext.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+/**
+ * Holds the current dispatched route.
+ */
+class RouteContext
+{
+    /**
+     * Instance to pass as a singleton.
+     *
+     * @var RouteContext
+     */
+    private static $instance;
+
+    /**
+     * Controller name.
+     *
+     * @var string
+     */
+    private $controller = 'index';
+
+    /**
+     * Action name.
+     *
+     * @var string
+     */
+    private $action = 'index';
+
+    /**
+     * Action mode.
+     *
+     * @var string
+     */
+    private $mode = 'Action';
+
+    /**
+     * Controller method name.
+     *
+     * @var string
+     */
+    private $method = 'indexAction';
+
+    /**
+     * CONSTRUCTOR.
+     */
+    final private function __construct()
+    {
+    }
+
+    /**
+     * GET INSTANCE.
+     *
+     * @return RouteContext
+     */
+    final public static function getInstance(): RouteContext
+    {
+        if (!isset(self::$instance)) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Set current route information.
+     *
+     * @param string $controller Controller name.
+     * @param string $action     Action name.
+     * @param string $mode       Action mode.
+     * @param string $method     Controller method name.
+     *
+     * @return void
+     */
+    final public function set(string $controller, string $action, string $mode, string $method): void
+    {
+        $this->controller = $controller;
+        $this->action = $action;
+        $this->mode = $mode;
+        $this->method = $method;
+    }
+
+    /**
+     * Get controller name.
+     *
+     * @return string Controller name.
+     */
+    final public function controller(): string
+    {
+        return $this->controller;
+    }
+
+    /**
+     * Get action name.
+     *
+     * @return string Action name.
+     */
+    final public function action(): string
+    {
+        return $this->action;
+    }
+
+    /**
+     * Get action mode.
+     *
+     * @return string Action mode.
+     */
+    final public function mode(): string
+    {
+        return $this->mode;
+    }
+
+    /**
+     * Get controller method name.
+     *
+     * @return string Controller method name.
+     */
+    final public function method(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * Check whether current action mode is REST.
+     *
+     * @return boolean REST mode flag.
+     */
+    final public function isRest(): bool
+    {
+        return $this->mode === 'Rest';
+    }
+
+    /**
+     * Check whether current action mode is server-rendered action.
+     *
+     * @return boolean Action mode flag.
+     */
+    final public function isAction(): bool
+    {
+        return $this->mode === 'Action';
+    }
+
+    /**
+     * Copy inhibit.
+     *
+     * @return void
+     */
+    final public function __clone()
+    {
+        throw new \RuntimeException('Clone is not allowed against ' . get_class($this));
+    }
+}

--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -315,10 +315,12 @@ class View
      */
     final public function error(string $p_message): void
     {
+        $routeContext = RouteContext::getInstance();
+        $controller = $routeContext->controller();
         self::$instance
             ->setString('t_root', URI_ROOT)
-            ->setString('t_controller', APP_CONTROLLER)
-            ->setString('t_controller_action', APP_CONTROLLER . '_' . APP_ACTION)
+            ->setString('t_controller', $controller)
+            ->setString('t_controller_action', $controller . '_' . $routeContext->action())
             ->setTitle('ERROR')
             ->setString('t_message', $p_message)
             ->setTemplate('error.tpl')

--- a/tests/Unit/Xion/RouteContextTest.php
+++ b/tests/Unit/Xion/RouteContextTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\RouteContext;
+use PHPUnit\Framework\TestCase;
+
+final class RouteContextTest extends TestCase
+{
+    public function testSetUpdatesCurrentRoute(): void
+    {
+        $routeContext = RouteContext::getInstance();
+
+        $routeContext->set('todo', 'index', 'Rest', 'indexGetRest');
+
+        self::assertSame('todo', $routeContext->controller());
+        self::assertSame('index', $routeContext->action());
+        self::assertSame('Rest', $routeContext->mode());
+        self::assertSame('indexGetRest', $routeContext->method());
+        self::assertTrue($routeContext->isRest());
+        self::assertFalse($routeContext->isAction());
+    }
+
+    public function testSetCanReplaceRouteWithoutRedefiningGlobals(): void
+    {
+        $routeContext = RouteContext::getInstance();
+
+        $routeContext->set('index', 'index', 'Action', 'indexAction');
+        $routeContext->set('session', 'login', 'Rest', 'loginPostRest');
+
+        self::assertSame('session', $routeContext->controller());
+        self::assertSame('login', $routeContext->action());
+        self::assertSame('Rest', $routeContext->mode());
+        self::assertSame('loginPostRest', $routeContext->method());
+    }
+}


### PR DESCRIPTION
## Summary
- `RouteContext` を追加し、Dispatcher が `APP_*` グローバル定数を `define()` する設計をやめました。
- Core 内の `APP_CONTROLLER` / `APP_ACTION` / `APP_ACTION_MODE` / `APP_ACTION_METHOD` 参照を `RouteContext` 経由へ置き換えました。
- `false == class_exists()` を `!class_exists()` に変更し、`getControllerInstance()` に戻り値型を付けました。
- `RouteContext` の単体テストを追加しました。

## Verification
- No remaining `APP_*`, `define('APP_')`, or yoda `class_exists` matches in PHP files
- `php -l` for all non-vendor PHP files: OK (46 files)
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- HTTP: `/` returns 200
- HTTP: `GET /session/login` returns 405 with `Allow: POST`
- HTTP: unauthenticated TODO returns `SESSION-CLOSED`
- HTTP: `admin` / `admin` login and TODO fetch succeed

## Notes
- Cursor lints still report pre-existing `DataModelBase` warnings unrelated to the changed route context lines.

Closes #42

Made with [Cursor](https://cursor.com)