### PR TITLE
docs(project): リフォーム思想を明文化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,19 @@
 
 Simple web application framework.
 
-NeNe is a legacy, simple, lightweight PHP framework. It uses a front controller and URL path segments to resolve controller classes and action methods.
+NeNe is a renovated legacy PHP framework.
+
+The original idea is more than ten years old: keep a tiny front-controller framework that people familiar with older PHP frameworks can understand at a glance. This repository keeps that philosophy and structure, then updates the project for modern PHP development with Composer, Docker, tests, OpenAPI, explicit security defaults, and current stable packages.
+
+NeNe is intentionally much smaller than full-stack frameworks. It keeps only the parts needed to build small services:
+
+- Convention-based routing from URL segments.
+- Server-rendered pages with Smarty.
+- Method-specific REST handlers for JSON APIs.
+- Lightweight database mappers.
+- Session, CSRF, error catalog, logging, and testable boundaries.
+
+The goal is not to replace Laravel, Symfony, CodeIgniter, or Laminas. The goal is to give legacy-framework users a small codebase they can read, keep, and safely modernize.
 
 ## Documentation
 
@@ -27,7 +39,9 @@ The dispatcher resolves the URL to:
 
 - `Nene\Controller\{Controller}Controller`
 - `{action}Action` for server-rendered pages
-- `{action}Rest` for JSON/API responses
+- `{action}{HttpMethod}Rest` for JSON/API responses, such as `indexGetRest` or `loginPostRest`
+
+The legacy `{action}Rest` fallback remains only for compatibility. New REST endpoints should use method-specific handlers.
 
 ## Requirements
 

--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -6,7 +6,9 @@ Use this directory to mirror important GitHub milestones when local context is u
 
 ### legacy-framework-stabilization
 
-Goal: finish the foundation needed to keep NeNe useful as a legacy, simple, lightweight PHP framework.
+Goal: finish the foundation needed to keep NeNe useful as a renovated legacy, simple, lightweight PHP framework.
+
+Context: NeNe keeps the philosophy of an older PHP framework that was built around a small front controller, URL segment routing, controller actions, Smarty templates, and lightweight database mappers. The milestone is not a rewrite into a modern full-stack framework. It is a careful renovation that keeps the familiar construction rules while making the codebase safer and usable with current PHP tooling.
 
 Completion criteria:
 
@@ -19,13 +21,30 @@ Completion criteria:
 - Keep NeNe easy, simple, and lightweight.
 - Maintain onboarding and implementation support docs under `docs/`, including ADR guidance.
 
-Current status: known stabilization Issues are complete, including local Docker setup, test foundation, REST dispatch behavior, OpenAPI/Swagger UI, SQLite fallback, and focused security hardening. No open Issues remain for this milestone.
+What was preserved:
+
+- The front controller and `/{controller}/{action}` routing style.
+- `Controller::actionAction()` for server-rendered pages.
+- Smarty templates and simple asset conventions.
+- Lightweight mapper/model classes instead of a heavy ORM.
+- A codebase small enough to understand without learning a large framework.
+
+What was renovated:
+
+- Docker-based local setup with MySQL and SQLite fallback.
+- PHPUnit unit tests and HTTP runtime smoke tests.
+- Method-specific REST dispatch such as `indexGetRest()` and `indexPostRest()`.
+- OpenAPI and Swagger UI for the sample REST contract.
+- Security-sensitive paths: sessions, cookies, password hashing, CSRF, JSONP, inline script JSON, error exposure, and request wrappers.
+- Static analysis and formatting foundations with Phan and PHP CS Fixer.
+
+Current status: known stabilization Issues are complete. No open Issues remain for this milestone.
 
 ### docs-foundation
 
 Purpose: establish project documentation, AI guidance, workflow, roadmap, TODO, and ADR practice.
 
-Current status: core project docs, workflow docs, API docs, TODO tracking, and the service implementation tutorial are in place. No open Issues remain for this milestone.
+Current status: core project docs, workflow docs, API docs, TODO tracking, renovation philosophy, and the service implementation tutorial are in place. No open Issues remain for this milestone.
 
 ### php-modernization
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -1,8 +1,41 @@
 # NeNe Project Overview
 
