### PR TITLE
Phan baseline と静的解析設定を追加する

### DIFF
--- a/.phan/baseline.php
+++ b/.phan/baseline.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This is an automatically generated baseline for Phan issues.
+ * When Phan is invoked with --load-baseline=path/to/baseline.php,
+ * The pre-existing issues listed in this file won't be emitted.
+ *
+ * This file can be updated by invoking Phan with --save-baseline=path/to/baseline.php
+ * (can be combined with --load-baseline)
+ */
+return [
+    // # Issue statistics:
+    // PhanTypeMismatchReturn : 3 occurrences
+    // PhanPossiblyUndeclaredVariable : 2 occurrences
+    // PhanUndeclaredProperty : 2 occurrences
+    // PhanUnreferencedUseNormal : 2 occurrences
+    // PhanTypeMagicVoidWithReturn : 1 occurrence
+    // PhanTypeMismatchArgument : 1 occurrence
+    // PhanTypeMismatchArgumentInternal : 1 occurrence
+    // PhanTypeMismatchDimFetch : 1 occurrence
+    // PhanTypeMismatchForeach : 1 occurrence
+    // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
+    // PhanTypeMissingReturn : 1 occurrence
+    // PhanTypeSuspiciousStringExpression : 1 occurrence
+    // PhanUndeclaredConstantOfClass : 1 occurrence
+    // PhanUndeclaredTypeThrowsType : 1 occurrence
+    // PhanUndeclaredVariableDim : 1 occurrence
+    // PhanUnextractableAnnotation : 1 occurrence
+
+    'file_suppressions' => [
+        'class/xion/ControllerBase.php' => [
+            'PhanTypeMissingReturn' => ['\\Nene\\Xion\\ControllerBase::preAction']
+        ],
+        'class/xion/DataMapperBase.php' => [
+            'PhanPossiblyUndeclaredVariable' => ['\\Nene\\Xion\\DataMapperBase::insert', '\\Nene\\Xion\\DataMapperBase::update'],
+            'PhanTypeMismatchReturn' => ['\\Nene\\Xion\\DataMapperBase::countAll', '\\Nene\\Xion\\DataMapperBase::countById', '\\Nene\\Xion\\DataMapperBase::insert'],
+            'PhanTypeSuspiciousStringExpression' => ['\\Nene\\Xion\\DataMapperBase::update'],
+            'PhanUndeclaredVariableDim' => ['\\Nene\\Xion\\DataMapperBase::update'],
+            'PhanUnreferencedUseNormal' => ['class/xion/DataMapperBase.php']
+        ],
+        'class/xion/DataModelBase.php' => [
+            'PhanTypeMagicVoidWithReturn' => ['\\Nene\\Xion\\DataModelBase::__set'],
+            'PhanTypeMismatchArgument' => ['\\Nene\\Xion\\DataModelBase::validate'],
+            'PhanTypeMismatchArgumentInternal' => ['\\Nene\\Xion\\DataModelBase::validate'],
+            'PhanTypeMismatchDimFetch' => ['\\Nene\\Xion\\DataModelBase::validate'],
+            'PhanTypeMismatchForeach' => ['\\Nene\\Xion\\DataModelBase::validate']
+        ],
+        'class/xion/ModelBase.php' => [
+            'PhanUnreferencedUseNormal' => ['class/xion/ModelBase.php']
+        ],
+        'class/xion/PdoConnection.php' => [
+            'PhanTypeMismatchPropertyProbablyReal' => ['\\Nene\\Xion\\PdoConnection::__destruct'],
+            'PhanUndeclaredConstantOfClass' => ['\\Nene\\Xion\\PdoConnection::__construct']
+        ],
+        'class/xion/Post.php' => [
+            'PhanUndeclaredProperty' => ['\\Nene\\Xion\\Post::setValues']
+        ],
+        'class/xion/QueryString.php' => [
+            'PhanUndeclaredProperty' => ['\\Nene\\Xion\\QueryString::setValues']
+        ],
+        'class/xion/RequestVariables.php' => [
+            'PhanUnextractableAnnotation' => ['\\Nene\\Xion\\RequestVariables']
+        ],
+        'class/xion/View.php' => [
+            'PhanUndeclaredTypeThrowsType' => ['\\Nene\\Xion\\View::__clone']
+        ],
+    ],
+    // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
+    // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
+];

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'target_php_version' => '8.4',
+    'minimum_target_php_version' => '8.4',
+    'directory_list' => [
+        'class',
+        'cli',
+        'config',
+        'htdocs',
+        'ini',
+        'tests',
+        'vendor'
+    ],
+    'exclude_analysis_directory_list' => [
+        'vendor'
+    ],
+    'exclude_file_list' => [
+        '.php-cs-fixer.dist.php'
+    ],
+    'suppress_issue_types' => [
+        // The baseline records existing issues; keep this list for noisy
+        // environment-level checks that do not help with incremental cleanup.
+        'PhanPluginRemoveDebugAny'
+    ],
+    'allow_polyfill_parser' => true,
+    'dead_code_detection' => false,
+    'unused_variable_detection' => false,
+    'quick_mode' => true
+];

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,11 @@
         "test": "phpunit --testsuite unit",
         "test:http": "phpunit --testsuite http",
         "test:all": "phpunit",
+        "analyze": "phan --allow-polyfill-parser --load-baseline .phan/baseline.php",
         "check": [
             "@test",
-            "@test:http"
+            "@test:http",
+            "@analyze"
         ]
     }
 }

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -38,6 +38,16 @@ For CI-style verification that also confirms HTTP tests are either runnable or s
 composer check
 ```
 
+## Static Analysis
+
+Phan is configured under `.phan/config.php` and can be run through Composer:
+
+```sh
+composer analyze
+```
+
+The initial `.phan/baseline.php` records issues that already exist in the legacy codebase. New work should avoid adding fresh Phan issues; reduce the baseline gradually in focused PRs rather than mixing broad static-analysis cleanup into unrelated changes.
+
 ## Docker
 
 Tests can also run in the Docker container:


### PR DESCRIPTION
## Summary
- `.phan/config.php` を追加し、PHP 8.4 target で Phan を実行できるようにした
- 現在の既知指摘を `.phan/baseline.php` に固定
- `composer analyze` を追加し、`composer check` に Phan を組み込んだ
- 静的解析の運用方針を testing docs に追記

## Test plan
- `composer validate`
- `composer analyze`
- `composer check`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer check`

Closes #74

Made with [Cursor](https://cursor.com)