### PR TITLE
SQLite fallback で TODO サンプルを動かす

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,17 +9,14 @@ NENE_PORT=8080
 # MySQL port exposed on the host machine.
 NENE_MYSQL_PORT=3307
 
-# Development database settings used by both app and MySQL containers.
+# Development database settings. The default Docker runtime uses MySQL.
+NENE_DB_TYPE=MySQL
+NENE_DB_HOST=mysql
+NENE_DB_PORT=3306
 NENE_DB_NAME=nene
 NENE_DB_USER=nene
 NENE_DB_PASS=nene
 NENE_DB_ROOT_PASS=root
 
-# The Docker app service injects these connection settings automatically:
-# NENE_DB_TYPE=MySQL
-# NENE_DB_HOST=mysql
-# NENE_DB_PORT=3306
-#
-# NENE_DB_FILE is only used by the legacy SQLite fallback outside the default
-# Docker MySQL setup.
-# NENE_DB_FILE=nene.db
+# SQLite fallback file name. Used when NENE_DB_TYPE=SQLite3.
+NENE_DB_FILE=nene.db

--- a/class/xion/PdoConnection.php
+++ b/class/xion/PdoConnection.php
@@ -66,6 +66,8 @@ class PdoConnection
                     break;
                 case 'SQLite3':
                     $this->connection = new PDO('sqlite:' . DB_DIR . DB_FILE);