-NeNe is a legacy, simple, lightweight PHP web application framework.
+NeNe is a renovated legacy PHP web application framework.
+
+The project started from an older, intentionally small PHP framework style. Its purpose is not to erase that shape, but to make it usable today: PHP 8.4 target, Composer packages, Docker setup, PHPUnit, Phan, PHP CS Fixer, OpenAPI, stronger sessions, CSRF, password hashing, and safer error handling.
+
+NeNe is for developers who are comfortable with older convention-based PHP frameworks and want a codebase they can read from end to end. It keeps the familiar "URL segment -> controller -> action" flow while modernizing the boundaries around it.
 
 The project should remain small and understandable. New work should improve maintainability, security, and standards compatibility without turning NeNe into a large full-stack framework.
+
+## Renovation Philosophy
+
+NeNe is a renovation project, not a rewrite.
+
+Keep:
+
+- The front controller entry point.
+- The `/{controller}/{action}` URL convention.
+- Controller method names such as `indexAction()`.
+- Simple Smarty-based server rendering.
+- Lightweight database mapper classes instead of a heavy ORM.
+- A small codebase that one developer can inspect quickly.
+
+Modernize:
+
+- Composer autoloading and package management.
+- PHP 8.4-oriented typing and strictness where practical.
+- Method-specific REST handlers such as `indexGetRest()` and `indexPostRest()`.
+- Centralized API responses and error codes.
+- Session lifecycle, CSRF, password hashing, JSON/JSONP safety, and public error behavior.
+- OpenAPI contracts, Swagger UI, PHPUnit, Phan, PHP CS Fixer, and Docker development.
+
+Avoid:
+
+- Replacing the framework with a large dependency.
+- Adding configurable routing magic that hides the URL convention.
+- Introducing an ORM or plugin system before a real project need exists.
+- Refactoring legacy conventions only for aesthetic reasons.
 
 ## Current Shape
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #104: Clarify NeNe's renovation philosophy and target audience.
 - #102: Add a service implementation tutorial for pages, REST endpoints, database-backed features, OpenAPI, and tests.
 - #99: Prepare documentation/sample sections for the home side menu: `Authentication`, `Routing Guide`, and `OpenAPI`.
 - #98: Refresh TODO from roadmap, milestones, and Issue state.

--- a/docs/tutorials/building-a-service.md
+++ b/docs/tutorials/building-a-service.md
@@ -2,6 +2,10 @@
 
 This tutorial shows the common implementation path for a small NeNe service.
 
+Read this as a guide for a renovated legacy framework. NeNe intentionally keeps the familiar shape of older PHP frameworks: URL segments select a controller and action, HTML pages use `actionAction()` methods, and data access stays close to small mapper classes. The modern parts are added around that shape: method-specific REST handlers, API response catalogs, OpenAPI, tests, Docker, and explicit security defaults.
+
+If you know frameworks such as CodeIgniter 2/3 or Zend Framework 1, the flow should feel familiar. The difference is that NeNe keeps the core much smaller and documents the modern safety rails you should add when building services.
+
 Use it as a checklist when adding application behavior:
 
 1. Add a server-rendered page when users need HTML.


### PR DESCRIPTION
## Summary
- README の冒頭に、NeNe が古い軽量 PHP フレームワーク思想を保ちながら現代運用へ整える renovation project であることを追加しました。
- `docs/project.md` に Renovation Philosophy を追加し、残すもの・現代化するもの・避けるものを明文化しました。
- `docs/milestones/README.md` に legacy-framework-stabilization の背景、preserved/renovated の整理を追加しました。
- `docs/tutorials/building-a-service.md` の冒頭に、CodeIgniter 2/3 や Zend Framework 1 に慣れた層向けの読み方を追加しました。
- `docs/todo/current.md` に #104 を反映しました。

## Test plan
- `composer test`
- Documentation diff reviewed.

Closes #104

Made with [Cursor](https://cursor.com)