### PR TITLE
OpenAPI contract test を symfony/yaml で構造化する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.95",
         "phan/phan": "^6.0",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^10.5",
+        "symfony/yaml": "^6.4"
     },
     "scripts": {
         "test": "phpunit --testsuite unit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "450e2e5393228103896efd1937af1cd8",
+    "content-hash": "277044197fe47226b1243532758148fb",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -5114,6 +5114,82 @@
                 }
             ],
             "time": "2026-02-08T20:44:54+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v6.4.38",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "f8d2f4af29053842c01b4cae6bd4c2c3191fc63c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8d2f4af29053842c01b4cae6bd4c2c3191fc63c",
+                "reference": "f8d2f4af29053842c01b4cae6bd4c2c3191fc63c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v6.4.38"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-05T06:55:40+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -27,9 +27,9 @@ http://localhost:8080/api-docs/
 
 ## Contract Test Parser Policy
 
-The current runtime contract test uses a small line-based reader for `openapi.yaml`. That is acceptable while the contract is small and the test only checks path, method, and documented HTTP status coverage.
+The runtime contract test parses `openapi.yaml` with `symfony/yaml`. This keeps the test resilient to normal YAML formatting changes while still keeping the assertion scope small.
 
-Before expanding the test into richer OpenAPI assertions, parse the YAML with a real parser such as `symfony/yaml` in `require-dev`. If the project starts validating response bodies against schemas, choose an OpenAPI/JSON Schema validation library deliberately instead of extending the current regular expressions.
+Before expanding the test into response body validation, choose an OpenAPI/JSON Schema validation library deliberately. Do not turn the runtime smoke test into a custom full OpenAPI validator.
 
 ## REST Convention
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -85,9 +85,9 @@ HTTP tests use a test title prefix and clean up matching TODO rows before each r
 
 ## OpenAPI Contract Test Scope
 
-`OpenApiRuntimeContractTest` currently reads `docs/api/openapi.yaml` with a lightweight line-based parser. This is intentional for the current small contract: the test only verifies that documented REST operations exist and that observed runtime HTTP statuses are listed in OpenAPI.
+`OpenApiRuntimeContractTest` reads `docs/api/openapi.yaml` with `symfony/yaml` and verifies a small runtime contract: documented REST operations must exist, and observed runtime HTTP statuses must be listed in OpenAPI.
 
-Do not treat that parser as a general YAML implementation. When OpenAPI grows to include broader `$ref` usage, shared response composition, many more paths, or response body schema validation, add a dev dependency such as `symfony/yaml` and parse the contract as structured data before expanding the assertions. If schema validation becomes a goal, evaluate an OpenAPI/JSON Schema validator separately instead of extending the regular expressions.
+This is not a full OpenAPI validator. When OpenAPI grows to require response body schema validation, evaluate an OpenAPI/JSON Schema validator separately instead of expanding this smoke test into a custom validator.
 
 ## Strategy for Coupled Code
 

--- a/tests/Http/OpenApiRuntimeContractTest.php
+++ b/tests/Http/OpenApiRuntimeContractTest.php
@@ -4,23 +4,22 @@ declare(strict_types=1);
 
 namespace Nene\Tests\Http;
 
