### PR TITLE
feat(install): DBセットアップと疎通確認を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The goal is not to replace Laravel, Symfony, CodeIgniter, or Laminas. The goal i
 - Workflow: `docs/workflow.md`
 - Coding standards: `docs/development/coding-standards.md`
 - Docker development: `docs/development/docker.md`
+- Server install: `docs/deployment/server-install.md`
 - Testing: `docs/development/testing.md`
 - AI agent guide: `AGENTS.md`
 
@@ -57,6 +58,13 @@ docker compose up --build
 Open `http://localhost:8080/`.
 
 Docker Compose starts MySQL 8.4 and initializes the development `users` and `todos` tables automatically. The default development login is `admin` / `admin`.
+
+For a traditional Apache/PHP server install, run Composer and then initialize the sample database:
+
+```sh
+composer install --no-dev --optimize-autoloader
+php cli/setupDatabase.php --env=.env --yes
+```
 
 ## Testing
 

--- a/class/controller/HealthController.php
+++ b/class/controller/HealthController.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Controller;
+
+use Nene\Xion\ControllerBase;
+use Nene\Xion\DatabaseInstaller;
+
+/**
+ * Installation and runtime health endpoint.
+ */
+class HealthController extends ControllerBase
+{
+    /**
+     * The health check is public and read-only.
+     *
+     * @return void
+     */
+    protected function preAction(): void
+    {
+        $this->SESSION_CHECK = false;
+    }
+
+    /**
+     * Check API, database, and sample schema reachability.
+     *
+     * @return array<string,mixed> Health response.
+     */
+    public function indexGetRest(): array
+    {
+        return $this->API_RESPONSE->success(DatabaseInstaller::health());
+    }
+}

--- a/class/controller/ServerinstallController.php
+++ b/class/controller/ServerinstallController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Controller;
+
+use Nene\Xion\ControllerBase;
+
+/**
+ * Server install documentation page.
+ */
+class ServerinstallController extends ControllerBase
+{
+    /**
+     * The deployment guide is public documentation.
+     *
+     * @return void
+     */
+    protected function preAction(): void
+    {
+        $this->SESSION_CHECK = false;
+    }
+
+    /**
+     * Show the traditional server installation guide.
+     *
+     * @return void
+     */
+    public function indexAction(): void
+    {
+        $this->setTitle('Server Install - NeNe');
+        $this->VIEW->setString(
+            't_contents',
+            'Install NeNe on an Apache/PHP server after git clone.'
+        );
+    }
+}

