### PR TITLE
HTTP runtime tests と CI チェックを拡充する

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Validate Composer metadata
+        run: composer validate
+
+      - name: Run unit tests
+        run: composer test
+
+      - name: Confirm HTTP tests skip without runtime
+        run: composer test:http

--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -39,15 +39,9 @@ class Dispatcher
      */
     final public function dispatch(): void
     {
-        $requestPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '';
-        $param = ltrim($requestPath, '/');
-        $param = rtrim($param, '/');
-        $params = [];
-        if ($param != '') {
-            $params = explode('/', $param);
-        }
-        $controller = (LAYERS_NUM < count($params)) ? $params[LAYERS_NUM] : 'index';
-        $action = ((LAYERS_NUM + 1) < count($params)) ? $params[LAYERS_NUM + 1] : 'index';
+        $requestRoute = $this->resolveRequestRoute($_SERVER['REQUEST_URI'] ?? '');
+        $controller = $requestRoute['controller'];
+        $action = $requestRoute['action'];
 
         $controllerInstance = $this->getControllerInstance($controller);
 
@@ -77,6 +71,28 @@ class Dispatcher
         }
         RouteContext::getInstance()->set($controller, $action, $route['mode'], $route['method']);
         $controllerInstance->run();
+    }
+
+    /**
+     * Resolve controller and action names from a request URI.
+     *
+     * @param string $requestUri Request URI.
+     *
+     * @return array{controller:string, action:string}
+     */
+    final public function resolveRequestRoute(string $requestUri): array
+    {
+        $requestPath = parse_url($requestUri, PHP_URL_PATH) ?: '';
+        $param = trim($requestPath, '/');
+        $params = [];
+        if ($param != '') {
+            $params = explode('/', $param);
+        }
+        $layersNum = defined('LAYERS_NUM') ? LAYERS_NUM : 0;
+        return [
+            'controller' => ($layersNum < count($params)) ? $params[$layersNum] : 'index',
+            'action' => (($layersNum + 1) < count($params)) ? $params[$layersNum + 1] : 'index'
+        ];
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
     "scripts": {
         "test": "phpunit --testsuite unit",
         "test:http": "phpunit --testsuite http",
-        "test:all": "phpunit"
+        "test:all": "phpunit",
+        "check": [
+            "@test",
+            "@test:http"
+        ]
     }
 }

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -32,6 +32,12 @@ vendor/bin/phpunit
 
 `composer test` runs the lightweight unit test suite only.
 
+For CI-style verification that also confirms HTTP tests are either runnable or safely skipped:
+
+```sh
+composer check
+```
+
 ## Docker
 
 Tests can also run in the Docker container:
