### PR TITLE
リリース前の基盤品質を整える

### DIFF
--- a/.phan/baseline.php
+++ b/.phan/baseline.php
@@ -9,10 +9,7 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchReturn : 3 occurrences
-    // PhanPossiblyUndeclaredVariable : 2 occurrences
-    // PhanUndeclaredProperty : 2 occurrences
-    // PhanUnreferencedUseNormal : 2 occurrences
+    // PhanPossiblyUndeclaredVariable : 1 occurrence
     // PhanTypeMagicVoidWithReturn : 1 occurrence
     // PhanTypeMismatchArgument : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
@@ -24,18 +21,16 @@ return [
     // PhanUndeclaredConstantOfClass : 1 occurrence
     // PhanUndeclaredTypeThrowsType : 1 occurrence
     // PhanUndeclaredVariableDim : 1 occurrence
-    // PhanUnextractableAnnotation : 1 occurrence
+    // PhanUnreferencedUseNormal : 1 occurrence
 
     'file_suppressions' => [
         'class/xion/ControllerBase.php' => [
             'PhanTypeMissingReturn' => ['\\Nene\\Xion\\ControllerBase::preAction']
         ],
         'class/xion/DataMapperBase.php' => [
-            'PhanPossiblyUndeclaredVariable' => ['\\Nene\\Xion\\DataMapperBase::insert', '\\Nene\\Xion\\DataMapperBase::update'],
-            'PhanTypeMismatchReturn' => ['\\Nene\\Xion\\DataMapperBase::countAll', '\\Nene\\Xion\\DataMapperBase::countById', '\\Nene\\Xion\\DataMapperBase::insert'],
+            'PhanPossiblyUndeclaredVariable' => ['\\Nene\\Xion\\DataMapperBase::update'],
             'PhanTypeSuspiciousStringExpression' => ['\\Nene\\Xion\\DataMapperBase::update'],
-            'PhanUndeclaredVariableDim' => ['\\Nene\\Xion\\DataMapperBase::update'],
-            'PhanUnreferencedUseNormal' => ['class/xion/DataMapperBase.php']
+            'PhanUndeclaredVariableDim' => ['\\Nene\\Xion\\DataMapperBase::update']
         ],
         'class/xion/DataModelBase.php' => [
             'PhanTypeMagicVoidWithReturn' => ['\\Nene\\Xion\\DataModelBase::__set'],
@@ -50,15 +45,6 @@ return [
         'class/xion/PdoConnection.php' => [
             'PhanTypeMismatchPropertyProbablyReal' => ['\\Nene\\Xion\\PdoConnection::__destruct'],
             'PhanUndeclaredConstantOfClass' => ['\\Nene\\Xion\\PdoConnection::__construct']
-        ],
-        'class/xion/Post.php' => [
-            'PhanUndeclaredProperty' => ['\\Nene\\Xion\\Post::setValues']
-        ],
-        'class/xion/QueryString.php' => [
-            'PhanUndeclaredProperty' => ['\\Nene\\Xion\\QueryString::setValues']
-        ],
-        'class/xion/RequestVariables.php' => [
-            'PhanUnextractableAnnotation' => ['\\Nene\\Xion\\RequestVariables']
         ],
         'class/xion/View.php' => [
             'PhanUndeclaredTypeThrowsType' => ['\\Nene\\Xion\\View::__clone']

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -140,7 +140,7 @@ abstract class ControllerBase
      *
      * @var CsrfProtectionPolicy
      */
-    protected $CSRF_PROTECTION_POLICY;
+    private $csrfProtectionPolicy;
 
     /**
      * Rest post
@@ -178,7 +178,7 @@ abstract class ControllerBase
         $this->AUTH_SESSION     = Xion\AuthSession::getInstance();
         $this->API_RESPONSE     = new Xion\ApiResponse();
         $this->ROUTE_CONTEXT    = Xion\RouteContext::getInstance();
-        $this->CSRF_PROTECTION_POLICY = new Xion\CsrfProtectionPolicy();
+        $this->csrfProtectionPolicy = new Xion\CsrfProtectionPolicy();
         $this->refController    = $_SESSION['global']['referer']['controller'] ?? '';
         $this->refAction        = $_SESSION['global']['referer']['action'] ?? '';
     }
@@ -375,7 +375,7 @@ abstract class ControllerBase
      */
     final protected function requiresCsrfProtection(): bool
     {
-        return $this->CSRF_PROTECTION_POLICY->requiresToken(
+        return $this->csrfProtectionPolicy->requiresToken(
             $this->ROUTE_CONTEXT,
             $this->method,
             $this->AUTH_SESSION->isLoggedIn()

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace Nene\Xion;
 
 use Monolog\Logger;
-use Nene\Database as Database;
 use Nene\Xion as Xion;
 use PDO;
 use PDOStatement;
@@ -87,15 +86,14 @@ abstract class DataMapperBase
      *
      * @param string  $key_sid         Column name for sequence ID of auto increment.
      * @param boolean $is_exclude_date Whether to exclude the creation date and update date of the database row.
-     * @param string  $className       The target class name.
+     * @param string  $className       Mapper or model class name.
      *
      * @return array Column name array.
      */
     public function getTableColumn(string $key_sid, bool $is_exclude_date = false, string $className = ''): array
     {
-        $className = $className === '' ? static::MODEL_CLASS : $className;
-        $DataMODEL  = str_replace('Mapper', '', $className);
-        $DataObj    = new $DataMODEL();
+        $modelClassName = $this->resolveModelClass($className);
+        $DataObj    = new $modelClassName();
         $column     = $DataObj->getSchema();
         if ($is_exclude_date) {
             unset($column[DB_COLUMN_NAME_CREATED]);
@@ -139,6 +137,7 @@ abstract class DataMapperBase
         if (!is_array($data)) {
             $data = [$data];
         }
+        $lastInsertId = 0;
         foreach ($data as $row) {
             if (!$row instanceof DataModelBase) {
                 throw new \InvalidArgumentException(
@@ -155,9 +154,10 @@ abstract class DataMapperBase
                 $stmt->bindValue(':' . $col, $row->$key);
             }
             $this->execute($stmt);
-            $row->{static::KEY_SID} = $this->DB->lastInsertId();
+            $lastInsertId = (int)$this->DB->lastInsertId();
+            $row->{static::KEY_SID} = $lastInsertId;
         }
-        return $row->{static::KEY_SID};
+        return $lastInsertId;
     }
 
     /**
@@ -210,7 +210,7 @@ abstract class DataMapperBase
      *
      * @return void
      */
-    public function delete(mixed $data)
+    public function delete(mixed $data): void
     {
         if (DB_IS_PHYSICAL_DELETE) {
             $stmt = $this->DB->prepare('
@@ -240,9 +240,9 @@ abstract class DataMapperBase
      *
      * @param integer $sid Primary key value to search.
      *
-     * @return mixed  Search results.
+     * @return object|false Search result.
      */
-    public function find(int $sid)
+    public function find(int $sid): object|false
     {
         $stmt = $this->DB->prepare('
             SELECT * FROM ' . static::TARGET_TABLE . '
@@ -289,22 +289,22 @@ abstract class DataMapperBase
             WHERE ' . static::KEY_SID . ' =:' . static::KEY_SID . '
         ');
         $stmt->bindParam(':' . static::KEY_SID, $sid, PDO::PARAM_INT);
-        return $this->execute($stmt)->fetchColumn();
+        return (int)$this->execute($stmt)->fetchColumn();
     }
 
     /**
      * Count all
      * Returns the number of rows in a database table.
      *
-     * @return integer number of rows.
+     * @return integer Number of rows.
      */
-    public function countAll()
+    public function countAll(): int
     {
         $stmt = $this->executeQuery('
             SELECT COUNT(*) FROM ' . static::TARGET_TABLE . '
             WHERE 1
         ');
-        return $stmt->fetchColumn();
+        return (int)$stmt->fetchColumn();
     }
 
     /**
@@ -315,7 +315,7 @@ abstract class DataMapperBase
      *
      * @return PDOStatement PDOStatement after try.
      */
-    final public function execute(PDOStatement $stmt)
+    final public function execute(PDOStatement $stmt): PDOStatement
     {
         try {
             $stmt->execute();
@@ -357,6 +357,24 @@ abstract class DataMapperBase
             APP_DEBUG ? $exception->getMessage() : 'Internal Server Error',
             500
         ));
+    }
+
+    /**
+     * Resolve the model class that provides schema metadata.
+     *
+     * @param string $className Mapper or model class name.
+     *
+     * @return class-string<DataModelBase> Model class name.
+     */
+    private function resolveModelClass(string $className = ''): string
+    {
+        if ($className === '') {
+            return static::MODEL_CLASS;
+        }
+        if (is_subclass_of($className, self::class)) {
+            return $className::MODEL_CLASS;
+        }
+        return $className;
     }
 
     /**

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -27,6 +27,7 @@ NeNe is a legacy PHP framework, but new work should move the codebase toward cur
 - Use PHP CS Fixer as the primary formatter when formatting is needed.
 - Do not mix formatting-only changes into unrelated PRs.
 - Preserve the existing namespace layout unless an Issue and ADR approve a migration.
+- Preserve legacy uppercase properties only where they are part of existing framework surface. New private/protected implementation details should use normal camelCase names unless compatibility requires the legacy style.
 
 PHP CS Fixer is configured in `.php-cs-fixer.dist.php`.
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #154, #155, #156: Clean up release-blocking code quality concerns in `ControllerBase` and `DataMapperBase`.
 - #152: Add the canonical transaction pattern to the sample page tutorial.
 - #150: Document the canonical transaction pattern for service tutorials and coding standards.
 - #148: Add a database transaction boundary for multi-step mapper work.


### PR DESCRIPTION
## Summary
- `ControllerBase` の新規CSRF policyプロパティを camelCase の private 実装詳細に変更
- `DataMapperBase` の戻り値型を明確化し、COUNT系とINSERT IDを整数へ正規化
- `getTableColumn()` のモデル解決を `MODEL_CLASS` 中心に変更し、Phan baselineを整理

## Test plan
- `composer test`
- `composer analyze`
- `php -l class/xion/ControllerBase.php`
- `php -l class/xion/DataMapperBase.php`

Closes #154
Closes #155
Closes #156

Made with [Cursor](https://cursor.com)