--- a/class/xion/DatabaseInstaller.php
+++ b/class/xion/DatabaseInstaller.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Database setup and health checks for the sample runtime.
+ */
+final class DatabaseInstaller
+{
+    /**
+     * Create required sample tables and seed development data.
+     *
+     * @return array<string,mixed> Installation summary.
+     */
+    public static function install(): array
+    {
+        $pdo = self::pdo(true);
+        self::createTables($pdo);
+        if (DB_TYPE === 'SQLite3') {
+            self::createSQLiteTimestampTriggers($pdo);
+            self::syncSQLiteFilePermissions();
+        }
+        self::seedSampleData($pdo);
+
+        return [
+            'databaseType' => DB_TYPE,
+            'databaseName' => DB_TYPE === 'MySQL' ? DB_NAME : DB_FILE,
+            'tables' => ['users', 'todos'],
+            'sampleUser' => 'admin',
+        ];
+    }
+
+    /**
+     * Check API, database connection, and sample schema status.
+     *
+     * @return array<string,mixed> Public health result.
+     */
+    public static function health(): array
+    {
+        $result = [
+            'healthStatus' => 'degraded',
+            'api' => true,
+            'database' => false,
+            'schema' => false,
+            'databaseType' => defined('DB_TYPE') ? DB_TYPE : '',
+        ];
+
+        try {
+            $pdo = self::pdo(false);
+            $pdo->query('SELECT 1');
+            $result['database'] = true;
+        } catch (\Throwable $throwable) {
+            return self::withDebugDetail($result, $throwable);
+        }
+
+        try {
+            self::assertTableExists($pdo, 'users');
+            self::assertTableExists($pdo, 'todos');
+            $result['schema'] = true;
+            $result['healthStatus'] = 'ok';
+        } catch (\Throwable $throwable) {
+            return self::withDebugDetail($result, $throwable);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Create a PDO connection without going through the HTTP termination path.
+     */
+    private static function pdo(bool $createSQLiteDirectory): PDO
+    {
+        if (!in_array(DB_TYPE, ['MySQL', 'SQLite3'], true)) {
+            throw new \RuntimeException('Unsupported DB_TYPE: ' . DB_TYPE);
+        }
+
+        if (DB_TYPE === 'MySQL') {
+            $pdo = new PDO(
+                'mysql:host=' . DB_HOST . ';port=' . DB_PORT . ';dbname=' . DB_NAME . ';charset=utf8mb4',
+                DB_USER,
+                DB_PASS
+            );
+            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            if (defined('PDO::MYSQL_ATTR_USE_BUFFERED_QUERY')) {
+                $pdo->setAttribute((int)constant('PDO::MYSQL_ATTR_USE_BUFFERED_QUERY'), true);
+            }
+            return $pdo;
+        }
+
+        if ($createSQLiteDirectory && !is_dir(DB_DIR) && !mkdir(DB_DIR, 0775, true) && !is_dir(DB_DIR)) {
+            throw new \RuntimeException('Database directory could not be created: ' . DB_DIR);
+        }
+
+        $pdo = new PDO('sqlite:' . DB_DIR . DB_FILE);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('PRAGMA foreign_keys = ON');
+        return $pdo;
+    }
+
+    /**
+     * Create the current sample tables for the configured database.
+     */
+    private static function createTables(PDO $pdo): void
+    {
+        if (DB_TYPE === 'MySQL') {
+            self::createMySQLTables($pdo);
+            return;
+        }
+
+        self::createSQLiteTables($pdo);
+    }
+
+    /**
+     * Create MySQL tables aligned with Docker initialization.
+     */
+    private static function createMySQLTables(PDO $pdo): void
+    {
+        $pdo->exec(<<<'SQL'
+CREATE TABLE IF NOT EXISTS users (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    user_id VARCHAR(64) NOT NULL,
+    user_pass VARCHAR(255) NOT NULL,
+    user_name VARCHAR(255) NOT NULL,
+    e_mail VARCHAR(255) NOT NULL,
+    is_deleted TINYINT(1) NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY users_user_id_unique (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL);
+
+        $pdo->exec(<<<'SQL'
+CREATE TABLE IF NOT EXISTS todos (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    user_id BIGINT UNSIGNED NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    is_completed TINYINT(1) NOT NULL DEFAULT 0,
+    is_deleted TINYINT(1) NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    KEY todos_user_id_index (user_id),
+    CONSTRAINT todos_user_id_foreign
+        FOREIGN KEY (user_id) REFERENCES users (id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL);
+    }
+
+    /**
+     * Create SQLite tables aligned with the MySQL sample layout.
+     */
+    private static function createSQLiteTables(PDO $pdo): void
+    {
+        $pdo->exec(<<<'SQL'
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    user_id TEXT NOT NULL,
+    user_pass TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    e_mail TEXT NOT NULL,
+    is_deleted INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (user_id)
+)
+SQL);
+
+        $pdo->exec(<<<'SQL'
+CREATE TABLE IF NOT EXISTS todos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    user_id INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    is_completed INTEGER NOT NULL DEFAULT 0,
+    is_deleted INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+)
+SQL);
+
+        $pdo->exec('CREATE INDEX IF NOT EXISTS todos_user_id_index ON todos (user_id)');
+    }
+
+    /**
+     * Keep SQLite updated_at close to MySQL's ON UPDATE CURRENT_TIMESTAMP.
+     */
+    private static function createSQLiteTimestampTriggers(PDO $pdo): void
+    {
+        $pdo->exec(<<<'SQL'
+CREATE TRIGGER IF NOT EXISTS users_updated_at_trigger
+AFTER UPDATE ON users
+FOR EACH ROW
+WHEN NEW.updated_at = OLD.updated_at
+BEGIN
+    UPDATE users SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END
+SQL);
+
+        $pdo->exec(<<<'SQL'
+CREATE TRIGGER IF NOT EXISTS todos_updated_at_trigger
+AFTER UPDATE ON todos
+FOR EACH ROW
+WHEN NEW.updated_at = OLD.updated_at
+BEGIN
+    UPDATE todos SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END
+SQL);
+    }
+
+    /**
+     * Insert sample account and TODO rows without duplicating them.
+     */
+    private static function seedSampleData(PDO $pdo): void
+    {
+        $adminPasswordHash = password_hash((string)(getenv('NENE_SAMPLE_ADMIN_PASSWORD') ?: 'admin'), PASSWORD_DEFAULT);
+
+        $stmt = $pdo->prepare(<<<'SQL'
+INSERT INTO users (user_id, user_pass, user_name, e_mail, is_deleted)
+SELECT 'admin', :user_pass, 'admin', 'admin@example.com', 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM users WHERE user_id = 'admin'
+)
+SQL);
+        $stmt->bindValue(':user_pass', $adminPasswordHash, PDO::PARAM_STR);
+        $stmt->execute();
+
+        self::seedTodo($pdo, 'Read the routing guide', true);
+        self::seedTodo($pdo, 'Create a controller action', false);
+    }
+
+    /**
+     * Insert one sample TODO when it does not exist yet.
+     */
+    private static function seedTodo(PDO $pdo, string $title, bool $isCompleted): void
+    {
+        $stmt = $pdo->prepare(<<<'SQL'
+INSERT INTO todos (user_id, title, is_completed, is_deleted)
+SELECT users.id, :title, :is_completed, 0
+FROM users
+WHERE users.user_id = 'admin'
+AND NOT EXISTS (
+    SELECT 1 FROM todos
+    WHERE todos.user_id = users.id
+    AND todos.title = :title
+)
+SQL);
+        $stmt->bindValue(':title', $title, PDO::PARAM_STR);
+        $stmt->bindValue(':is_completed', $isCompleted ? 1 : 0, PDO::PARAM_INT);
+        $stmt->execute();
+    }
+
+    /**
+     * Verify that a table can be queried.
+     */
+    private static function assertTableExists(PDO $pdo, string $table): void
+    {
+        if (!in_array($table, ['users', 'todos'], true)) {
+            throw new \InvalidArgumentException('Unexpected table check: ' . $table);
+        }
+
+        $pdo->query('SELECT COUNT(*) FROM ' . $table);
+    }
+
+    /**
+     * Match the SQLite file permission with the writable data directory.
+     */
+    private static function syncSQLiteFilePermissions(): void
+    {
+        $databasePath = DB_DIR . DB_FILE;
+        $directoryGroup = filegroup(DB_DIR);
+        if ($directoryGroup !== false) {
+            @chgrp($databasePath, $directoryGroup);
+        }
+
+        @chmod($databasePath, 0664);
+    }
+
+    /**
+     * Add diagnostic details only when public debug output is enabled.
+     *
+     * @param array<string,mixed> $result Public health result.
+     *
+     * @return array<string,mixed>
+     */
+    private static function withDebugDetail(array $result, \Throwable $throwable): array
+    {
+        if (defined('APP_DEBUG') && APP_DEBUG) {
+            $result['detail'] = $throwable->getMessage();
+        }
+
+        return $result;
+    }
+}

--- a/class/xion/EnvLoader.php
+++ b/class/xion/EnvLoader.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+/**
+ * Minimal dotenv-style loader for CLI setup commands.
+ */
+final class EnvLoader
+{
+    /**
+     * Load KEY=VALUE lines from a local env file when it exists.
+     *
+     * Existing process environment values win over file values so server-level
+     * configuration can override local files.
+     *
+     * @return array<string,string> Loaded values keyed by environment name.
+     */
+    public static function loadIfExists(string $path): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $loaded = [];
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if ($lines === false) {
+            throw new \RuntimeException('Environment file could not be read: ' . $path);
+        }
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            [$name, $value] = self::parseLine($line);
+            if ($name === '' || getenv($name) !== false) {
+                continue;
+            }
+
+            putenv($name . '=' . $value);
+            $_ENV[$name] = $value;
+            $loaded[$name] = $value;
+        }
+
+        return $loaded;
+    }
+
+    /**
+     * Parse one dotenv-like line.
+     *
+     * @return array{0:string,1:string}
+     */
+    private static function parseLine(string $line): array
+    {
+        $parts = explode('=', $line, 2);
+        if (count($parts) !== 2) {
+            return ['', ''];
+        }
+
+        $name = trim($parts[0]);
+        $value = trim($parts[1]);
+        if (
+            strlen($value) >= 2
+            && (($value[0] === '"' && substr($value, -1) === '"')
+                || ($value[0] === "'" && substr($value, -1) === "'"))
+        ) {
+            $value = substr($value, 1, -1);
+        }
+
+        return [$name, $value];
+    }
+}

--- a/cli/setupDatabase.php
+++ b/cli/setupDatabase.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+use Nene\Xion\DatabaseInstaller;
+use Nene\Xion\EnvLoader;
+use Nene\Xion\Initialize;
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+ini_set('display_errors', '1');
+error_reporting(E_ALL);
+date_default_timezone_set('Asia/Tokyo');
+
+$options = getopt('', ['env::', 'yes', 'help']) ?: [];
+if (isset($options['help'])) {
+    showHelp();
+    return 0;
+}
+
+$envPath = resolveEnvPath(is_string($options['env'] ?? null) ? $options['env'] : '.env');
+$loadedEnv = EnvLoader::loadIfExists($envPath);
+
+Initialize::init();
+
+echo 'Welcome NeNe-PHP database setup!' . PHP_EOL . PHP_EOL;
+echo 'Environment file: ' . ($loadedEnv === [] ? 'not loaded' : $envPath) . PHP_EOL;
+echo 'Database type: ' . DB_TYPE . PHP_EOL;
+echo 'Database target: ' . (DB_TYPE === 'MySQL' ? DB_HOST . ':' . DB_PORT . '/' . DB_NAME : DB_DIR . DB_FILE) . PHP_EOL;
+echo 'This command creates users/todos tables and inserts the sample admin data when missing.' . PHP_EOL . PHP_EOL;
+
+if (!isset($options['yes'])) {
+    echo 'Do you want to continue? (Y/N)' . PHP_EOL;
+    $answer = trim((string)fgets(STDIN));
+    if (!in_array(strtolower($answer), ['y', 'yes'], true)) {
+        echo 'OK. Bye!' . PHP_EOL;
+        return 0;
+    }
+}
+
+try {
+    $summary = DatabaseInstaller::install();
+    $health = DatabaseInstaller::health();
+} catch (Throwable $throwable) {
+    fwrite(STDERR, 'Database setup failed: ' . $throwable->getMessage() . PHP_EOL);
+    return 1;
+}
+
+echo 'Database setup completed.' . PHP_EOL;
+echo 'Tables: ' . implode(', ', $summary['tables']) . PHP_EOL;
+echo 'Sample account: admin / ' . (getenv('NENE_SAMPLE_ADMIN_PASSWORD') ?: 'admin') . PHP_EOL;
+echo 'Health: API=' . boolText((bool)$health['api'])
+    . ' DB=' . boolText((bool)$health['database'])
+    . ' Schema=' . boolText((bool)$health['schema']) . PHP_EOL;
+
+return 0;
+
+/**
+ * Show command usage.
+ */
+function showHelp(): void
+{
+    echo <<<'TEXT'
+Usage:
+  php cli/setupDatabase.php [--env=.env] [--yes]
+
+Options:
+  --env   Load a dotenv-style file before NeNe initializes configuration.
+          Existing process environment variables take priority.
+  --yes   Run without the confirmation prompt.
+  --help  Show this help.
+
+TEXT;
+}
+
+/**
+ * Resolve a relative env file path from the repository root.
+ */
+function resolveEnvPath(string $path): string
+{
+    if ($path === '') {
+        return dirname(__DIR__) . '/.env';
+    }
+
+    if (str_starts_with($path, '/')) {
+        return $path;
+    }
+
+    return dirname(__DIR__) . '/' . $path;
+}
+
+/**
+ * Render a boolean value for CLI output.
+ */
+function boolText(bool $value): string
+{
+    return $value ? 'OK' : 'NG';
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This directory contains project documentation for humans and AI agents.
 - `development/coding-standards.md`: Coding standards.
 - `development/commit-conventions.md`: Commit message rules.
 - `development/docker.md`: Docker local development.
+- `deployment/server-install.md`: Traditional Apache/PHP server installation after `git clone`.
 - `development/testing.md`: Testing strategy and commands.
 - `tutorials/building-a-service.md`: Practical guide for adding pages, REST endpoints, database-backed features, OpenAPI, and tests.
 - `roadmap.md`: Project direction.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -9,11 +9,49 @@ servers:
   - url: http://localhost:8080
     description: Local Docker development server
 tags:
+  - name: Health
+    description: Installation and runtime health checks.
   - name: Session
     description: Session authentication endpoints.
   - name: TODO
     description: Authenticated TODO sample endpoints.
 paths:
+  /health/index:
+    get:
+      tags:
+        - Health
+      summary: Check API, database, and sample schema health
+      operationId: healthCheck
+      responses:
+        "200":
+          description: Health result. A degraded result still uses 200 so installers can inspect setup state.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthSuccessEnvelope"
+              examples:
+                ok:
+                  value:
+                    Result: true
+                    Data:
+                      status: success
+                      errorCode: ""
+                      healthStatus: ok
+                      api: true
+                      database: true
+                      schema: true
+                      databaseType: MySQL
+                degraded:
+                  value:
+                    Result: true
+                    Data:
+                      status: success
+                      errorCode: ""
+                      healthStatus: degraded
+                      api: true
+                      database: false
+                      schema: false
+                      databaseType: MySQL
   /session/login:
     post:
       tags:
@@ -331,6 +369,43 @@ components:
           properties:
             Data:
               $ref: "#/components/schemas/ApiSuccessData"
+    HealthStatus:
+      allOf:
+        - $ref: "#/components/schemas/ApiSuccessData"
+        - type: object
+          required:
+            - api
+            - database
+            - schema
+            - databaseType
+            - healthStatus
+          properties:
+            healthStatus:
+              type: string
+              enum:
+                - ok
+                - degraded
+            api:
+              type: boolean
+            database:
+              type: boolean
+            schema:
+              type: boolean
+            databaseType:
+              type: string
+              enum:
+                - MySQL
+                - SQLite3
+            detail:
+              type: string
+              description: Debug-only diagnostic detail when APP_DEBUG is enabled.
+    HealthSuccessEnvelope:
+      allOf:
+        - $ref: "#/components/schemas/JsonEnvelope"
+        - type: object
+          properties:
+            Data:
+              $ref: "#/components/schemas/HealthStatus"
     LoginRequest:
       type: object
       required:

--- a/docs/deployment/server-install.md
+++ b/docs/deployment/server-install.md
@@ -1,0 +1,307 @@
+# Server Install Guide
+
+This guide explains how to install NeNe on a traditional Apache/PHP server after `git clone`.
+
+Docker is still the recommended local development environment. A server install is for production-like hosting, shared hosting, VPS, or a small Apache/PHP server where NeNe is deployed directly.
+
+## Confirmed Short Path
+
+The shortest confirmed path is:
+
+```sh
+git clone git@github.com:hideyukiMORI/NeNe.git
+cd NeNe
+composer install --no-dev --optimize-autoloader
+```
+
+This flow has been confirmed with the public sample site at <https://nene-php.com/>.
+
+After Composer finishes, point the web server document root to:
+
+```text
+/path/to/NeNe/htdocs
+```
+
+Open the configured domain and confirm that the NeNe top page appears.
+
+Then create the sample database tables:
+
+```sh
+php cli/setupDatabase.php --env=.env --yes
+```
+
+The command is safe to run more than once. It creates the current sample `users` and `todos` tables when missing and inserts the default `admin` sample user only when that user does not already exist.
+
+## Requirements
+
+- PHP 8.4 is the project target.
+- Composer is required before deployment.
+- Apache must allow URL rewriting for `htdocs/.htaccess`.
+- PHP extensions depend on the database:
+  - `pdo_mysql` for MySQL.
+  - `pdo_sqlite` for SQLite fallback.
+- The deployed user must be able to read the project files.
+- Runtime directories such as `data/` and Smarty cache directories must be writable when the selected runtime uses them.
+
+## Important Directory Rule
+
+Only `htdocs/` should be public.
+
+Do not expose the repository root as the web document root. The repository root contains application code, configuration, documentation, tests, and Composer metadata.
+
+Recommended layout:
+
+```text
+/home/example/NeNe/
+    class/
+    config/
+    docs/
+    htdocs/        <- Apache DocumentRoot
+    ini/
+    vendor/
+    view/
+```
+
+If a hosting provider forces a directory such as `public_html`, prefer setting that directory to point to `NeNe/htdocs` from the hosting control panel. Avoid copying the entire repository into a public directory unless the server is configured so only `htdocs/` is reachable.
+
+## Composer Notes
+
+Run Composer from the repository root:
+
+```sh
+composer install --no-dev --optimize-autoloader
+```
+
+Use `--no-dev` on production servers so PHPUnit, Phan, PHP CS Fixer, and other development-only tools are not installed.
+
+If Composer fails with:
+
+```text
+/usr/bin/env: php: No such file or directory
+```
+
+the shell cannot find the PHP CLI binary. This is a server PATH issue, not a NeNe application error.
+
+Check which PHP command is available:
+
+```sh
+which php
+php -v
+```
+
+On shared hosting, PHP may live under a versioned path. Use the hosting provider's documented PHP CLI path, or run Composer through that binary directly when needed:
+
+```sh
+/path/to/php /path/to/composer install --no-dev --optimize-autoloader
+```
+
+## Environment Variables
+
+NeNe reads runtime settings with `getenv()` in `ini/xSystemIni.php`.
+
+The `.env.example` file is mainly for Docker Compose. It is not automatically loaded by plain Apache/PHP. On a server, configure environment variables through one of these mechanisms:
+
+- Hosting control panel environment variable settings.
+- Apache `SetEnv` directives.
+- Web server or process manager configuration.
+- A server-specific bootstrap approach approved for that hosting environment.
+
+For the setup CLI, it is fine to copy `.env.example` to `.env`, edit the database values, and run `php cli/setupDatabase.php --env=.env --yes`. The CLI loads that file explicitly. The web request path still needs the server to provide the same values through its normal environment mechanism.
+
+Common production values:
+
+```apacheconf
+SetEnv NENE_APP_ENV production
+SetEnv NENE_APP_DEBUG 0
+SetEnv NENE_SESSION_SECURE 1
+SetEnv NENE_SESSION_HTTPONLY 1
+SetEnv NENE_SESSION_SAMESITE Lax
+```
+
+Database values for MySQL:
+
+```apacheconf
+SetEnv NENE_DB_TYPE MySQL
+SetEnv NENE_DB_HOST localhost
+SetEnv NENE_DB_PORT 3306
+SetEnv NENE_DB_NAME nene
+SetEnv NENE_DB_USER nene_user
+SetEnv NENE_DB_PASS change_me
+```
+
+Do not commit real passwords, tokens, or hosting-specific `.env` files.
+
+## Database Setup
+
+Docker creates the development MySQL schema automatically. A traditional server does not.
+
+For production MySQL, create:
+
+- A database.
+- A database user with only the permissions needed by the application.
+- Tables compatible with the current sample schema.
+
+The sample TODO app expects:
+
+- `users`
+- `todos`
+
+Use the Docker initialization SQL and SQLite initializer as references when preparing a server schema. Keep the sample `admin` account only for local testing; replace or remove it for production use.
+
+For the current sample runtime, use the setup command:
+
+```sh
+php cli/setupDatabase.php --env=.env --yes
+```
+
+The command loads a dotenv-style file before NeNe initializes configuration. Existing process environment variables take priority over the file, so hosting-level settings still win.
+
+Useful options:
+
+```sh
+php cli/setupDatabase.php --help
+php cli/setupDatabase.php --env=.env
+php cli/setupDatabase.php --env=/absolute/path/to/nene.env --yes
+```
+
+Expected success output includes:
+
+```text
+Database setup completed.
+Tables: users, todos
+Sample account: admin / admin
+Health: API=OK DB=OK Schema=OK
+```
+
+The browser health endpoint returns the same idea through the NeNe JSON envelope:
+
+```json
+{
+  "Result": true,
+  "Data": {
+    "status": "success",
+    "errorCode": "",
+    "healthStatus": "ok",
+    "api": true,
+    "database": true,
+    "schema": true,
+    "databaseType": "MySQL"
+  }
+}
+```
+
+## SQLite Option
+
+When no database environment variables are provided, NeNe can fall back to SQLite-oriented defaults.
+
+Initialize the SQLite sample data from the repository root:
+
+```sh
+php cli/initSQLite.php
+```
+
+SQLite is useful for a very small sample deployment or quick hosting verification. MySQL is recommended once the application stores real service data.
+
+## Apache Rewrite
+
+NeNe uses URL-based routing:
+
+```text
+/{controller}/{action}
+```
+
+Examples:
+
+```text
+/index/index
+/serverinstall/index
+/todo/index
+```
+
+The front controller is `htdocs/index.php`, and `htdocs/.htaccess` routes clean URLs into it. Apache must allow `.htaccess` rewrite rules for the `htdocs/` directory.
+
+If direct access to `/index/index` returns a 404 from Apache, check:
+
+- `mod_rewrite` is enabled.
+- `AllowOverride` permits rewrite rules.
+- The document root is `htdocs/`.
+- The `.htaccess` file was uploaded.
+
+## Deployment Check
+
+After installation, verify:
+
+```sh
+composer install --no-dev --optimize-autoloader
+php cli/setupDatabase.php --env=.env --yes
+```
+
+Then open these URLs in a browser:
+
+- `/`
+- `/index/index`
+- `/health/index`
+- `/serverinstall/index`
+- `/api-docs/`
+- `/api-docs/openapi.php`
+
+Expected behavior:
+
+- The top page loads with the dark NeNe developer design.
+- The top page health card shows `API: OK`, `DB: OK`, and `Schema: OK`.
+- The server install page explains the deployment flow.
+- The health endpoint returns a JSON response without exposing database credentials.
+- Swagger UI opens.
+- The OpenAPI YAML endpoint returns `application/yaml`.
+
+## Production Checklist
+
+- `NENE_APP_ENV=production`.
+- `NENE_APP_DEBUG=0`.
+- HTTPS is enabled.
+- `NENE_SESSION_SECURE=1` under HTTPS.
+- Real credentials are configured outside Git.
+- The web document root is `htdocs/`, not the repository root.
+- Development dependencies are not installed.
+- Sample credentials are removed or changed.
+- Database permissions are scoped to the application.
+- File permissions allow runtime writes only where needed.
+- Server logs are available for PHP and Apache errors.
+
+## Troubleshooting
+
+### Composer cannot find PHP
+
+Use the PHP CLI path provided by the server:
+
+```sh
+/path/to/php /path/to/composer install --no-dev --optimize-autoloader
+```
+
+### Page opens but assets are missing
+
+Confirm that the domain points to `htdocs/` and that `URI_ROOT` in `ini/xSystemIni.php` still matches the deployment path. Root deployments should keep `URI_ROOT` as `/`.
+
+### Clean URLs return 404
+
+Confirm Apache rewrite support and `.htaccess` loading.
+
+### API returns internal server error
+
+Temporarily inspect server logs. Keep `NENE_APP_DEBUG=0` in public production, and diagnose from logs rather than exposing details in the HTTP response.
+
+### Login or TODO sample fails
+
+Confirm that the database schema exists and the configured database user can read and write the expected tables.
+
+Run:
+
+```sh
+php cli/setupDatabase.php --env=.env --yes
+```
+
+Then check:
+
+```text
+/health/index
+```

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,8 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #121: Add server install database setup CLI and runtime health check.
+- #120: Add a traditional Apache/PHP server install guide and public documentation page.
 - #116: Expand HTTP runtime coverage for explicit routing, REST method boundaries, and JSON-only responses.
 - #108: Remove legacy JSONP output and move JSON handling to the response boundary.
 - #106: Update roadmap and milestones to reflect current status and architecture policy.
@@ -44,7 +46,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- No active short-term TODO after #116. Use new GitHub Issues for follow-up work.
+- No active short-term TODO after #121. Use new GitHub Issues for follow-up work.
 
 ## Backlog Candidates
 

--- a/htdocs/css/index/index.css
+++ b/htdocs/css/index/index.css
@@ -196,6 +196,7 @@
 
 .developers__card,
 .guide-panel,
+.health-card,
 .openapi-card,
 .quick-start-card,
 .sample-card,
@@ -254,6 +255,74 @@
     padding: 14px;
 }
 
+.health-card {
+    align-items: center;
+    display: grid;
+    gap: 18px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 18px;
+}
+
+.health-card--ok {
+    border-color: rgba(120, 218, 154, 0.28);
+}
+
+.health-card--degraded {
+    border-color: rgba(255, 193, 120, 0.28);
+}
+
+.health-card__summary span {
+    color: #f2f2ee;
+    display: block;
+    font-size: 0.98rem;
+    font-weight: 700;
+    margin-bottom: 6px;
+}
+
+.health-card__summary p {
+    color: #aaa9a1;
+    font-size: 0.9rem;
+    line-height: 1.55;
+    margin: 0;
+}
+
+.health-card__checks {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.health-badge {
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    padding: 6px 10px;
+}
+
+.health-badge.is-ok {
+    background: rgba(120, 218, 154, 0.14);
+    color: #9be7b3;
+}
+
+.health-badge.is-ng {
+    background: rgba(255, 143, 143, 0.13);
+    color: #ffabab;
+}
+
+.health-card code {
+    background: #050505;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    color: #f2f2ee;
+    font-family: "IBM Plex Sans", "IBM Plex Sans JP", sans-serif;
+    font-size: 0.84rem;
+    grid-column: 1 / -1;
+    line-height: 1.6;
+    overflow-wrap: anywhere;
+    padding: 10px 12px;
+}
+
 .guide-panel,
 .openapi-card {
     padding: 18px;
@@ -278,7 +347,6 @@
 
 .tutorial__doc-link {
     color: #8f82ff;
-    flex: 0 0 auto;
     font-size: 0.86rem;
     font-weight: 600;
     text-decoration: none;
@@ -286,6 +354,14 @@
 
 .tutorial__doc-link:hover {
     color: #f2f2ee;
+}
+
+.tutorial__links {
+    align-items: flex-end;
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    gap: 10px;
 }
 
 .tutorial__steps {
@@ -535,8 +611,13 @@
     }
 
     .developers__layout,
-    .developers__cards {
+    .developers__cards,
+    .health-card {
         grid-template-columns: 1fr;
+    }
+
+    .health-card__checks {
+        justify-content: flex-start;
     }
 
     .developers__sidebar {
@@ -548,6 +629,10 @@
 
     .tutorial__intro {
         flex-direction: column;
+    }
+
+    .tutorial__links {
+        align-items: flex-start;
     }
 
     .todo-panel__form {

--- a/htdocs/css/serverinstall/index.css
+++ b/htdocs/css/serverinstall/index.css
@@ -1,0 +1,241 @@
+body {
+    background: #080808;
+    color: #f4f2ea;
+    font-family: "IBM Plex Sans", "IBM Plex Sans JP", sans-serif;
+    margin: 0;
+}
+
+footer {
+    background: #080808;
+    color: #706f68;
+    padding: 28px 24px;
+    text-align: center;
+}
+
+footer a {
+    color: #aaa9a1;
+}
+
+.server-install {
+    background:
+        radial-gradient(circle at top left, rgba(143, 130, 255, 0.2), transparent 34rem),
+        linear-gradient(180deg, #10100f 0%, #080808 48%, #050505 100%);
+    min-height: 100vh;
+    padding: 72px 24px;
+}
+
+.server-install a {
+    color: #a79cff;
+    text-decoration: none;
+}
+
+.server-install a:hover {
+    color: #f4f2ea;
+}
+
+.server-install code {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    border-radius: 8px;
+    color: #f7f5ed;
+    display: inline-block;
+    font-family: "SFMono-Regular", Consolas, monospace;
+    font-size: 0.86rem;
+    padding: 3px 7px;
+}
+
+.server-install pre {
+    background: #11110f;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 18px;
+    box-shadow: 0 22px 80px rgba(0, 0, 0, 0.28);
+    margin: 0;
+    overflow-x: auto;
+    padding: 22px;
+}
+
+.server-install pre code {
+    background: transparent;
+    border: 0;
+    color: #f4f2ea;
+    display: block;
+    line-height: 1.7;
+    padding: 0;
+}
+
+.server-install__hero,
+.server-install__grid,
+.server-install__panel {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1040px;
+}
+
+.server-install__hero {
+    margin-bottom: 28px;
+}
+
+.server-install__hero h1 {
+    font-size: clamp(2.5rem, 7vw, 5.5rem);
+    letter-spacing: -0.07em;
+    line-height: 0.96;
+    margin: 0 0 22px;
+    max-width: 760px;
+}
+
+.server-install__hero p {
+    color: #bdbbb2;
+    font-size: 1rem;
+    line-height: 1.8;
+    margin: 0;
+    max-width: 760px;
+}
+
+.server-install__eyebrow {
+    color: #8f82ff;
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    margin: 0 0 12px;
+    text-transform: uppercase;
+}
+
+.server-install__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 26px;
+}
+
+.server-install__actions a {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    color: #f4f2ea;
+    font-size: 0.9rem;
+    font-weight: 700;
+    padding: 11px 16px;
+}
+
+.server-install__panel,
+.server-install__card {
+    background: rgba(18, 18, 17, 0.78);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 26px;
+    box-shadow: 0 28px 90px rgba(0, 0, 0, 0.22);
+}
+
+.server-install__panel {
+    margin-top: 18px;
+    padding: 28px;
+}
+
+.server-install__confirmed {
+    align-items: start;
+    display: grid;
+    gap: 22px;
+    grid-template-columns: minmax(0, 0.85fr) minmax(300px, 1fr);
+}
+
+.server-install__panel h2,
+.server-install__card h2 {
+    font-size: 1.28rem;
+    letter-spacing: -0.02em;
+    margin: 0 0 10px;
+}
+
+.server-install__panel p,
+.server-install__card p,
+.server-install__faq p {
+    color: #aaa9a1;
+    line-height: 1.72;
+    margin: 0;
+}
+
+.server-install__grid {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-top: 18px;
+}
+
+.server-install__card {
+    padding: 24px;
+}
+
+.server-install__card span {
+    color: #8f82ff;
+    display: inline-block;
+    font-size: 0.78rem;
+    font-weight: 700;
+    margin-bottom: 22px;
+}
+
+.server-install__card code {
+    margin-top: 18px;
+    max-width: 100%;
+    overflow-x: auto;
+}
+
+.server-install__checklist {
+    display: grid;
+    gap: 10px;
+    list-style: none;
+    margin: 18px 0 0;
+    padding: 0;
+}
+
+.server-install__checklist li {
+    color: #c9c7bd;
+    line-height: 1.65;
+    padding-left: 24px;
+    position: relative;
+}
+
+.server-install__checklist li::before {
+    color: #8f82ff;
+    content: "✓";
+    font-weight: 700;
+    left: 0;
+    position: absolute;
+    top: 0;
+}
+
+.server-install__faq {
+    display: grid;
+    gap: 18px;
+    margin-top: 18px;
+}
+
+.server-install__faq div {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding-top: 18px;
+}
+
+.server-install__faq h3 {
+    font-size: 1rem;
+    margin: 0 0 8px;
+}
+
+.server-install__faq code {
+    margin-top: 10px;
+    max-width: 100%;
+    overflow-x: auto;
+}
+
+@media (max-width: 820px) {
+    .server-install {
+        padding: 48px 16px;
+    }
+
+    .server-install__confirmed,
+    .server-install__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .server-install__panel,
+    .server-install__card {
+        border-radius: 20px;
+        padding: 20px;
+    }
+}

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -27,6 +27,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const sidebarLinks = [
         { href: '#getting-started', label: 'Getting Started' },
         { href: '#quick-start', label: 'Quick Start' },
+        { href: '#health-check', label: 'Health Check' },
         { href: '#tutorial', label: 'Tutorial' },
         { href: '#authentication', label: 'Authentication' },
         { href: '#sample-app', label: 'Sample TODO' },
@@ -43,6 +44,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     e(Hero),
                     e(GuideGrid),
                     e(QuickStart),
+                    e(HealthStatus),
                     e(ServiceTutorial),
                     e(AuthenticationGuide),
                     e(SampleApp),
@@ -121,6 +123,77 @@ document.addEventListener('DOMContentLoaded', function() {
         );
     }
 
+    function HealthStatus() {
+        const healthState = useState({
+            status: 'loading',
+            api: false,
+            database: false,
+            schema: false,
+            message: 'Checking runtime...'
+        });
+        const health = healthState[0];
+        const setHealth = healthState[1];
+
+        useEffect(function() {
+            fetch('/health/index')
+                .then(function(response) {
+                    return response.json().then(function(body) {
+                        if (!response.ok || !body.Result || !body.Data) {
+                            throw new Error('Health check failed.');
+                        }
+                        setHealth({
+                            status: body.Data.healthStatus || 'degraded',
+                            api: Boolean(body.Data.api),
+                            database: Boolean(body.Data.database),
+                            schema: Boolean(body.Data.schema),
+                            message: body.Data.healthStatus === 'ok'
+                                ? 'API, database, and sample schema are ready.'
+                                : 'API is reachable, but database setup is not complete.'
+                        });
+                    });
+                })
+                .catch(function(error) {
+                    setHealth({
+                        status: 'degraded',
+                        api: false,
+                        database: false,
+                        schema: false,
+                        message: error.message
+                    });
+                });
+        }, []);
+
+        return e('section', { className: 'developers__section', id: 'health-check' },
+            e('div', { className: 'developers__section-heading' },
+                e('div', null,
+                    e('p', { className: 'developers__eyebrow' }, 'Health Check'),
+                    e('h2', null, 'Confirm API and database setup')
+                ),
+                e('p', null, 'The sample page checks whether the runtime can reach the API, database, and required tables.')
+            ),
+            e('div', { className: 'health-card health-card--' + health.status },
+                e('div', { className: 'health-card__summary' },
+                    e('span', null, health.status === 'ok' ? 'Ready' : health.status === 'loading' ? 'Checking' : 'Needs setup'),
+                    e('p', null, health.message)
+                ),
+                e('div', { className: 'health-card__checks' },
+                    e(HealthBadge, { label: 'API', ok: health.api }),
+                    e(HealthBadge, { label: 'DB', ok: health.database }),
+                    e(HealthBadge, { label: 'Schema', ok: health.schema })
+                ),
+                health.status === 'ok'
+                    ? null
+                    : e('code', null, 'php cli/setupDatabase.php --env=.env --yes')
+            )
+        );
+    }
+
+    function HealthBadge(props) {
+        return e('span', {
+            className: props.ok ? 'health-badge is-ok' : 'health-badge is-ng'
+        }, props.label + ': ' + (props.ok ? 'OK' : 'NG'));
+    }
+
     function ServiceTutorial() {
         const tutorialSteps = [
             {
@@ -159,10 +232,16 @@ document.addEventListener('DOMContentLoaded', function() {
             ),
             e('div', { className: 'tutorial__intro' },
                 e('p', null, 'NeNe keeps the old-school URL and controller shape familiar to CodeIgniter or Zend Framework 1 users, then adds modern safety rails around it: JSON-only REST, OpenAPI, tests, Docker, and explicit error catalogs.'),
-                e('a', {
-                    className: 'tutorial__doc-link',
-                    href: 'https://github.com/hideyukiMORI/NeNe/blob/main/docs/tutorials/building-a-service.md'
-                }, 'Read the full Markdown tutorial')
+                e('div', { className: 'tutorial__links' },
+                    e('a', {
+                        className: 'tutorial__doc-link',
+                        href: 'https://github.com/hideyukiMORI/NeNe/blob/main/docs/tutorials/building-a-service.md'
+                    }, 'Read the full Markdown tutorial'),
+                    e('a', {
+                        className: 'tutorial__doc-link',
+                        href: '/serverinstall/index'
+                    }, 'Server install guide')
+                )
             ),
             e('div', { className: 'tutorial__steps' },
                 tutorialSteps.map(function(step) {

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -37,6 +37,36 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertStringContainsString('Tutorial', $response->body());
         self::assertStringContainsString('Build a small service', $response->body());
         self::assertStringContainsString('docs/tutorials/building-a-service.md', $response->body());
+        self::assertStringContainsString('/serverinstall/index', $response->body());
+        self::assertStringContainsString('/health/index', $response->body());
+        self::assertStringContainsString('php cli/setupDatabase.php --env=.env --yes', $response->body());
+    }
+
+    public function testHealthEndpointReportsApiDatabaseAndSchemaStatus(): void
+    {
+        $response = $this->client->request('GET', '/health/index');
+        $payload = $response->json();
+
+        self::assertSame(200, $response->statusCode());
+        self::assertSame(true, $payload['Result']);
+        self::assertSame('success', $payload['Data']['status']);
+        self::assertSame('ok', $payload['Data']['healthStatus']);
+        self::assertSame(true, $payload['Data']['api']);
+        self::assertSame(true, $payload['Data']['database']);
+        self::assertSame(true, $payload['Data']['schema']);
+    }
+
+    public function testServerInstallGuidePageRespondsWithDeploymentChecklist(): void
+    {
+        $response = $this->client->request('GET', '/serverinstall/index');
+
+        self::assertSame(200, $response->statusCode());
+        self::assertStringContainsString('text/html', $response->headerLine('Content-Type'));
+        self::assertStringContainsString('Install NeNe after git clone', $response->body());
+        self::assertStringContainsString('composer install --no-dev --optimize-autoloader', $response->body());
+        self::assertStringContainsString('php cli/setupDatabase.php --env=.env --yes', $response->body());
+        self::assertStringContainsString('NENE_APP_ENV=production', $response->body());
+        self::assertStringContainsString('nene-php.com', $response->body());
     }
 
     public function testSwaggerUiAndOpenApiDocumentAreServed(): void

--- a/tests/Http/OpenApiRuntimeContractTest.php
+++ b/tests/Http/OpenApiRuntimeContractTest.php
@@ -23,12 +23,13 @@ final class OpenApiRuntimeContractTest extends HttpRuntimeTestCase
         $operations = $this->documentedOperations($openApi);
 
         $examples = [
+            ['GET', '/health/index', '/health/index', null],
             ['POST', '/session/login', '/session/login', ['user_id' => 'admin', 'user_pass' => 'admin']],
             ['POST', '/session/logout', '/session/logout', []],
             ['GET', '/todo/index', '/todo/index', null],
             ['POST', '/todo/index', '/todo/index', ['title' => self::TEST_TODO_PREFIX . 'contract']],
             ['PUT', '/todo/item/id_{id}', '/todo/item/id_1', ['is_completed' => true]],
-            ['DELETE', '/todo/item/id_{id}', '/todo/item/id_1', null]
+            ['DELETE', '/todo/item/id_{id}', '/todo/item/id_1', null],
         ];
 
         foreach ($examples as [$method, $documentedPath, $runtimePath, $body]) {

--- a/tests/Unit/Xion/EnvLoaderTest.php
+++ b/tests/Unit/Xion/EnvLoaderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\EnvLoader;
+use PHPUnit\Framework\TestCase;
+
+final class EnvLoaderTest extends TestCase
+{
+    private const TEST_ENV_NAME = 'NENE_ENV_LOADER_TEST_VALUE';
+
+    protected function tearDown(): void
+    {
+        putenv(self::TEST_ENV_NAME);
+        unset($_ENV[self::TEST_ENV_NAME]);
+    }
+
+    public function testLoadIfExistsReadsSimpleEnvFile(): void
+    {
+        $path = $this->writeTempEnvFile(self::TEST_ENV_NAME . '=from-file');
+
+        $loaded = EnvLoader::loadIfExists($path);
+
+        self::assertSame(['NENE_ENV_LOADER_TEST_VALUE' => 'from-file'], $loaded);
+        self::assertSame('from-file', getenv(self::TEST_ENV_NAME));
+    }
+
+    public function testExistingProcessEnvironmentWinsOverFileValue(): void
+    {
+        putenv(self::TEST_ENV_NAME . '=from-process');
+        $_ENV[self::TEST_ENV_NAME] = 'from-process';
+        $path = $this->writeTempEnvFile(self::TEST_ENV_NAME . '=from-file');
+
+        $loaded = EnvLoader::loadIfExists($path);
+
+        self::assertSame([], $loaded);
+        self::assertSame('from-process', getenv(self::TEST_ENV_NAME));
+    }
+
+    /**
+     * @return string Temporary env file path.
+     */
+    private function writeTempEnvFile(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'nene-env-');
+        self::assertIsString($path);
+        file_put_contents($path, $contents . PHP_EOL);
+        return $path;
+    }
+}

--- a/view/source/serverinstall/index.tpl
+++ b/view/source/serverinstall/index.tpl
@@ -1,0 +1,135 @@
+{extends file='layout/app.tpl'}
+{block name='content'}
+                <main class="server-install">
+                    <section class="server-install__hero">
+                        <p class="server-install__eyebrow">Deployment Guide</p>
+                        <h1>Install NeNe after git clone</h1>
+                        <p>
+                            NeNe can run on Docker for local development, but a real server install only needs the
+                            repository, Composer dependencies, Apache rewrite support, and a document root pointed at
+                            <code>htdocs/</code>.
+                        </p>
+                        <div class="server-install__actions">
+                            <a href="https://github.com/hideyukiMORI/NeNe/blob/main/docs/deployment/server-install.md">Read full Markdown guide</a>
+                            <a href="/">Back to top</a>
+                        </div>
+                    </section>
+
+                    <section class="server-install__panel server-install__confirmed">
+                        <div>
+                            <p class="server-install__eyebrow">Confirmed Short Path</p>
+                            <h2>Minimum commands</h2>
+                            <p>
+                                This flow has been confirmed with the public sample site at
+                                <a href="https://nene-php.com/" target="_blank" rel="noopener noreferrer">nene-php.com</a>.
+                            </p>
+                        </div>
+                        <pre><code>git clone git@github.com:hideyukiMORI/NeNe.git
+cd NeNe
+composer install --no-dev --optimize-autoloader
+php cli/setupDatabase.php --env=.env --yes</code></pre>
+                    </section>
+
+                    <section class="server-install__grid">
+                        <article class="server-install__card">
+                            <span>01</span>
+                            <h2>Point Apache to htdocs</h2>
+                            <p>
+                                The repository root contains application code and docs. Only <code>htdocs/</code> should
+                                be public, because it contains the front controller and public assets.
+                            </p>
+                            <code>/path/to/NeNe/htdocs</code>
+                        </article>
+
+                        <article class="server-install__card">
+                            <span>02</span>
+                            <h2>Install production dependencies</h2>
+                            <p>
+                                Run Composer from the repository root. Use <code>--no-dev</code> so test and analysis
+                                tools are not installed on the server.
+                            </p>
+                            <code>composer install --no-dev --optimize-autoloader</code>
+                        </article>
+
+                        <article class="server-install__card">
+                            <span>03</span>
+                            <h2>Set runtime environment</h2>
+                            <p>
+                                Plain Apache/PHP does not automatically load <code>.env</code>. Configure values with
+                                hosting environment settings or Apache <code>SetEnv</code>.
+                            </p>
+                            <code>NENE_APP_ENV=production</code>
+                        </article>
+
+                        <article class="server-install__card">
+                            <span>04</span>
+                            <h2>Prepare the database</h2>
+                            <p>
+                                Docker initializes MySQL automatically. On a server, run the setup command after editing
+                                the environment values so the sample <code>users</code> and <code>todos</code> tables exist.
+                            </p>
+                            <code>php cli/setupDatabase.php --env=.env --yes</code>
+                        </article>
+                    </section>
+
+                    <section class="server-install__panel">
+                        <p class="server-install__eyebrow">Health Check</p>
+                        <h2>Confirm the runtime from the browser</h2>
+                        <p>
+                            The top page calls <code>/health/index</code> and displays whether the API, database
+                            connection, and sample schema are ready. It is a small ping-style check for first installs.
+                        </p>
+                        <pre><code>{
+  "status": "success",
+  "healthStatus": "ok",
+  "api": true,
+  "database": true,
+  "schema": true
+}</code></pre>
+                    </section>
+
+                    <section class="server-install__panel">
+                        <p class="server-install__eyebrow">Production Checklist</p>
+                        <h2>Before making it public</h2>
+                        <ul class="server-install__checklist">
+                            <li>Set <code>NENE_APP_ENV=production</code> and <code>NENE_APP_DEBUG=0</code>.</li>
+                            <li>Use HTTPS and set <code>NENE_SESSION_SECURE=1</code>.</li>
+                            <li>Keep real database passwords outside Git.</li>
+                            <li>Expose only <code>htdocs/</code>, not the repository root.</li>
+                            <li>Remove or change sample credentials before storing real data.</li>
+                            <li>Confirm Apache rewrite rules are active for clean URL routing.</li>
+                        </ul>
+                    </section>
+
+                    <section class="server-install__panel">
+                        <p class="server-install__eyebrow">Troubleshooting</p>
+                        <h2>Common hosting issues</h2>
+                        <div class="server-install__faq">
+                            <div>
+                                <h3>Composer says php was not found</h3>
+                                <p>
+                                    The server shell cannot find the PHP CLI binary. Use the hosting provider's PHP path,
+                                    then run Composer through that binary.
+                                </p>
+                                <code>/path/to/php /path/to/composer install --no-dev --optimize-autoloader</code>
+                            </div>
+                            <div>
+                                <h3>Clean URLs return 404</h3>
+                                <p>
+                                    Check <code>mod_rewrite</code>, <code>AllowOverride</code>, <code>.htaccess</code>,
+                                    and whether the document root points to <code>htdocs/</code>.
+                                </p>
+                            </div>
+                            <div>
+                                <h3>The TODO sample cannot login</h3>
+                                <p>
+                                    Confirm the database settings and make sure the <code>users</code> and
+                                    <code>todos</code> tables exist for the configured database. Run
+                                    <code>php cli/setupDatabase.php --env=.env --yes</code>, then check
+                                    <code>/health/index</code>.
+                                </p>
+                            </div>
+                        </div>
+                    </section>
+                </main>
+{/block}


### PR DESCRIPTION
## Summary
- Add `cli/setupDatabase.php` to load an env file, create `users`/`todos`, and seed the sample admin data idempotently.
- Add `/health/index` plus a top-page health card for API, database, and schema checks.
- Expand the server install guide and public install page with DB setup, health checks, and troubleshooting.

## Test plan
- `php -l class/xion/EnvLoader.php && php -l class/xion/DatabaseInstaller.php && php -l class/controller/HealthController.php && php -l cli/setupDatabase.php && php -l tests/Unit/Xion/EnvLoaderTest.php && php -l tests/Http/HttpSmokeTest.php && php -l tests/Http/OpenApiRuntimeContractTest.php && node --check htdocs/js/index/index.js`
- `docker compose exec -T app php cli/setupDatabase.php --yes`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `git diff --check`
- Browser check: `/` health card and `/serverinstall/index`

## Notes
- `composer format:check` still reports pre-existing formatting diffs in `class/controller/TodoController.php`, `class/db/Todo.php`, and `ini/xSiteIni.php`; this PR does not mix that formatting cleanup.

Closes #121

Made with [Cursor](https://cursor.com)