@@ -57,6 +63,15 @@ NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http
 ```
 
 If `NENE_HTTP_BASE_URL` is not configured, or the target server is unreachable, the HTTP test suite is skipped. This keeps normal unit testing fast and independent from Docker.
+
+For a full local runtime check:
+
+```sh
+docker compose up --build -d
+NENE_HTTP_BASE_URL=http://localhost:8080 composer check
+```
+
+HTTP tests use a test title prefix and clean up matching TODO rows before each runtime test. Tests that create TODOs also register them for cleanup during teardown, so failed tests should not leave long-lived sample data behind.
 
 ## Strategy for Coupled Code
 

--- a/tests/Http/HttpErrorTest.php
+++ b/tests/Http/HttpErrorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Http;
+
+require_once __DIR__ . '/HttpRuntimeTestCase.php';
+
+final class HttpErrorTest extends HttpRuntimeTestCase
+{
+    public function testLoginFailureReturnsCatalogError(): void
+    {
+        $response = $this->client->json('POST', '/session/login', [
+            'user_id' => 'admin',
+            'user_pass' => 'wrong'
+        ]);
+        $payload = $response->json();
+
+        self::assertSame(200, $response->statusCode());
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('LOGIN-FAILED', $payload['Data']['errorCode']);
+    }
+
+    public function testCreatingTodoWithEmptyTitleReturnsBadRequest(): void
+    {
+        $this->loginAsAdmin();
+
+        $response = $this->client->json('POST', '/todo/index', ['title' => '']);
+        $payload = $response->json();
+
+        self::assertSame(400, $response->statusCode());
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('TODO-TITLE-REQUIRED', $payload['Data']['errorCode']);
+    }
+
+    public function testUpdatingMissingTodoReturnsNotFound(): void
+    {
+        $this->loginAsAdmin();
+
+        $response = $this->client->json('PUT', '/todo/item/id_999999999', [
+            'title' => self::TEST_TODO_PREFIX . 'missing'
+        ]);
+        $payload = $response->json();
+
+        self::assertSame(404, $response->statusCode());
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('TODO-NOT-FOUND', $payload['Data']['errorCode']);
+    }
+
+    public function testDeletingMissingTodoReturnsNotFound(): void
+    {
+        $this->loginAsAdmin();
+
+        $response = $this->client->request('DELETE', '/todo/item/id_999999999');
+        $payload = $response->json();
+
+        self::assertSame(404, $response->statusCode());
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('TODO-NOT-FOUND', $payload['Data']['errorCode']);
+    }
+
+    public function testInvalidTodoIdReturnsBadRequest(): void
+    {
+        $this->loginAsAdmin();
+
+        $response = $this->client->json('PUT', '/todo/item/id_invalid', [
+            'title' => self::TEST_TODO_PREFIX . 'invalid'
+        ]);
+        $payload = $response->json();
+
+        self::assertSame(400, $response->statusCode());
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('TODO-ID-REQUIRED', $payload['Data']['errorCode']);
+    }
+}

--- a/tests/Http/HttpRuntimeTestCase.php
+++ b/tests/Http/HttpRuntimeTestCase.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/HttpClient.php';
+
+abstract class HttpRuntimeTestCase extends TestCase
+{
+    protected const BASE_URL_ENV = 'NENE_HTTP_BASE_URL';
+    protected const TEST_TODO_PREFIX = 'HTTP runtime test ';
+
+    /**
+     * Runtime test client.
+     *
+     * @var HttpClient
+     */
+    protected $client;
+
+    /**
+     * TODO ids created by a test.
+     *
+     * @var array<int,int>
+     */
+    private $cleanupTodoIds = [];
+
+    protected function setUp(): void
+    {
+        $baseUrl = $this->baseUrl();
+        $this->client = new HttpClient($baseUrl);
+        try {
+            $this->client->request('GET', '/api-docs/openapi.php');
+        } catch (\RuntimeException $exception) {
+            self::markTestSkipped('HTTP runtime is not reachable: ' . $exception->getMessage());
+        }
+
+        $this->deleteTodosWithTitlePrefix(self::TEST_TODO_PREFIX);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->cleanupTodoIds !== []) {
+            $cleanupClient = $this->newClient();
+            $this->loginAsAdmin($cleanupClient);
+            foreach (array_unique($this->cleanupTodoIds) as $todoId) {
+                $cleanupClient->request('DELETE', '/todo/item/id_' . $todoId);
+            }
+        }
+        $this->cleanupTodoIds = [];
+    }
+
+    protected function newClient(): HttpClient
+    {
+        return new HttpClient($this->baseUrl());
+    }
+
+    protected function loginAsAdmin(?HttpClient $client = null): HttpClient
+    {
+        $client = $client ?? $this->client;
+        $response = $client->json('POST', '/session/login', [
+            'user_id' => 'admin',
+            'user_pass' => 'admin'
+        ]);
+        $payload = $response->json();
+
+        self::assertSame(200, $response->statusCode());
+        self::assertSame('success', $payload['Data']['status']);
+        return $client;
+    }
+
+    /**
+     * @return array<string,mixed> Created TODO payload.
+     */
+    protected function createTodo(string $title, ?HttpClient $client = null): array
+    {
+        $client = $client ?? $this->client;
+        $response = $client->json('POST', '/todo/index', ['title' => $title]);
+        $payload = $response->json();
+
+        self::assertSame(200, $response->statusCode());
+        self::assertSame('success', $payload['Data']['status']);
+
+        $todo = $payload['Data']['todo'];
+        $this->cleanupTodoIds[] = (int)$todo['id'];
+        return $todo;
+    }
+
+    private function baseUrl(): string
+    {
+        $baseUrl = (string)getenv(self::BASE_URL_ENV);
+        if ($baseUrl === '') {
+            self::markTestSkipped(self::BASE_URL_ENV . ' is not configured.');
+        }
+        return $baseUrl;
+    }
+
+    private function deleteTodosWithTitlePrefix(string $titlePrefix): void
+    {
+        $cleanupClient = $this->newClient();
+        $this->loginAsAdmin($cleanupClient);
+
+        $listResponse = $cleanupClient->request('GET', '/todo/index');
+        $listPayload = $listResponse->json();
+        foreach ($listPayload['Data']['todos'] ?? [] as $todo) {
+            if (str_starts_with((string)$todo['title'], $titlePrefix)) {
+                $cleanupClient->request('DELETE', '/todo/item/id_' . (int)$todo['id']);
+            }
+        }
+    }
+}

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -4,36 +4,10 @@ declare(strict_types=1);
 
 namespace Nene\Tests\Http;
 
-use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/HttpRuntimeTestCase.php';
 
-require_once __DIR__ . '/HttpClient.php';
-
-final class HttpSmokeTest extends TestCase
+final class HttpSmokeTest extends HttpRuntimeTestCase
 {
-    private const BASE_URL_ENV = 'NENE_HTTP_BASE_URL';
-
-    /**
-     * Runtime test client.
-     *
-     * @var HttpClient
-     */
-    private $client;
-
-    protected function setUp(): void
-    {
-        $baseUrl = (string)getenv(self::BASE_URL_ENV);
-        if ($baseUrl === '') {
-            self::markTestSkipped(self::BASE_URL_ENV . ' is not configured.');
-        }
-
-        $this->client = new HttpClient($baseUrl);
-        try {
-            $this->client->request('GET', '/api-docs/openapi.php');
-        } catch (\RuntimeException $exception) {
-            self::markTestSkipped('HTTP runtime is not reachable: ' . $exception->getMessage());
-        }
-    }
-
     public function testTopPageRespondsWithDevelopersHtml(): void
     {
         $response = $this->client->request('GET', '/');
@@ -70,24 +44,10 @@ final class HttpSmokeTest extends TestCase
 
     public function testSessionAndTodoCrudFlowRunsThroughHttpRuntime(): void
     {
-        $loginResponse = $this->client->json('POST', '/session/login', [
-            'user_id' => 'admin',
-            'user_pass' => 'admin'
-        ]);
-        $loginPayload = $loginResponse->json();
+        $this->loginAsAdmin();
 
-        self::assertSame(200, $loginResponse->statusCode());
-        self::assertSame(true, $loginPayload['Result']);
-        self::assertSame('success', $loginPayload['Data']['status']);
-        self::assertSame('admin', $loginPayload['Data']['user']['user_id']);
-
-        $title = 'HTTP runtime test ' . bin2hex(random_bytes(4));
-        $createResponse = $this->client->json('POST', '/todo/index', ['title' => $title]);
-        $createPayload = $createResponse->json();
-        $createdTodo = $createPayload['Data']['todo'];
-
-        self::assertSame(200, $createResponse->statusCode());
-        self::assertSame('success', $createPayload['Data']['status']);
+        $title = self::TEST_TODO_PREFIX . bin2hex(random_bytes(4));
+        $createdTodo = $this->createTodo($title);
         self::assertSame($title, $createdTodo['title']);
 
         $listResponse = $this->client->request('GET', '/todo/index');

--- a/tests/Http/OpenApiRuntimeContractTest.php
+++ b/tests/Http/OpenApiRuntimeContractTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Http;
+
+require_once __DIR__ . '/HttpRuntimeTestCase.php';
+
+final class OpenApiRuntimeContractTest extends HttpRuntimeTestCase
+{
+    public function testDocumentedRestOperationsRespondWithDocumentedStatuses(): void
+    {
+        $openApiResponse = $this->client->request('GET', '/api-docs/openapi.php');
+        $openApi = $openApiResponse->body();
+        $operations = $this->documentedOperations($openApi);
+
+        $examples = [
+            ['POST', '/session/login', '/session/login', ['user_id' => 'admin', 'user_pass' => 'admin']],
+            ['POST', '/session/logout', '/session/logout', []],
+            ['GET', '/todo/index', '/todo/index', null],
+            ['POST', '/todo/index', '/todo/index', ['title' => self::TEST_TODO_PREFIX . 'contract']],
+            ['PUT', '/todo/item/id_{id}', '/todo/item/id_1', ['is_completed' => true]],
+            ['DELETE', '/todo/item/id_{id}', '/todo/item/id_1', null]
+        ];
+
+        foreach ($examples as [$method, $documentedPath, $runtimePath, $body]) {
+            self::assertContains(
+                [$method, $documentedPath],
+                $operations,
+                $method . ' ' . $documentedPath . ' is missing from OpenAPI.'
+            );
+
+            $client = $this->newClient();
+            $response = is_array($body)
+                ? $client->json($method, $runtimePath, $body)
+                : $client->request($method, $runtimePath);
+
+            self::assertContains(
+                (string)$response->statusCode(),
+                $this->documentedStatuses($openApi, $documentedPath, $method),
+                $method . ' ' . $documentedPath . ' returned undocumented status ' . $response->statusCode()
+            );
+        }
+    }
+
+    /**
+     * @return array<int,array{0:string,1:string}>
+     */
+    private function documentedOperations(string $openApi): array
+    {
+        $operations = [];
+        $currentPath = null;
+        foreach (explode("\n", $openApi) as $line) {
+            if (preg_match('/^  (\/[^:]+):$/', $line, $matches)) {
+                $currentPath = $matches[1];
+                continue;
+            }
+            if ($currentPath !== null && preg_match('/^    (get|post|put|patch|delete):$/', $line, $matches)) {
+                $operations[] = [strtoupper($matches[1]), $currentPath];
+            }
+        }
+        return $operations;
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function documentedStatuses(string $openApi, string $path, string $method): array
+    {
+        $lines = explode("\n", $openApi);
+        $insidePath = false;
+        $insideMethod = false;
+        $insideResponses = false;
+        $statuses = [];
+
+        foreach ($lines as $line) {
+            if (preg_match('/^  (\/[^:]+):$/', $line, $matches)) {
+                $insidePath = $matches[1] === $path;
+                $insideMethod = false;
+                $insideResponses = false;
+                continue;
+            }
+            if (!$insidePath) {
+                continue;
+            }
+            if (preg_match('/^    (get|post|put|patch|delete):$/', $line, $matches)) {
+                $insideMethod = strtoupper($matches[1]) === strtoupper($method);
+                $insideResponses = false;
+                continue;
+            }
+            if ($insideMethod && preg_match('/^      responses:$/', $line)) {
+                $insideResponses = true;
+                continue;
+            }
+            if ($insideResponses && preg_match('/^        "(\d{3})":$/', $line, $matches)) {
+                $statuses[] = $matches[1];
+                continue;
+            }
+            if ($insideResponses && preg_match('/^      [a-zA-Z_][^:]*:/', $line)) {
+                break;
+            }
+        }
+
+        return $statuses;
+    }
+}

--- a/tests/Unit/Xion/DispatcherTest.php
+++ b/tests/Unit/Xion/DispatcherTest.php
@@ -9,6 +9,30 @@ use PHPUnit\Framework\TestCase;
 
 final class DispatcherTest extends TestCase
 {
+    public function testResolveRequestRouteDefaultsToIndex(): void
+    {
+        $route = (new Dispatcher())->resolveRequestRoute('/');
+
+        self::assertSame('index', $route['controller']);
+        self::assertSame('index', $route['action']);
+    }
+
+    public function testResolveRequestRouteIgnoresQueryString(): void
+    {
+        $route = (new Dispatcher())->resolveRequestRoute('/todo/item/id_1?debug=1');
+
+        self::assertSame('todo', $route['controller']);
+        self::assertSame('item', $route['action']);
+    }
+
+    public function testResolveRequestRouteDefaultsMissingAction(): void
+    {
+        $route = (new Dispatcher())->resolveRequestRoute('/session');
+
+        self::assertSame('session', $route['controller']);
+        self::assertSame('index', $route['action']);
+    }
+
     public function testResolveActionRoutePrefersHttpMethodRestHandler(): void
     {
         $controller = new class {


### PR DESCRIPTION
## Summary
- OpenAPI に記載された REST operations が実 HTTP で文書化済み status を返すか検証
- HTTP runtime tests の共通基底を追加し、テスト用 TODO の cleanup を強化
- login failure、TODO title required、not found、invalid id の異常系 HTTP tests を追加
- Dispatcher の URI 解析を `resolveRequestRoute()` として切り出し unit test を追加
- `composer check` と GitHub Actions の unit/skip-safe HTTP test workflow を追加

## Test plan
- `php -l class/xion/Dispatcher.php`
- `php -l tests/Unit/Xion/DispatcherTest.php`
- `php -l tests/Http/HttpClient.php`
- `php -l tests/Http/HttpRuntimeTestCase.php`
- `php -l tests/Http/HttpSmokeTest.php`
- `php -l tests/Http/HttpErrorTest.php`
- `php -l tests/Http/OpenApiRuntimeContractTest.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer validate`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test`
- `COMPOSER_ALLOW_SUPERUSER=1 composer test:http`（runtime 未設定時 skip）
- `NENE_HTTP_BASE_URL=http://localhost:8080 COMPOSER_ALLOW_SUPERUSER=1 composer test:http`
- `COMPOSER_ALLOW_SUPERUSER=1 composer check`
- `NENE_HTTP_BASE_URL=http://localhost:8080 COMPOSER_ALLOW_SUPERUSER=1 composer check`
- Cursor lints: no errors

Closes #56

Made with [Cursor](https://cursor.com)