### PR TITLE
security(view): script JSON 出力を安全化する

### DIFF
--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -284,9 +284,24 @@ class View
     {
         self::$instance->smarty->assign(
             't_dataObject',
-            '<script type="text/javascript">const dataObject = ' . json_encode($dataArray) . '</script>'
+            '<script type="text/javascript">const dataObject = ' . self::encodeScriptJson($dataArray) . ';</script>'
         );
         return self::$instance;
+    }
+
+    /**
+     * Encode data safely for embedding inside an inline script block.
+     *
+     * @param array<string,mixed> $dataArray Data to expose to the template script.
+     *
+     * @return string JSON string safe for `<script>` context.
+     */
+    final public static function encodeScriptJson(array $dataArray): string
+    {
+        return json_encode(
+            $dataArray,
+            JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR
+        );
     }
 
     /**

--- a/tests/Unit/Xion/ViewTest.php
+++ b/tests/Unit/Xion/ViewTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\View;
+use PHPUnit\Framework\TestCase;
+
+final class ViewTest extends TestCase
+{
+    public function testEncodeScriptJsonEscapesScriptBreakingCharacters(): void
+    {
+        $json = View::encodeScriptJson([
+            'html' => '</script><script>alert("xss")</script>',
+            'quote' => "'\"&<>",
+        ]);
+
+        self::assertStringNotContainsString('</script>', $json);
+        self::assertStringNotContainsString('<script>', $json);
+        self::assertStringContainsString('\u003C\/script\u003E', $json);
+        self::assertStringContainsString('\u0022', $json);
+        self::assertStringContainsString('\u0027', $json);
+        self::assertStringContainsString('\u0026', $json);
+    }
+}


### PR DESCRIPTION
## Summary
- `View::setDataObject()` の inline script JSON を `JSON_HEX_*` と `JSON_THROW_ON_ERROR` 付きの helper に寄せました。
- `</script>` や quote/ampersand が script context で安全に escape される unit test を追加しました。

## Test plan
- `php -l class/xion/View.php tests/Unit/Xion/ViewTest.php`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff class/xion/View.php tests/Unit/Xion/ViewTest.php`

Closes #85

Made with [Cursor](https://cursor.com)