### PR TITLE
test(response): termination boundary の検証を追加する

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -180,7 +180,7 @@ abstract class ControllerBase
      *
      * Controller execution.
      *
-     * @return mixed
+     * @return void
      */
     final public function run()
     {
@@ -216,7 +216,6 @@ abstract class ControllerBase
 
         if ($this->ROUTE_CONTEXT->isRest()) {
             Xion\JsonResponder::outputArray($return);
-            return $return;
         } else {
             $this->setCSS();
             $this->setJS();

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -413,9 +413,9 @@ abstract class DataMapperBase
      * @param string $errorCode    Error code.
      * @param string $errorMessage Error message.
      *
-     * @return void
+     * @return never
      */
-    final protected function error(string $errorCode, string $errorMessage): void
+    final protected function error(string $errorCode, string $errorMessage): never
     {
         JsonResponder::outputError($errorCode, $errorMessage);
     }

--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -229,6 +229,7 @@ class Dispatcher
      */
     private function notFoundResponse(): HttpResponse
     {
-        return HttpResponse::html((string)file_get_contents(DIR_ROOT . '/404.html'), 404);
+        $body = file_get_contents(DIR_ROOT . '/404.html');
+        return HttpResponse::html(is_string($body) ? $body : '404 Not Found', 404);
     }
 }

--- a/tests/Unit/Xion/JsonResponderTest.php
+++ b/tests/Unit/Xion/JsonResponderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nene\Tests\Unit\Xion;
 
+use Nene\Xion\HttpTermination;
 use Nene\Xion\JsonResponder;
 use PHPUnit\Framework\TestCase;
 
@@ -51,5 +52,33 @@ final class JsonResponderTest extends TestCase
         self::assertSame(405, $response->statusCode());
         self::assertSame(['Content-Type' => 'application/json; charset=utf-8'], $response->headers());
         self::assertStringContainsString('"METHOD-NOT-ALLOWED"', $response->body());
+    }
+
+    public function testOutputArrayThrowsHttpTerminationWithJsonResponse(): void
+    {
+        try {
+            JsonResponder::outputArray(['status' => 'success']);
+            self::fail('JsonResponder::outputArray() should throw HttpTermination.');
+        } catch (HttpTermination $termination) {
+            $response = $termination->response();
+            self::assertSame(200, $response->statusCode());
+            self::assertSame(['Content-Type' => 'application/json; charset=utf-8'], $response->headers());
+            self::assertStringContainsString('"Result":true', $response->body());
+            self::assertStringContainsString('"status":"success"', $response->body());
+        }
+    }
+
+    public function testOutputErrorThrowsHttpTerminationWithErrorEnvelope(): void
+    {
+        try {
+            JsonResponder::outputError('SAMPLE-ERROR', 'Sample error.');
+            self::fail('JsonResponder::outputError() should throw HttpTermination.');
+        } catch (HttpTermination $termination) {
+            $response = $termination->response();
+            self::assertSame(200, $response->statusCode());
+            self::assertSame(['Content-Type' => 'application/json; charset=utf-8'], $response->headers());
+            self::assertStringContainsString('"Result":false', $response->body());
+            self::assertStringContainsString('"ErrorCode":"SAMPLE-ERROR"', $response->body());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `JsonResponder::outputArray()` / `outputError()` が `HttpTermination` を投げることを unit test で検証
- `ControllerBase::run()` の到達不能コードを削除し、PHPDoc を `void` に整理
- `DataMapperBase::error()` の返り型を `never` に揃え、404 body に fallback を追加

## Test plan
- `php -l class/xion/ControllerBase.php && php -l class/xion/DataMapperBase.php && php -l class/xion/Dispatcher.php && php -l tests/Unit/Xion/JsonResponderTest.php`
- `composer test`
- `composer analyze`
- `git diff --check`

Closes #112

Made with [Cursor](https://cursor.com)