### PR TITLE
サンプルページにトランザクション標準パターンを表示する

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #152: Add the canonical transaction pattern to the sample page tutorial.
 - #150: Document the canonical transaction pattern for service tutorials and coding standards.
 - #148: Add a database transaction boundary for multi-step mapper work.
 - #135: Refactor `ControllerBase` responsibilities into a testable CSRF protection boundary.

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -228,6 +228,12 @@ document.addEventListener('DOMContentLoaded', function() {
             },
             {
                 number: '04',
+                title: 'Wrap multi-step writes in a transaction',
+                text: 'Use TransactionManager at the use-case boundary when one operation needs multiple writes, SQL statements, or mappers.',
+                code: 'TransactionManager::run(fn () => $mapper->create($title, $body))'
+            },
+            {
+                number: '05',
                 title: 'Document and test the contract',
                 text: 'Add error codes, update OpenAPI, and cover the behavior with unit or HTTP runtime tests.',
                 code: 'composer test && NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http'

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -40,6 +40,7 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertStringContainsString('/serverinstall/index', $response->body());
         self::assertStringContainsString('/health/index', $response->body());
         self::assertStringContainsString('php cli/setupDatabase.php --env=.env --yes', $response->body());
+        self::assertStringContainsString('TransactionManager::run', $response->body());
         self::assertStringContainsString('Environment: ', $response->body());
         self::assertStringContainsString("health.environment === 'development'", $response->body());
         self::assertStringContainsString('DB Type: ', $response->body());


### PR DESCRIPTION
## Summary
- トップページの `Build a small service` チュートリアルに、`TransactionManager` を使うトランザクション手順を追加しました。
- サンプルページJSのHTTP smoke testに `TransactionManager::run` の確認を追加しました。
- TODOに Issue #152 の完了を反映しました。

## Test plan
- [x] `node --check htdocs/js/index/index.js && php -l tests/Http/HttpSmokeTest.php`
- [x] `composer test`
- [x] `composer test:http`（既存条件によりHTTPテスト21件skip）
- [x] `docker compose exec -T app composer test:all`（既存条件によりHTTPテスト21件skip）
- [x] `docker compose exec -T app composer analyze`
- [x] `php -r '... file_get_contents("http://localhost:8080/js/index/index.js") ...'`

Closes #152

Made with [Cursor](https://cursor.com)