### PR TITLE
security(auth): 保存パスワードを hash 化する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,6 @@ NENE_DB_ROOT_PASS=root
 
 # SQLite fallback file name. Used when NENE_DB_TYPE=SQLite3.
 NENE_DB_FILE=nene.db
+
+# Optional SQLite initializer sample password override. The value is hashed before insert.
+NENE_SAMPLE_ADMIN_PASSWORD=admin

--- a/class/db/User.php
+++ b/class/db/User.php
@@ -37,7 +37,7 @@ class User extends DataModelBase
         'user_pass'  => parent::STRING,
         'user_name'  => parent::STRING,
         'e_mail'     => parent::STRING,
-        'is_deleted' => parent::STRING
+        'is_deleted' => parent::STRING,
     ];
 
     /**
@@ -46,13 +46,12 @@ class User extends DataModelBase
      * @var array
      */
     protected static $validation = [
-        'user_id'    => ['required' => true],
         'created_at' => ['required' => true],
         'updated_at' => ['required' => true],
         'user_id'    => ['required' => true, 'maxlength' => 64],
-        'user_pass'  => ['required' => true, 'maxlength' => 64, 'minlength' => 6],
+        'user_pass'  => ['required' => true, 'maxlength' => 255, 'minlength' => 6],
         'user_name'  => ['required' => true, 'maxlength' => 255],
         'e_mail'     => ['required' => true, 'maxlength' => 255],
-        'is_deleted' => ['required' => true, 'bool' => true]
+        'is_deleted' => ['required' => true, 'bool' => true],
     ];
 }

