### PR TITLE
security(error): 公開エラー表示を環境制御にする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@
 # HTTP port exposed by the app container.
 NENE_PORT=8080
 
+# Runtime mode. Keep debug output disabled outside trusted local development.
+NENE_APP_ENV=development
+NENE_APP_DEBUG=1
+
 # MySQL port exposed on the host machine.
 NENE_MYSQL_PORT=3307
 

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -18,11 +18,11 @@ declare(strict_types=1);
 namespace Nene\Xion;
 
 use Monolog\Logger;
-use Nene\Database   as Database;
-use Nene\Xion       as Xion;
-use Nene\Func       as Func;
-use PDOStatement;
+use Nene\Database as Database;
+use Nene\Func as Func;
+use Nene\Xion as Xion;
 use PDO;
+use PDOStatement;
 
 /**
  * Abstract class for data mapper
@@ -266,7 +266,7 @@ abstract class DataMapperBase
      */
     public function findALL(int $limit = 0): PDOStatement
     {
-        $limitSQL = $limit === 0 ? '' : " LIMIT " . (int)$limit;
+        $limitSQL = $limit === 0 ? '' : ' LIMIT ' . (int)$limit;
         $stmt = $this->executeQuery('
             SELECT * FROM ' . static::TARGET_TABLE . '
             WHERE 1
@@ -321,7 +321,7 @@ abstract class DataMapperBase
         try {
             $stmt->execute();
         } catch (\PDOException $e) {
-            echo $e->getMessage();
+            $this->handleDatabaseException($e);
             exit();
         }
         return $stmt;
@@ -340,10 +340,24 @@ abstract class DataMapperBase
         try {
             $stmt = $this->DB->query($query);
         } catch (\PDOException $e) {
-            echo $e->getMessage();
+            $this->handleDatabaseException($e);
             exit();
         }
         return $stmt;
+    }
+
+    /**
+     * Handle database exceptions without exposing details in production.
+     *
+     * @param \PDOException $exception Database exception.
+     *
+     * @return void
+     */
+    private function handleDatabaseException(\PDOException $exception): void
+    {
+        $this->LOGGER->error('Database query failed.', ['exception' => $exception]);
+        http_response_code(500);
+        echo APP_DEBUG ? $exception->getMessage() : 'Internal Server Error';
     }
 
     /**

--- a/class/xion/PdoConnection.php
+++ b/class/xion/PdoConnection.php
@@ -71,7 +71,10 @@ class PdoConnection
                     break;
             }
         } catch (\PDOException $e) {
-            die('Connection failed : ' . $e->getMessage());
+            error_log('Database connection failed: ' . $e->getMessage());
+            http_response_code(500);
+            echo APP_DEBUG ? 'Connection failed : ' . $e->getMessage() : 'Internal Server Error';
+            exit();
         }
     }
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,8 @@ services:
       mysql:
         condition: service_healthy
     environment:
+      NENE_APP_ENV: "${NENE_APP_ENV:-development}"
+      NENE_APP_DEBUG: "${NENE_APP_DEBUG:-1}"
       NENE_DB_TYPE: "${NENE_DB_TYPE:-MySQL}"
       NENE_DB_HOST: "${NENE_DB_HOST:-mysql}"
       NENE_DB_PORT: "${NENE_DB_PORT:-3306}"

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -83,6 +83,16 @@ NENE_HTTP_BASE_URL=http://localhost:8080 composer check
 
 HTTP tests use a test title prefix and clean up matching TODO rows before each runtime test. Tests that create TODOs also register them for cleanup during teardown, so failed tests should not leave long-lived sample data behind.
 
+### Error Exposure Check
+
+`HttpErrorExposureTest` is an optional HTTP runtime test for public error responses. It runs only when `NENE_HTTP_ERROR_BASE_URL` points to a deliberately broken production-like app, for example one started with `NENE_APP_DEBUG=0` and invalid database settings.
+
+```sh
+NENE_HTTP_ERROR_BASE_URL=http://localhost:8081 vendor/bin/phpunit tests/Http/HttpErrorExposureTest.php
+```
+
+The test confirms that database connection failures return a generic `Internal Server Error` body instead of leaking `SQLSTATE` or connection details.
+
 ## OpenAPI Contract Test Scope
 
 `OpenApiRuntimeContractTest` reads `docs/api/openapi.yaml` with `symfony/yaml` and verifies a small runtime contract: documented REST operations must exist, and observed runtime HTTP statuses must be listed in OpenAPI.

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -1,14 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Nene;
 
 use Nene\Xion as Xion;
 
-ini_set('display_errors', '1');             // DISPLAY ERROR
-error_reporting(E_ALL);                     // ERROR REPORT
-session_cache_expire(180);                  // SESSION => 3H
-date_default_timezone_set('Asia/Tokyo');    // TIME ZONE
-session_start();                            // SESSION START
+ini_set('display_errors', '0');
+ini_set('log_errors', '1');
+error_reporting(E_ALL);
 
 /**
  * AYANE : ayane.co.jp
@@ -23,9 +23,24 @@ session_start();                            // SESSION START
  *
  * @author HideyukiMORI
  */
-require_once '../vendor/autoload.php';       // AUTO LOAD
+require_once '../vendor/autoload.php';
 
 Xion\Initialize::init();
+
+configurePublicErrorDisplay();
+session_cache_expire(180);
+date_default_timezone_set('Asia/Tokyo');
+session_start();
+
 $dispatcher = new Xion\Dispatcher();
 $dispatcher->dispatch();
 exit();
+
+/**
+ * Configure whether PHP errors can be shown in HTTP responses.
+ */
+function configurePublicErrorDisplay(): void
+{
+    ini_set('display_errors', APP_DEBUG ? '1' : '0');
+    ini_set('display_startup_errors', APP_DEBUG ? '1' : '0');
+}

--- a/ini/xSystemIni.php
+++ b/ini/xSystemIni.php
@@ -28,6 +28,11 @@ declare(strict_types=1);
  * - Use define() for values that are resolved at runtime, such as paths based
  *   on __DIR__ or values read from environment variables.
  *
+ * Runtime mode:
+ * - NENE_APP_ENV names the runtime environment.
+ * - NENE_APP_DEBUG controls whether detailed PHP errors may be shown in HTTP
+ *   responses. Keep it disabled outside trusted local development.
+ *
  * Local development:
  * - Docker Compose passes NENE_DB_* values into the application container.
  * - Without those variables, NeNe falls back to the SQLite-oriented defaults
@@ -66,12 +71,19 @@ $getEnv = static function (string $name, string $default): string {
 /*
  * Application.
  *
- * VERSION is exposed to templates for cache-busting and display. DEBUG_MODE is
- * currently a legacy integer flag because templates and framework code expect
- * 1 or 0 rather than a boolean.
+ * VERSION is exposed to templates for cache-busting and display. APP_DEBUG is
+ * the runtime boolean flag; DEBUG_MODE remains the legacy integer equivalent
+ * because templates and framework code expect 1 or 0.
  */
 const VERSION = '0.0.0.1';
-const DEBUG_MODE = 1; // 1 = on, 0 = off.
+define('APP_ENV', $getEnv('NENE_APP_ENV', 'development'));
+define('APP_DEBUG', in_array(strtolower($getEnv('NENE_APP_DEBUG', APP_ENV === 'production' ? '0' : '1')), [
+    '1',
+    'true',
+    'on',
+    'yes',
+], true));
+define('DEBUG_MODE', APP_DEBUG ? 1 : 0); // 1 = on, 0 = off.
 const LOG_LEVEL = 'INFO'; // EMERGENCY or INFO.
 
 // Session namespace used by the original framework session connection.

--- a/tests/Http/HttpErrorExposureTest.php
+++ b/tests/Http/HttpErrorExposureTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/HttpClient.php';
+
+final class HttpErrorExposureTest extends TestCase
+{
+    private const ERROR_BASE_URL_ENV = 'NENE_HTTP_ERROR_BASE_URL';
+
+    public function testProductionErrorResponseDoesNotExposeDatabaseDetails(): void
+    {
+        $baseUrl = (string)getenv(self::ERROR_BASE_URL_ENV);
+        if ($baseUrl === '') {
+            self::markTestSkipped(self::ERROR_BASE_URL_ENV . ' is not configured.');
+        }
+
+        $client = new HttpClient($baseUrl);
+        $response = $client->json('POST', '/session/login', [
+            'user_id' => 'admin',
+            'user_pass' => 'admin',
+        ]);
+
+        self::assertSame(500, $response->statusCode());
+        self::assertSame('Internal Server Error', $response->body());
+        self::assertStringNotContainsString('SQLSTATE', $response->body());
+        self::assertStringNotContainsString('Connection failed', $response->body());
+    }
+}


### PR DESCRIPTION
## Summary
- `NENE_APP_ENV` / `NENE_APP_DEBUG` で public error display を制御するようにしました。
- DB 接続・クエリ例外は production 相当では `Internal Server Error` のみ返し、詳細はログへ寄せます。
- 壊れた DB 接続先に対する optional HTTP runtime test を追加しました。

## Test plan
- `php -l htdocs/index.php ini/xSystemIni.php class/xion/DataMapperBase.php class/xion/PdoConnection.php tests/Http/HttpErrorExposureTest.php`
- `composer test`
- `composer analyze`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff htdocs/index.php ini/xSystemIni.php class/xion/DataMapperBase.php class/xion/PdoConnection.php tests/Http/HttpErrorExposureTest.php`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `NENE_HTTP_ERROR_BASE_URL=http://localhost:18082 vendor/bin/phpunit tests/Http/HttpErrorExposureTest.php`

Closes #80

Made with [Cursor](https://cursor.com)