### PR TITLE
docs(install): SQLite初期化手順を明記する

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ composer install --no-dev --optimize-autoloader
 php cli/setupDatabase.php --env=.env --yes
 ```
 
+If you intentionally use the SQLite3 fallback, initialize the SQLite sample file instead:
+
+```sh
+php cli/initSQLite.php
+```
+
 ## Testing
 
 ```sh

--- a/docs/deployment/server-install.md
+++ b/docs/deployment/server-install.md
@@ -24,13 +24,19 @@ After Composer finishes, point the web server document root to:
 
 Open the configured domain and confirm that the NeNe top page appears.
 
-Then create the sample database tables:
+Then create the sample database tables. For MySQL, use the general setup command:
 
 ```sh
 php cli/setupDatabase.php --env=.env --yes
 ```
 
-The command is safe to run more than once. It creates the current sample `users` and `todos` tables when missing and inserts the default `admin` sample user only when that user does not already exist.
+For SQLite3 fallback, initialize the SQLite file explicitly:
+
+```sh
+php cli/initSQLite.php
+```
+
+Both commands are safe to run more than once. They create the current sample `users` and `todos` tables when missing and insert the default `admin` sample user only when that user does not already exist.
 
 ## Requirements
 
@@ -161,7 +167,7 @@ The sample TODO app expects:
 
 Use the Docker initialization SQL and SQLite initializer as references when preparing a server schema. Keep the sample `admin` account only for local testing; replace or remove it for production use.
 
-For the current sample runtime, use the setup command:
+For the current MySQL sample runtime, use the setup command:
 
 ```sh
 php cli/setupDatabase.php --env=.env --yes
@@ -207,10 +213,16 @@ The browser health endpoint returns the same idea through the NeNe JSON envelope
 
 When no database environment variables are provided, NeNe can fall back to SQLite-oriented defaults.
 
-Initialize the SQLite sample data from the repository root:
+When you intentionally use `NENE_DB_TYPE=SQLite3`, initialize the SQLite sample data from the repository root:
 
 ```sh
 php cli/initSQLite.php
+```
+
+This creates the SQLite database file under `data/`, creates the `users` and `todos` tables, and inserts the default `admin` sample user. You can also use the general setup command with an env file that sets `NENE_DB_TYPE=SQLite3`:
+
+```sh
+php cli/setupDatabase.php --env=.env --yes
 ```
 
 SQLite is useful for a very small sample deployment or quick hosting verification. MySQL is recommended once the application stores real service data.
@@ -247,6 +259,12 @@ After installation, verify:
 ```sh
 composer install --no-dev --optimize-autoloader
 php cli/setupDatabase.php --env=.env --yes
+```
+
+If you are using SQLite3 instead of MySQL, run:
+
+```sh
+php cli/initSQLite.php
 ```
 
 Then open these URLs in a browser:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #125: Clarify the SQLite3 initialization command in install documentation.
 - #123: Load the repository-root `.env` before web runtime initialization.
 - #121: Add server install database setup CLI and runtime health check.
 - #120: Add a traditional Apache/PHP server install guide and public documentation page.
@@ -47,7 +48,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- No active short-term TODO after #123. Use new GitHub Issues for follow-up work.
+- No active short-term TODO after #125. Use new GitHub Issues for follow-up work.
 
 ## Backlog Candidates
 

--- a/view/source/serverinstall/index.tpl
+++ b/view/source/serverinstall/index.tpl
@@ -66,9 +66,10 @@ php cli/setupDatabase.php --env=.env --yes</code></pre>
                             <h2>Prepare the database</h2>
                             <p>
                                 Docker initializes MySQL automatically. On a server, run the setup command after editing
-                                the environment values so the sample <code>users</code> and <code>todos</code> tables exist.
+                                the environment values. If you intentionally use SQLite3, run the SQLite initializer.
                             </p>
-                            <code>php cli/setupDatabase.php --env=.env --yes</code>
+                            <code>MySQL: php cli/setupDatabase.php --env=.env --yes</code>
+                            <code>SQLite3: php cli/initSQLite.php</code>
                         </article>
                     </section>
 
@@ -124,9 +125,9 @@ php cli/setupDatabase.php --env=.env --yes</code></pre>
                                 <h3>The TODO sample cannot login</h3>
                                 <p>
                                     Confirm the database settings and make sure the <code>users</code> and
-                                    <code>todos</code> tables exist for the configured database. Run
-                                    <code>php cli/setupDatabase.php --env=.env --yes</code>, then check
-                                    <code>/health/index</code>.
+                                    <code>todos</code> tables exist for the configured database. For MySQL, run
+                                    <code>php cli/setupDatabase.php --env=.env --yes</code>. For SQLite3, run
+                                    <code>php cli/initSQLite.php</code>. Then check <code>/health/index</code>.
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- Clarify that MySQL installs should use `php cli/setupDatabase.php --env=.env --yes`.
- Clarify that intentional SQLite3 fallback installs can run `php cli/initSQLite.php`.
- Reflect the same command split in the public server install page and README.

## Test plan
- `git diff --check`
- `php -l cli/initSQLite.php`

Closes #125

Made with [Cursor](https://cursor.com)