### PR TITLE
security(dispatcher): error 応答を catalog に寄せる

### DIFF
--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 
 namespace Nene\Xion;
 
+use Nene\Func as Func;
+
 /**
  * Dispatches controllers and models.
  */
@@ -55,19 +57,14 @@ class Dispatcher
             echo file_get_contents(DIR_ROOT . '/404.html');
             exit;
         } elseif ($route['status'] === 405) {
-            header('HTTP/1.0 405 Method Not Allowed');
             header('Allow: ' . implode(', ', $route['allowed']));
-            echo json_encode([
-                'Result' => false,
-                'Error' => [
-                    'ErrorCode' => 'METHOD-NOT-ALLOWED',
-                    'ErrorMessage' => 'The HTTP method is not allowed for this endpoint.'
-                ]
-            ]);
-            exit;
+            $this->outputJsonFailure('METHOD-NOT-ALLOWED');
         } elseif ($route['status'] === 500) {
-            echo $action . 'Action' . ' and ' . $action . 'Rest Duplicate';
-            exit();
+            Log::getInstance('error')->error('Route conflict detected.', [
+                'controller' => $controller,
+                'action' => $action,
+            ]);
+            $this->outputJsonFailure('ROUTE-CONFLICT');
         }
         RouteContext::getInstance()->set($controller, $action, $route['mode'], $route['method']);
         $controllerInstance->run();
@@ -91,7 +88,7 @@ class Dispatcher
         $layersNum = defined('LAYERS_NUM') ? LAYERS_NUM : 0;
         return [
             'controller' => ($layersNum < count($params)) ? $params[$layersNum] : 'index',
-            'action' => (($layersNum + 1) < count($params)) ? $params[$layersNum + 1] : 'index'
+            'action' => (($layersNum + 1) < count($params)) ? $params[$layersNum + 1] : 'index',
         ];
     }
 
@@ -119,7 +116,7 @@ class Dispatcher
                 'status' => 200,
                 'mode' => 'Rest',
                 'method' => $methodRestMethod,
-                'allowed' => $allowedMethods
+                'allowed' => $allowedMethods,
             ];
         }
         if (
@@ -130,7 +127,7 @@ class Dispatcher
                 'status' => 500,
                 'mode' => '',
                 'method' => '',
-                'allowed' => $allowedMethods
+                'allowed' => $allowedMethods,
             ];
         }
         if (method_exists($controllerInstance, $actionMethod)) {
@@ -138,7 +135,7 @@ class Dispatcher
                 'status' => 200,
                 'mode' => 'Action',
                 'method' => $actionMethod,
-                'allowed' => $allowedMethods
+                'allowed' => $allowedMethods,
             ];
         }
         if (method_exists($controllerInstance, $legacyRestMethod)) {
@@ -146,7 +143,7 @@ class Dispatcher
                 'status' => 200,
                 'mode' => 'Rest',
                 'method' => $legacyRestMethod,
-                'allowed' => $allowedMethods
+                'allowed' => $allowedMethods,
             ];
         }
         if ($allowedMethods !== []) {
@@ -154,14 +151,14 @@ class Dispatcher
                 'status' => 405,
                 'mode' => '',
                 'method' => '',
-                'allowed' => $allowedMethods
+                'allowed' => $allowedMethods,
             ];
         }
         return [
             'status' => 404,
             'mode' => '',
             'method' => '',
-            'allowed' => []
+            'allowed' => [],
         ];
     }
 
@@ -216,5 +213,17 @@ class Dispatcher
         }
         $controllerInstance = new $className();
         return $controllerInstance;
+    }
+
+    /**
+     * Output a catalog-backed JSON failure response and terminate dispatch.
+     *
+     * @param string $errorCode Catalog error code.
+     *
+     * @return void
+     */
+    private function outputJsonFailure(string $errorCode): void
+    {
+        Func\Json::outputArrayToJson((new ApiResponse())->failure($errorCode), 'json', '');
     }
 }

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -15,6 +15,14 @@ return [
         'message' => 'Invalid CSRF token.',
         'httpStatus' => 403,
     ],
