### PR TITLE
HTTP runtime smoke tests を導入する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,8 @@
         "phpunit/phpunit": "^10.5"
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit --testsuite unit",
+        "test:http": "phpunit --testsuite http",
+        "test:all": "phpunit"
     }
 }

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -30,6 +30,8 @@ Or directly:
 vendor/bin/phpunit
 ```
 
+`composer test` runs the lightweight unit test suite only.
+
 ## Docker
 
 Tests can also run in the Docker container:
@@ -37,6 +39,24 @@ Tests can also run in the Docker container:
 ```sh
 docker compose run --rm app sh -lc "composer install --no-interaction --prefer-dist && composer test"
 ```
+
+## HTTP Runtime Smoke Tests
+
+HTTP runtime tests exercise the Docker-served application through real HTTP requests. They cover the top page, Swagger UI, session login/logout, TODO CRUD, and REST method handling.
+
+Start the Docker environment first:
+
+```sh
+docker compose up --build -d
+```
+
+Then run:
+
+```sh
+NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http
+```
+
+If `NENE_HTTP_BASE_URL` is not configured, or the target server is unreachable, the HTTP test suite is skipped. This keeps normal unit testing fast and independent from Docker.
 
 ## Strategy for Coupled Code
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,9 @@
         <testsuite name="unit">
             <directory>tests/Unit</directory>
         </testsuite>
+        <testsuite name="http">
+            <directory>tests/Http</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/tests/Http/HttpClient.php
+++ b/tests/Http/HttpClient.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Http;
+
+/**
+ * Small HTTP client for runtime smoke tests.
+ */
+final class HttpClient
+{
+    /**
+     * Base URL without trailing slash.
+     *
+     * @var string
+     */
+    private $baseUrl;
+
+    /**
+     * Cookie jar keyed by cookie name.
+     *
+     * @var array<string,string>
+     */
+    private $cookies = [];
+
+    public function __construct(string $baseUrl)
+    {
+        $this->baseUrl = rtrim($baseUrl, '/');
+    }
+
+    /**
+     * Send a JSON request.
+     *
+     * @param array<string,mixed> $payload JSON payload.
+     * @param array<string,string> $headers Request headers.
+     *
+     * @return HttpResponse
+     */
+    public function json(string $method, string $path, array $payload = [], array $headers = []): HttpResponse
+    {
+        return $this->request(
+            $method,
+            $path,
+            json_encode($payload, JSON_THROW_ON_ERROR),
+            array_merge(['Content-Type' => 'application/json'], $headers)
+        );
+    }
+
+    /**
+     * Send an HTTP request.
+     *
+     * @param array<string,string> $headers Request headers.
+     *
+     * @return HttpResponse
+     */
+    public function request(string $method, string $path, ?string $body = null, array $headers = []): HttpResponse
+    {
+        $requestHeaders = $this->formatHeaders($headers);
+        $cookieHeader = $this->buildCookieHeader();
+        if ($cookieHeader !== '') {
+            $requestHeaders[] = 'Cookie: ' . $cookieHeader;
+        }
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => strtoupper($method),
+                'header' => implode("\r\n", $requestHeaders),
+                'content' => $body ?? '',
+                'ignore_errors' => true,
+                'timeout' => 5
+            ]
+        ]);
+
+        $responseHeaders = [];
+        $responseBody = @file_get_contents($this->baseUrl . $path, false, $context);
+        if (isset($http_response_header) && is_array($http_response_header)) {
+            $responseHeaders = $http_response_header;
+        }
+        if ($responseBody === false) {
+            throw new \RuntimeException('HTTP request failed: ' . $this->baseUrl . $path);
+        }
+
+        $response = HttpResponse::fromRawHeaders($responseHeaders, $responseBody);
+        $this->storeCookies($response->headers());
+        return $response;
+    }
+
+    /**
+     * @param array<string,string> $headers Request headers.
+     *
+     * @return array<int,string>
+     */
+    private function formatHeaders(array $headers): array
+    {
+        $formatted = [];
+        foreach ($headers as $name => $value) {
+            $formatted[] = $name . ': ' . $value;
+        }
+        return $formatted;
+    }
+
+    private function buildCookieHeader(): string
+    {
+        $pairs = [];
+        foreach ($this->cookies as $name => $value) {
+            $pairs[] = $name . '=' . $value;
+        }
+        return implode('; ', $pairs);
+    }
+
+    /**
+     * @param array<string,array<int,string>> $headers Response headers.
+     *
+     * @return void
+     */
+    private function storeCookies(array $headers): void
+    {
+        foreach ($headers['set-cookie'] ?? [] as $cookieHeader) {
+            $cookiePair = explode(';', $cookieHeader, 2)[0];
+            $parts = explode('=', $cookiePair, 2);
+            if (count($parts) === 2) {
+                $this->cookies[$parts[0]] = $parts[1];
+            }
+        }
+    }
+}
+
+/**
+ * Runtime HTTP response value object for tests.
+ */
+final class HttpResponse
+{
+    /**
+     * HTTP status code.
+     *
+     * @var int
+     */
+    private $statusCode;
+
+    /**
+     * Response headers keyed by lower-case header name.
+     *
+     * @var array<string,array<int,string>>
+     */
+    private $headers;
+
+    /**
+     * Response body.
+     *
+     * @var string
+     */
+    private $body;
+
+    /**
+     * @param array<string,array<int,string>> $headers Response headers.
+     */
+    private function __construct(int $statusCode, array $headers, string $body)
+    {
+        $this->statusCode = $statusCode;
+        $this->headers = $headers;
+        $this->body = $body;
+    }
+
+    /**
+     * @param array<int,string> $rawHeaders Raw response headers.
+     */
+    public static function fromRawHeaders(array $rawHeaders, string $body): self
+    {
+        $statusCode = 0;
+        $headers = [];
+        foreach ($rawHeaders as $headerLine) {
+            if (preg_match('/^HTTP\/\S+\s+(\d{3})/', $headerLine, $matches)) {
+                $statusCode = (int)$matches[1];
+                continue;
+            }
+            $parts = explode(':', $headerLine, 2);
+            if (count($parts) !== 2) {
+                continue;
+            }
+            $name = strtolower(trim($parts[0]));
+            $headers[$name][] = trim($parts[1]);
+        }
+        return new self($statusCode, $headers, $body);
+    }
+
+    public function statusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    /**
+     * @return array<string,array<int,string>>
+     */
+    public function headers(): array
+    {
+        return $this->headers;
+    }
+
+    public function headerLine(string $name): string
+    {
+        return implode(', ', $this->headers[strtolower($name)] ?? []);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function json(): array
+    {
+        $decoded = json_decode($this->body, true);
+        if (!is_array($decoded)) {
+            throw new \RuntimeException('Response body is not a JSON object: ' . $this->body);
+        }
+        return $decoded;
+    }
+}

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/HttpClient.php';
+
+final class HttpSmokeTest extends TestCase
+{
+    private const BASE_URL_ENV = 'NENE_HTTP_BASE_URL';
+
+    /**
+     * Runtime test client.
+     *
+     * @var HttpClient
+     */
+    private $client;
+
+    protected function setUp(): void
+    {
+        $baseUrl = (string)getenv(self::BASE_URL_ENV);
+        if ($baseUrl === '') {
+            self::markTestSkipped(self::BASE_URL_ENV . ' is not configured.');
+        }
+
+        $this->client = new HttpClient($baseUrl);
+        try {
+            $this->client->request('GET', '/api-docs/openapi.php');
+        } catch (\RuntimeException $exception) {
+            self::markTestSkipped('HTTP runtime is not reachable: ' . $exception->getMessage());
+        }
+    }
+
+    public function testTopPageRespondsWithDevelopersHtml(): void
+    {
+        $response = $this->client->request('GET', '/');
+
+        self::assertSame(200, $response->statusCode());
+        self::assertStringContainsString('text/html', $response->headerLine('Content-Type'));
+        self::assertStringContainsString('id="app"', $response->body());
+        self::assertStringContainsString('/js/index/index.js', $response->body());
+    }
+
+    public function testSwaggerUiAndOpenApiDocumentAreServed(): void
+    {
+        $swaggerResponse = $this->client->request('GET', '/api-docs/');
+        $openApiResponse = $this->client->request('GET', '/api-docs/openapi.php');
+
+        self::assertSame(200, $swaggerResponse->statusCode());
+        self::assertStringContainsString('SwaggerUIBundle', $swaggerResponse->body());
+
+        self::assertSame(200, $openApiResponse->statusCode());
+        self::assertStringContainsString('application/yaml', $openApiResponse->headerLine('Content-Type'));
+        self::assertStringContainsString('openapi: 3.1.0', $openApiResponse->body());
+    }
+
+    public function testTodoListRequiresSession(): void
+    {
+        $response = $this->client->request('GET', '/todo/index');
+        $payload = $response->json();
+
+        self::assertSame(200, $response->statusCode());
+        self::assertSame(true, $payload['Result']);
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('SESSION-CLOSED', $payload['Data']['errorCode']);
+    }
+
+    public function testSessionAndTodoCrudFlowRunsThroughHttpRuntime(): void
+    {
+        $loginResponse = $this->client->json('POST', '/session/login', [
+            'user_id' => 'admin',
+            'user_pass' => 'admin'
+        ]);
+        $loginPayload = $loginResponse->json();
+
+        self::assertSame(200, $loginResponse->statusCode());
+        self::assertSame(true, $loginPayload['Result']);
+        self::assertSame('success', $loginPayload['Data']['status']);
+        self::assertSame('admin', $loginPayload['Data']['user']['user_id']);
+
+        $title = 'HTTP runtime test ' . bin2hex(random_bytes(4));
+        $createResponse = $this->client->json('POST', '/todo/index', ['title' => $title]);
+        $createPayload = $createResponse->json();
+        $createdTodo = $createPayload['Data']['todo'];
+
+        self::assertSame(200, $createResponse->statusCode());
+        self::assertSame('success', $createPayload['Data']['status']);
+        self::assertSame($title, $createdTodo['title']);
+
+        $listResponse = $this->client->request('GET', '/todo/index');
+        $listPayload = $listResponse->json();
+        $todoIds = array_column($listPayload['Data']['todos'], 'id');
+
+        self::assertSame(200, $listResponse->statusCode());
+        self::assertContains($createdTodo['id'], $todoIds);
+
+        $updatedTitle = $title . ' updated';
+        $updateResponse = $this->client->json('PUT', '/todo/item/id_' . $createdTodo['id'], [
+            'title' => $updatedTitle,
+            'is_completed' => true
+        ]);
+        $updatePayload = $updateResponse->json();
+
+        self::assertSame(200, $updateResponse->statusCode());
+        self::assertSame($updatedTitle, $updatePayload['Data']['todo']['title']);
+        self::assertSame(true, $updatePayload['Data']['todo']['is_completed']);
+
+        $deleteResponse = $this->client->request('DELETE', '/todo/item/id_' . $createdTodo['id']);
+        $deletePayload = $deleteResponse->json();
+
+        self::assertSame(200, $deleteResponse->statusCode());
+        self::assertSame($createdTodo['id'], $deletePayload['Data']['id']);
+
+        $logoutResponse = $this->client->json('POST', '/session/logout');
+        $logoutPayload = $logoutResponse->json();
+
+        self::assertSame(200, $logoutResponse->statusCode());
+        self::assertSame('success', $logoutPayload['Data']['status']);
+    }
+
+    public function testUnsupportedRestMethodReturnsMethodNotAllowed(): void
+    {
+        $response = $this->client->request('GET', '/todo/item/id_1');
+        $payload = $response->json();
+
+        self::assertSame(405, $response->statusCode());
+        self::assertStringContainsString('DELETE', $response->headerLine('Allow'));
+        self::assertStringContainsString('PUT', $response->headerLine('Allow'));
+        self::assertSame(false, $payload['Result']);
+        self::assertSame('METHOD-NOT-ALLOWED', $payload['Error']['ErrorCode']);
+    }
+}


### PR DESCRIPTION
## Summary
- PHPUnit に `http` testsuite を追加し、`composer test:http` / `composer test:all` を追加
- 依存を増やさない HTTP client helper を追加し、cookie と JSON request/response を扱えるようにした
- トップページ、Swagger/OpenAPI、未ログイン TODO、login/TODO CRUD/logout、405 応答を実 HTTP 経由で検証する smoke tests を追加
- HTTP runtime test の実行方法を docs に追記

## Test plan
- `php -l tests/Http/HttpClient.php`
- `php -l tests/Http/HttpSmokeTest.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test:http`（`NENE_HTTP_BASE_URL` 未設定時は skip）
- `NENE_HTTP_BASE_URL=http://localhost:8080 COMPOSER_ALLOW_SUPERUSER=1 composer test:http`
- Cursor lints: no errors

Closes #54

Made with [Cursor](https://cursor.com)