### PR TITLE
feat(health): 開発時に環境名を表示する

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #131: Show the runtime environment label in the development health check card.
 - #129: Show the database type in the development health check card.
 - #127: Remove the tracked generated SQLite database artifact.
 - #125: Clarify the SQLite3 initialization command in install documentation.
@@ -50,7 +51,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- No active short-term TODO after #129. Use new GitHub Issues for follow-up work.
+- No active short-term TODO after #131. Use new GitHub Issues for follow-up work.
 
 ## Backlog Candidates
 

--- a/htdocs/css/index/index.css
+++ b/htdocs/css/index/index.css
@@ -295,8 +295,11 @@
 
 .health-card__meta {
     color: #8f82ff;
+    display: flex;
+    flex-wrap: wrap;
     font-size: 0.82rem;
     font-weight: 700;
+    gap: 10px;
     grid-column: 1 / -1;
     letter-spacing: 0.02em;
     margin: 0;

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -187,8 +187,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     e(HealthBadge, { label: 'DB', ok: health.database }),
                     e(HealthBadge, { label: 'Schema', ok: health.schema })
                 ),
-                health.environment && health.environment !== 'production' && health.databaseType
-                    ? e('p', { className: 'health-card__meta' }, 'DB Type: ' + health.databaseType)
+                health.environment === 'development'
+                    ? e('div', { className: 'health-card__meta' },
+                        e('span', null, 'Environment: ' + health.environment),
+                        health.databaseType ? e('span', null, 'DB Type: ' + health.databaseType) : null
+                    )
                     : null,
                 health.status === 'ok'
                     ? null

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -40,6 +40,8 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertStringContainsString('/serverinstall/index', $response->body());
         self::assertStringContainsString('/health/index', $response->body());
         self::assertStringContainsString('php cli/setupDatabase.php --env=.env --yes', $response->body());
+        self::assertStringContainsString('Environment: ', $response->body());
+        self::assertStringContainsString("health.environment === 'development'", $response->body());
         self::assertStringContainsString('DB Type: ', $response->body());
     }
 


### PR DESCRIPTION
## Summary
- Show `Environment: development` on the top-page Health Check card when the runtime reports development.
- Keep environment and DB type metadata hidden outside development.
- Update HTTP smoke assertions for the development-only UI text.

## Test plan
- `php -l tests/Http/HttpSmokeTest.php && node --check htdocs/js/index/index.js && git diff --check`
- `composer test`
- `composer analyze`
- `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http`
- Browser check: `/` shows `Environment: development` and `DB Type: MySQL`

Closes #131

Made with [Cursor](https://cursor.com)