+    'METHOD-NOT-ALLOWED' => [
+        'message' => 'The HTTP method is not allowed for this endpoint.',
+        'httpStatus' => 405,
+    ],
+    'ROUTE-CONFLICT' => [
+        'message' => 'Route configuration conflict.',
+        'httpStatus' => 500,
+    ],
     'TODO-ID-REQUIRED' => [
         'message' => 'TODO id is required.',
         'httpStatus' => 400,

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -264,7 +264,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/DispatcherErrorEnvelope"
+            $ref: "#/components/schemas/MethodNotAllowedEnvelope"
   schemas:
     JsonEnvelope:
       type: object
@@ -526,23 +526,17 @@ components:
                       const: TODO-TITLE-REQUIRED
                     errorMessage:
                       const: TODO title is required.
-    DispatcherErrorEnvelope:
-      type: object
-      required:
-        - Result
-        - Error
-      properties:
-        Result:
-          type: boolean
-          const: false
-        Error:
-          type: object
-          required:
-            - ErrorCode
-            - ErrorMessage
+    MethodNotAllowedEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/ErrorEnvelope"
+        - type: object
           properties:
-            ErrorCode:
-              type: string
-              const: METHOD-NOT-ALLOWED
-            ErrorMessage:
-              type: string
+            Data:
+              allOf:
+                - $ref: "#/components/schemas/ApiFailureData"
+                - type: object
+                  properties:
+                    errorCode:
+                      const: METHOD-NOT-ALLOWED
+                    errorMessage:
+                      const: The HTTP method is not allowed for this endpoint.

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -111,7 +111,8 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertSame(405, $response->statusCode());
         self::assertStringContainsString('DELETE', $response->headerLine('Allow'));
         self::assertStringContainsString('PUT', $response->headerLine('Allow'));
-        self::assertSame(false, $payload['Result']);
-        self::assertSame('METHOD-NOT-ALLOWED', $payload['Error']['ErrorCode']);
+        self::assertSame(true, $payload['Result']);
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('METHOD-NOT-ALLOWED', $payload['Data']['errorCode']);
     }
 }

--- a/tests/Unit/Xion/DispatcherTest.php
+++ b/tests/Unit/Xion/DispatcherTest.php
@@ -35,7 +35,7 @@ final class DispatcherTest extends TestCase
 
     public function testResolveActionRoutePrefersHttpMethodRestHandler(): void
     {
-        $controller = new class {
+        $controller = new class () {
             public function indexGetRest(): array
             {
                 return [];
@@ -57,7 +57,7 @@ final class DispatcherTest extends TestCase
 
     public function testResolveActionRouteKeepsLegacyRestFallbackForCompatibility(): void
     {
-        $controller = new class {
+        $controller = new class () {
             public function loginRest(): array
             {
                 return [];
@@ -73,7 +73,7 @@ final class DispatcherTest extends TestCase
 
     public function testResolveActionRouteReturnsMethodNotAllowedWhenOnlyOtherRestMethodsExist(): void
     {
-        $controller = new class {
+        $controller = new class () {
             public function itemPutRest(): array
             {
                 return [];
@@ -89,5 +89,23 @@ final class DispatcherTest extends TestCase
 
         self::assertSame(405, $route['status']);
         self::assertSame(['DELETE', 'PUT'], $route['allowed']);
+    }
+
+    public function testResolveActionRouteReturnsConflictForActionAndLegacyRestDuplicate(): void
+    {
+        $controller = new class () {
+            public function indexAction(): void
+            {
+            }
+
+            public function indexRest(): array
+            {
+                return [];
+            }
+        };
+
+        $route = (new Dispatcher())->resolveActionRoute($controller, 'index', 'GET');
+
+        self::assertSame(500, $route['status']);
     }
 }

--- a/tests/Unit/Xion/ErrorCodeTest.php
+++ b/tests/Unit/Xion/ErrorCodeTest.php
@@ -28,6 +28,8 @@ final class ErrorCodeTest extends TestCase
     {
         self::assertSame(400, ErrorCode::getInstance()->getHttpStatus('TODO-TITLE-REQUIRED'));
         self::assertSame(404, ErrorCode::getInstance()->getHttpStatus('TODO-NOT-FOUND'));
+        self::assertSame(405, ErrorCode::getInstance()->getHttpStatus('METHOD-NOT-ALLOWED'));
+        self::assertSame(500, ErrorCode::getInstance()->getHttpStatus('ROUTE-CONFLICT'));
     }
 
     public function testGetErrorTextReturnsDeterministicFallbackForMissingCode(): void


### PR DESCRIPTION
## Summary
- Dispatcher の 405 と route conflict 500 を `ApiResponse` / `config/error_codes.php` に寄せました。
- `METHOD-NOT-ALLOWED` と `ROUTE-CONFLICT` を error catalog に追加しました。
- OpenAPI と HTTP runtime test を共通 REST failure payload に更新しました。

## Test plan
- `php -l class/xion/Dispatcher.php config/error_codes.php tests/Unit/Xion/DispatcherTest.php tests/Unit/Xion/ErrorCodeTest.php tests/Http/HttpSmokeTest.php`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff class/xion/Dispatcher.php config/error_codes.php tests/Unit/Xion/DispatcherTest.php tests/Unit/Xion/ErrorCodeTest.php tests/Http/HttpSmokeTest.php`

Closes #86

Made with [Cursor](https://cursor.com)