### PR TITLE
refactor(error): HTTP status をエラーカタログで管理する

### DIFF
--- a/class/controller/TodoController.php
+++ b/class/controller/TodoController.php
@@ -49,7 +49,6 @@ class TodoController extends ControllerBase
         $userId = $this->getLoginUserId();
         $title = trim((string)($this->REQUEST_JSON['title'] ?? ''));
         if ($title === '') {
-            header('HTTP/1.0 400 Bad Request');
             return $this->API_RESPONSE->failure('TODO-TITLE-REQUIRED');
         }
         $todoMapper = new Database\TodoMapper();
@@ -68,7 +67,6 @@ class TodoController extends ControllerBase
         $userId = $this->getLoginUserId();
         $id = $this->getTodoId();
         if ($id === null) {
-            header('HTTP/1.0 400 Bad Request');
             return $this->API_RESPONSE->failure('TODO-ID-REQUIRED');
         }
         $title = array_key_exists('title', $this->REQUEST_JSON)
@@ -78,13 +76,11 @@ class TodoController extends ControllerBase
             ? filter_var($this->REQUEST_JSON['is_completed'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)
             : null;
         if ($title === '') {
-            header('HTTP/1.0 400 Bad Request');
             return $this->API_RESPONSE->failure('TODO-TITLE-REQUIRED');
         }
         $todoMapper = new Database\TodoMapper();
         $todo = $todoMapper->updateForUser($userId, $id, $title, $isCompleted);
         if ($todo === null) {
-            header('HTTP/1.0 404 Not Found');
             return $this->API_RESPONSE->failure('TODO-NOT-FOUND');
         }
         return $this->API_RESPONSE->success([
@@ -102,12 +98,10 @@ class TodoController extends ControllerBase
         $userId = $this->getLoginUserId();
         $id = $this->getTodoId();
         if ($id === null) {
-            header('HTTP/1.0 400 Bad Request');
             return $this->API_RESPONSE->failure('TODO-ID-REQUIRED');
         }
         $todoMapper = new Database\TodoMapper();
         if (!$todoMapper->deleteForUser($userId, $id)) {
-            header('HTTP/1.0 404 Not Found');
             return $this->API_RESPONSE->failure('TODO-NOT-FOUND');
         }
         return $this->API_RESPONSE->success([

--- a/class/xion/ApiResponse.php
+++ b/class/xion/ApiResponse.php
@@ -61,6 +61,7 @@ class ApiResponse
      */
     public function failure(string $errorCode): array
     {
+        http_response_code($this->errorCode->getHttpStatus($errorCode));
         return [
             'status' => 'failure',
             'errorCode' => $errorCode,

--- a/class/xion/ErrorCode.php
+++ b/class/xion/ErrorCode.php
@@ -67,11 +67,26 @@ class ErrorCode
      */
     final public function getErrorText(string $errorCode): string
     {
-        if (array_key_exists($errorCode, $this->ERROR_CODE)) {
-            return $this->ERROR_CODE[$errorCode];
+        if (isset($this->ERROR_CODE[$errorCode]['message'])) {
+            return (string)$this->ERROR_CODE[$errorCode]['message'];
         } else {
             return 'Error code [' . $errorCode . '] is not defined.';
         }
+    }
+
+    /**
+     * Get HTTP status for error code.
+     *
+     * @param string $errorCode Error code.
+     *
+     * @return integer HTTP status code.
+     */
+    final public function getHttpStatus(string $errorCode): int
+    {
+        if (isset($this->ERROR_CODE[$errorCode]['httpStatus'])) {
+            return (int)$this->ERROR_CODE[$errorCode]['httpStatus'];
+        }
+        return 500;
     }
 
     /**

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -3,9 +3,24 @@
 declare(strict_types=1);
 
 return [
-    'SESSION-CLOSED' => 'Session timeout. Please log in again.',
-    'LOGIN-FAILED' => 'Wrong user ID or user PASS',
-    'TODO-ID-REQUIRED' => 'TODO id is required.',
-    'TODO-NOT-FOUND' => 'TODO item was not found.',
-    'TODO-TITLE-REQUIRED' => 'TODO title is required.'
+    'SESSION-CLOSED' => [
+        'message' => 'Session timeout. Please log in again.',
+        'httpStatus' => 200
+    ],
+    'LOGIN-FAILED' => [
+        'message' => 'Wrong user ID or user PASS',
+        'httpStatus' => 200
+    ],
+    'TODO-ID-REQUIRED' => [
+        'message' => 'TODO id is required.',
+        'httpStatus' => 400
+    ],
+    'TODO-NOT-FOUND' => [
+        'message' => 'TODO item was not found.',
+        'httpStatus' => 404
+    ],
+    'TODO-TITLE-REQUIRED' => [
+        'message' => 'TODO title is required.',
+        'httpStatus' => 400
+    ]
 ];

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -62,7 +62,7 @@ REST endpoints should make accepted HTTP methods explicit.
 - Build REST payloads through `Nene\Xion\ApiResponse` instead of hand-writing response arrays in controllers.
 - Success payloads use `status: success` and `errorCode: ""`; failure payloads use `status: failure`, `errorCode`, and `errorMessage`.
 - Error codes must be stable uppercase kebab-case strings with a domain prefix, such as `LOGIN-FAILED` or `TODO-NOT-FOUND`.
-- Define error code messages in the server-side catalog at `config/error_codes.php`; controllers should reference codes, not inline messages.
+- Define error code messages and HTTP status values in the server-side catalog at `config/error_codes.php`; controllers should reference codes, not inline messages or direct HTTP status headers.
 - Treat browser-visible error-code assets as exports or compatibility files, not the source of truth.
 
 ## OpenAPI

--- a/tests/Unit/Xion/ApiResponseTest.php
+++ b/tests/Unit/Xion/ApiResponseTest.php
@@ -35,4 +35,11 @@ final class ApiResponseTest extends TestCase
             'errorMessage' => 'Wrong user ID or user PASS'
         ], $response);
     }
+
+    public function testFailureSetsHttpStatusFromErrorCode(): void
+    {
+        (new ApiResponse())->failure('TODO-TITLE-REQUIRED');
+
+        self::assertSame(400, http_response_code());
+    }
 }

--- a/tests/Unit/Xion/ErrorCodeTest.php
+++ b/tests/Unit/Xion/ErrorCodeTest.php
@@ -24,11 +24,22 @@ final class ErrorCodeTest extends TestCase
         );
     }
 
+    public function testGetHttpStatusReturnsCatalogStatus(): void
+    {
+        self::assertSame(400, ErrorCode::getInstance()->getHttpStatus('TODO-TITLE-REQUIRED'));
+        self::assertSame(404, ErrorCode::getInstance()->getHttpStatus('TODO-NOT-FOUND'));
+    }
+
     public function testGetErrorTextReturnsDeterministicFallbackForMissingCode(): void
     {
         self::assertSame(
             'Error code [UNKNOWN-CODE] is not defined.',
             ErrorCode::getInstance()->getErrorText('UNKNOWN-CODE')
         );
+    }
+
+    public function testGetHttpStatusReturnsServerErrorForMissingCode(): void
+    {
+        self::assertSame(500, ErrorCode::getInstance()->getHttpStatus('UNKNOWN-CODE'));
     }
 }


### PR DESCRIPTION
## Summary
- `config/error_codes.php` の各エラーに `message` と `httpStatus` を持たせました。
- `ErrorCode` に HTTP status accessor を追加し、`ApiResponse::failure()` がカタログ値で `http_response_code()` を設定するようにしました。
- `TodoController` から直接の 400/404 `header()` 呼び出しを削除しました。
- エラーコード管理ルールとテストを更新しました。

## Verification
- `php -l config/error_codes.php`
- `php -l class/xion/ErrorCode.php`
- `php -l class/xion/ApiResponse.php`
- `php -l class/controller/TodoController.php`
- `php -l tests/Unit/Xion/ErrorCodeTest.php`
- `php -l tests/Unit/Xion/ApiResponseTest.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- HTTP: bad login remains `200 LOGIN-FAILED`
- HTTP: session-closed remains `200 SESSION-CLOSED`
- HTTP: empty TODO title returns `400 TODO-TITLE-REQUIRED`
- HTTP: missing TODO returns `404 TODO-NOT-FOUND`
- HTTP: invalid TODO id returns `400 TODO-ID-REQUIRED`
- Cursor lints: no errors

Closes #44

Made with [Cursor](https://cursor.com)