### PR TITLE
OpenAPI 契約と Swagger UI を導入する

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -11,16 +11,19 @@ NeNe should use OpenAPI for public HTTP API contracts.
 
 ## Current State
 
-No OpenAPI contract is defined yet.
-
-## Starter Structure
-
-When API documentation begins, prefer:
+The starter OpenAPI contract is defined at:
 
 ```text
 docs/api/openapi.yaml
-docs/api/schemas/
 ```
+
+Local Swagger UI is available at:
+
+```text
+http://localhost:8080/api-docs/
+```
+
+`docs/api/openapi.yaml` is the source of truth. The Swagger UI page serves that file through `htdocs/api-docs/openapi.php` so the contract is not duplicated under the document root.
 
 ## REST Convention
 
@@ -29,7 +32,7 @@ NeNe currently treats controller methods ending in `Rest` as REST/API handlers.
 Example:
 
 ```text
-/session/login -> SessionController::loginRest()
+/session/login -> SessionController::loginPostRest()
 ```
 
 OpenAPI paths should describe the URL and the request/response contract, not the internal method name.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,495 @@
+openapi: 3.1.0
+info:
+  title: NeNe Sample REST API
+  version: 0.1.0
+  description: |
+    OpenAPI contract for the current NeNe sample REST endpoints.
+    The YAML file under `docs/api/` is the source of truth for API documentation.
+servers:
+  - url: http://localhost:8080
+    description: Local Docker development server
+tags:
+  - name: Session
+    description: Session authentication endpoints.
+  - name: TODO
+    description: Authenticated TODO sample endpoints.
+paths:
+  /session/login:
+    post:
+      tags:
+        - Session
+      summary: Sign in to the sample application
+      operationId: login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+            examples:
+              default:
+                value:
+                  user_id: admin
+                  user_pass: admin
+      responses:
+        "200":
+          description: Login succeeded or credentials were rejected.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/LoginSuccessEnvelope"
+                  - $ref: "#/components/schemas/LoginFailureEnvelope"
+              examples:
+                success:
+                  value:
+                    Result: true
+                    Data:
+                      status: success
+                      errorCode: ""
+                      user:
+                        id: 1
+                        user_id: admin
+                failure:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: LOGIN-FAILED
+                      errorMessage: Wrong user ID or user PASS
+  /session/logout:
+    post:
+      tags:
+        - Session
+      summary: Sign out from the sample application
+      operationId: logout
+      responses:
+        "200":
+          description: Logout completed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BasicSuccessEnvelope"
+  /todo/index:
+    get:
+      tags:
+        - TODO
+      summary: List TODO items for the signed-in user
+      operationId: listTodos
+      security:
+        - sessionCookie: []
+      responses:
+        "200":
+          description: TODO list or session failure.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/TodoListSuccessEnvelope"
+                  - $ref: "#/components/schemas/SessionClosedEnvelope"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+    post:
+      tags:
+        - TODO
+      summary: Create a TODO item for the signed-in user
+      operationId: createTodo
+      security:
+        - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TodoCreateRequest"
+            examples:
+              default:
+                value:
+                  title: Write OpenAPI docs
+      responses:
+        "200":
+          description: TODO created or session failure.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/TodoSuccessEnvelope"
+                  - $ref: "#/components/schemas/SessionClosedEnvelope"
+        "400":
+          description: TODO title was missing.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TodoTitleRequiredEnvelope"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+  /todo/item/id_{id}:
+    put:
+      tags:
+        - TODO
+      summary: Update a TODO item for the signed-in user
+      operationId: updateTodo
+      security:
+        - sessionCookie: []
+      parameters:
+        - $ref: "#/components/parameters/TodoId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TodoUpdateRequest"
+            examples:
+              completion:
+                value:
+                  is_completed: true
+              rename:
+                value:
+                  title: Review OpenAPI docs
+      responses:
+        "200":
+          description: TODO updated or session failure.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/TodoSuccessEnvelope"
+                  - $ref: "#/components/schemas/SessionClosedEnvelope"
+        "400":
+          description: TODO id or title was invalid.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/TodoIdRequiredEnvelope"
+                  - $ref: "#/components/schemas/TodoTitleRequiredEnvelope"
+        "404":
+          $ref: "#/components/responses/TodoNotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+    delete:
+      tags:
+        - TODO
+      summary: Delete a TODO item for the signed-in user
+      operationId: deleteTodo
+      security:
+        - sessionCookie: []
+      parameters:
+        - $ref: "#/components/parameters/TodoId"
+      responses:
+        "200":
+          description: TODO deleted or session failure.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/TodoDeleteSuccessEnvelope"
+                  - $ref: "#/components/schemas/SessionClosedEnvelope"
+        "400":
+          description: TODO id was missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TodoIdRequiredEnvelope"
+        "404":
+          $ref: "#/components/responses/TodoNotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+components:
+  securitySchemes:
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: PHPSESSID
+      description: PHP session cookie created by `/session/login`.
+  parameters:
+    TodoId:
+      name: id
+      in: path
+      required: true
+      description: TODO id encoded in NeNe URL parameter format.
+      schema:
+        type: integer
+        minimum: 1
+  responses:
+    TodoNotFound:
+      description: TODO item was not found for the signed-in user.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/TodoNotFoundEnvelope"
+    MethodNotAllowed:
+      description: HTTP method is not allowed for this endpoint.
+      headers:
+        Allow:
+          description: Comma-separated allowed HTTP methods.
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DispatcherErrorEnvelope"
+  schemas:
+    JsonEnvelope:
+      type: object
+      required:
+        - Result
+        - Data
+      properties:
+        Result:
+          type: boolean
+          const: true
+        Data:
+          type: object
+    ApiSuccessData:
+      type: object
+      required:
+        - status
+        - errorCode
+      properties:
+        status:
+          type: string
+          const: success
+        errorCode:
+          type: string
+          const: ""
+    ApiFailureData:
+      type: object
+      required:
+        - status
+        - errorCode
+        - errorMessage
+      properties:
+        status:
+          type: string
+          const: failure
+        errorCode:
+          type: string
+        errorMessage:
+          type: string
+    BasicSuccessEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/JsonEnvelope"
+        - type: object
+          properties:
+            Data:
+              $ref: "#/components/schemas/ApiSuccessData"
+    LoginRequest:
+      type: object
+      required:
+        - user_id
+        - user_pass
+      properties:
+        user_id:
+          type: string
+        user_pass:
+          type: string
+          format: password
+    LoginUser:
+      type: object
+      required:
+        - id
+        - user_id
+      properties:
+        id:
+          type: integer
+        user_id:
+          type: string
+    LoginSuccessEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/JsonEnvelope"
+        - type: object
+          properties:
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiSuccessData"
+                - type: object
+                  required:
+                    - user
+                  properties:
+                    user:
+                      $ref: "#/components/schemas/LoginUser"
+    LoginFailureEnvelope:
+      $ref: "#/components/schemas/LoginFailedEnvelope"
+    Todo:
+      type: object
+      required:
+        - id
+        - user_id
+        - title
+        - is_completed
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: integer
+        user_id:
+          type: integer
+        title:
+          type: string
+        is_completed:
+          type: boolean
+        created_at:
+          type: string
+          description: Database timestamp string.
+        updated_at:
+          type: string
+          description: Database timestamp string.
+    TodoCreateRequest:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+          minLength: 1
+    TodoUpdateRequest:
+      type: object
+      minProperties: 1
+      properties:
+        title:
+          type: string
+          minLength: 1
+        is_completed:
+          type: boolean
+    TodoListSuccessEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/JsonEnvelope"
+        - type: object
+          properties:
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiSuccessData"
+                - type: object
+                  required:
+                    - todos
+                  properties:
+                    todos:
+                      type: array
+                      items:
+                        $ref: "#/components/schemas/Todo"
+    TodoSuccessEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/JsonEnvelope"
+        - type: object
+          properties:
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiSuccessData"
+                - type: object
+                  required:
+                    - todo
+                  properties:
+                    todo:
+                      $ref: "#/components/schemas/Todo"
+    TodoDeleteSuccessEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/JsonEnvelope"
+        - type: object
+          properties:
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiSuccessData"
+                - type: object
+                  required:
+                    - id
+                  properties:
+                    id:
+                      type: integer
+    ErrorEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/JsonEnvelope"
+        - type: object
+          properties:
+            Data:
+              $ref: "#/components/schemas/ApiFailureData"
+    SessionClosedEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/ErrorEnvelope"
+        - type: object
+          properties:
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiFailureData"
+                - type: object
+                  properties:
+                    errorCode:
+                      const: SESSION-CLOSED
+                    errorMessage:
+                      const: Session timeout. Please log in again.
+    LoginFailedEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/ErrorEnvelope"
+        - type: object
+          properties:
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiFailureData"
+                - type: object
+                  properties:
+                    errorCode:
+                      const: LOGIN-FAILED
+                    errorMessage:
+                      const: Wrong user ID or user PASS
+    TodoIdRequiredEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/ErrorEnvelope"
+        - type: object
+          properties:
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiFailureData"
+                - type: object
+                  properties:
+                    errorCode:
+                      const: TODO-ID-REQUIRED
+                    errorMessage:
+                      const: TODO id is required.
+    TodoNotFoundEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/ErrorEnvelope"
+        - type: object
+          properties:
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiFailureData"
+                - type: object
+                  properties:
+                    errorCode:
+                      const: TODO-NOT-FOUND
+                    errorMessage:
+                      const: TODO item was not found.
+    TodoTitleRequiredEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/ErrorEnvelope"
+        - type: object
+          properties:
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiFailureData"
+                - type: object
+                  properties:
+                    errorCode:
+                      const: TODO-TITLE-REQUIRED
+                    errorMessage:
+                      const: TODO title is required.
+    DispatcherErrorEnvelope:
+      type: object
+      required:
+        - Result
+        - Error
+      properties:
+        Result:
+          type: boolean
+          const: false
+        Error:
+          type: object
+          required:
+            - ErrorCode
+            - ErrorMessage
+          properties:
+            ErrorCode:
+              type: string
+              const: METHOD-NOT-ALLOWED
+            ErrorMessage:
+              type: string

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #50: Add starter OpenAPI contract and Swagger UI.
 - #16: Add PHPUnit test foundation and first pure function tests.
 - #8: Rename default branch from `master` to `main`.
 - #6: Add project documentation, AI guide, coding standards, workflow, roadmap, TODO, milestones, and ADR foundation.
