### PR TITLE
トランザクションの正解パターンをチュートリアルに明記する

### DIFF
--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -92,9 +92,11 @@ New public HTTP APIs should be documented with OpenAPI.
 
 ## Database Transactions
 
-Data mapper methods should keep `DataMapperBase::execute()` as a single-statement execution boundary. Do not start and commit a transaction inside every `execute()` call.
+`Nene\Xion\TransactionManager` is the canonical transaction boundary for NeNe application code. Humans and AI agents should use this pattern when adding multi-step database writes.
 
-Use `Nene\Xion\TransactionManager` at the service or use-case boundary when one logical operation needs multiple writes, multiple SQL statements, or multiple mappers:
+Data mapper methods must keep `DataMapperBase::execute()` as a single-statement execution boundary. Do not start and commit a transaction inside every `execute()` call.
+
+Use `TransactionManager` at the service, controller, or use-case boundary when one logical operation needs multiple writes, multiple SQL statements, or multiple mappers:
 
 ```php
 $transaction = new TransactionManager();
@@ -105,6 +107,8 @@ $transaction->run(function () use ($userMapper, $profileMapper): void {
 ```
 
 The transaction manager commits when the callback succeeds and rolls back when it throws. If a transaction is already active, it leaves the outer transaction responsible for the final commit or rollback.
+
+Do not create an alternate transaction helper for new features unless an Issue and ADR explain why `TransactionManager` is insufficient.
 
 ## Testing and Static Analysis
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #150: Document the canonical transaction pattern for service tutorials and coding standards.
 - #148: Add a database transaction boundary for multi-step mapper work.
 - #135: Refactor `ControllerBase` responsibilities into a testable CSRF protection boundary.
 - #144: Adjust Phase 6 around reference implementations and small-service delivery.

--- a/docs/tutorials/building-a-service.md
+++ b/docs/tutorials/building-a-service.md
@@ -124,6 +124,7 @@ namespace Nene\Controller;
 
 use Nene\Database as Database;
 use Nene\Xion\ControllerBase;
+use Nene\Xion\TransactionManager;
 
 class ArticleController extends ControllerBase
 {
@@ -144,9 +145,12 @@ class ArticleController extends ControllerBase
         }
 
         $mapper = new Database\ArticleMapper();
+        $transaction = new TransactionManager();
 
         return $this->API_RESPONSE->success([
-            'article' => $mapper->create($title),
+            'article' => $transaction->run(function () use ($mapper, $title): array {
+                return $mapper->create($title);
+            }),
         ]);
     }
 
@@ -179,6 +183,40 @@ GET  /article/item/id_1 -> ArticleController::itemGetRest()
 ```
 
 State-changing REST requests such as `POST`, `PUT`, `PATCH`, and `DELETE` require a valid login session and `X-CSRF-Token` when the user is logged in. `/session/login` returns the token as `Data.csrfToken`.
+
+## Add Database Transactions
+
+Use `Nene\Xion\TransactionManager` as the standard transaction boundary. This is the canonical pattern for humans and AI agents when one logical operation needs multiple SQL statements, multiple writes, or multiple mappers.
+
+Do not start a transaction inside `DataMapperBase::execute()`. That method is a single-statement execution boundary. Transactions belong around the use case that needs all writes to succeed or fail together.
+
+Single mapper example:
+
+```php
+$mapper = new Database\ArticleMapper();
+$transaction = new TransactionManager();
+
+$article = $transaction->run(function () use ($mapper, $title, $body): array {
+    return $mapper->create($title, $body);
+});
+```
+
+Multiple mapper example:
+
+```php
+$articleMapper = new Database\ArticleMapper();
+$auditMapper = new Database\AuditLogMapper();
+$transaction = new TransactionManager();
+
+$article = $transaction->run(function () use ($articleMapper, $auditMapper, $title, $body): array {
+    $article = $articleMapper->create($title, $body);
+    $auditMapper->record('article.created', (int)$article['id']);
+
+    return $article;
+});
+```
+
+`TransactionManager::run()` commits when the callback returns and rolls back when the callback throws. If another transaction is already active, the outer boundary remains responsible for the final commit or rollback.
 
 ## Add Error Codes
 


### PR DESCRIPTION
## Summary
- `TransactionManager` をNeNeの標準トランザクション境界として明記しました。
- サービス実装チュートリアルに、単一Mapperと複数Mapperのトランザクション例を追加しました。
- `DataMapperBase::execute()` ではトランザクションを開始しない方針をより強く明文化しました。

## Test plan
- [x] Markdown diagnostics: no linter errors

Closes #150

Made with [Cursor](https://cursor.com)