### PR TITLE
common.css から未使用スタイルを削除する

### DIFF
--- a/htdocs/css/common.css
+++ b/htdocs/css/common.css
@@ -12,26 +12,9 @@ body {
     padding: 0;
 }
 
-hr {
-    height: 1px;
-    border: none;
-    border-top: 1px solid #ccc;
-}
-
 .content {
     min-height: calc(100vh - 72px);
     padding: 0;
-}
-.hidden {
-    display: none;
-}
-.error {
-    color: red;
-}
-
-/* ========== HEADER ========== */
-header {
-    display: none;
 }
 
 /* ========== FOOTER ========== */
@@ -48,54 +31,3 @@ footer a {
     color: #aaa;
     text-decoration:  none;
 }
-
-/* ========== FORM ========== */
-form input,
-form label,
-form small {
-    display: block;
-}
-form > div {
-    margin-bottom: 12px;
-}
-form label {
-    font-size: 0.8rem;
-    margin-bottom: 4px;
-}
-form small {
-    font-size: 0.7rem;
-}
-form input {
-    border: 1px solid #666;
-    border-radius: 4px;
-    box-sizing: border-box;
-    height: 2.5rem;
-    line-height: 1.5;
-    margin-bottom: 4px;
-    padding: 10px;
-}
-form button {
-    border: 1px solid #666;
-    border-radius: 4px;
-    height: 2.5rem;
-    line-height: 1.5;
-    margin-bottom: 4px;
-    padding: 10px;
-}
-
-.input__w-255 {
-    width: 255px;
-}
-.input__w-128 {
-    width: 128px;
-}
-.input__w-100p {
-    width: 100%;
-}
-form button:hover {
-    background-color: black;
-    border-color: black;
-    color: white;
-    cursor: pointer;
-}
-


### PR DESCRIPTION
## Summary
- `common.css` から旧 header、旧フォーム、未使用 utility class のスタイルを削除
- React サンプルで共通利用している body、`.content`、footer の基礎スタイルは維持

## Test plan
- `composer validate`
- `composer test`
- `composer test:http`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `composer check`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer check`

Closes #62

Made with [Cursor](https://cursor.com)