### PR TITLE
AI可読性と小規模納品の次フェーズを明文化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ NeNe is a renovated legacy PHP framework.
 
 The original idea is more than ten years old: keep a tiny front-controller framework that people familiar with older PHP frameworks can understand at a glance. This repository keeps that philosophy and structure, then updates the project for modern PHP development with Composer, Docker, tests, OpenAPI, explicit security defaults, and current stable packages.
 
-NeNe is intentionally much smaller than full-stack frameworks. It keeps only the parts needed to build small services:
+NeNe is intentionally much smaller than full-stack frameworks. It is designed to stay readable by both humans and AI agents, so code generated or edited with AI assistance should still be easy for a developer to inspect, understand, and keep.
+
+NeNe keeps only the parts needed to build small services:
 
 - Convention-based routing from URL segments.
 - Server-rendered pages with Smarty.
@@ -14,7 +16,7 @@ NeNe is intentionally much smaller than full-stack frameworks. It keeps only the
 - Lightweight database mappers.
 - Session, CSRF, error catalog, logging, and testable boundaries.
 
-The goal is not to replace Laravel, Symfony, CodeIgniter, or Laminas. The goal is to give legacy-framework users a small codebase they can read, keep, and safely modernize.
+The goal is not to replace Laravel, Symfony, CodeIgniter, or Laminas. The goal is to give legacy-framework users a small codebase they can read, keep, safely modernize, and move from clone to a working small-service delivery path quickly.
 
 ## Documentation
 

--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -82,6 +82,35 @@ Purpose: make framework progress visible through small versioned tags.
 
 Current status: `v0.1.0` is the first planned tag. It represents the point where NeNe has a working local Docker setup, traditional server install documentation, MySQL/SQLite sample database setup, a public `nene-php.com` sample deployment, OpenAPI/Swagger UI, tests, and a clear renovated-legacy framework policy.
 
+### ai-readable-small-service-delivery
+
+Goal: make NeNe a small PHP framework that stays friendly to both human developers and AI agents while supporting fast, secure small-service delivery.
+
+Context: NeNe's next phase should build on the renovated legacy foundation. The framework should not grow into a large full-stack platform. Instead, it should keep the visible `/{controller}/{action}` flow, small codebase, Docker setup, OpenAPI, tests, and security defaults as a practical advantage: a developer should be able to clone the project, understand the shape quickly, let an AI agent help with routine code, and still review the result without fighting hidden framework behavior.
+
+Positioning:
+
+- AI-readable, not AI-only.
+- Human-friendly, not magic-heavy.
+- Fast for small services, not a replacement for large enterprise frameworks.
+- Secure by default for realistic local development and small deployments.
+
+Scope:
+
+- Keep conventions explicit enough that AI-written and human-written changes follow the same shape.
+- Improve tutorials, examples, comments, and PHPDoc where they reduce review friction.
+- Keep the path from clone to local verification short and repeatable.
+- Keep traditional Apache/PHP deployment guidance clear for small real-world projects.
+- Maintain focused tests, OpenAPI contracts, and security defaults as part of the delivery workflow.
+
+Completion criteria:
+
+- Documentation clearly describes NeNe as human-friendly and AI-readable without overstating AI guarantees.
+- A first service can be built by following docs from page/controller through REST endpoint, database access, OpenAPI, and tests.
+- Local Docker setup remains simple, including app, MySQL, phpMyAdmin, Swagger UI, and test commands.
+- Production-facing docs continue to warn about secrets, debug output, local Docker credentials, phpMyAdmin exposure, and database initialization.
+- New examples do not introduce hidden routing, heavy ORM behavior, or broad framework abstractions.
+
 ## Maintenance Rule
 
 When a GitHub milestone becomes active, update this directory with:

--- a/docs/project.md
+++ b/docs/project.md
@@ -6,7 +6,11 @@ The project started from an older, intentionally small PHP framework style. Its 
 
 NeNe is for developers who are comfortable with older convention-based PHP frameworks and want a codebase they can read from end to end. It keeps the familiar "URL segment -> controller -> action" flow while modernizing the boundaries around it.
 
