### PR TITLE
security(jsonp): callback 名を検証する

### DIFF
--- a/class/func/Json.php
+++ b/class/func/Json.php
@@ -60,14 +60,12 @@ class Json
     ): void {
         $responseArray = [
             'Result' => true,
-            'Data'   => $jsonArray
+            'Data'   => $jsonArray,
         ];
         if ($format == 'jsonp') {
-            if ($callback == null || !$callback) {
-                $callback = 'jsonCallback';
-            }
+            $callback = self::sanitizeJsonpCallback($callback);
             $json = json_encode($responseArray, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
-            header("Content-type: application/x-javascript");
+            header('Content-Type: application/javascript; charset=utf-8');
             echo $callback . '(' . $json . ')';
         } else {
             $json = json_encode($responseArray);
@@ -75,6 +73,25 @@ class Json
             echo $json;
         }
         exit();
+    }
+
+    /**
+     * Allow only JavaScript identifier paths for legacy JSONP callbacks.
+     *
+     * @param string $callback Callback function name.
+     *
+     * @return string Safe callback function name.
+     */
+    final public static function sanitizeJsonpCallback(string $callback): string
+    {
+        $callback = trim($callback);
+        if ($callback === '') {
+            return 'jsonCallback';
+        }
+        if (preg_match('/^[A-Za-z_$][0-9A-Za-z_$]*(\.[A-Za-z_$][0-9A-Za-z_$]*)*$/', $callback) !== 1) {
+            return 'jsonCallback';
+        }
+        return $callback;
     }
 
     /**
@@ -91,8 +108,8 @@ class Json
             'Result' => false,
             'Error'  => [
                 'ErrorCode'    => $errorCode,
-                'ErrorMessage' => $errorMessage
-            ]
+                'ErrorMessage' => $errorMessage,
+            ],
         ];
         $json = json_encode($responseArray);
         header('Content-Type: application/json; charset=utf-8');

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -46,3 +46,7 @@ OpenAPI paths should describe the URL and the request/response contract, not the
 ## CSRF Protection
 
 Cookie-authenticated state-changing REST requests must send the `X-CSRF-Token` header. `/session/login` returns the token as `Data.csrfToken`; the React sample stores it in memory and sends it with TODO create/update/delete and logout requests.
+
+## JSONP
+
+JSON is the default REST response format. Legacy JSONP output remains for compatibility, but callbacks must be valid JavaScript identifier paths such as `jsonCallback` or `App.callbacks.done`; invalid callback values fall back to `jsonCallback`.

--- a/tests/Unit/Func/JsonTest.php
+++ b/tests/Unit/Func/JsonTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Func;
+
+use Nene\Func\Json;
+use PHPUnit\Framework\TestCase;
+
+final class JsonTest extends TestCase
+{
+    public function testSanitizeJsonpCallbackAllowsIdentifierPaths(): void
+    {
+        self::assertSame('jsonCallback', Json::sanitizeJsonpCallback('jsonCallback'));
+        self::assertSame('App.callbacks.done', Json::sanitizeJsonpCallback('App.callbacks.done'));
+        self::assertSame('$callback._done', Json::sanitizeJsonpCallback('$callback._done'));
+    }
+
+    public function testSanitizeJsonpCallbackRejectsExecutableInput(): void
+    {
+        self::assertSame('jsonCallback', Json::sanitizeJsonpCallback('alert(1)'));
+        self::assertSame('jsonCallback', Json::sanitizeJsonpCallback('foo;alert(1)'));
+        self::assertSame('jsonCallback', Json::sanitizeJsonpCallback('foo["bar"]'));
+        self::assertSame('jsonCallback', Json::sanitizeJsonpCallback(''));
+    }
+}


### PR DESCRIPTION
## Summary
- legacy JSONP callback を JavaScript identifier path allowlist で検証します。
- 不正な callback は `jsonCallback` にフォールバックし、`Content-Type` を `application/javascript; charset=utf-8` に統一しました。
- callback sanitization の unit test と API docs を追加しました。

## Test plan
- `php -l class/func/Json.php tests/Unit/Func/JsonTest.php`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff class/func/Json.php tests/Unit/Func/JsonTest.php`

Closes #84

Made with [Cursor](https://cursor.com)