### PR TITLE
docs(release): v0.1.0リリース記録を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The goal is not to replace Laravel, Symfony, CodeIgniter, or Laminas. The goal i
 - Coding standards: `docs/development/coding-standards.md`
 - Docker development: `docs/development/docker.md`
 - Server install: `docs/deployment/server-install.md`
+- Releases: `docs/releases.md`
 - Testing: `docs/development/testing.md`
 - AI agent guide: `AGENTS.md`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This directory contains project documentation for humans and AI agents.
 - `development/testing.md`: Testing strategy and commands.
 - `tutorials/building-a-service.md`: Practical guide for adding pages, REST endpoints, database-backed features, OpenAPI, and tests.
 - `roadmap.md`: Project direction.
+- `releases.md`: Human-readable release notes and version checkpoints.
 - `todo/current.md`: Current TODO summary.
 - `milestones/README.md`: Milestone management.
 - `adr/README.md`: Architecture decision records.

--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -38,7 +38,13 @@ What was renovated:
 - Security-sensitive paths: sessions, cookies, password hashing, CSRF, JSON-only REST responses, inline script JSON, error exposure, and request wrappers.
 - Static analysis and formatting foundations with Phan and PHP CS Fixer.
 
-Current status: known stabilization Issues are complete. No open Issues remain for this milestone.
+Real server sample:
+
+- `https://nene-php.com/` is the current public sample deployment for NeNe.
+- The deployment validates the non-Docker path: `git clone`, Composer install, root `.env` loading, database initialization, public `htdocs/` document root, health check, and the React TODO sample.
+- The sample intentionally remains small. Its purpose is to prove that the renovated legacy framework can be installed on a traditional Apache/PHP server without turning the project into a large full-stack framework.
+
+Current status: known stabilization Issues are complete. No open Issues remain for this milestone. The current milestone state is suitable for the first framework tag, `v0.1.0`.
 
 ### docs-foundation
 
@@ -69,6 +75,12 @@ Current status: the starter OpenAPI contract and Swagger UI are in place for the
 Purpose: protect NeNe's renovated legacy architecture from unnecessary redesign.
 
 Current status: no broad architecture rewrite is planned. NeNe should keep the front controller, `/{controller}/{action}` routing, `{action}Action()` page handlers, method-specific REST handlers, Smarty templates, and lightweight mapper/model style. Architecture work should document boundaries, add tests, or clarify conventions. Any change that hides URL routing, replaces the MVC shape, adds a heavy ORM, or changes compatibility policy should require a focused Issue and ADR.
+
+### release-management
+
+Purpose: make framework progress visible through small versioned tags.
+
+Current status: `v0.1.0` is the first planned tag. It represents the point where NeNe has a working local Docker setup, traditional server install documentation, MySQL/SQLite sample database setup, a public `nene-php.com` sample deployment, OpenAPI/Swagger UI, tests, and a clear renovated-legacy framework policy.
 
 ## Maintenance Rule
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,35 @@
+# Releases
+
+This file records human-readable release notes for NeNe framework tags.
+
+## v0.1.0
+
+Status: initial release tag.
+
+`v0.1.0` is the first usable milestone for the renovated NeNe framework. It marks the point where the legacy-style structure is still intact, but the project has enough modern tooling, documentation, setup flow, and runtime checks to be cloned, installed, and evaluated on a real server.
+
+### Verified Sample
+
+- Public sample: `https://nene-php.com/`
+- Purpose: verify the traditional Apache/PHP install path outside Docker.
+- Confirmed flow: `git clone`, Composer install, root `.env` loading, database setup, public `htdocs/` document root, `/health/index`, and the sample TODO login flow.
+
+### Highlights
+
+- Preserved the front controller and `/{controller}/{action}` routing style.
+- Preserved `Controller::actionAction()` pages, Smarty templates, and lightweight mapper/model conventions.
+- Added method-specific REST handlers such as `indexGetRest()` and `indexPostRest()`.
+- Added Docker local development with MySQL 8.4 and SQLite fallback support.
+- Added Composer-based dependency management and current stable package updates.
+- Added PHPUnit unit tests, HTTP runtime smoke tests, and OpenAPI runtime contract checks.
+- Added OpenAPI 3.1 documentation and Swagger UI.
+- Hardened sessions, cookie attributes, password hashing, CSRF, JSON-only REST responses, inline JSON escaping, public error display, and request variable boundaries.
+- Added Phan and PHP CS Fixer foundations for gradual modernization.
+- Added server install documentation and a public `/serverinstall/index` page.
+- Added database setup CLI and a health check for API, database, schema, runtime environment, and database type.
+
+### Version Meaning
+
+This is not a promise that NeNe is a finished general-purpose framework. It is a stable checkpoint for the renovation project: small, readable, legacy-friendly, and usable enough to start service experiments without hiding the old framework shape.
+
+Future tags should stay small and issue-driven. Prefer version bumps when a user-visible setup flow, framework convention, security boundary, or documented API contract changes.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #133: Document the `v0.1.0` release milestone and prepare the first framework tag.
 - #131: Show the runtime environment label in the development health check card.
 - #129: Show the database type in the development health check card.
 - #127: Remove the tracked generated SQLite database artifact.
@@ -51,7 +52,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- No active short-term TODO after #131. Use new GitHub Issues for follow-up work.
+- No active short-term TODO after #133. Use new GitHub Issues for follow-up work.
 
 ## Backlog Candidates
 


### PR DESCRIPTION
## Summary
- `docs/milestones/README.md` に `https://nene-php.com/` の実サーバサンプル検証を追記
- `docs/releases.md` を追加し、`v0.1.0` の位置づけとハイライトを記録
- README と docs index からリリース記録へ導線を追加

## Test plan
- `git diff --check`
- `composer test`
- `composer analyze`

## Release note
After this PR is merged, create and push the initial `v0.1.0` tag from `main`.

Closes #133

Made with [Cursor](https://cursor.com)