### PR TITLE
Phase 6を参照実装と小規模納品導線中心に調整する

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ NeNe is a renovated legacy PHP framework.
 
 The original idea is more than ten years old: keep a tiny front-controller framework that people familiar with older PHP frameworks can understand at a glance. This repository keeps that philosophy and structure, then updates the project for modern PHP development with Composer, Docker, tests, OpenAPI, explicit security defaults, and current stable packages.
 
-NeNe is intentionally much smaller than full-stack frameworks. It is designed to stay readable by both humans and AI agents, so code generated or edited with AI assistance should still be easy for a developer to inspect, understand, and keep.
+NeNe is intentionally much smaller than full-stack frameworks. Its visible conventions are meant to stay readable by both humans and AI agents, so code generated or edited with AI assistance can follow the same shape a developer would normally review.
 
 NeNe keeps only the parts needed to build small services:
 

--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -84,20 +84,21 @@ Current status: `v0.1.0` is the first planned tag. It represents the point where
 
 ### ai-readable-small-service-delivery
 
-Goal: make NeNe a small PHP framework that stays friendly to both human developers and AI agents while supporting fast, secure small-service delivery.
+Goal: make NeNe a small PHP framework that proves its existing human-friendly and AI-readable shape through working examples while supporting fast, secure small-service delivery.
 
-Context: NeNe's next phase should build on the renovated legacy foundation. The framework should not grow into a large full-stack platform. Instead, it should keep the visible `/{controller}/{action}` flow, small codebase, Docker setup, OpenAPI, tests, and security defaults as a practical advantage: a developer should be able to clone the project, understand the shape quickly, let an AI agent help with routine code, and still review the result without fighting hidden framework behavior.
+Context: NeNe's next phase should build on the renovated legacy foundation. The framework should not grow into a large full-stack platform, and it does not need a broad redesign just to become "AI-readable." It already has visible `/{controller}/{action}` flow, predictable controller and REST method names, a small codebase, Docker setup, OpenAPI, tests, and security defaults. The next step is to prove those strengths with reference implementations and a delivery path that a human can review comfortably, whether the change was written by a person or assisted by an AI agent.
 
 Positioning:
 
-- AI-readable, not AI-only.
+- AI-readable as an outcome of explicit conventions, not as a separate architecture goal.
 - Human-friendly, not magic-heavy.
 - Fast for small services, not a replacement for large enterprise frameworks.
 - Secure by default for realistic local development and small deployments.
 
 Scope:
 
-- Keep conventions explicit enough that AI-written and human-written changes follow the same shape.
+- Keep conventions explicit enough that AI-assisted and human-written changes follow the same shape.
+- Use working reference implementations to show the preferred shape for small features.
 - Improve tutorials, examples, comments, and PHPDoc where they reduce review friction.
 - Keep the path from clone to local verification short and repeatable.
 - Keep traditional Apache/PHP deployment guidance clear for small real-world projects.
@@ -105,8 +106,9 @@ Scope:
 
 Completion criteria:
 
-- Documentation clearly describes NeNe as human-friendly and AI-readable without overstating AI guarantees.
+- Documentation clearly describes NeNe as human-friendly and AI-readable without overstating AI guarantees or implying a broad architecture rewrite.
 - A first service can be built by following docs from page/controller through REST endpoint, database access, OpenAPI, and tests.
+- #145 defines a concrete reference implementation for the expected page, REST, mapper, OpenAPI, and test workflow.
 - Local Docker setup remains simple, including app, MySQL, phpMyAdmin, Swagger UI, and test commands.
 - Production-facing docs continue to warn about secrets, debug output, local Docker credentials, phpMyAdmin exposure, and database initialization.
 - New examples do not introduce hidden routing, heavy ORM behavior, or broad framework abstractions.

--- a/docs/project.md
+++ b/docs/project.md
@@ -6,7 +6,7 @@ The project started from an older, intentionally small PHP framework style. Its 
 
 NeNe is for developers who are comfortable with older convention-based PHP frameworks and want a codebase they can read from end to end. It keeps the familiar "URL segment -> controller -> action" flow while modernizing the boundaries around it.
 
