### PR TITLE
docs(roadmap): 現状評価と設計方針を反映する

### DIFF
--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -50,13 +50,25 @@ Current status: core project docs, workflow docs, API docs, TODO tracking, renov
 
 Purpose: keep PHP and Composer dependencies current, improve PHPDoc and typing, and make formatting/static analysis repeatable.
 
+Current status: modernization foundation is in place. Composer packages were updated where practical, unused packages/assets were removed, Docker PHP 8.4 is the documented target, PHP CS Fixer is configured, and Phan has a repeatable baseline. Remaining work should be gradual PHPDoc/type/baseline cleanup in focused Issues, not a broad rewrite of stable legacy classes.
+
 ### security-hardening
 
 Purpose: reduce security risk through dependency updates, secure defaults, input/output review, and safer error handling.
 
+Current status: focused security hardening is complete for the reviewed request/session/template/error-handling paths. Sessions, cookie attributes, password hashing, CSRF, JSONP callback validation, inline script JSON encoding, Dispatcher JSON errors, authentication status codes, and request variable storage have been hardened. Future security work should be handled as new small Issues when findings appear.
+
 ### openapi-contracts
 
 Purpose: document public REST endpoints with OpenAPI and keep API behavior explicit.
+
+Current status: the starter OpenAPI contract and Swagger UI are in place for the current Session and TODO sample endpoints. Runtime contract tests verify that documented operations and observed statuses stay aligned. Future work should expand the contract when new REST endpoints are added, rather than inventing endpoints only to grow OpenAPI.
+
+### framework-architecture-policy
+
+Purpose: protect NeNe's renovated legacy architecture from unnecessary redesign.
+
+Current status: no broad architecture rewrite is planned. NeNe should keep the front controller, `/{controller}/{action}` routing, `{action}Action()` page handlers, method-specific REST handlers, Smarty templates, and lightweight mapper/model style. Architecture work should document boundaries, add tests, or clarify conventions. Any change that hides URL routing, replaces the MVC shape, adds a heavy ORM, or changes compatibility policy should require a focused Issue and ADR.
 
 ## Maintenance Rule
 

--- a/docs/project.md
+++ b/docs/project.md
@@ -37,6 +37,27 @@ Avoid:
 - Introducing an ORM or plugin system before a real project need exists.
 - Refactoring legacy conventions only for aesthetic reasons.
 
+## Architecture Policy
+
+Large architecture changes are not the current goal.
+
+NeNe should feel familiar to developers who have used older PHP MVC frameworks. The important design surface is the visible, predictable path from URL to controller method:
+
+```text
+/{controller}/{action}
+```
+
+That route convention is part of the product philosophy. Improvements should make it safer, clearer, and easier to test without hiding it behind a new router abstraction.
+
+When considering changes, prefer this order:
+
+1. Document the existing convention.
+2. Add focused tests around the boundary.
+3. Improve safety or typing locally.
+4. Create an ADR only if the change affects routing, controller conventions, dependency policy, security posture, or API boundaries.
+
+Do not treat legacy style as a defect by itself. In NeNe, some legacy shape is intentionally preserved so the framework stays small, readable, and approachable for its target users.
+
 ## Current Shape
 
 - PHP application framework with a front controller entry point at `htdocs/index.php`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,45 +1,134 @@
 # Roadmap
 
-This roadmap describes NeNe's current direction. Each item should become GitHub Issues before implementation.
+This roadmap describes NeNe's current direction and status. GitHub Issues and PRs remain the source of truth for actionable work.
+
+NeNe is a renovation project for an old, small PHP framework style. The goal is not a broad redesign. The goal is to keep the familiar legacy construction rules while making the project usable with current PHP, security, documentation, and testing practices.
+
+## Guiding Policy
+
+NeNe should continue to emphasize:
+
+- URL-segment routing: `/{controller}/{action}`.
+- Controller action naming: `{action}Action()` for server-rendered pages.
+- Method-specific REST naming: `{action}{HttpMethod}Rest()` for JSON APIs.
+- Smarty-based server rendering as the default HTML path.
+- Lightweight mapper/model classes instead of a heavy ORM.
+- Small, readable framework code over large abstractions.
+- Modern safety rails around the legacy shape: Docker, tests, OpenAPI, Phan, PHP CS Fixer, CSRF, password hashing, error catalogs, and safer output handling.
+
+NeNe should avoid:
+
+- Replacing the core with a large full-stack framework.
+- Introducing configurable routing that hides the URL convention.
+- Rewriting the MVC shape only to look more modern.
+- Adding an ORM, plugin system, or SPA-first architecture before a real service need exists.
 
 ## 0. Legacy Framework Stabilization
 
-- Keep the legacy directory structure and URL-based routing rules.
-- Resolve known security issues.
-- Make clone-based setup simple, fast, and stable.
-- Add Docker-based local development.
-- Finish dispatcher behavior for correct REST handling.
-- Complete OpenAPI introduction.
-- Keep NeNe as an old-school, simple, lightweight framework.
-- Improve onboarding docs, ADRs, and implementation support.
+Status: substantially complete.
+
+Completed:
+
+- Preserved the legacy directory structure and URL-based routing rules.
+- Added Docker-based local development with MySQL.
+- Kept SQLite fallback aligned with the sample TODO tables.
+- Finished method-specific REST dispatch behavior.
+- Added OpenAPI and Swagger UI for current public REST endpoints.
+- Added PHPUnit unit tests and HTTP runtime smoke tests.
+- Resolved the known focused security hardening Issues.
+- Added onboarding docs and a service implementation tutorial.
+
+Ongoing policy:
+
+- Keep the old-school lightweight framework character.
+- Treat future stabilization work as small Issues, not a new architecture phase.
 
 ## 1. Documentation Foundation
 
