### PR TITLE
test(http): runtime routing coverage を拡張する

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -64,7 +64,7 @@ docker compose run --rm app sh -lc "composer install --no-interaction --prefer-d
 
 ## HTTP Runtime Smoke Tests
 
-HTTP runtime tests exercise the Docker-served application through real HTTP requests. They cover the top page, Swagger UI, session login/logout, TODO CRUD, and REST method handling.
+HTTP runtime tests exercise the Docker-served application through real HTTP requests. They cover the top page, explicit URL routing, Swagger UI, session login/logout, TODO CRUD, REST method handling, and the JSON-only REST response policy.
 
 Start the Docker environment first:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #116: Expand HTTP runtime coverage for explicit routing, REST method boundaries, and JSON-only responses.
 - #108: Remove legacy JSONP output and move JSON handling to the response boundary.
 - #106: Update roadmap and milestones to reflect current status and architecture policy.
 - #104: Clarify NeNe's renovation philosophy and target audience.
@@ -43,7 +44,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- No active short-term TODO after #108. Use new GitHub Issues for follow-up work.
+- No active short-term TODO after #116. Use new GitHub Issues for follow-up work.
 
 ## Backlog Candidates
 

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -19,6 +19,16 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertStringContainsString('/css/index/index.css', $response->body());
     }
 
+    public function testExplicitIndexRouteRespondsWithDevelopersHtml(): void
+    {
+        $response = $this->client->request('GET', '/index/index');
+
+        self::assertSame(200, $response->statusCode());
+        self::assertStringContainsString('text/html', $response->headerLine('Content-Type'));
+        self::assertStringContainsString('id="app"', $response->body());
+        self::assertStringContainsString('/js/index/index.js', $response->body());
+    }
+
     public function testSwaggerUiAndOpenApiDocumentAreServed(): void
     {
         $swaggerResponse = $this->client->request('GET', '/api-docs/');
@@ -63,6 +73,33 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertSame(200, $logoutResponse->statusCode());
         self::assertStringContainsString('PHPSESSID=', $logoutCookie);
         self::assertStringContainsString('expires=', strtolower($logoutCookie));
+    }
+
+    public function testLoginRestEndpointRejectsUnsupportedMethod(): void
+    {
+        $response = $this->client->request('GET', '/session/login');
+        $payload = $response->json();
+
+        self::assertSame(405, $response->statusCode());
+        self::assertSame('POST', $response->headerLine('Allow'));
+        self::assertSame(true, $payload['Result']);
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('METHOD-NOT-ALLOWED', $payload['Data']['errorCode']);
+    }
+
+    public function testRestResponseStaysJsonWhenCallbackQueryIsPresent(): void
+    {
+        $response = $this->client->json('POST', '/session/login?callback=jsonCallback', [
+            'user_id' => 'admin',
+            'user_pass' => 'admin',
+        ]);
+        $payload = $response->json();
+
+        self::assertSame(200, $response->statusCode());
+        self::assertStringContainsString('application/json', $response->headerLine('Content-Type'));
+        self::assertStringNotContainsString('jsonCallback(', $response->body());
+        self::assertSame(true, $payload['Result']);
+        self::assertSame('success', $payload['Data']['status']);
     }
 
     public function testSessionAndTodoCrudFlowRunsThroughHttpRuntime(): void


### PR DESCRIPTION
## Summary
- `/index/index` の明示的URLルーティングをHTTP runtime testで確認
- `/session/login` の未対応HTTP methodが `405` と `Allow: POST` を返すことを確認
- `callback` query付きでもREST responseがJSONのままで、JSONPに戻らないことを確認
- HTTP testing docsとTODOを現在のカバレッジに合わせて更新

## Test plan
- `php -l tests/Http/HttpSmokeTest.php`
- `composer test`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`（18 tests, 169 assertions, 1 skipped）
- `composer analyze`
- `git diff --check`

Closes #116

Made with [Cursor](https://cursor.com)