### PR TITLE
fix(install): Web起動時に.envを読み込む

### DIFF
--- a/docs/deployment/server-install.md
+++ b/docs/deployment/server-install.md
@@ -99,14 +99,27 @@ On shared hosting, PHP may live under a versioned path. Use the hosting provider
 
 NeNe reads runtime settings with `getenv()` in `ini/xSystemIni.php`.
 
-The `.env.example` file is mainly for Docker Compose. It is not automatically loaded by plain Apache/PHP. On a server, configure environment variables through one of these mechanisms:
+On a traditional server, copy `.env.example` to `.env` in the repository root and edit the values:
+
+```sh
+cp .env.example .env
+vi .env
+```
+
+The web front controller loads the repository-root `.env` before NeNe initializes configuration. Existing server or process environment values still take priority over file values, so hosting-level settings can override `.env` safely.
+
+You can also configure values through the server itself:
 
 - Hosting control panel environment variable settings.
 - Apache `SetEnv` directives.
 - Web server or process manager configuration.
 - A server-specific bootstrap approach approved for that hosting environment.
 
-For the setup CLI, it is fine to copy `.env.example` to `.env`, edit the database values, and run `php cli/setupDatabase.php --env=.env --yes`. The CLI loads that file explicitly. The web request path still needs the server to provide the same values through its normal environment mechanism.
+The setup CLI also loads `.env` explicitly when you pass `--env=.env`:
+
+```sh
+php cli/setupDatabase.php --env=.env --yes
+```
 
 Common production values:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #123: Load the repository-root `.env` before web runtime initialization.
 - #121: Add server install database setup CLI and runtime health check.
 - #120: Add a traditional Apache/PHP server install guide and public documentation page.
 - #116: Expand HTTP runtime coverage for explicit routing, REST method boundaries, and JSON-only responses.
@@ -46,7 +47,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- No active short-term TODO after #121. Use new GitHub Issues for follow-up work.
+- No active short-term TODO after #123. Use new GitHub Issues for follow-up work.
 
 ## Backlog Candidates
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -25,6 +25,7 @@ error_reporting(E_ALL);
  */
 require_once '../vendor/autoload.php';
 
+Xion\EnvLoader::loadIfExists(dirname(__DIR__) . '/.env');
 Xion\Initialize::init();
 
 configurePublicErrorDisplay();

--- a/view/source/serverinstall/index.tpl
+++ b/view/source/serverinstall/index.tpl
@@ -55,10 +55,10 @@ php cli/setupDatabase.php --env=.env --yes</code></pre>
                             <span>03</span>
                             <h2>Set runtime environment</h2>
                             <p>
-                                Plain Apache/PHP does not automatically load <code>.env</code>. Configure values with
-                                hosting environment settings or Apache <code>SetEnv</code>.
+                                Copy <code>.env.example</code> to <code>.env</code> and edit it in the repository root.
+                                Web requests load that file before NeNe initializes configuration.
                             </p>
-                            <code>NENE_APP_ENV=production</code>
+                            <code>NENE_DB_TYPE=MySQL</code>
                         </article>
 
                         <article class="server-install__card">


### PR DESCRIPTION
## Summary
- Load the repository-root `.env` before `Initialize::init()` in `htdocs/index.php`.
- Keep server/process environment values higher priority through the existing `EnvLoader` behavior.
- Update the server install guide and public install page so `.env` behavior matches the runtime.

## Test plan
- `php -l htdocs/index.php`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `docker compose exec -T app php cli/setupDatabase.php --yes`
- `git diff --check`

## Notes
- `composer format:check` still reports pre-existing formatting diffs in `class/controller/TodoController.php`, `class/db/Todo.php`, and `ini/xSiteIni.php`.

Closes #123

Made with [Cursor](https://cursor.com)