### PR TITLE
Docker開発環境にphpMyAdminとdarkwolfテーマを追加する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ NENE_SESSION_LIFETIME=0
 # MySQL port exposed on the host machine.
 NENE_MYSQL_PORT=3307
 
+# phpMyAdmin port exposed on the host machine for local development.
+NENE_PHPMYADMIN_PORT=8081
+
 # Development database settings. The default Docker runtime uses MySQL.
 NENE_DB_TYPE=MySQL
 NENE_DB_HOST=mysql

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Open `http://localhost:8080/`.
 
 Docker Compose starts MySQL 8.4 and initializes the development `users` and `todos` tables automatically. The default development login is `admin` / `admin`.
 
+For local database inspection, open phpMyAdmin at `http://localhost:8081/` and log in with the development database user `nene` / `nene`. The Docker image includes the darkwolf phpMyAdmin theme.
+
 For a traditional Apache/PHP server install, run Composer and then initialize the sample database:
 
 ```sh

--- a/compose.yaml
+++ b/compose.yaml
@@ -48,6 +48,18 @@ services:
       timeout: 5s
       retries: 20
 
+  phpmyadmin:
+    build:
+      context: ./docker/phpmyadmin
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      PMA_HOST: mysql
+      PMA_PORT: 3306
+    ports:
+      - "${NENE_PHPMYADMIN_PORT:-8081}:80"
+
 volumes:
   mysql-data:
   vendor:

--- a/docker/phpmyadmin/Dockerfile
+++ b/docker/phpmyadmin/Dockerfile
@@ -1,0 +1,15 @@
+FROM phpmyadmin:5.2-apache
+
+ARG DARKWOLF_VERSION=5.2
+ARG DARKWOLF_SHA256=4f1d394d042492caa703b267078d4e8c13eb3d128d5c758d451ac69fce7eb8a8
+
+COPY config.user.inc.php /etc/phpmyadmin/config.user.inc.php
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl unzip; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL -o /tmp/darkwolf.zip "https://files.phpmyadmin.net/themes/darkwolf/${DARKWOLF_VERSION}/darkwolf-${DARKWOLF_VERSION}.zip"; \
+    echo "${DARKWOLF_SHA256}  /tmp/darkwolf.zip" | sha256sum -c -; \
+    unzip -q /tmp/darkwolf.zip -d /var/www/html/themes; \
+    rm -f /tmp/darkwolf.zip

--- a/docker/phpmyadmin/config.user.inc.php
+++ b/docker/phpmyadmin/config.user.inc.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+$cfg['ThemeDefault'] = 'darkwolf';

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -21,6 +21,22 @@ Open:
 http://localhost:8080/
 ```
 
+phpMyAdmin is also available for the local MySQL development database:
+
+```text
+http://localhost:8081/
+```
+
+Log in with the development database credentials:
+
+```text
+server: mysql
+user: nene
+password: nene
+```
+
+The phpMyAdmin image includes the darkwolf theme for phpMyAdmin 5.2. It is intended only for trusted local development; do not expose this service in production.
+
 ## Environment Variables
 
 Docker Compose includes local development defaults, so `.env` is optional. To customize ports or database credentials, copy the committed example and edit your local file:
@@ -36,7 +52,13 @@ The application reads runtime, session, and database settings through `getenv()`
 Use another port if needed:
 
 ```sh
-NENE_PORT=8081 docker compose up --build
+NENE_PORT=8082 docker compose up --build
+```
+
+Use another phpMyAdmin port if needed:
+
+```sh
+NENE_PHPMYADMIN_PORT=8083 docker compose up --build
 ```
 
 ## Session Cookie Settings
@@ -79,6 +101,8 @@ The first MySQL startup runs `docker/mysql/init/001_schema.sql`, which creates:
 It also inserts the default development account and sample TODO rows.
 
 The MySQL container is exposed on host port `3307` by default to avoid colliding with a host MySQL server.
+
+The phpMyAdmin container connects to MySQL through the internal Compose service name `mysql` and is exposed on host port `8081` by default. It uses the same development database credentials shown above, and selects the bundled darkwolf theme by default.
 
 Default development account:
 
@@ -133,4 +157,5 @@ docker compose down
 - `mod_rewrite` is enabled so `htdocs/.htaccess` can route URLs to `index.php`.
 - Composer dependencies are stored in a Docker named volume named `vendor`.
 - MySQL data is stored in a Docker named volume named `mysql-data`.
+- phpMyAdmin is a local development helper and should not be exposed from production deployments.
 - Generated files under `log/`, `view/compile/`, and SQLite database files are ignored by Git.


### PR DESCRIPTION
## Summary
- Docker Compose にローカル開発用の phpMyAdmin サービスを追加しました。
- phpMyAdmin 5.2 系イメージへ darkwolf テーマをSHA256検証付きで同梱し、初期テーマに設定しました。
- README、`.env.example`、Docker開発ドキュメントにアクセス方法、ポート変更、本番公開しない注意を追記しました。

## Test plan
- [x] `docker compose config`
- [x] `docker compose build phpmyadmin`
- [x] `docker compose up --build -d`
- [x] `curl -fsSI http://localhost:8080/`
- [x] `curl -fsSI http://localhost:8081/`
- [x] `docker compose exec -T phpmyadmin sh -lc 'test -d /var/www/html/themes/darkwolf && php -r '\''include \"/etc/phpmyadmin/config.user.inc.php\"; echo $cfg[\"ThemeDefault\"] ?? \"\";'\'''`
- [x] `docker compose exec -T app composer test`

Closes #138

Made with [Cursor](https://cursor.com)