-- Add AI and contributor guidance.
-- Document routing, controller conventions, and current architecture.
-- Establish coding standards, workflow, roadmap, TODO, milestone, and ADR practices.
+Status: substantially complete.
+
+Completed:
+
+- Added AI and contributor guidance.
+- Added workflow, roadmap, TODO, milestone, ADR, coding standards, and commit convention docs.
+- Documented the renovation philosophy and target audience.
+- Documented current routing and controller conventions.
+- Added API docs and service-building tutorial guidance.
+
+Ongoing policy:
+
+- Update docs when conventions change.
+- Keep docs focused on how NeNe is actually used, not generic framework theory.
 
 ## 2. PHP Modernization
 
-- Keep Composer dependencies current and remove unused packages.
-- Gradually improve PHPDoc and native type declarations.
-- Make PHP CS Fixer and PSR-12 usage repeatable.
-- Establish a static analysis baseline for Phan.
+Status: foundation complete; gradual cleanup remains ongoing.
+
+Completed:
+
+- Updated direct Composer packages to current stable versions where practical.
+- Removed unused packages and generated/legacy assets where appropriate.
+- Set Docker PHP 8.4 as the development target.
+- Added PHP CS Fixer configuration and repeatable format scripts.
+- Added Phan configuration and baseline for repeatable static analysis.
+- Improved typing and PHPDoc in touched areas.
+
+Ongoing policy:
+
+- Improve PHPDoc, native types, and baseline reductions only in focused Issues.
+- Do not rewrite stable legacy classes just to remove historical style.
 
 ## 3. Security Hardening
 
-- Triage Dependabot alerts quickly.
-- Review request input handling, output escaping, session handling, and error responses.
-- Document secure defaults for controllers, REST responses, templates, and logs.
+Status: focused hardening complete; security remains a maintenance practice.
+
+Completed:
+
+- Controlled public error display through environment settings.
+- Hardened session lifecycle and cookie attributes.
+- Switched sample credentials to password hashes.
+- Added CSRF protection for state-changing cookie-authenticated REST requests.
+- Validated JSONP callbacks.
+- Safely encoded inline script JSON.
+- Moved Dispatcher errors into the shared JSON error responder.
+- Changed authentication failures to HTTP `401`.
+- Fixed request variable storage and added boundary tests.
+
+Ongoing policy:
+
+- Treat new security findings as small, prioritized Issues.
+- Keep error messages, HTTP status values, and response shape centralized.
+- Do not expose internal paths, stack traces, SQL details, or secrets in production responses.
 
 ## 4. OpenAPI and API Contracts
 
-- Define where OpenAPI files live.
-- Document REST method conventions.
-- Add OpenAPI contracts for public JSON endpoints.
+Status: starter contract complete; expansion should follow real endpoints.
+
+Completed:
+
+- Defined `docs/api/openapi.yaml` as the source OpenAPI contract.
+- Added Swagger UI served from the committed contract.
+- Added runtime checks that documented operations and observed statuses stay aligned.
+- Migrated YAML parsing to `symfony/yaml` for structured contract reading.
+- Documented REST method conventions and auth/CSRF behavior.
+
+Ongoing policy:
+
+- Add or update OpenAPI when adding public REST endpoints.
+- Avoid building a custom full OpenAPI validator; choose a library deliberately if body schema validation becomes necessary.
 
 ## 5. Framework Architecture
 
-- Document current routing and lifecycle.
-- Decide which legacy conventions should remain stable.
-- Use ADRs before major changes to routing, configuration, dependency policy, or API boundaries.
+Status: policy clarified; no broad redesign planned.
+
+Current decision:
+
+- Keep the current front controller, URL routing, controller action, Smarty, and lightweight mapper architecture.
+- Use ADRs only when a change would alter routing, controller conventions, dependency policy, compatibility, security posture, or API boundaries.
+- Prefer documenting boundaries and adding tests over replacing the core design.
+
+Future candidates:
+
+- Extract dispatcher route parsing further only if future tests or services need it.
+- Reduce legacy static-analysis baseline issues in focused cleanup PRs.
+- Revisit CI Docker runtime coverage when repository resources and runtime cost make it practical.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #106: Update roadmap and milestones to reflect current status and architecture policy.
 - #104: Clarify NeNe's renovation philosophy and target audience.
 - #102: Add a service implementation tutorial for pages, REST endpoints, database-backed features, OpenAPI, and tests.
 - #99: Prepare documentation/sample sections for the home side menu: `Authentication`, `Routing Guide`, and `OpenAPI`.


### PR DESCRIPTION
## Summary
- `docs/roadmap.md` を現状評価版に更新し、各フェーズの完了・継続方針・将来候補を分けました。
- URL routing、controller action、Smarty、lightweight mapper を守る guiding policy を明記しました。
- `docs/milestones/README.md` に PHP modernization / security hardening / OpenAPI contracts / architecture policy の現状を追加しました。
- `docs/project.md` に Architecture Policy を追加し、大きな設計変更が現在の目的ではないことを明文化しました。
- `docs/todo/current.md` に #106 を反映しました。

## Test plan
- `composer test`
- Documentation diff reviewed.

Closes #106

Made with [Cursor](https://cursor.com)