+                    $this->connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                    $this->connection->exec('PRAGMA foreign_keys = ON');
                     break;
             }
         } catch (\PDOException $e) {

--- a/cli/initSQLite.php
+++ b/cli/initSQLite.php
@@ -1,71 +1,181 @@
 <?php
 
-ini_set('display_errors', 1);               // DISPLAY ERROR
-error_reporting(E_ALL);                     // ERROR REPORT
-session_cache_expire(180);                  // SESSION => 3H
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @link      https://ayane.co.jp/
+ */
 
-echo ('Welcome NeNe-PHP CLI!!!' . PHP_EOL . PHP_EOL);
-echo ('Do you want to initialize SQLite? (Y/N)' . PHP_EOL);
+declare(strict_types=1);
 
-$il = trim(fgets(STDIN));
-if ($il !== 'Y' && $il !== 'y') {
-    echo ('OK. Bye!' . PHP_EOL . PHP_EOL);
-    exit();
+use Nene\Xion\Initialize;
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+ini_set('display_errors', '1');
+error_reporting(E_ALL);
+date_default_timezone_set('Asia/Tokyo');
+
+Initialize::init();
+
+echo 'Welcome NeNe-PHP CLI!' . PHP_EOL . PHP_EOL;
+echo 'This command initializes the SQLite database used by the fallback sample runtime.' . PHP_EOL;
+echo 'Target file: ' . DB_DIR . DB_FILE . PHP_EOL . PHP_EOL;
+echo 'Do you want to initialize SQLite? (Y/N)' . PHP_EOL;
+
+$answer = trim((string)fgets(STDIN));
+if (!in_array(strtolower($answer), ['y', 'yes'], true)) {
+    echo 'OK. Bye!' . PHP_EOL;
+    exit(0);
 }
-
-echo ('Yes, initialize SQLite.' . PHP_EOL);
 
 try {
-    $db = new PDO('sqlite:./data/nene.db');
-    if (!$db) {
-        echo ('Oops. Database creation failed.' . PHP_EOL);
-        echo ('Bye!' . PHP_EOL . PHP_EOL);
-        exit();
-    }
-} catch (Exception $e) {
-    echo ('CONNECT ERROR.' . PHP_EOL);
-    echo ($e->getMessage() . PHP_EOL);
-    exit();
+    initializeSQLite(DB_DIR, DB_FILE);
+} catch (Throwable $exception) {
+    fwrite(STDERR, 'SQLite initialization failed: ' . $exception->getMessage() . PHP_EOL);
+    exit(1);
 }
 
-echo ('The database was created successfully.' . PHP_EOL);
+echo 'Processing has been completed.' . PHP_EOL;
 
-$db->exec(<<<_SQL_
+/**
+ * Initialize a SQLite database with the same sample tables as MySQL.
+ */
+function initializeSQLite(string $databaseDir, string $databaseFile): void
+{
+    if (!is_dir($databaseDir) && !mkdir($databaseDir, 0775, true) && !is_dir($databaseDir)) {
+        throw new RuntimeException('Database directory could not be created: ' . $databaseDir);
+    }
+
+    $databasePath = $databaseDir . $databaseFile;
+    $db = new PDO('sqlite:' . $databasePath);
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $db->exec('PRAGMA foreign_keys = ON');
+
+    createTables($db);
+    createTimestampTriggers($db);
+    seedSampleData($db);
+    syncDatabaseFilePermissions($databaseDir, $databasePath);
+
+    echo 'SQLite database is ready: ' . $databasePath . PHP_EOL;
+    echo 'Default account: admin / admin' . PHP_EOL;
+}
+
+/**
+ * Create tables aligned with docker/mysql/init/001_schema.sql.
+ */
+function createTables(PDO $db): void
+{
+    $db->exec(<<<'SQL'
 CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    created_at TEXT,
-    updated_at TEXT,
-    user_id TEXT,
-    user_pass TEXT,
-    user_name TEXT,
-    e_mail TEXT,
-    is_deleted INTEGER
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    user_id TEXT NOT NULL,
+    user_pass TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    e_mail TEXT NOT NULL,
+    is_deleted INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (user_id)
 )
-_SQL_);
-$res = $db->query("SELECT COUNT(*) FROM users WHERE user_id = 'admin'");
-$count = $res->fetchColumn();
-if ($count == 0) {
-    $date = date('YmdHis');
-    $res = $db->query(<<<_SQL_
-INSERT INTO users (
-    created_at,
-    updated_at,
-    user_id, user_pass,
-    user_name,
-    e_mail, is_deleted
-) values (
-    {$date},
-    {$date},
-    'admin',
-    'admin',
-    'admin',
-    '',
-    0
+SQL);
+
+    $db->exec(<<<'SQL'
+CREATE TABLE IF NOT EXISTS todos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    user_id INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    is_completed INTEGER NOT NULL DEFAULT 0,
+    is_deleted INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 )
-_SQL_);
-    echo ('The "admin" account has been added. The password is "admin".' . PHP_EOL . PHP_EOL);
-} else {
-    echo ('The admin account already exists in the user table.' . PHP_EOL . PHP_EOL);
+SQL);
+
+    $db->exec('CREATE INDEX IF NOT EXISTS todos_user_id_index ON todos (user_id)');
 }
 
-echo ('Processing has been completed. Thank you very much.');
+/**
+ * Keep updated_at close to MySQL's ON UPDATE CURRENT_TIMESTAMP behavior.
+ */
+function createTimestampTriggers(PDO $db): void
+{
+    $db->exec(<<<'SQL'
+CREATE TRIGGER IF NOT EXISTS users_updated_at_trigger
+AFTER UPDATE ON users
+FOR EACH ROW
+WHEN NEW.updated_at = OLD.updated_at
+BEGIN
+    UPDATE users SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END
+SQL);
+
+    $db->exec(<<<'SQL'
+CREATE TRIGGER IF NOT EXISTS todos_updated_at_trigger
+AFTER UPDATE ON todos
+FOR EACH ROW
+WHEN NEW.updated_at = OLD.updated_at
+BEGIN
+    UPDATE todos SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END
+SQL);
+}
+
+/**
+ * Insert the default development account and TODO samples idempotently.
+ */
+function seedSampleData(PDO $db): void
+{
+    $db->exec(<<<'SQL'
+INSERT INTO users (user_id, user_pass, user_name, e_mail, is_deleted)
+SELECT 'admin', 'admin', 'admin', 'admin@example.com', 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM users WHERE user_id = 'admin'
+)
+SQL);
+
+    seedTodo($db, 'Read the routing guide', true);
+    seedTodo($db, 'Create a controller action', false);
+}
+
+/**
+ * Insert a sample TODO for the admin user when it does not exist yet.
+ */
+function seedTodo(PDO $db, string $title, bool $isCompleted): void
+{
+    $stmt = $db->prepare(<<<'SQL'
+INSERT INTO todos (user_id, title, is_completed, is_deleted)
+SELECT users.id, :title, :is_completed, 0
+FROM users
+WHERE users.user_id = 'admin'
+AND NOT EXISTS (
+    SELECT 1 FROM todos
+    WHERE todos.user_id = users.id
+    AND todos.title = :title
+)
+SQL);
+    $stmt->bindValue(':title', $title, PDO::PARAM_STR);
+    $stmt->bindValue(':is_completed', $isCompleted ? 1 : 0, PDO::PARAM_INT);
+    $stmt->execute();
+}
+
+/**
+ * Match the SQLite file permission with the writable data directory.
+ */
+function syncDatabaseFilePermissions(string $databaseDir, string $databasePath): void
+{
+    $directoryGroup = filegroup($databaseDir);
+    if ($directoryGroup !== false) {
+        @chgrp($databasePath, $directoryGroup);
+    }
+
+    @chmod($databasePath, 0664);
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,9 +6,10 @@ services:
       mysql:
         condition: service_healthy
     environment:
-      NENE_DB_TYPE: MySQL
-      NENE_DB_HOST: mysql
-      NENE_DB_PORT: 3306
+      NENE_DB_TYPE: "${NENE_DB_TYPE:-MySQL}"
+      NENE_DB_HOST: "${NENE_DB_HOST:-mysql}"
+      NENE_DB_PORT: "${NENE_DB_PORT:-3306}"
+      NENE_DB_FILE: "${NENE_DB_FILE:-nene.db}"
       NENE_DB_NAME: "${NENE_DB_NAME:-nene}"
       NENE_DB_USER: "${NENE_DB_USER:-nene}"
       NENE_DB_PASS: "${NENE_DB_PASS:-nene}"

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -84,10 +84,16 @@ NENE_DB_NAME=nene_local NENE_DB_USER=nene NENE_DB_PASS=nene docker compose up --
 
 ## Optional SQLite Initialization
 
-The legacy SQLite initializer remains available for non-Docker or fallback usage:
+The SQLite initializer remains available for non-Docker or fallback usage. It creates the same sample tables as the MySQL initializer and inserts the default `admin` account with sample TODO rows:
 
 ```sh
 docker compose run --rm app sh -lc "printf 'Y\n' | php cli/initSQLite.php"
+```
+
+To run the application against SQLite instead of the Docker MySQL service, start the app with SQLite environment values:
+
+```sh
+NENE_DB_TYPE=SQLite3 NENE_DB_FILE=nene.db docker compose up --build app
 ```
 
 ## Stop


### PR DESCRIPTION
## Summary
- `cli/initSQLite.php` を PHP 8.4 方針に合わせて整理し、MySQL 初期化 SQL と同等の `users` / `todos` レイアウトを作成
- default `admin/admin` と sample TODO rows を SQLite にも投入
- SQLite 接続で例外モードと foreign key を有効化し、Docker/.env から SQLite fallback を選べるように調整

## Test plan
- `php -l cli/initSQLite.php`
- `php -l class/xion/PdoConnection.php`
- `composer validate`
- `composer test`
- `composer test:http`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `composer check`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer check`
- Docker PHP 8.4 上で `NENE_DB_TYPE=SQLite3` + `NENE_DB_FILE=<temp>.db` の SQLite 初期化を実行し、`users=1` / `todos=2` / `admin=1` を確認
- Docker PHP 8.4 + Apache + SQLite DB で `NENE_HTTP_BASE_URL=http://127.0.0.1:18081 composer test:http` を実行し 11 tests / 91 assertions 通過

Closes #68

Made with [Cursor](https://cursor.com)