+use Symfony\Component\Yaml\Yaml;
+
 require_once __DIR__ . '/HttpRuntimeTestCase.php';
 
 final class OpenApiRuntimeContractTest extends HttpRuntimeTestCase
 {
     /*
-     * This test intentionally uses a lightweight line-based OpenAPI reader.
-     * Its current purpose is a runtime smoke check: documented REST operations
-     * should exist, and observed HTTP statuses should be listed in the contract.
-     *
-     * It is not a general YAML parser. When the OpenAPI contract grows beyond
-     * this simple path/method/status check, replace this extraction logic with
-     * a dev dependency such as symfony/yaml before adding richer assertions.
+     * This is still a runtime smoke check rather than a full OpenAPI validator:
+     * documented REST operations should exist, and observed HTTP statuses
+     * should be listed in the contract. symfony/yaml is used so this test reads
+     * the contract as structured data instead of depending on indentation.
      */
     public function testDocumentedRestOperationsRespondWithDocumentedStatuses(): void
     {
         $openApiResponse = $this->client->request('GET', '/api-docs/openapi.php');
-        $openApi = $openApiResponse->body();
+        $openApi = $this->parseOpenApi($openApiResponse->body());
         $operations = $this->documentedOperations($openApi);
 
         $examples = [
@@ -53,63 +52,50 @@ final class OpenApiRuntimeContractTest extends HttpRuntimeTestCase
     }
 
     /**
+     * @return array<string,mixed>
+     */
+    private function parseOpenApi(string $yaml): array
+    {
+        $parsed = Yaml::parse($yaml);
+
+        self::assertIsArray($parsed);
+        return $parsed;
+    }
+
+    /**
+     * @param array<string,mixed> $openApi Parsed OpenAPI document.
+     *
      * @return array<int,array{0:string,1:string}>
      */
-    private function documentedOperations(string $openApi): array
+    private function documentedOperations(array $openApi): array
     {
         $operations = [];
-        $currentPath = null;
-        foreach (explode("\n", $openApi) as $line) {
-            if (preg_match('/^  (\/[^:]+):$/', $line, $matches)) {
-                $currentPath = $matches[1];
+        $paths = $openApi['paths'] ?? [];
+        self::assertIsArray($paths);
+
+        foreach ($paths as $path => $pathItem) {
+            if (!is_string($path) || !is_array($pathItem)) {
                 continue;
             }
-            if ($currentPath !== null && preg_match('/^    (get|post|put|patch|delete):$/', $line, $matches)) {
-                $operations[] = [strtoupper($matches[1]), $currentPath];
+            foreach (['get', 'post', 'put', 'patch', 'delete'] as $method) {
+                if (array_key_exists($method, $pathItem)) {
+                    $operations[] = [strtoupper($method), $path];
+                }
             }
         }
         return $operations;
     }
 
     /**
+     * @param array<string,mixed> $openApi Parsed OpenAPI document.
+     *
      * @return array<int,string>
      */
-    private function documentedStatuses(string $openApi, string $path, string $method): array
+    private function documentedStatuses(array $openApi, string $path, string $method): array
     {
-        $lines = explode("\n", $openApi);
-        $insidePath = false;
-        $insideMethod = false;
-        $insideResponses = false;
-        $statuses = [];
+        $responses = $openApi['paths'][$path][strtolower($method)]['responses'] ?? [];
+        self::assertIsArray($responses);
 
-        foreach ($lines as $line) {
-            if (preg_match('/^  (\/[^:]+):$/', $line, $matches)) {
-                $insidePath = $matches[1] === $path;
-                $insideMethod = false;
-                $insideResponses = false;
-                continue;
-            }
-            if (!$insidePath) {
-                continue;
-            }
-            if (preg_match('/^    (get|post|put|patch|delete):$/', $line, $matches)) {
-                $insideMethod = strtoupper($matches[1]) === strtoupper($method);
-                $insideResponses = false;
-                continue;
-            }
-            if ($insideMethod && preg_match('/^      responses:$/', $line)) {
-                $insideResponses = true;
-                continue;
-            }
-            if ($insideResponses && preg_match('/^        "(\d{3})":$/', $line, $matches)) {
-                $statuses[] = $matches[1];
-                continue;
-            }
-            if ($insideResponses && preg_match('/^      [a-zA-Z_][^:]*:/', $line)) {
-                break;
-            }
-        }
-
-        return $statuses;
+        return array_map('strval', array_keys($responses));
     }
 }


### PR DESCRIPTION
## Summary
- `symfony/yaml` を require-dev に追加
- `OpenApiRuntimeContractTest` を line-based parsing から YAML parse ベースへ変更
- OpenAPI parser 方針の docs を現在の実装に合わせて更新

## Test plan
- `php -l tests/Http/OpenApiRuntimeContractTest.php`
- `composer validate`
- `composer test:http`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer check`

Closes #78

Made with [Cursor](https://cursor.com)