+NeNe should also be friendly to AI-assisted development. That does not mean promising that every generated change is automatically good. It means keeping the framework small, explicit, documented, and testable enough that code written by a human or an AI agent can be reviewed by a human without first decoding a large amount of framework magic.
+
 The project should remain small and understandable. New work should improve maintainability, security, and standards compatibility without turning NeNe into a large full-stack framework.
+
+For small services, the desired experience is a short path from `git clone` to local verification, then to a simple deployable shape: Docker for local work, traditional Apache/PHP documentation for server install, explicit database setup, OpenAPI where public APIs exist, and focused tests around behavior that matters.
 
 ## Renovation Philosophy
 
@@ -29,6 +33,7 @@ Modernize:
 - Centralized API responses and error codes.
 - Session lifecycle, CSRF, password hashing, JSON-only REST responses, and public error behavior.
 - OpenAPI contracts, Swagger UI, PHPUnit, Phan, PHP CS Fixer, and Docker development.
+- AI-readable conventions, docs, and tests that keep human review practical.
 
 Avoid:
 
@@ -96,6 +101,8 @@ Examples:
 NeNe should evolve as:
 
 - A legacy-compatible but modernizing PHP framework.
+- A human-friendly and AI-readable framework where generated or hand-written changes follow the same visible conventions.
+- A fast path for building and delivering small, secure services without adopting a large full-stack framework.
 - PSR-aware, especially for autoloading, coding style, HTTP/API boundaries, and logging.
 - Composer-based, with packages kept on current stable versions where practical.
 - Security-conscious by default.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,6 +14,8 @@ NeNe should continue to emphasize:
 - Smarty-based server rendering as the default HTML path.
 - Lightweight mapper/model classes instead of a heavy ORM.
 - Small, readable framework code over large abstractions.
+- Human-friendly and AI-readable conventions that make generated or hand-written changes reviewable in the same way.
+- A short path from `git clone` to local verification and small-service delivery.
 - Modern safety rails around the legacy shape: Docker, tests, OpenAPI, Phan, PHP CS Fixer, CSRF, password hashing, error catalogs, and safer output handling.
 
 NeNe should avoid:
@@ -132,3 +134,29 @@ Future candidates:
 - Extract dispatcher route parsing further only if future tests or services need it.
 - Reduce legacy static-analysis baseline issues in focused cleanup PRs.
 - Revisit CI Docker runtime coverage when repository resources and runtime cost make it practical.
+
+## 6. AI-Readable Small-Service Delivery
+
+Status: next phase.
+
+Goal:
+
+NeNe should become a framework that is pleasant to use with both human and AI-assisted development. The target is not to claim that AI output is always correct. The target is to keep the codebase explicit enough that AI-written and human-written changes look similar, follow the same conventions, and remain practical for a human developer to review.
+
+This phase should strengthen NeNe as a small-service delivery framework: quick to clone, quick to run, quick to inspect, and safe enough by default for realistic small projects.
+
+Principles:
+
+- Prefer visible conventions over hidden framework magic.
+- Keep routing, controller names, REST method boundaries, configuration, and database setup easy to trace.
+- Keep docs, examples, OpenAPI contracts, and tests close to the behavior they describe.
+- Preserve a fast Docker-based local workflow and a clear traditional Apache/PHP server install path.
+- Treat security defaults, explicit errors, CSRF, password hashing, session settings, and dependency hygiene as part of the developer experience.
+- Avoid adding large abstractions that make the code harder for humans or AI agents to understand.
+
+Future candidates:
+
+- Make the first-service tutorial even more repeatable from clone to local verification.
+- Add focused examples that show the expected shape of AI-assisted changes: page, REST endpoint, mapper, OpenAPI, and test.
+- Improve comments and PHPDoc only where they help readers understand framework boundaries.
+- Add lightweight checklists for small-service delivery readiness, including environment, database, OpenAPI, tests, and production safety notes.


### PR DESCRIPTION
## Summary
- README と project docs に、人間にもAIにも追いやすい小さなフレームワークとしての位置づけを追記しました。
- roadmap に `AI-Readable Small-Service Delivery` を次フェーズとして追加しました。
- milestones に `ai-readable-small-service-delivery` を追加し、目的、スコープ、完了条件を整理しました。

## Test plan
- [x] Markdown diagnostics: no linter errors

Closes #142

Made with [Cursor](https://cursor.com)