### PR TITLE
Docker 環境変数の .env.example を追加する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# NeNe Docker development environment
+#
+# Copy this file to `.env` when you want to override local Docker settings.
+# Do not commit `.env`; it may contain local secrets.
+
+# HTTP port exposed by the app container.
+NENE_PORT=8080
+
+# MySQL port exposed on the host machine.
+NENE_MYSQL_PORT=3307
+
+# Development database settings used by both app and MySQL containers.
+NENE_DB_NAME=nene
+NENE_DB_USER=nene
+NENE_DB_PASS=nene
+NENE_DB_ROOT_PASS=root
+
+# The Docker app service injects these connection settings automatically:
+# NENE_DB_TYPE=MySQL
+# NENE_DB_HOST=mysql
+# NENE_DB_PORT=3306
+#
+# NENE_DB_FILE is only used by the legacy SQLite fallback outside the default
+# Docker MySQL setup.
+# NENE_DB_FILE=nene.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 
 tags
 vendor
+.env
+.env.*
+!.env.example
 view/compile
 log
 data/*.db

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -21,6 +21,18 @@ Open:
 http://localhost:8080/
 ```
 
+## Environment Variables
+
+Docker Compose includes local development defaults, so `.env` is optional. To customize ports or database credentials, copy the committed example and edit your local file:
+
+```sh
+cp .env.example .env
+```
+
+The local `.env` file is ignored by Git. Keep real secrets out of the repository.
+
+The application reads database settings through `getenv()` in `ini/xSystemIni.php`. In Docker, Compose injects the connection type, host, and container port into the app service. The shared credentials and exposed host ports can be changed through `.env`.
+
 Use another port if needed:
 
 ```sh


### PR DESCRIPTION
## Summary
- Docker Compose 用の `.env.example` を追加
- ローカル `.env` / `.env.*` を ignore し、`.env.example` はコミット対象として保持
- Docker docs に `.env.example` の使い方と `getenv()` / Compose 注入の関係を追記

## Test plan
- `docker compose --env-file .env.example config`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- Cursor lints: no errors

Closes #46

Made with [Cursor](https://cursor.com)