### PR TITLE
DBトランザクション境界を追加する

### DIFF
--- a/class/xion/TransactionManager.php
+++ b/class/xion/TransactionManager.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+use Throwable;
+
+/**
+ * Runs database work inside a PDO transaction.
+ */
+class TransactionManager
+{
+    /**
+     * Shared database connection.
+     *
+     * @var PDO
+     */
+    private $pdo;
+
+    /**
+     * CONSTRUCTOR.
+     *
+     * @param PDO|null $pdo Database connection. Defaults to NeNe's shared PDO.
+     */
+    public function __construct(?PDO $pdo = null)
+    {
+        $this->pdo = $pdo ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * Run the callback inside a transaction.
+     *
+     * If an outer transaction already exists, this method does not commit or roll it back.
+     * The outer boundary remains responsible for the final decision.
+     *
+     * @template T
+     *
+     * @param callable():T $callback Work to run.
+     *
+     * @return T Callback result.
+     *
+     * @throws Throwable Re-throws callback failures after rollback.
+     */
+    final public function run(callable $callback): mixed
+    {
+        if ($this->pdo->inTransaction()) {
+            return $callback();
+        }
+
+        $this->pdo->beginTransaction();
+        try {
+            $result = $callback();
+            $this->pdo->commit();
+            return $result;
+        } catch (Throwable $throwable) {
+            if ($this->pdo->inTransaction()) {
+                $this->pdo->rollBack();
+            }
+            throw $throwable;
+        }
+    }
+}

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -90,6 +90,22 @@ New public HTTP APIs should be documented with OpenAPI.
 - Prefer JSON responses for API endpoints.
 - Keep OpenAPI files in `docs/api/` unless a future ADR chooses another location.
 
+## Database Transactions
+
+Data mapper methods should keep `DataMapperBase::execute()` as a single-statement execution boundary. Do not start and commit a transaction inside every `execute()` call.
+
+Use `Nene\Xion\TransactionManager` at the service or use-case boundary when one logical operation needs multiple writes, multiple SQL statements, or multiple mappers:
+
+```php
+$transaction = new TransactionManager();
+$transaction->run(function () use ($userMapper, $profileMapper): void {
+    $userMapper->create($user);
+    $profileMapper->create($profile);
+});
+```
+
+The transaction manager commits when the callback succeeds and rolls back when it throws. If a transaction is already active, it leaves the outer transaction responsible for the final commit or rollback.
+
 ## Testing and Static Analysis
 
 - At minimum, run PHP syntax checks for changed PHP files.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #148: Add a database transaction boundary for multi-step mapper work.
 - #135: Refactor `ControllerBase` responsibilities into a testable CSRF protection boundary.
 - #144: Adjust Phase 6 around reference implementations and small-service delivery.
 - #142: Document AI readability and small-service delivery as the next project phase.

--- a/tests/Unit/Xion/TransactionManagerTest.php
+++ b/tests/Unit/Xion/TransactionManagerTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\TransactionManager;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class TransactionManagerTest extends TestCase
+{
+    private TransactionRecordingPdo $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new TransactionRecordingPdo();
+    }
+
+    public function testRunCommitsSuccessfulCallbackAndReturnsValue(): void
+    {
+        $result = (new TransactionManager($this->pdo))->run(function (): string {
+            $this->pdo->recordWrite('committed');
+            return 'done';
+        });
+
+        self::assertSame('done', $result);
+        self::assertSame(['committed'], $this->pdo->committedWrites());
+        self::assertSame(1, $this->pdo->beginCount);
+        self::assertSame(1, $this->pdo->commitCount);
+        self::assertSame(0, $this->pdo->rollbackCount);
+        self::assertFalse($this->pdo->inTransaction());
+    }
+
+    public function testRunRollsBackWhenCallbackThrows(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('failed');
+
+        try {
+            (new TransactionManager($this->pdo))->run(function (): void {
+                $this->pdo->recordWrite('rolled-back');
+                throw new RuntimeException('failed');
+            });
+        } finally {
+            self::assertSame([], $this->pdo->committedWrites());
+            self::assertSame(1, $this->pdo->beginCount);
+            self::assertSame(0, $this->pdo->commitCount);
+            self::assertSame(1, $this->pdo->rollbackCount);
+            self::assertFalse($this->pdo->inTransaction());
+        }
+    }
+
+    public function testRunDoesNotCommitOuterTransaction(): void
+    {
+        $this->pdo->beginTransaction();
+
+        (new TransactionManager($this->pdo))->run(function (): void {
+            $this->pdo->recordWrite('outer-owned');
+        });
+
+        self::assertTrue($this->pdo->inTransaction());
+        self::assertSame([], $this->pdo->committedWrites());
+        self::assertSame(1, $this->pdo->beginCount);
+        self::assertSame(0, $this->pdo->commitCount);
+        self::assertSame(0, $this->pdo->rollbackCount);
+
+        $this->pdo->rollBack();
+
+        self::assertSame([], $this->pdo->committedWrites());
+        self::assertFalse($this->pdo->inTransaction());
+    }
+}
+
+final class TransactionRecordingPdo extends PDO
+{
+    public int $beginCount = 0;
+    public int $commitCount = 0;
+    public int $rollbackCount = 0;
+
+    /**
+     * @var array<int,string>
+     */
+    private array $committedWrites = [];
+
+    /**
+     * @var array<int,string>
+     */
+    private array $pendingWrites = [];
+
+    private bool $inTransaction = false;
+
+    public function __construct()
+    {
+    }
+
+    public function beginTransaction(): bool
+    {
+        $this->beginCount++;
+        $this->inTransaction = true;
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        $this->commitCount++;
+        $this->committedWrites = array_merge($this->committedWrites, $this->pendingWrites);
+        $this->pendingWrites = [];
+        $this->inTransaction = false;
+        return true;
+    }
+
+    public function rollBack(): bool
+    {
+        $this->rollbackCount++;
+        $this->pendingWrites = [];
+        $this->inTransaction = false;
+        return true;
+    }
+
+    public function inTransaction(): bool
+    {
+        return $this->inTransaction;
+    }
+
+    public function recordWrite(string $value): void
+    {
+        if ($this->inTransaction) {
+            $this->pendingWrites[] = $value;
+            return;
+        }
+        $this->committedWrites[] = $value;
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    public function committedWrites(): array
+    {
+        return $this->committedWrites;
+    }
+}


### PR DESCRIPTION
## Summary
- `TransactionManager` を追加し、複数SQLや複数Mapperを1つの処理単位で commit / rollback できるようにしました。
- 成功時commit、例外時rollback、既存トランザクション中は外側に委ねる挙動を単体テストで固定しました。
- `DataMapperBase::execute()` は1 statement実行境界のままにする方針を開発ドキュメントへ追記しました。

## Test plan
- [x] `php -l class/xion/TransactionManager.php && php -l tests/Unit/Xion/TransactionManagerTest.php`
- [x] `composer test`
- [x] `composer analyze`
- [x] `docker compose exec -T app composer test:all`（既存条件によりHTTPテスト21件skip）
- [x] `docker compose exec -T app composer analyze`

Closes #148

Made with [Cursor](https://cursor.com)