### PR TITLE
security(csrf): 状態変更 API に CSRF token を要求する

### DIFF
--- a/class/controller/SessionController.php
+++ b/class/controller/SessionController.php
@@ -51,7 +51,10 @@ class SessionController extends ControllerBase
             return $this->API_RESPONSE->failure('LOGIN-FAILED');
         }
         $loginUser = $this->AUTH_SESSION->login($user);
-        return $this->API_RESPONSE->success(['user' => $loginUser]);
+        return $this->API_RESPONSE->success([
+            'user' => $loginUser,
+            'csrfToken' => $this->AUTH_SESSION->csrfToken(),
+        ]);
     }
 
     /**

--- a/class/xion/AuthSession.php
+++ b/class/xion/AuthSession.php
@@ -70,6 +70,7 @@ class AuthSession
         ];
         $_SESSION['xion']['login_mode'] = 'login';
         $_SESSION['xion']['user'] = $loginUser;
+        $_SESSION['xion']['csrf_token'] = bin2hex(random_bytes(32));
         return $loginUser;
     }
 
@@ -162,6 +163,29 @@ class AuthSession
     {
         $user = $this->user();
         return $user === null ? '' : (string)($user['user_id'] ?? '');
+    }
+
+    /**
+     * Get the CSRF token for the current authenticated session.
+     *
+     * @return string CSRF token.
+     */
+    final public function csrfToken(): string
+    {
+        return (string)($_SESSION['xion']['csrf_token'] ?? '');
+    }
+
+    /**
+     * Verify a submitted CSRF token against the authenticated session token.
+     *
+     * @param string $token Submitted CSRF token.
+     *
+     * @return boolean Whether the token is valid.
+     */
+    final public function verifyCsrfToken(string $token): bool
+    {
+        $sessionToken = $this->csrfToken();
+        return $sessionToken !== '' && hash_equals($sessionToken, $token);
     }
 
     /**

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -215,6 +215,14 @@ abstract class ControllerBase
         if ($this->SESSION_CHECK) {
             $this->sessionCheck();
         }
+        if ($this->requiresCsrfProtection() && !$this->AUTH_SESSION->verifyCsrfToken($this->csrfTokenFromRequest())) {
+            Func\Json::outputArrayToJson(
+                $this->API_RESPONSE->failure('CSRF-TOKEN-INVALID'),
+                $this->OUTPUT_JSON_STYLE,
+                filter_input(INPUT_GET, 'callback') ?: '',
+                $this->SESSION_CHECK
+            );
+        }
 
         $methodName = $this->ROUTE_CONTEXT->method();
         $return = $this->$methodName();
@@ -387,6 +395,32 @@ abstract class ControllerBase
     final protected function logout(bool $destroySession = false): void
     {
         $this->AUTH_SESSION->logout($destroySession);
+    }
+
+    /**
+     * Determine whether the current REST request must include a CSRF token.
+     *
+     * @return boolean Whether CSRF validation is required.
+     */
+    final protected function requiresCsrfProtection(): bool
+    {
+        if (!$this->ROUTE_CONTEXT->isRest() || !in_array($this->method, ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+            return false;
+        }
+        if ($this->ROUTE_CONTEXT->method() === 'loginPostRest') {
+            return false;
+        }
+        return $this->AUTH_SESSION->isLoggedIn();
+    }
+
+    /**
+     * Read the CSRF token from the request header.
+     *
+     * @return string Submitted token.
+     */
+    final protected function csrfTokenFromRequest(): string
+    {
+        return (string)($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');
     }
 
     /**

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -5,22 +5,26 @@ declare(strict_types=1);
 return [
     'SESSION-CLOSED' => [
         'message' => 'Session timeout. Please log in again.',
-        'httpStatus' => 200
+        'httpStatus' => 200,
     ],
     'LOGIN-FAILED' => [
         'message' => 'Wrong user ID or user PASS',
-        'httpStatus' => 200
+        'httpStatus' => 200,
+    ],
+    'CSRF-TOKEN-INVALID' => [
+        'message' => 'Invalid CSRF token.',
+        'httpStatus' => 403,
     ],
     'TODO-ID-REQUIRED' => [
         'message' => 'TODO id is required.',
-        'httpStatus' => 400
+        'httpStatus' => 400,
     ],
     'TODO-NOT-FOUND' => [
         'message' => 'TODO item was not found.',
-        'httpStatus' => 404
+        'httpStatus' => 404,
     ],
     'TODO-TITLE-REQUIRED' => [
         'message' => 'TODO title is required.',
-        'httpStatus' => 400
-    ]
+        'httpStatus' => 400,
+    ],
 ];

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -42,3 +42,7 @@ Example:
 ```
 
 OpenAPI paths should describe the URL and the request/response contract, not the internal method name.
+
+## CSRF Protection
+
+Cookie-authenticated state-changing REST requests must send the `X-CSRF-Token` header. `/session/login` returns the token as `Data.csrfToken`; the React sample stores it in memory and sends it with TODO create/update/delete and logout requests.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -47,6 +47,7 @@ paths:
                     Data:
                       status: success
                       errorCode: ""
+                      csrfToken: sample-csrf-token
                       user:
                         id: 1
                         user_id: admin
@@ -63,6 +64,9 @@ paths:
         - Session
       summary: Sign out from the sample application
       operationId: logout
+      security:
+        - sessionCookie: []
+          csrfToken: []
       responses:
         "200":
           description: Logout completed.
@@ -70,6 +74,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BasicSuccessEnvelope"
+        "403":
+          description: CSRF token was missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CsrfTokenInvalidEnvelope"
   /todo/index:
     get:
       tags:
@@ -96,6 +106,7 @@ paths:
       operationId: createTodo
       security:
         - sessionCookie: []
+          csrfToken: []
       requestBody:
         required: true
         content:
@@ -121,6 +132,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TodoTitleRequiredEnvelope"
+        "403":
+          description: CSRF token was missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CsrfTokenInvalidEnvelope"
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
   /todo/item/id_{id}:
@@ -131,6 +148,7 @@ paths:
       operationId: updateTodo
       security:
         - sessionCookie: []
+          csrfToken: []
       parameters:
         - $ref: "#/components/parameters/TodoId"
       requestBody:
@@ -165,6 +183,12 @@ paths:
                   - $ref: "#/components/schemas/TodoTitleRequiredEnvelope"
         "404":
           $ref: "#/components/responses/TodoNotFound"
+        "403":
+          description: CSRF token was missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CsrfTokenInvalidEnvelope"
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
     delete:
@@ -174,6 +198,7 @@ paths:
       operationId: deleteTodo
       security:
         - sessionCookie: []
+          csrfToken: []
       parameters:
         - $ref: "#/components/parameters/TodoId"
       responses:
@@ -193,6 +218,12 @@ paths:
                 $ref: "#/components/schemas/TodoIdRequiredEnvelope"
         "404":
           $ref: "#/components/responses/TodoNotFound"
+        "403":
+          description: CSRF token was missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CsrfTokenInvalidEnvelope"
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
 components:
@@ -202,6 +233,11 @@ components:
       in: cookie
       name: PHPSESSID
       description: PHP session cookie created by `/session/login`.
+    csrfToken:
+      type: apiKey
+      in: header
+      name: X-CSRF-Token
+      description: CSRF token returned by `/session/login` as `Data.csrfToken`.
   parameters:
     TodoId:
       name: id
@@ -306,9 +342,12 @@ components:
                 - type: object
                   required:
                     - user
+                    - csrfToken
                   properties:
                     user:
                       $ref: "#/components/schemas/LoginUser"
+                    csrfToken:
+                      type: string
     LoginFailureEnvelope:
       $ref: "#/components/schemas/LoginFailedEnvelope"
     Todo:
@@ -431,6 +470,20 @@ components:
                       const: LOGIN-FAILED
                     errorMessage:
                       const: Wrong user ID or user PASS
+    CsrfTokenInvalidEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/ErrorEnvelope"
+        - type: object
+          properties:
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiFailureData"
+                - type: object
+                  properties:
+                    errorCode:
+                      const: CSRF-TOKEN-INVALID
+                    errorMessage:
+                      const: Invalid CSRF token.
     TodoIdRequiredEnvelope:
       allOf:
         - $ref: "#/components/schemas/ErrorEnvelope"

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -141,6 +141,9 @@ document.addEventListener('DOMContentLoaded', function() {
         const userState = useState(null);
         const user = userState[0];
         const setUser = userState[1];
+        const csrfTokenState = useState('');
+        const csrfToken = csrfTokenState[0];
+        const setCsrfToken = csrfTokenState[1];
 
         useEffect(function() {
             if (isSignedIn) {
@@ -153,6 +156,9 @@ document.addEventListener('DOMContentLoaded', function() {
             requestOptions.headers = Object.assign({
                 'Content-Type': 'application/json'
             }, requestOptions.headers || {});
+            if (csrfToken && requestOptions.method && requestOptions.method.toUpperCase() !== 'GET') {
+                requestOptions.headers['X-CSRF-Token'] = csrfToken;
+            }
             return fetch(url, requestOptions)
                 .then(function(response) {
                     return response.json().then(function(body) {
@@ -206,6 +212,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 })
             }).then(function(data) {
                 setUser(data.user);
+                setCsrfToken(data.csrfToken || '');
                 setIsSignedIn(true);
             }).catch(function(error) {
                 setLoginError(error.message);
@@ -276,6 +283,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 setTask('');
                 setStatus('');
                 setUser(null);
+                setCsrfToken('');
                 setIsSignedIn(false);
             }).catch(function(error) {
                 setStatus(error.message);

--- a/tests/Http/HttpClient.php
+++ b/tests/Http/HttpClient.php
@@ -23,6 +23,13 @@ final class HttpClient
      */
     private $cookies = [];
 
+    /**
+     * CSRF token returned by the login API.
+     *
+     * @var string
+     */
+    private $csrfToken = '';
+
     public function __construct(string $baseUrl)
     {
         $this->baseUrl = rtrim($baseUrl, '/');
@@ -55,6 +62,9 @@ final class HttpClient
      */
     public function request(string $method, string $path, ?string $body = null, array $headers = []): HttpResponse
     {
+        if ($this->csrfToken !== '' && strtoupper($method) !== 'GET' && !isset($headers['X-CSRF-Token'])) {
+            $headers['X-CSRF-Token'] = $this->csrfToken;
+        }
         $requestHeaders = $this->formatHeaders($headers);
         $cookieHeader = $this->buildCookieHeader();
         if ($cookieHeader !== '') {
@@ -67,8 +77,8 @@ final class HttpClient
                 'header' => implode("\r\n", $requestHeaders),
                 'content' => $body ?? '',
                 'ignore_errors' => true,
-                'timeout' => 5
-            ]
+                'timeout' => 5,
+            ],
         ]);
 
         $responseHeaders = [];
@@ -82,7 +92,13 @@ final class HttpClient
 
         $response = HttpResponse::fromRawHeaders($responseHeaders, $responseBody);
         $this->storeCookies($response->headers());
+        $this->storeCsrfToken($response);
         return $response;
+    }
+
+    public function setCsrfToken(string $csrfToken): void
+    {
+        $this->csrfToken = $csrfToken;
     }
 
     /**
@@ -121,6 +137,14 @@ final class HttpClient
             if (count($parts) === 2) {
                 $this->cookies[$parts[0]] = $parts[1];
             }
+        }
+    }
+
+    private function storeCsrfToken(HttpResponse $response): void
+    {
+        $decoded = json_decode($response->body(), true);
+        if (is_array($decoded) && isset($decoded['Data']['csrfToken']) && is_string($decoded['Data']['csrfToken'])) {
+            $this->csrfToken = $decoded['Data']['csrfToken'];
         }
     }
 }

--- a/tests/Http/HttpErrorTest.php
+++ b/tests/Http/HttpErrorTest.php
@@ -12,7 +12,7 @@ final class HttpErrorTest extends HttpRuntimeTestCase
     {
         $response = $this->client->json('POST', '/session/login', [
             'user_id' => 'admin',
-            'user_pass' => 'wrong'
+            'user_pass' => 'wrong',
         ]);
         $payload = $response->json();
 
@@ -33,12 +33,40 @@ final class HttpErrorTest extends HttpRuntimeTestCase
         self::assertSame('TODO-TITLE-REQUIRED', $payload['Data']['errorCode']);
     }
 
+    public function testStateChangingTodoRequestRequiresValidCsrfToken(): void
+    {
+        $this->loginAsAdmin();
+        $this->client->setCsrfToken('invalid-token');
+
+        $response = $this->client->json('POST', '/todo/index', [
+            'title' => self::TEST_TODO_PREFIX . 'csrf',
+        ]);
+        $payload = $response->json();
+
+        self::assertSame(403, $response->statusCode());
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('CSRF-TOKEN-INVALID', $payload['Data']['errorCode']);
+    }
+
+    public function testLogoutRequiresValidCsrfToken(): void
+    {
+        $this->loginAsAdmin();
+        $this->client->setCsrfToken('invalid-token');
+
+        $response = $this->client->json('POST', '/session/logout');
+        $payload = $response->json();
+
+        self::assertSame(403, $response->statusCode());
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('CSRF-TOKEN-INVALID', $payload['Data']['errorCode']);
+    }
+
     public function testUpdatingMissingTodoReturnsNotFound(): void
     {
         $this->loginAsAdmin();
 
         $response = $this->client->json('PUT', '/todo/item/id_999999999', [
-            'title' => self::TEST_TODO_PREFIX . 'missing'
+            'title' => self::TEST_TODO_PREFIX . 'missing',
         ]);
         $payload = $response->json();
 
@@ -64,7 +92,7 @@ final class HttpErrorTest extends HttpRuntimeTestCase
         $this->loginAsAdmin();
 
         $response = $this->client->json('PUT', '/todo/item/id_invalid', [
-            'title' => self::TEST_TODO_PREFIX . 'invalid'
+            'title' => self::TEST_TODO_PREFIX . 'invalid',
         ]);
         $payload = $response->json();
 

--- a/tests/Http/HttpRuntimeTestCase.php
+++ b/tests/Http/HttpRuntimeTestCase.php
@@ -62,12 +62,13 @@ abstract class HttpRuntimeTestCase extends TestCase
         $client = $client ?? $this->client;
         $response = $client->json('POST', '/session/login', [
             'user_id' => 'admin',
-            'user_pass' => 'admin'
+            'user_pass' => 'admin',
         ]);
         $payload = $response->json();
 
         self::assertSame(200, $response->statusCode());
         self::assertSame('success', $payload['Data']['status']);
+        self::assertNotSame('', $payload['Data']['csrfToken'] ?? '');
         return $client;
     }
 

--- a/tests/Unit/Xion/AuthSessionTest.php
+++ b/tests/Unit/Xion/AuthSessionTest.php
@@ -34,6 +34,9 @@ final class AuthSessionTest extends TestCase
         self::assertSame(1, $authSession->userId());
         self::assertSame('admin', $authSession->userIdentifier());
         self::assertSame($user, $authSession->user());
+        self::assertNotSame('', $authSession->csrfToken());
+        self::assertTrue($authSession->verifyCsrfToken($authSession->csrfToken()));
+        self::assertFalse($authSession->verifyCsrfToken('invalid-token'));
     }
 
     public function testLogoutClearsAuthenticationSession(): void


### PR DESCRIPTION
## Summary
- `/session/login` で per-login CSRF token を発行し、状態変更 REST API で `X-CSRF-Token` を検証します。
- React sample と HTTP runtime client が token を送るようにしました。
- OpenAPI に CSRF header security scheme と 403 error response を追加しました。

## Test plan
- `php -l class/xion/AuthSession.php class/xion/ControllerBase.php class/controller/SessionController.php config/error_codes.php tests/Http/HttpClient.php tests/Http/HttpErrorTest.php tests/Http/HttpRuntimeTestCase.php tests/Unit/Xion/AuthSessionTest.php`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff class/xion/AuthSession.php class/xion/ControllerBase.php class/controller/SessionController.php config/error_codes.php tests/Http/HttpClient.php tests/Http/HttpErrorTest.php tests/Http/HttpRuntimeTestCase.php tests/Unit/Xion/AuthSessionTest.php`

Closes #83

Made with [Cursor](https://cursor.com)