### PR TITLE
ControllerBaseからCSRF判定境界を分離する

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -136,6 +136,13 @@ abstract class ControllerBase
     protected $ROUTE_CONTEXT;
 
     /**
+     * CSRF validation decision boundary.
+     *
+     * @var CsrfProtectionPolicy
+     */
+    protected $CSRF_PROTECTION_POLICY;
+
+    /**
      * Rest post
      *
      * @var array
@@ -171,6 +178,7 @@ abstract class ControllerBase
         $this->AUTH_SESSION     = Xion\AuthSession::getInstance();
         $this->API_RESPONSE     = new Xion\ApiResponse();
         $this->ROUTE_CONTEXT    = Xion\RouteContext::getInstance();
+        $this->CSRF_PROTECTION_POLICY = new Xion\CsrfProtectionPolicy();
         $this->refController    = $_SESSION['global']['referer']['controller'] ?? '';
         $this->refAction        = $_SESSION['global']['referer']['action'] ?? '';
     }
@@ -367,13 +375,11 @@ abstract class ControllerBase
      */
     final protected function requiresCsrfProtection(): bool
     {
-        if (!$this->ROUTE_CONTEXT->isRest() || !in_array($this->method, ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
-            return false;
-        }
-        if ($this->ROUTE_CONTEXT->method() === 'loginPostRest') {
-            return false;
-        }
-        return $this->AUTH_SESSION->isLoggedIn();
+        return $this->CSRF_PROTECTION_POLICY->requiresToken(
+            $this->ROUTE_CONTEXT,
+            $this->method,
+            $this->AUTH_SESSION->isLoggedIn()
+        );
     }
 
     /**

--- a/class/xion/CsrfProtectionPolicy.php
+++ b/class/xion/CsrfProtectionPolicy.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+/**
+ * Decides whether a controller request must pass CSRF validation.
+ */
+class CsrfProtectionPolicy
+{
+    /**
+     * HTTP methods that can mutate server state.
+     *
+     * @var array<int,string>
+     */
+    private const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+    /**
+     * Determine whether the current request must include a CSRF token.
+     *
+     * @param RouteContext $routeContext  Current route context.
+     * @param string       $requestMethod HTTP request method.
+     * @param boolean      $isLoggedIn    Login state for the current session.
+     *
+     * @return boolean Whether CSRF validation is required.
+     */
+    final public function requiresToken(RouteContext $routeContext, string $requestMethod, bool $isLoggedIn): bool
+    {
+        if (!$routeContext->isRest() || !in_array(strtoupper($requestMethod), self::STATE_CHANGING_METHODS, true)) {
+            return false;
+        }
+        if ($routeContext->method() === 'loginPostRest') {
+            return false;
+        }
+        return $isLoggedIn;
+    }
+}

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #135: Refactor `ControllerBase` responsibilities into a testable CSRF protection boundary.
 - #144: Adjust Phase 6 around reference implementations and small-service delivery.
 - #142: Document AI readability and small-service delivery as the next project phase.
 - #140: Clarify Docker development database credentials for phpMyAdmin and MySQL.
@@ -58,7 +59,6 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 ## Next
 
 - #145: Add an AI-assisted small-service reference implementation covering page, REST, mapper, OpenAPI, and tests.
-- #135: Refactor `ControllerBase` responsibilities into smaller testable boundaries.
 
 ## Backlog Candidates
 

--- a/tests/Unit/Xion/CsrfProtectionPolicyTest.php
+++ b/tests/Unit/Xion/CsrfProtectionPolicyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\CsrfProtectionPolicy;
+use Nene\Xion\RouteContext;
+use PHPUnit\Framework\TestCase;
+
+final class CsrfProtectionPolicyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        RouteContext::getInstance()->reset();
+    }
+
+    public function testRequiresTokenForLoggedInStateChangingRestRequest(): void
+    {
+        RouteContext::getInstance()->set('todo', 'index', 'Rest', 'indexPostRest');
+
+        self::assertTrue((new CsrfProtectionPolicy())->requiresToken(RouteContext::getInstance(), 'POST', true));
+    }
+
+    public function testDoesNotRequireTokenForReadOnlyRestRequest(): void
+    {
+        RouteContext::getInstance()->set('todo', 'index', 'Rest', 'indexGetRest');
+
+        self::assertFalse((new CsrfProtectionPolicy())->requiresToken(RouteContext::getInstance(), 'GET', true));
+    }
+
+    public function testDoesNotRequireTokenForServerRenderedAction(): void
+    {
+        RouteContext::getInstance()->set('index', 'index', 'Action', 'indexAction');
+
+        self::assertFalse((new CsrfProtectionPolicy())->requiresToken(RouteContext::getInstance(), 'POST', true));
+    }
+
+    public function testDoesNotRequireTokenForLoginRestRequest(): void
+    {
+        RouteContext::getInstance()->set('session', 'login', 'Rest', 'loginPostRest');
+
+        self::assertFalse((new CsrfProtectionPolicy())->requiresToken(RouteContext::getInstance(), 'POST', false));
+    }
+
+    public function testDoesNotRequireTokenWhenSessionIsNotLoggedIn(): void
+    {
+        RouteContext::getInstance()->set('todo', 'index', 'Rest', 'indexPostRest');
+
+        self::assertFalse((new CsrfProtectionPolicy())->requiresToken(RouteContext::getInstance(), 'POST', false));
+    }
+}


### PR DESCRIPTION
## Summary
- `ControllerBase` に混在していたCSRF要否判定を `CsrfProtectionPolicy` に切り出しました。
- RESTの状態変更メソッド、ログインREST、HTMLアクション、未ログイン時の判定を単体テストで追加しました。
- `docs/todo/current.md` を Issue #135 の進捗に合わせて更新しました。

## Test plan
- [x] `php -l class/xion/CsrfProtectionPolicy.php && php -l class/xion/ControllerBase.php && php -l tests/Unit/Xion/CsrfProtectionPolicyTest.php`
- [x] `composer test`
- [x] `composer analyze`
- [x] `composer test:http`（ローカル環境では既存条件によりHTTPテストは21件skip）
- [x] `docker compose exec -T app composer test:all`（HTTPテストは既存条件により21件skip）
- [x] `docker compose exec -T app composer analyze`

Closes #135

Made with [Cursor](https://cursor.com)