### PR TITLE
AIセルフレビューとサービス層標準を文書化する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This file is the first document for AI agents and automation working on NeNe.
 - Contributor guide: `docs/CONTRIBUTING.md`
 - Workflow: `docs/workflow.md`
 - Coding standards: `docs/development/coding-standards.md`
+- AI self-review: `docs/ai/README.md`
 - Commit conventions: `docs/development/commit-conventions.md`
 - Roadmap: `docs/roadmap.md`
 - Current TODO: `docs/todo/current.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory contains project documentation for humans and AI agents.
 - `deployment/server-install.md`: Traditional Apache/PHP server installation after `git clone`.
 - `development/testing.md`: Testing strategy and commands.
 - `tutorials/building-a-service.md`: Practical guide for adding pages, REST endpoints, database-backed features, OpenAPI, and tests.
+- `ai/README.md`: AI-assisted implementation and self-review checklists.
 - `roadmap.md`: Project direction.
 - `releases.md`: Human-readable release notes and version checkpoints.
 - `todo/current.md`: Current TODO summary.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,19 @@
+# AI-Assisted Development
+
+This directory gives AI agents and human reviewers a compact checklist for NeNe changes.
+
+NeNe should stay small, explicit, and reviewable. AI-assisted code is acceptable only when it follows the same visible conventions that a human NeNe developer would normally use.
+
+## Read Before Implementing
+
+- `../project.md`: project shape, routing convention, and framework/application boundaries.
+- `../development/coding-standards.md`: coding standards and responsibility boundaries.
+- `../tutorials/building-a-service.md`: standard path for pages, REST endpoints, mapper work, OpenAPI, and tests.
+
+## Self-Review Checklists
+
+- `self-review/service-implementation.md`: full feature checklist for small-service changes.
+- `self-review/controller.md`: controller size and HTTP boundary checklist.
+- `self-review/database.md`: mapper, model, SQL, and transaction checklist.
+
+Use these checklists before opening a PR. If a change intentionally does not follow one of these rules, explain the reason in the Issue or PR.

--- a/docs/ai/self-review/controller.md
+++ b/docs/ai/self-review/controller.md
@@ -1,0 +1,28 @@
+# Controller Self-Review
+
+Use this checklist to keep NeNe controllers thin and predictable.
+
+## Controller Responsibilities
+
+- The controller maps one visible route convention to one method, such as `/article/index` to `ArticleController::indexGetRest()`.
+- The controller reads request data from `REQUEST_JSON`, request parameters, or framework helpers.
+- The controller performs HTTP-boundary checks such as required parameters and response selection.
+- The controller calls a mapper only for simple read/write behavior, or calls a service when the use case has business rules.
+- The controller returns through `ApiResponse` for REST endpoints.
+- The controller sets template values for server-rendered pages and leaves rendering to `ControllerBase`.
+
+## Move Logic Out When
+
+- A method coordinates multiple mappers.
+- A method needs a transaction.
+- A method has business decisions that are not about HTTP, sessions, CSRF, or response shape.
+- The same logic would be needed by another page, REST endpoint, CLI command, or test.
+- The controller method is becoming difficult to read top-to-bottom.
+
+## Avoid
+
+- Do not put SQL in controllers.
+- Do not build raw JSON response arrays by hand when `ApiResponse` can express the result.
+- Do not start PDO transactions directly in controllers when `TransactionManager` should own the boundary.
+- Do not add new `{action}Rest()` methods unless compatibility requires the legacy all-method fallback.
+- Do not add framework-core helpers to avoid writing a small service class or mapper method.

--- a/docs/ai/self-review/database.md
+++ b/docs/ai/self-review/database.md
@@ -1,0 +1,34 @@
+# Database Self-Review
+
+Use this checklist when a change touches mappers, models, SQL, schema setup, or transactions.
+
+## Mapper and Model Shape
+
+- Each mapper extends `Nene\Xion\DataMapperBase`.
+- Each mapper defines `MODEL_CLASS`, `TARGET_TABLE`, and `KEY_SID` when it uses the base mapper conventions.
+- `MODEL_CLASS` points to the model class that owns schema metadata.
+- Each model extends `Nene\Xion\DataModelBase` when it uses NeNe schema validation.
+- Mapper methods use typed parameters and return values where practical.
+- Mapper method names describe database intent, such as `findRowById()`, `findRowsByUserId()`, or `createForUser()`.
+
+## SQL Boundary
+
+- SQL lives in mapper methods, not controllers or templates.
+- Bound parameters are used for request-derived values.
+- Reads return predictable shapes, such as `array`, `?array`, `int`, or `bool`.
+- Writes return a useful result or throw when the write cannot be verified.
+- MySQL and SQLite setup stay aligned when a feature adds or changes tables.
+
+## Transactions
+
+- `DataMapperBase::execute()` remains a single-statement boundary.
+- Do not start and commit a transaction inside every mapper method.
+- Use `Nene\Xion\TransactionManager` at the service/use-case boundary for multi-step writes.
+- Use one transaction when one logical operation needs multiple SQL statements or multiple mappers.
+- Let exceptions roll back the transaction; do not hide failed writes behind partial success payloads.
+
+## Static Analysis
+
+- Avoid new `mixed` return types unless the value is genuinely open-ended and documented.
+- Do not rely on mapper-name string replacement to resolve a model class.
+- Reduce Phan baseline entries when a focused mapper cleanup makes that safe.

--- a/docs/ai/self-review/service-implementation.md
+++ b/docs/ai/self-review/service-implementation.md
@@ -1,0 +1,34 @@
+# Service Implementation Self-Review
+
+Use this checklist when adding or changing a NeNe feature. It is written for AI agents, but human contributors should be able to use it the same way.
+
+## Scope
+
+- The change is tied to a GitHub Issue.
+- The PR changes one feature or one documented cleanup, not unrelated framework work.
+- The feature code stays outside `class/xion/` unless the Issue is explicitly about framework core.
+- The change does not introduce a new routing system, ORM, plugin layer, or dispatcher scan path.
+
+## Standard Shape
+
+- Controller methods read HTTP input and return `ApiResponse` payloads or set template values.
+- Service/use-case code owns business rules when logic is more than simple request/response wiring.
+- Mapper classes own SQL and database row conversion.
+- Model classes own schema metadata and model validation.
+- Error messages and HTTP statuses are added to `config/error_codes.php`.
+
+## API and Security
+
+- New REST endpoints use method-specific handlers such as `indexGetRest()` or `indexPostRest()`.
+- State-changing REST endpoints keep the existing session and CSRF behavior.
+- Public REST behavior is reflected in `docs/api/openapi.yaml`.
+- Input from request JSON, path parameters, query strings, and headers is validated before use.
+- Production responses do not expose stack traces, SQL details, secrets, or local paths.
+
+## Tests and Docs
+
+- Add focused unit tests for pure service logic when practical.
+- Add HTTP runtime tests when routing, sessions, cookies, JSON shape, OpenAPI status coverage, or browser-visible behavior changes.
+- Update tutorials or self-review docs when the implementation creates a new preferred pattern.
+- Run `composer test` and `composer analyze`.
+- Run `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http` when HTTP runtime behavior changes.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -82,6 +82,33 @@ REST endpoints should make accepted HTTP methods explicit.
 - Define error code messages and HTTP status values in the server-side catalog at `config/error_codes.php`; controllers should reference codes, not inline messages or direct HTTP status headers.
 - Treat browser-visible error-code assets as exports or compatibility files, not the source of truth.
 
+## Service and Use-Case Logic
+
+Controllers are HTTP boundaries. Keep business decisions in service/use-case code once a controller method does more than simple request parsing, mapper delegation, and response selection.
+
+Use the existing `Nene\Model\` namespace under `class/model/` for application service classes when a feature needs a separate business-logic boundary. This uses the current Composer autoload map and does not require a new dispatcher path or framework abstraction.
+
+Controller responsibilities:
+
+- Read request JSON, route parameters, query values, and session/auth state.
+- Call a mapper for very small CRUD behavior, or call a service when the use case has business rules.
+- Convert service results into `ApiResponse` success or failure payloads.
+- Set template values for server-rendered pages.
+
+Service/use-case responsibilities:
+
+- Express one application operation with a clear method name, such as `createArticle()` or `completeTodoForUser()`.
+- Validate business rules that are not purely HTTP shape checks.
+- Coordinate multiple mappers, multiple SQL statements, or side effects.
+- Own the `TransactionManager::run()` boundary when one logical operation must commit or roll back as a unit.
+- Return plain domain/application data, not HTTP responses, Smarty templates, or raw controller payload envelopes.
+
+Mapper responsibilities:
+
+- Keep SQL and database row conversion inside mapper classes.
+- Do not know about HTTP request shape, templates, or `ApiResponse`.
+- Do not start transactions for every statement; leave transaction boundaries to service/use-case code.
+
 ## OpenAPI
 
 New public HTTP APIs should be documented with OpenAPI.

--- a/docs/project.md
+++ b/docs/project.md
@@ -72,6 +72,19 @@ Do not treat legacy style as a defect by itself. In NeNe, some legacy shape is i
 - Smarty is used for server-rendered templates.
 - Monolog is used for logging.
 
+## Framework and Application Boundaries
+
+NeNe keeps framework core and the bundled sample/application code in the same repository, but they have different responsibilities:
+
+- `class/xion/` is framework core. It contains dispatching, controller base behavior, request/session helpers, response helpers, database base classes, logging, and transaction boundaries.
+- `class/controller/`, `class/db/`, `class/model/`, and `class/func/` are the current sample/application-side namespaces. The bundled TODO, session, health, and documentation pages live here to show how a small NeNe service is built.
+- `view/source/`, `htdocs/css/`, and `htdocs/js/` are application-facing presentation assets discovered by convention.
+- `docs/api/`, `config/error_codes.php`, database setup scripts, and tests are part of the application contract whenever a sample or real service exposes public behavior.
+
+The current rule is documentation-first separation. Do not add a second dispatcher scan path, alternate controller namespace, or `app/` directory unless an Issue and ADR decide that the project is ready for that compatibility change.
+
+For now, new examples and reference implementations should make the boundary visible by treating `class/xion/` as the framework and all feature code as application code that uses it.
+
 ## Routing Convention
 
 NeNe routes by URL path segments.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Active
 
-- None.
+- #160: Document AI self-review checklists and service-layer implementation standards.
 
 ## Recently Completed
 

--- a/docs/tutorials/building-a-service.md
+++ b/docs/tutorials/building-a-service.md
@@ -15,6 +15,8 @@ Use it as a checklist when adding application behavior:
 
 NeNe is intentionally small. Prefer explicit controller methods, clear data mappers, and focused tests over hidden framework behavior.
 
+Treat `class/xion/` as framework core. Most page, REST, service, mapper, and model work should happen in the application-side namespaces such as `class/controller/`, `class/model/`, `class/db/`, and `class/func/`. Do not change dispatcher or core behavior for a normal service feature.
+
 ## Before You Start
 
 Work from a GitHub Issue and a topic branch.

--- a/docs/tutorials/building-a-service.md
+++ b/docs/tutorials/building-a-service.md
@@ -184,6 +184,79 @@ GET  /article/item/id_1 -> ArticleController::itemGetRest()
 
 State-changing REST requests such as `POST`, `PUT`, `PATCH`, and `DELETE` require a valid login session and `X-CSRF-Token` when the user is logged in. `/session/login` returns the token as `Data.csrfToken`.
 
+## Keep Controllers Thin
+
+Small read-only or single-write endpoints may call a mapper directly from the controller. Move logic into a service/use-case class when a controller method starts to coordinate business decisions, multiple mappers, multiple SQL statements, or a transaction.
+
+Use the existing `Nene\Model\` namespace under `class/model/` for application service classes. This keeps the current Composer autoload shape and avoids adding a second dispatcher path.
+
+Controller example:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Controller;
+
+use Nene\Model\ArticleService;
+use Nene\Xion\ControllerBase;
+
+class ArticleController extends ControllerBase
+{
+    public function indexPostRest(): array
+    {
+        $title = trim((string)($this->REQUEST_JSON['title'] ?? ''));
+        $body = trim((string)($this->REQUEST_JSON['body'] ?? ''));
+
+        $service = new ArticleService();
+        $result = $service->createArticle($title, $body);
+        if (!$result['ok']) {
+            return $this->API_RESPONSE->failure($result['errorCode']);
+        }
+
+        return $this->API_RESPONSE->success([
+            'article' => $result['article'],
+        ]);
+    }
+}
+```
+
+Service example:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Model;
+
+use Nene\Database as Database;
+use Nene\Xion\TransactionManager;
+
+class ArticleService
+{
+    public function createArticle(string $title, string $body): array
+    {
+        if ($title === '') {
+            return ['ok' => false, 'errorCode' => 'ARTICLE-TITLE-REQUIRED'];
+        }
+
+        $mapper = new Database\ArticleMapper();
+        $transaction = new TransactionManager();
+
+        return [
+            'ok' => true,
+            'article' => $transaction->run(function () use ($mapper, $title, $body): array {
+                return $mapper->create($title, $body);
+            }),
+        ];
+    }
+}
+```
+
+The service returns plain application data. The controller decides how to turn that result into a REST response. Mappers still own SQL.
+
 ## Add Database Transactions
 
 Use `Nene\Xion\TransactionManager` as the standard transaction boundary. This is the canonical pattern for humans and AI agents when one logical operation needs multiple SQL statements, multiple writes, or multiple mappers.
@@ -433,11 +506,13 @@ Before opening a PR:
 
 - Create or confirm the GitHub Issue.
 - Add or update controller methods.
+- Add service/use-case code when business logic would make a controller method hard to read.
 - Add templates/assets for HTML pages.
 - Add mapper/model/schema changes for database-backed features.
 - Add error codes to `config/error_codes.php`.
 - Update `docs/api/openapi.yaml` for public REST endpoints.
 - Add focused unit or HTTP runtime tests.
+- Review `docs/ai/self-review/` before opening the PR.
 - Run `composer test`.
 - Run `composer analyze`.
 - Run `NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http` when HTTP behavior changes.

--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -210,30 +210,36 @@ document.addEventListener('DOMContentLoaded', function() {
         const tutorialSteps = [
             {
                 number: '01',
+                title: 'Know the boundary',
+                text: 'Treat class/xion as framework core. Add page, REST, service, mapper, and model code in the application-side namespaces.',
+                code: 'class/controller + class/model + class/db use class/xion'
+            },
+            {
+                number: '02',
                 title: 'Add a fixed page',
                 text: 'Use an HTML action such as PageController::aboutAction() and place its template under view/source/page/about.tpl.',
                 code: 'GET /page/about -> PageController::aboutAction()'
             },
             {
-                number: '02',
+                number: '03',
                 title: 'Add a REST endpoint',
                 text: 'Use method-specific handlers so everyone writes the same style of JSON endpoint.',
                 code: 'POST /article/index -> ArticleController::indexPostRest()'
             },
             {
-                number: '03',
+                number: '04',
                 title: 'Store data with a mapper',
                 text: 'Keep persistence explicit with a small model and mapper instead of hiding behavior behind a large ORM.',
                 code: 'ArticleMapper::create($title, $body)'
             },
             {
-                number: '04',
+                number: '05',
                 title: 'Wrap multi-step writes in a transaction',
                 text: 'Use TransactionManager at the use-case boundary when one operation needs multiple writes, SQL statements, or mappers.',
                 code: 'TransactionManager::run(fn () => $mapper->create($title, $body))'
             },
             {
-                number: '05',
+                number: '06',
                 title: 'Document and test the contract',
                 text: 'Add error codes, update OpenAPI, and cover the behavior with unit or HTTP runtime tests.',
                 code: 'composer test && NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http'

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -40,6 +40,7 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertStringContainsString('/serverinstall/index', $response->body());
         self::assertStringContainsString('/health/index', $response->body());
         self::assertStringContainsString('php cli/setupDatabase.php --env=.env --yes', $response->body());
+        self::assertStringContainsString('class/xion as framework core', $response->body());
         self::assertStringContainsString('TransactionManager::run', $response->body());
         self::assertStringContainsString('Environment: ', $response->body());
         self::assertStringContainsString("health.environment === 'development'", $response->body());


### PR DESCRIPTION
## Summary
- framework core と sample/application code の境界を `docs/project.md` に明記
- AI向けセルフレビュー入口と Controller / Database / Service 実装チェックリストを `docs/ai/` に追加
- Controller / Service / Mapper の責務分担と `class/model/` を使うサービス層標準をドキュメント化

## Test plan
- `composer analyze`
- `git diff --check`

Closes #160

Made with [Cursor](https://cursor.com)