--- a/class/db/UserMapper.php
+++ b/class/db/UserMapper.php
@@ -50,15 +50,28 @@ class UserMapper extends DataMapperBase
      */
     final public function checkLogin(string $user_id, string $user_pass): int
     {
+        return $this->findByCredentials($user_id, $user_pass) === null ? 0 : 1;
+    }
+
+    /**
+     * Find an active user by user ID.
+     *
+     * @param string $user_id User ID.
+     *
+     * @return array<string,mixed>|null User row including password hash.
+     */
+    private function findActiveUserByUserId(string $user_id): ?array
+    {
         $stmt = $this->DB->prepare('
-            SELECT COUNT(*) FROM ' . static::TARGET_TABLE . '
-            WHERE   user_id =:user_id
-            AND     user_pass =:user_pass
+            SELECT id, user_id, user_pass, user_name, e_mail
+            FROM ' . static::TARGET_TABLE . '
+            WHERE user_id = :user_id
+            AND is_deleted = 0
             LIMIT 1
         ');
-        $stmt->bindParam(':user_id', $user_id, PDO::PARAM_STR);
-        $stmt->bindParam(':user_pass', $user_pass, PDO::PARAM_STR);
-        return (int)$this->execute($stmt)->fetchColumn();
+        $stmt->bindValue(':user_id', $user_id, PDO::PARAM_STR);
+        $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+        return is_array($row) ? $row : null;
     }
 
     /**
@@ -71,17 +84,12 @@ class UserMapper extends DataMapperBase
      */
     final public function findByCredentials(string $user_id, string $user_pass): ?array
     {
-        $stmt = $this->DB->prepare('
-            SELECT id, user_id, user_name, e_mail
-            FROM ' . static::TARGET_TABLE . '
-            WHERE user_id = :user_id
-            AND user_pass = :user_pass
-            AND is_deleted = 0
-            LIMIT 1
-        ');
-        $stmt->bindValue(':user_id', $user_id, PDO::PARAM_STR);
-        $stmt->bindValue(':user_pass', $user_pass, PDO::PARAM_STR);
-        $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
-        return is_array($row) ? $row : null;
+        $row = $this->findActiveUserByUserId($user_id);
+        if ($row === null || !password_verify($user_pass, (string)$row['user_pass'])) {
+            return null;
+        }
+
+        unset($row['user_pass']);
+        return $row;
     }
 }

--- a/cli/initSQLite.php
+++ b/cli/initSQLite.php
@@ -65,7 +65,7 @@ function initializeSQLite(string $databaseDir, string $databaseFile): void
     syncDatabaseFilePermissions($databaseDir, $databasePath);
 
     echo 'SQLite database is ready: ' . $databasePath . PHP_EOL;
-    echo 'Default account: admin / admin' . PHP_EOL;
+    echo 'Default development account: admin / admin' . PHP_EOL;
 }
 
 /**
@@ -134,13 +134,17 @@ SQL);
  */
 function seedSampleData(PDO $db): void
 {
-    $db->exec(<<<'SQL'
+    $adminPasswordHash = password_hash((string)(getenv('NENE_SAMPLE_ADMIN_PASSWORD') ?: 'admin'), PASSWORD_DEFAULT);
+
+    $stmt = $db->prepare(<<<'SQL'
 INSERT INTO users (user_id, user_pass, user_name, e_mail, is_deleted)
-SELECT 'admin', 'admin', 'admin', 'admin@example.com', 0
+SELECT 'admin', :user_pass, 'admin', 'admin@example.com', 0
 WHERE NOT EXISTS (
     SELECT 1 FROM users WHERE user_id = 'admin'
 )
 SQL);
+    $stmt->bindValue(':user_pass', $adminPasswordHash, PDO::PARAM_STR);
+    $stmt->execute();
 
     seedTodo($db, 'Read the routing guide', true);
     seedTodo($db, 'Create a controller action', false);

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,7 @@ services:
       NENE_DB_NAME: "${NENE_DB_NAME:-nene}"
       NENE_DB_USER: "${NENE_DB_USER:-nene}"
       NENE_DB_PASS: "${NENE_DB_PASS:-nene}"
+      NENE_SAMPLE_ADMIN_PASSWORD: "${NENE_SAMPLE_ADMIN_PASSWORD:-admin}"
     ports:
       - "${NENE_PORT:-8080}:80"
     volumes:

--- a/docker/mysql/init/001_schema.sql
+++ b/docker/mysql/init/001_schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS users (
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     user_id VARCHAR(64) NOT NULL,
-    user_pass VARCHAR(64) NOT NULL,
+    user_pass VARCHAR(255) NOT NULL,
     user_name VARCHAR(255) NOT NULL,
     e_mail VARCHAR(255) NOT NULL,
     is_deleted TINYINT(1) NOT NULL DEFAULT 0,
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS todos (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 INSERT INTO users (user_id, user_pass, user_name, e_mail, is_deleted)
-SELECT 'admin', 'admin', 'admin', 'admin@example.com', 0
+SELECT 'admin', '$2y$10$vzh5MQipioE5H4GkmRttzekB3s/z5dr.tEnBBOENSW3s.pdyoy906', 'admin', 'admin@example.com', 0
 WHERE NOT EXISTS (
     SELECT 1 FROM users WHERE user_id = 'admin'
 );

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -87,7 +87,7 @@ user: admin
 password: admin
 ```
 
-Do not use this account in production.
+The seed stores this password with PHP `password_hash()` and the app verifies it with `password_verify()`. The credential is only for the local sample; do not use this account in production.
 
 To expose MySQL on another host port:
 
@@ -107,6 +107,12 @@ The SQLite initializer remains available for non-Docker or fallback usage. It cr
 
 ```sh
 docker compose run --rm app sh -lc "printf 'Y\n' | php cli/initSQLite.php"
+```
+
+For SQLite-only sample data, `NENE_SAMPLE_ADMIN_PASSWORD` can override the inserted admin password before it is hashed:
+
+```sh
+NENE_DB_TYPE=SQLite3 NENE_SAMPLE_ADMIN_PASSWORD=local-secret docker compose run --rm app sh -lc "printf 'Y\n' | php cli/initSQLite.php"
 ```
 
 To run the application against SQLite instead of the Docker MySQL service, start the app with SQLite environment values:


### PR DESCRIPTION
## Summary
- `UserMapper` のログイン照合を平文比較から `password_verify()` に変更しました。
- MySQL seed の `users.user_pass` を hash 済みにし、カラム長を 255 に広げました。
- SQLite initializer は `password_hash()` で sample password を保存し、SQLite 用 override を docs に記録しました。

## Test plan
- `php -l class/db/UserMapper.php class/db/User.php cli/initSQLite.php`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `docker compose run --rm --no-deps -e NENE_DB_TYPE=SQLite3 -e NENE_DB_FILE=issue82_test.db app sh -lc "printf 'Y\\n' | php cli/initSQLite.php && php -r '...'"`

Closes #82

Made with [Cursor](https://cursor.com)