@@ -16,7 +17,6 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 - Create a Phan baseline or configuration so static analysis can become repeatable.
 - Review PHP CS Fixer setup and document the exact formatting command.
-- Add an OpenAPI starter document for REST endpoints.
 - Document routing examples with real controllers.
 - Prepare documentation/sample pages for the home side menu: `Authentication`, `Routing Guide`, and `OpenAPI`.
 - Review security-sensitive request, session, template, and error handling.

--- a/htdocs/api-docs/index.html
+++ b/htdocs/api-docs/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>NeNe API Docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+    <style>
+        body {
+            margin: 0;
+            background: #0f1117;
+        }
+
+        .swagger-ui .topbar {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+        window.addEventListener('load', function() {
+            window.ui = SwaggerUIBundle({
+                url: './openapi.php',
+                dom_id: '#swagger-ui',
+                deepLinking: true,
+                presets: [
+                    SwaggerUIBundle.presets.apis
+                ],
+                layout: 'BaseLayout'
+            });
+        });
+    </script>
+</body>
+</html>

--- a/htdocs/api-docs/openapi.php
+++ b/htdocs/api-docs/openapi.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+$openApiPath = dirname(__DIR__, 2) . '/docs/api/openapi.yaml';
+
+if (!is_file($openApiPath)) {
+    http_response_code(404);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'OpenAPI document was not found.';
+    exit;
+}
+
+header('Content-Type: application/yaml; charset=utf-8');
+readfile($openApiPath);

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', function() {
         { href: '#sample-app', label: 'Authentication' },
         { href: '#sample-app', label: 'Sample TODO' },
         { href: '#getting-started', label: 'Routing Guide' },
-        { href: '#getting-started', label: 'OpenAPI' }
+        { href: '/api-docs/', label: 'OpenAPI' }
     ];
 
     function App() {


### PR DESCRIPTION
## Summary
- `docs/api/openapi.yaml` を追加し、現在の Session/TODO REST API 契約を定義
- `htdocs/api-docs/` に Swagger UI と OpenAPI 配信 endpoint を追加
- API docs、TODO、トップページの OpenAPI リンクを更新

## Test plan
- `python3` + PyYAML による `docs/api/openapi.yaml` の parse 確認
- `php -l htdocs/api-docs/openapi.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- `php -S 127.0.0.1:18080 -t htdocs` で `/api-docs/` と `/api-docs/openapi.php` の 200 応答を確認
- Cursor lints: no errors

Closes #50

Made with [Cursor](https://cursor.com)