### PR TITLE
RouteContext をテストごとに初期化できるようにする

### DIFF
--- a/class/xion/RouteContext.php
+++ b/class/xion/RouteContext.php
@@ -96,6 +96,19 @@ class RouteContext
     }
 
     /**
+     * Reset current route information to framework defaults.
+     *
+     * @return void
+     */
+    final public function reset(): void
+    {
+        $this->controller = 'index';
+        $this->action = 'index';
+        $this->mode = 'Action';
+        $this->method = 'indexAction';
+    }
+
+    /**
      * Get controller name.
      *
      * @return string Controller name.

--- a/tests/Unit/Xion/RouteContextTest.php
+++ b/tests/Unit/Xion/RouteContextTest.php
@@ -9,6 +9,26 @@ use PHPUnit\Framework\TestCase;
 
 final class RouteContextTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        RouteContext::getInstance()->reset();
+    }
+
+    public function testResetRestoresDefaultRoute(): void
+    {
+        $routeContext = RouteContext::getInstance();
+
+        $routeContext->set('todo', 'index', 'Rest', 'indexGetRest');
+        $routeContext->reset();
+
+        self::assertSame('index', $routeContext->controller());
+        self::assertSame('index', $routeContext->action());
+        self::assertSame('Action', $routeContext->mode());
+        self::assertSame('indexAction', $routeContext->method());
+        self::assertFalse($routeContext->isRest());
+        self::assertTrue($routeContext->isAction());
+    }
+
     public function testSetUpdatesCurrentRoute(): void
     {
         $routeContext = RouteContext::getInstance();


### PR DESCRIPTION
## Summary
- `RouteContext::reset()` を追加し、singleton の route state を初期値へ戻せるようにした
- `RouteContextTest::setUp()` で毎テスト前に初期化するようにした
- reset 後に `index/index/Action/indexAction` へ戻ることをテストで確認した

## Test plan
- `php -l class/xion/RouteContext.php`
- `php -l tests/Unit/Xion/RouteContextTest.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- Cursor lints: no errors

Closes #48

Made with [Cursor](https://cursor.com)