### PR TITLE
docs(frontpage): service tutorial を統合する

### DIFF
--- a/htdocs/css/index/index.css
+++ b/htdocs/css/index/index.css
@@ -198,7 +198,9 @@
 .guide-panel,
 .openapi-card,
 .quick-start-card,
-.sample-card {
+.sample-card,
+.tutorial__intro,
+.tutorial-step {
     background: rgba(18, 18, 18, 0.78);
     border: 1px solid rgba(255, 255, 255, 0.09);
     border-radius: 14px;
@@ -255,6 +257,92 @@
 .guide-panel,
 .openapi-card {
     padding: 18px;
+}
+
+.tutorial__intro {
+    align-items: flex-start;
+    display: flex;
+    gap: 18px;
+    justify-content: space-between;
+    margin-bottom: 14px;
+    padding: 18px;
+}
+
+.tutorial__intro p {
+    color: #aaa9a1;
+    font-size: 0.92rem;
+    line-height: 1.65;
+    margin: 0;
+    max-width: 560px;
+}
+
+.tutorial__doc-link {
+    color: #8f82ff;
+    flex: 0 0 auto;
+    font-size: 0.86rem;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.tutorial__doc-link:hover {
+    color: #f2f2ee;
+}
+
+.tutorial__steps {
+    display: grid;
+    gap: 12px;
+}
+
+.tutorial-step {
+    padding: 18px;
+}
+
+.tutorial-step__meta {
+    align-items: center;
+    display: flex;
+    gap: 12px;
+    margin-bottom: 10px;
+}
+
+.tutorial-step__meta span {
+    align-items: center;
+    background: rgba(143, 130, 255, 0.16);
+    border: 1px solid rgba(143, 130, 255, 0.32);
+    border-radius: 999px;
+    color: #bdb7ff;
+    display: inline-flex;
+    font-size: 0.72rem;
+    font-weight: 700;
+    height: 28px;
+    justify-content: center;
+    letter-spacing: 0.06em;
+    width: 42px;
+}
+
+.tutorial-step h3 {
+    color: #f2f2ee;
+    font-size: 1rem;
+    margin: 0;
+}
+
+.tutorial-step p {
+    color: #aaa9a1;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    margin: 0 0 12px;
+}
+
+.tutorial-step code {
+    background: #050505;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    color: #f2f2ee;
+    display: block;
+    font-family: "IBM Plex Sans", "IBM Plex Sans JP", sans-serif;
+    font-size: 0.84rem;
+    line-height: 1.6;
+    overflow-wrap: anywhere;
+    padding: 10px 12px;
 }
 
 .guide-panel {
@@ -456,6 +544,10 @@
         border-bottom: 1px solid rgba(255, 255, 255, 0.08);
         padding: 0 0 18px;
         position: static;
+    }
+
+    .tutorial__intro {
+        flex-direction: column;
     }
 
     .todo-panel__form {

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -27,6 +27,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const sidebarLinks = [
         { href: '#getting-started', label: 'Getting Started' },
         { href: '#quick-start', label: 'Quick Start' },
+        { href: '#tutorial', label: 'Tutorial' },
         { href: '#authentication', label: 'Authentication' },
         { href: '#sample-app', label: 'Sample TODO' },
         { href: '#routing-guide', label: 'Routing Guide' },
@@ -42,6 +43,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     e(Hero),
                     e(GuideGrid),
                     e(QuickStart),
+                    e(ServiceTutorial),
                     e(AuthenticationGuide),
                     e(SampleApp),
                     e(RoutingGuide),
@@ -115,6 +117,64 @@ document.addEventListener('DOMContentLoaded', function() {
             ),
             e('div', { className: 'quick-start-card' },
                 e('pre', null, e('code', null, 'git clone git@github.com:hideyukiMORI/NeNe.git\ncd NeNe\ndocker compose up --build'))
+            )
+        );
+    }
+
+    function ServiceTutorial() {
+        const tutorialSteps = [
+            {
+                number: '01',
+                title: 'Add a fixed page',
+                text: 'Use an HTML action such as PageController::aboutAction() and place its template under view/source/page/about.tpl.',
+                code: 'GET /page/about -> PageController::aboutAction()'
+            },
+            {
+                number: '02',
+                title: 'Add a REST endpoint',
+                text: 'Use method-specific handlers so everyone writes the same style of JSON endpoint.',
+                code: 'POST /article/index -> ArticleController::indexPostRest()'
+            },
+            {
+                number: '03',
+                title: 'Store data with a mapper',
+                text: 'Keep persistence explicit with a small model and mapper instead of hiding behavior behind a large ORM.',
+                code: 'ArticleMapper::create($title, $body)'
+            },
+            {
+                number: '04',
+                title: 'Document and test the contract',
+                text: 'Add error codes, update OpenAPI, and cover the behavior with unit or HTTP runtime tests.',
+                code: 'composer test && NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http'
+            }
+        ];
+
+        return e('section', { className: 'developers__section tutorial', id: 'tutorial' },
+            e('div', { className: 'developers__section-heading' },
+                e('div', null,
+                    e('p', { className: 'developers__eyebrow' }, 'Tutorial'),
+                    e('h2', null, 'Build a small service')
+                ),
+                e('p', null, 'The docs remain the source of truth, but this page gives the shortest path from page to REST API.')
+            ),
+            e('div', { className: 'tutorial__intro' },
+                e('p', null, 'NeNe keeps the old-school URL and controller shape familiar to CodeIgniter or Zend Framework 1 users, then adds modern safety rails around it: JSON-only REST, OpenAPI, tests, Docker, and explicit error catalogs.'),
+                e('a', {
+                    className: 'tutorial__doc-link',
+                    href: 'https://github.com/hideyukiMORI/NeNe/blob/main/docs/tutorials/building-a-service.md'
+                }, 'Read the full Markdown tutorial')
+            ),
+            e('div', { className: 'tutorial__steps' },
+                tutorialSteps.map(function(step) {
+                    return e('article', { className: 'tutorial-step', key: step.number },
+                        e('div', { className: 'tutorial-step__meta' },
+                            e('span', null, step.number),
+                            e('h3', null, step.title)
+                        ),
+                        e('p', null, step.text),
+                        e('code', null, step.code)
+                    );
+                })
             )
         );
     }

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -29,6 +29,16 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertStringContainsString('/js/index/index.js', $response->body());
     }
 
+    public function testTopPageJavaScriptIncludesServiceTutorialGuide(): void
+    {
+        $response = $this->client->request('GET', '/js/index/index.js');
+
+        self::assertSame(200, $response->statusCode());
+        self::assertStringContainsString('Tutorial', $response->body());
+        self::assertStringContainsString('Build a small service', $response->body());
+        self::assertStringContainsString('docs/tutorials/building-a-service.md', $response->body());
+    }
+
     public function testSwaggerUiAndOpenApiDocumentAreServed(): void
     {
         $swaggerResponse = $this->client->request('GET', '/api-docs/');


### PR DESCRIPTION
## Summary
- トップページのサイドメニューに `Tutorial` を追加
- `docs/tutorials/building-a-service.md` の入門版をトップページに追加し、固定ページ、REST、mapper、OpenAPI/tests の流れを案内
- 既存ダークテーマに合わせた tutorial card / step styling を追加
- HTTP runtime test で tutorial 導線がJS assetに含まれることを確認

## Test plan
- `node --check htdocs/js/index/index.js`
- `composer test`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`（19 tests, 176 assertions, 1 skipped）
- `composer analyze`
- `git diff --check`
- Browser snapshot at `http://localhost:8080/`

Closes #118

Made with [Cursor](https://cursor.com)