### PR TITLE
OpenAPI contract test parser 方針を記録する

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -25,6 +25,12 @@ http://localhost:8080/api-docs/
 
 `docs/api/openapi.yaml` is the source of truth. The Swagger UI page serves that file through `htdocs/api-docs/openapi.php` so the contract is not duplicated under the document root.
 
+## Contract Test Parser Policy
+
+The current runtime contract test uses a small line-based reader for `openapi.yaml`. That is acceptable while the contract is small and the test only checks path, method, and documented HTTP status coverage.
+
+Before expanding the test into richer OpenAPI assertions, parse the YAML with a real parser such as `symfony/yaml` in `require-dev`. If the project starts validating response bodies against schemas, choose an OpenAPI/JSON Schema validation library deliberately instead of extending the current regular expressions.
+
 ## REST Convention
 
 NeNe currently treats controller methods ending in `Rest` as REST/API handlers.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -73,6 +73,12 @@ NENE_HTTP_BASE_URL=http://localhost:8080 composer check
 
 HTTP tests use a test title prefix and clean up matching TODO rows before each runtime test. Tests that create TODOs also register them for cleanup during teardown, so failed tests should not leave long-lived sample data behind.
 
+## OpenAPI Contract Test Scope
+
+`OpenApiRuntimeContractTest` currently reads `docs/api/openapi.yaml` with a lightweight line-based parser. This is intentional for the current small contract: the test only verifies that documented REST operations exist and that observed runtime HTTP statuses are listed in OpenAPI.
+
+Do not treat that parser as a general YAML implementation. When OpenAPI grows to include broader `$ref` usage, shared response composition, many more paths, or response body schema validation, add a dev dependency such as `symfony/yaml` and parse the contract as structured data before expanding the assertions. If schema validation becomes a goal, evaluate an OpenAPI/JSON Schema validator separately instead of extending the regular expressions.
+
 ## Strategy for Coupled Code
 
 For coupled framework code, prefer this order:

--- a/tests/Http/OpenApiRuntimeContractTest.php
+++ b/tests/Http/OpenApiRuntimeContractTest.php
@@ -8,6 +8,15 @@ require_once __DIR__ . '/HttpRuntimeTestCase.php';
 
 final class OpenApiRuntimeContractTest extends HttpRuntimeTestCase
 {
+    /*
+     * This test intentionally uses a lightweight line-based OpenAPI reader.
+     * Its current purpose is a runtime smoke check: documented REST operations
+     * should exist, and observed HTTP statuses should be listed in the contract.
+     *
+     * It is not a general YAML parser. When the OpenAPI contract grows beyond
+     * this simple path/method/status check, replace this extraction logic with
+     * a dev dependency such as symfony/yaml before adding richer assertions.
+     */
     public function testDocumentedRestOperationsRespondWithDocumentedStatuses(): void
     {
         $openApiResponse = $this->client->request('GET', '/api-docs/openapi.php');


### PR DESCRIPTION
## Summary
- `OpenApiRuntimeContractTest` が軽量な line-based reader である理由をコードコメントに追記
- `docs/development/testing.md` に現在の OpenAPI contract test の範囲と parser 導入基準を記録
- `docs/api/README.md` に `symfony/yaml` や schema validator 検討タイミングを明記

## Test plan
- `php -l tests/Http/OpenApiRuntimeContractTest.php`
- `composer test:http`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`

Closes #70

Made with [Cursor](https://cursor.com)