### PR TITLE
v0.2.0リリースを準備する

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,6 +2,31 @@
 
 This file records human-readable release notes for NeNe framework tags.
 
+## v0.2.0
+
+Status: release tag.
+
+`v0.2.0` is the small-service delivery preparation release. It keeps the renovated legacy framework shape from `v0.1.0`, then improves local development comfort, documents the next AI-assisted delivery phase, and adds clearer framework boundaries for controller security and database transactions.
+
+### Highlights
+
+- Changed the project license to MIT.
+- Added phpMyAdmin to the Docker development environment with the `darkwolf` theme.
+- Documented local Docker MySQL/phpMyAdmin credentials and development-only security expectations.
+- Added Phase 6 direction for AI-readable, human-reviewable small-service delivery.
+- Extracted CSRF protection decision logic from `ControllerBase` into a testable policy boundary.
+- Added `Nene\Xion\TransactionManager` as the canonical transaction boundary for multi-step mapper work.
+- Documented the transaction pattern in coding standards, service tutorials, and the sample page tutorial.
+- Tightened selected `DataMapperBase` return types and reduced the Phan baseline.
+- Changed mapper/model schema lookup to use `MODEL_CLASS` instead of mapper-name string replacement.
+- Updated the runtime `VERSION` constant to `0.2.0`.
+
+### Verification
+
+- `composer test`
+- `composer analyze`
+- GitHub Actions `unit` check on release-preparation PRs.
+
 ## v0.1.0
 
 Status: initial release tag.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #158: Prepare the `v0.2.0` release notes and runtime version.
 - #154, #155, #156: Clean up release-blocking code quality concerns in `ControllerBase` and `DataMapperBase`.
 - #152: Add the canonical transaction pattern to the sample page tutorial.
 - #150: Document the canonical transaction pattern for service tutorials and coding standards.

--- a/ini/xSystemIni.php
+++ b/ini/xSystemIni.php
@@ -78,7 +78,7 @@ $getEnv = static function (string $name, string $default): string {
  * the runtime boolean flag; DEBUG_MODE remains the legacy integer equivalent
  * because templates and framework code expect 1 or 0.
  */
-const VERSION = '0.0.0.1';
+const VERSION = '0.2.0';
 define('APP_ENV', $getEnv('NENE_APP_ENV', 'development'));
 define('APP_DEBUG', in_array(strtolower($getEnv('NENE_APP_DEBUG', APP_ENV === 'production' ? '0' : '1')), [
     '1',


### PR DESCRIPTION
## Summary
- `docs/releases.md` に `v0.2.0` のリリースノートを追加
- 実行時 `VERSION` を `0.2.0` に更新
- `docs/todo/current.md` にリリース準備Issueを反映

## Test plan
- `php -l ini/xSystemIni.php`
- `composer test`
- `composer analyze`

Closes #158

Made with [Cursor](https://cursor.com)