### PR TITLE
feat(health): 開発時にDB種別を表示する

### DIFF
--- a/class/xion/DatabaseInstaller.php
+++ b/class/xion/DatabaseInstaller.php
@@ -46,6 +46,7 @@ final class DatabaseInstaller
             'api' => true,
             'database' => false,
             'schema' => false,
+            'environment' => defined('APP_ENV') ? APP_ENV : '',
             'databaseType' => defined('DB_TYPE') ? DB_TYPE : '',
         ];
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #129: Show the database type in the development health check card.
 - #127: Remove the tracked generated SQLite database artifact.
 - #125: Clarify the SQLite3 initialization command in install documentation.
 - #123: Load the repository-root `.env` before web runtime initialization.
@@ -49,7 +50,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- No active short-term TODO after #127. Use new GitHub Issues for follow-up work.
+- No active short-term TODO after #129. Use new GitHub Issues for follow-up work.
 
 ## Backlog Candidates
 

--- a/htdocs/css/index/index.css
+++ b/htdocs/css/index/index.css
@@ -293,6 +293,15 @@
     justify-content: flex-end;
 }
 
+.health-card__meta {
+    color: #8f82ff;
+    font-size: 0.82rem;
+    font-weight: 700;
+    grid-column: 1 / -1;
+    letter-spacing: 0.02em;
+    margin: 0;
+}
+
 .health-badge {
     border-radius: 999px;
     font-size: 0.78rem;

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -128,6 +128,8 @@ document.addEventListener('DOMContentLoaded', function() {
             status: 'loading',
             api: false,
             database: false,
+            databaseType: '',
+            environment: '',
             schema: false,
             message: 'Checking runtime...'
         });
@@ -145,6 +147,8 @@ document.addEventListener('DOMContentLoaded', function() {
                             status: body.Data.healthStatus || 'degraded',
                             api: Boolean(body.Data.api),
                             database: Boolean(body.Data.database),
+                            databaseType: body.Data.databaseType || '',
+                            environment: body.Data.environment || '',
                             schema: Boolean(body.Data.schema),
                             message: body.Data.healthStatus === 'ok'
                                 ? 'API, database, and sample schema are ready.'
@@ -157,6 +161,8 @@ document.addEventListener('DOMContentLoaded', function() {
                         status: 'degraded',
                         api: false,
                         database: false,
+                        databaseType: '',
+                        environment: '',
                         schema: false,
                         message: error.message
                     });
@@ -181,6 +187,9 @@ document.addEventListener('DOMContentLoaded', function() {
                     e(HealthBadge, { label: 'DB', ok: health.database }),
                     e(HealthBadge, { label: 'Schema', ok: health.schema })
                 ),
+                health.environment && health.environment !== 'production' && health.databaseType
+                    ? e('p', { className: 'health-card__meta' }, 'DB Type: ' + health.databaseType)
+                    : null,
                 health.status === 'ok'
                     ? null
                     : e('code', null, 'php cli/setupDatabase.php --env=.env --yes')

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -40,6 +40,7 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertStringContainsString('/serverinstall/index', $response->body());
         self::assertStringContainsString('/health/index', $response->body());
         self::assertStringContainsString('php cli/setupDatabase.php --env=.env --yes', $response->body());
+        self::assertStringContainsString('DB Type: ', $response->body());
     }
 
     public function testHealthEndpointReportsApiDatabaseAndSchemaStatus(): void
@@ -54,6 +55,8 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertSame(true, $payload['Data']['api']);
         self::assertSame(true, $payload['Data']['database']);
         self::assertSame(true, $payload['Data']['schema']);
+        self::assertSame('development', $payload['Data']['environment']);
+        self::assertSame('MySQL', $payload['Data']['databaseType']);
     }
 
     public function testServerInstallGuidePageRespondsWithDeploymentChecklist(): void


### PR DESCRIPTION
## Summary
- Add `environment` to the health response so the UI can decide whether setup details may be shown.
- Show `DB Type: MySQL` / `DB Type: SQLite3` on the top-page Health Check card only outside production.
- Cover the health response and JavaScript text with HTTP runtime assertions.

## Test plan
- `php -l class/xion/DatabaseInstaller.php && php -l tests/Http/HttpSmokeTest.php && node --check htdocs/js/index/index.js && git diff --check`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- `docker compose exec -T app php cli/setupDatabase.php --yes`
- Browser check: `/` shows `DB Type: MySQL` in development

## Notes
- `composer format:check` still reports pre-existing formatting diffs in `class/controller/TodoController.php`, `class/db/Todo.php`, and `ini/xSiteIni.php`.

Closes #129

Made with [Cursor](https://cursor.com)