### PR TITLE
security(request): request 変数の保存先を統一する

### DIFF
--- a/class/xion/Post.php
+++ b/class/xion/Post.php
@@ -39,7 +39,7 @@ class Post extends RequestVariables
     final protected function setValues(): void
     {
         foreach ($_POST as $key => $value) {
-            $this->_values[$key] = $value;
+            $this->values[$key] = $value;
         }
     }
 }

--- a/class/xion/QueryString.php
+++ b/class/xion/QueryString.php
@@ -39,7 +39,7 @@ class QueryString extends RequestVariables
     final protected function setValues(): void
     {
         foreach ($_GET as $key => $value) {
-            $this->_values[$key] = $value;
+            $this->values[$key] = $value;
         }
     }
 }

--- a/class/xion/RequestVariables.php
+++ b/class/xion/RequestVariables.php
@@ -28,9 +28,9 @@ abstract class RequestVariables
     /**
      * Request variables
      *
-     * @var [type]
+     * @var array<string,mixed>
      */
-    protected $values;
+    protected $values = [];
 
     /**
      * CONSTRUCTOR.
@@ -47,7 +47,7 @@ abstract class RequestVariables
      *
      * @return void
      */
-    abstract protected function setValues();
+    abstract protected function setValues(): void;
 
     /**
      * Get value.

--- a/tests/Unit/Xion/RequestVariablesTest.php
+++ b/tests/Unit/Xion/RequestVariablesTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\Post;
+use Nene\Xion\QueryString;
+use Nene\Xion\Request;
+use PHPUnit\Framework\TestCase;
+
+final class RequestVariablesTest extends TestCase
+{
+    /** @var array<string,mixed> */
+    private array $originalGet;
+
+    /** @var array<string,mixed> */
+    private array $originalPost;
+
+    /** @var array<string,mixed> */
+    private array $originalServer;
+
+    protected function setUp(): void
+    {
+        $this->originalGet = $_GET;
+        $this->originalPost = $_POST;
+        $this->originalServer = $_SERVER;
+
+        if (!defined('LAYERS_NUM')) {
+            define('LAYERS_NUM', 0);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = $this->originalGet;
+        $_POST = $this->originalPost;
+        $_SERVER = $this->originalServer;
+    }
+
+    public function testPostStoresValuesInBaseRequestStorage(): void
+    {
+        $_POST = [
+            'title' => 'write tests',
+            'tags' => ['security', 'boundary'],
+        ];
+
+        $post = new Post();
+
+        self::assertTrue($post->has('title'));
+        self::assertSame('write tests', $post->get('title'));
+        self::assertSame(['security', 'boundary'], $post->get('tags'));
+        self::assertSame($_POST, $post->get());
+    }
+
+    public function testQueryStringStoresValuesInBaseRequestStorage(): void
+    {
+        $_GET = [
+            'page' => '1',
+            'filter' => 'active',
+        ];
+
+        $query = new QueryString();
+
+        self::assertTrue($query->has('page'));
+        self::assertSame('1', $query->get('page'));
+        self::assertSame('active', $query->get('filter'));
+        self::assertSame($_GET, $query->get());
+    }
+
+    public function testRequestReadsPostQueryAndUrlParametersThroughWrappers(): void
+    {
+        $_POST = ['title' => 'from post'];
+        $_GET = ['q' => 'from query'];
+        $_SERVER['REQUEST_URI'] = '/todo/item/id_42';
+
+        $request = new Request();
+
+        self::assertSame('from post', $request->getPost('title'));
+        self::assertSame('from query', $request->getQuery('q'));
+        self::assertSame('42', $request->getParam('id'));
+    }
+}


### PR DESCRIPTION
## Summary
- `Post` / `QueryString` が基底 `RequestVariables::$values` に保存するよう修正しました。
- `RequestVariables::$values` を配列として初期化し、`setValues()` の戻り値を明示しました。
- GET/POST wrapper と `Request` 経由の URL parameter 取得を unit test で確認しました。

## Test plan
- `php -l class/xion/RequestVariables.php class/xion/Post.php class/xion/QueryString.php tests/Unit/Xion/RequestVariablesTest.php`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff class/xion/RequestVariables.php class/xion/Post.php class/xion/QueryString.php tests/Unit/Xion/RequestVariablesTest.php`

Closes #88

Made with [Cursor](https://cursor.com)