### PR TITLE
api(auth): 認証失敗を 401 にする

### DIFF
--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 return [
     'SESSION-CLOSED' => [
         'message' => 'Session timeout. Please log in again.',
-        'httpStatus' => 200,
+        'httpStatus' => 401,
     ],
     'LOGIN-FAILED' => [
         'message' => 'Wrong user ID or user PASS',
-        'httpStatus' => 200,
+        'httpStatus' => 401,
     ],
     'CSRF-TOKEN-INVALID' => [
         'message' => 'Invalid CSRF token.',

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -47,6 +47,10 @@ OpenAPI paths should describe the URL and the request/response contract, not the
 
 Cookie-authenticated state-changing REST requests must send the `X-CSRF-Token` header. `/session/login` returns the token as `Data.csrfToken`; the React sample stores it in memory and sends it with TODO create/update/delete and logout requests.
 
+## Authentication Failure Status
+
+Authentication failures use HTTP `401 Unauthorized`. `LOGIN-FAILED` means submitted credentials were rejected, and `SESSION-CLOSED` means a cookie-authenticated endpoint was called without a valid login session.
+
 ## JSONP
 
 JSON is the default REST response format. Legacy JSONP output remains for compatibility, but callbacks must be valid JavaScript identifier paths such as `jsonCallback` or `App.callbacks.done`; invalid callback values fall back to `jsonCallback`.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -33,13 +33,11 @@ paths:
                   user_pass: admin
       responses:
         "200":
-          description: Login succeeded or credentials were rejected.
+          description: Login succeeded.
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/LoginSuccessEnvelope"
-                  - $ref: "#/components/schemas/LoginFailureEnvelope"
+                $ref: "#/components/schemas/LoginSuccessEnvelope"
               examples:
                 success:
                   value:
@@ -51,6 +49,13 @@ paths:
                       user:
                         id: 1
                         user_id: admin
+        "401":
+          description: Credentials were rejected.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoginFailureEnvelope"
+              examples:
                 failure:
                   value:
                     Result: true
@@ -90,13 +95,17 @@ paths:
         - sessionCookie: []
       responses:
         "200":
-          description: TODO list or session failure.
+          description: TODO list.
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/TodoListSuccessEnvelope"
-                  - $ref: "#/components/schemas/SessionClosedEnvelope"
+                $ref: "#/components/schemas/TodoListSuccessEnvelope"
+        "401":
+          description: Session is missing or expired.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionClosedEnvelope"
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
     post:
@@ -119,13 +128,17 @@ paths:
                   title: Write OpenAPI docs
       responses:
         "200":
-          description: TODO created or session failure.
+          description: TODO created.
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/TodoSuccessEnvelope"
-                  - $ref: "#/components/schemas/SessionClosedEnvelope"
+                $ref: "#/components/schemas/TodoSuccessEnvelope"
+        "401":
+          description: Session is missing or expired.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionClosedEnvelope"
         "400":
           description: TODO title was missing.
           content:
@@ -166,13 +179,17 @@ paths:
                   title: Review OpenAPI docs
       responses:
         "200":
-          description: TODO updated or session failure.
+          description: TODO updated.
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/TodoSuccessEnvelope"
-                  - $ref: "#/components/schemas/SessionClosedEnvelope"
+                $ref: "#/components/schemas/TodoSuccessEnvelope"
+        "401":
+          description: Session is missing or expired.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionClosedEnvelope"
         "400":
           description: TODO id or title was invalid.
           content:
@@ -203,13 +220,17 @@ paths:
         - $ref: "#/components/parameters/TodoId"
       responses:
         "200":
-          description: TODO deleted or session failure.
+          description: TODO deleted.
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/TodoDeleteSuccessEnvelope"
-                  - $ref: "#/components/schemas/SessionClosedEnvelope"
+                $ref: "#/components/schemas/TodoDeleteSuccessEnvelope"
+        "401":
+          description: Session is missing or expired.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionClosedEnvelope"
         "400":
           description: TODO id was missing or invalid.
           content:

--- a/tests/Http/HttpErrorTest.php
+++ b/tests/Http/HttpErrorTest.php
@@ -16,7 +16,7 @@ final class HttpErrorTest extends HttpRuntimeTestCase
         ]);
         $payload = $response->json();
 
-        self::assertSame(200, $response->statusCode());
+        self::assertSame(401, $response->statusCode());
         self::assertSame('failure', $payload['Data']['status']);
         self::assertSame('LOGIN-FAILED', $payload['Data']['errorCode']);
     }

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -36,7 +36,7 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         $response = $this->client->request('GET', '/todo/index');
         $payload = $response->json();
 
-        self::assertSame(200, $response->statusCode());
+        self::assertSame(401, $response->statusCode());
         self::assertSame(true, $payload['Result']);
         self::assertSame('failure', $payload['Data']['status']);
         self::assertSame('SESSION-CLOSED', $payload['Data']['errorCode']);

--- a/tests/Unit/Xion/ErrorCodeTest.php
+++ b/tests/Unit/Xion/ErrorCodeTest.php
@@ -26,6 +26,8 @@ final class ErrorCodeTest extends TestCase
 
     public function testGetHttpStatusReturnsCatalogStatus(): void
     {
+        self::assertSame(401, ErrorCode::getInstance()->getHttpStatus('SESSION-CLOSED'));
+        self::assertSame(401, ErrorCode::getInstance()->getHttpStatus('LOGIN-FAILED'));
         self::assertSame(400, ErrorCode::getInstance()->getHttpStatus('TODO-TITLE-REQUIRED'));
         self::assertSame(404, ErrorCode::getInstance()->getHttpStatus('TODO-NOT-FOUND'));
         self::assertSame(405, ErrorCode::getInstance()->getHttpStatus('METHOD-NOT-ALLOWED'));


### PR DESCRIPTION
## Summary
- `SESSION-CLOSED` と `LOGIN-FAILED` の HTTP status を 401 に変更しました。
- OpenAPI を 200 成功と 401 認証失敗に分けました。
- HTTP runtime tests と error catalog unit test を更新しました。

## Test plan
- `php -l config/error_codes.php tests/Http/HttpSmokeTest.php tests/Http/HttpErrorTest.php tests/Unit/Xion/ErrorCodeTest.php`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff config/error_codes.php tests/Http/HttpSmokeTest.php tests/Http/HttpErrorTest.php tests/Unit/Xion/ErrorCodeTest.php`

Closes #87

Made with [Cursor](https://cursor.com)