### PR TITLE
chore(license): MITライセンスへ変更する

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Hideyuki MORI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ composer test
 
 ## License
 
-Proprietary.
+MIT.

--- a/class/controller/HealthController.php
+++ b/class/controller/HealthController.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/controller/IndexController.php
+++ b/class/controller/IndexController.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/controller/SessionController.php
+++ b/class/controller/SessionController.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/controller/TodoController.php
+++ b/class/controller/TodoController.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/db/Todo.php
+++ b/class/db/Todo.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/db/TodoMapper.php
+++ b/class/db/TodoMapper.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/db/User.php
+++ b/class/db/User.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/db/UserMapper.php
+++ b/class/db/UserMapper.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/func/Text.php
+++ b/class/func/Text.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/ApiResponse.php
+++ b/class/xion/ApiResponse.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/AuthSession.php
+++ b/class/xion/AuthSession.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/DataModelBase.php
+++ b/class/xion/DataModelBase.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/ErrorCode.php
+++ b/class/xion/ErrorCode.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/HttpEmitter.php
+++ b/class/xion/HttpEmitter.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/HttpResponse.php
+++ b/class/xion/HttpResponse.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/HttpTermination.php
+++ b/class/xion/HttpTermination.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/Initialize.php
+++ b/class/xion/Initialize.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/JsonResponder.php
+++ b/class/xion/JsonResponder.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/Log.php
+++ b/class/xion/Log.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/ModelBase.php
+++ b/class/xion/ModelBase.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/PdoConnection.php
+++ b/class/xion/PdoConnection.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/Post.php
+++ b/class/xion/Post.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/QueryString.php
+++ b/class/xion/QueryString.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/Request.php
+++ b/class/xion/Request.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/RequestVariables.php
+++ b/class/xion/RequestVariables.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/RouteContext.php
+++ b/class/xion/RouteContext.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/UrlParameter.php
+++ b/class/xion/UrlParameter.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/cli/initSQLite.php
+++ b/cli/initSQLite.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/cli/setupDatabase.php
+++ b/cli/setupDatabase.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "hideyukimori/nene",
     "description": "Simple web application framework",
-    "license": "proprietary",
+    "license": "MIT",
     "autoload": {
 		"psr-4": {
 			"Nene\\Init\\"      : "class/init/",

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #136: Change the project license to MIT.
 - #133: Document the `v0.1.0` release milestone and prepare the first framework tag.
 - #131: Show the runtime environment label in the development health check card.
 - #129: Show the database type in the development health check card.
@@ -52,7 +53,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- No active short-term TODO after #133. Use new GitHub Issues for follow-up work.
+- #135: Refactor `ControllerBase` responsibilities into smaller testable boundaries.
 
 ## Backlog Candidates
 

--- a/ini/xSiteIni.php
+++ b/ini/xSiteIni.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 

--- a/ini/xSystemIni.php
+++ b/ini/xSystemIni.php
@@ -9,7 +9,7 @@
  * @package   AYANE
  * @author    hideyukiMORI <info@ayane.co.jp>
  * @copyright 2021 AYANE
- * @license   https://choosealicense.com/no-permission/ NO LICENSE
+ * @license   https://opensource.org/licenses/MIT MIT License
  * @link      https://ayane.co.jp/
  */
 


### PR DESCRIPTION
## Summary
- MIT `LICENSE` を追加
- `composer.json` と README のライセンス表記を MIT に変更
- 既存 PHPDoc ヘッダの `NO LICENSE` 表記を MIT License に統一
- TODO を #136 完了予定と #135 次タスクに更新

## Notes
- `composer.json` は `git diff --check` を通すため、既存 CRLF を LF に正規化しています。内容変更は license metadata のみです。
- Runtime behavior is unchanged.

## Test plan
- `git diff --check`
- `composer validate --no-check-publish`
- `composer test`
- `composer analyze`
- `rg 'Proprietary|NO LICENSE|no-permission|choosealicense|"license": "proprietary"'`

Closes #136

Made with [Cursor](https://cursor.com)