-NeNe should also be friendly to AI-assisted development. That does not mean promising that every generated change is automatically good. It means keeping the framework small, explicit, documented, and testable enough that code written by a human or an AI agent can be reviewed by a human without first decoding a large amount of framework magic.
+NeNe is also a good fit for AI-assisted development because its existing conventions are visible and predictable. That does not mean promising that every generated change is automatically good. It means keeping the framework small, explicit, documented, and testable enough that code written by a human or assisted by an AI agent can be reviewed by a human without first decoding a large amount of framework magic.
 
 The project should remain small and understandable. New work should improve maintainability, security, and standards compatibility without turning NeNe into a large full-stack framework.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@ NeNe should continue to emphasize:
 - Smarty-based server rendering as the default HTML path.
 - Lightweight mapper/model classes instead of a heavy ORM.
 - Small, readable framework code over large abstractions.
-- Human-friendly and AI-readable conventions that make generated or hand-written changes reviewable in the same way.
+- Explicit conventions that make generated or hand-written changes reviewable in the same way.
 - A short path from `git clone` to local verification and small-service delivery.
 - Modern safety rails around the legacy shape: Docker, tests, OpenAPI, Phan, PHP CS Fixer, CSRF, password hashing, error catalogs, and safer output handling.
 
@@ -141,22 +141,23 @@ Status: next phase.
 
 Goal:
 
-NeNe should become a framework that is pleasant to use with both human and AI-assisted development. The target is not to claim that AI output is always correct. The target is to keep the codebase explicit enough that AI-written and human-written changes look similar, follow the same conventions, and remain practical for a human developer to review.
+NeNe already has several AI-era strengths: visible URL conventions, predictable controller and REST method names, small framework code, OpenAPI, and focused tests. Phase 6 should not turn "AI-readable" into a broad redesign goal. It should prove those existing strengths through repeatable examples and a delivery path that stays easy for humans to review.
 
-This phase should strengthen NeNe as a small-service delivery framework: quick to clone, quick to run, quick to inspect, and safe enough by default for realistic small projects.
+This phase should strengthen NeNe as a small-service delivery framework: quick to clone, quick to run, quick to inspect, and safe enough by default for realistic small projects. AI assistance is useful when it produces changes that look like normal NeNe changes and remain practical for a human developer to review.
 
 Principles:
 
 - Prefer visible conventions over hidden framework magic.
 - Keep routing, controller names, REST method boundaries, configuration, and database setup easy to trace.
-- Keep docs, examples, OpenAPI contracts, and tests close to the behavior they describe.
+- Prefer working reference implementations over extra explanation when examples can show the expected shape.
+- Keep docs, OpenAPI contracts, and tests close to the behavior they describe.
 - Preserve a fast Docker-based local workflow and a clear traditional Apache/PHP server install path.
 - Treat security defaults, explicit errors, CSRF, password hashing, session settings, and dependency hygiene as part of the developer experience.
 - Avoid adding large abstractions that make the code harder for humans or AI agents to understand.
 
 Future candidates:
 
+- #145: Add a small-service reference implementation that shows the expected shape of AI-assisted changes: page, REST endpoint, mapper, OpenAPI, and test.
 - Make the first-service tutorial even more repeatable from clone to local verification.
-- Add focused examples that show the expected shape of AI-assisted changes: page, REST endpoint, mapper, OpenAPI, and test.
 - Improve comments and PHPDoc only where they help readers understand framework boundaries.
 - Add lightweight checklists for small-service delivery readiness, including environment, database, OpenAPI, tests, and production safety notes.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,10 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #144: Adjust Phase 6 around reference implementations and small-service delivery.
+- #142: Document AI readability and small-service delivery as the next project phase.
+- #140: Clarify Docker development database credentials for phpMyAdmin and MySQL.
+- #138: Add phpMyAdmin with the darkwolf theme to the Docker development environment.
 - #136: Change the project license to MIT.
 - #133: Document the `v0.1.0` release milestone and prepare the first framework tag.
 - #131: Show the runtime environment label in the development health check card.
@@ -53,6 +57,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
+- #145: Add an AI-assisted small-service reference implementation covering page, REST, mapper, OpenAPI, and tests.
 - #135: Refactor `ControllerBase` responsibilities into smaller testable boundaries.
 
 ## Backlog Candidates


### PR DESCRIPTION
## Summary
- Phase 6 を「AI可読性のための広い再設計」ではなく、既存の明示的な規約を参照実装で証明する方向に調整しました。
- `#145` を、ページ、REST、Mapper、OpenAPI、テストを含む小規模サービス参照実装の次タスクとして接続しました。
- `docs/todo/current.md` に最近完了した Issue と次タスクを反映しました。

## Test plan
- [x] Markdown diagnostics: no linter errors

Closes #144

Made with [Cursor](https://cursor.com)