### PR TITLE
レビューしやすい次フェーズと公開戦略を整理する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This directory contains project documentation for humans and AI agents.
 - `ai/README.md`: AI-assisted implementation and self-review checklists.
 - `roadmap.md`: Project direction.
 - `releases.md`: Human-readable release notes and version checkpoints.
+- `publication-strategy.md`: Public release, article, Packagist, and outreach strategy.
 - `todo/current.md`: Current TODO summary.
 - `milestones/README.md`: Milestone management.
 - `adr/README.md`: Architecture decision records.

--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -82,22 +82,26 @@ Purpose: make framework progress visible through small versioned tags.
 
 Current status: `v0.1.0` is the first planned tag. It represents the point where NeNe has a working local Docker setup, traditional server install documentation, MySQL/SQLite sample database setup, a public `nene-php.com` sample deployment, OpenAPI/Swagger UI, tests, and a clear renovated-legacy framework policy.
 
-### ai-readable-small-service-delivery
+### reviewable-small-service-delivery
 
-Goal: make NeNe a small PHP framework that proves its existing human-friendly and AI-readable shape through working examples while supporting fast, secure small-service delivery.
+Goal: make NeNe a small PHP framework that lowers code review cost by keeping human-written and AI-assisted small-service changes in the same visible implementation shape.
 
-Context: NeNe's next phase should build on the renovated legacy foundation. The framework should not grow into a large full-stack platform, and it does not need a broad redesign just to become "AI-readable." It already has visible `/{controller}/{action}` flow, predictable controller and REST method names, a small codebase, Docker setup, OpenAPI, tests, and security defaults. The next step is to prove those strengths with reference implementations and a delivery path that a human can review comfortably, whether the change was written by a person or assisted by an AI agent.
+Context: NeNe's next phase should build on the renovated legacy foundation. The framework should not grow into a large full-stack platform, and it does not need a broad redesign just to become "AI-readable." It already has visible `/{controller}/{action}` flow, predictable controller and REST method names, a small codebase, Docker setup, OpenAPI, tests, security defaults, and self-review checklists. The next step is to make those strengths reduce real review friction: a reviewer should quickly know where to inspect HTTP input, business rules, SQL, API contracts, and tests.
+
+The legacy inheritance matters. Older PHP frameworks often made control flow easy to trace because the route, controller, action, and mapper were visible. This milestone keeps that readability, then adds modern review aids so different humans and different AI tools still produce code that looks like normal NeNe code.
 
 Positioning:
 
-- AI-readable as an outcome of explicit conventions, not as a separate architecture goal.
-- Human-friendly, not magic-heavy.
+- Review-cost reduction as the practical value of explicit conventions.
+- AI-readable as an outcome of stable human-reviewable patterns, not as a separate architecture goal.
+- Human-friendly and review-friendly, not magic-heavy.
 - Fast for small services, not a replacement for large enterprise frameworks.
 - Secure by default for realistic local development and small deployments.
 
 Scope:
 
 - Keep conventions explicit enough that AI-assisted and human-written changes follow the same shape.
+- Keep Controller / Service / Mapper responsibilities stable enough that implementation style does not vary by author or AI tool.
 - Use working reference implementations to show the preferred shape for small features.
 - Improve tutorials, examples, comments, and PHPDoc where they reduce review friction.
 - Keep the path from clone to local verification short and repeatable.
@@ -106,9 +110,11 @@ Scope:
 
 Completion criteria:
 
-- Documentation clearly describes NeNe as human-friendly and AI-readable without overstating AI guarantees or implying a broad architecture rewrite.
-- A first service can be built by following docs from page/controller through REST endpoint, database access, OpenAPI, and tests.
-- #145 defines a concrete reference implementation for the expected page, REST, mapper, OpenAPI, and test workflow.
+- Documentation clearly describes NeNe as review-friendly and AI-readable as a result of stable conventions, without overstating AI guarantees or implying a broad architecture rewrite.
+- A first service can be built by following docs from page/controller through Service/use-case, REST endpoint, database access, OpenAPI, and tests.
+- #163 defines the review-cost-reduction framing for Phase 6.
+- #164 updates the public entry message around reviewable small-service delivery.
+- #165 and #145 define a concrete reference implementation for the expected Controller, Service, Mapper, OpenAPI, and test workflow.
 - Local Docker setup remains simple, including app, MySQL, phpMyAdmin, Swagger UI, and test commands.
 - Production-facing docs continue to warn about secrets, debug output, local Docker credentials, phpMyAdmin exposure, and database initialization.
 - New examples do not introduce hidden routing, heavy ORM behavior, or broad framework abstractions.

--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -90,11 +90,14 @@ Context: NeNe's next phase should build on the renovated legacy foundation. The 
 
 The legacy inheritance matters. Older PHP frameworks often made control flow easy to trace because the route, controller, action, and mapper were visible. This milestone keeps that readability, then adds modern review aids so different humans and different AI tools still produce code that looks like normal NeNe code.
 
+Modern patterns remain useful, but this milestone should avoid making review participation depend on specialist pattern knowledge. For small services, a simple visible convention is often more valuable than a cooler abstraction if it lets more people review changes confidently.
+
 Positioning:
 
 - Review-cost reduction as the practical value of explicit conventions.
 - AI-readable as an outcome of stable human-reviewable patterns, not as a separate architecture goal.
 - Human-friendly and review-friendly, not magic-heavy.
+- Modern safety rails without requiring fashionable architecture-pattern fluency for ordinary reviews.
 - Fast for small services, not a replacement for large enterprise frameworks.
 - Secure by default for realistic local development and small deployments.
 
@@ -115,6 +118,7 @@ Completion criteria:
 - #163 defines the review-cost-reduction framing for Phase 6.
 - #164 updates the public entry message around reviewable small-service delivery.
 - #165 and #145 define a concrete reference implementation for the expected Controller, Service, Mapper, OpenAPI, and test workflow.
+- #167 explains how stable conventions help avoid reviewer scarcity caused by specialized design-pattern knowledge.
 - Local Docker setup remains simple, including app, MySQL, phpMyAdmin, Swagger UI, and test commands.
 - Production-facing docs continue to warn about secrets, debug output, local Docker credentials, phpMyAdmin exposure, and database initialization.
 - New examples do not introduce hidden routing, heavy ORM behavior, or broad framework abstractions.

--- a/docs/publication-strategy.md
+++ b/docs/publication-strategy.md
@@ -10,6 +10,10 @@ The public angle should speak to a common developer pain:
 
 > Have you ever lost time in code review just trying to understand the writer's style? NeNe aims to lower that cost by keeping small-service changes in the same visible shape, whether they are written by a person or assisted by an AI tool.
 
+Another useful angle:
+
+> Modern design patterns and fashionable coding styles can be powerful. But when only a few people have learned those patterns deeply enough to review them, a project can slow down because reviewers become scarce. NeNe favors visible, repeatable conventions so more developers can participate in review without first learning a large framework-specific style.
+
 ## Current Public State
 
 NeNe already has enough material for a first public introduction:
@@ -33,12 +37,14 @@ Use this positioning consistently:
 - Legacy-friendly, not legacy-bound.
 - Review-friendly first: human-written and AI-assisted changes should follow the same visible conventions.
 - Human-readable and AI-readable because conventions are stable and explicit.
+- Modern enough to be safe and testable, but intentionally not pattern-heavy when a simple visible convention is enough.
 - Explicit URL routing and controller methods over hidden framework magic.
 - OpenAPI and tests around real endpoints, not documentation for its own sake.
 
 Avoid these messages:
 
 - Do not call NeNe a Laravel, Symfony, CodeIgniter, or Laminas replacement.
+- Do not attack modern design patterns. Explain that NeNe optimizes for small-service reviewability when the team does not want reviewer availability to depend on specialist pattern knowledge.
 - Do not overstate AI support. Say that NeNe is reviewable for human-written or AI-assisted changes.
 - Do not imply production readiness for large multi-team systems.
 - Do not hide that Smarty and URL-segment routing are intentional old-school choices.
@@ -191,6 +197,7 @@ Core message:
 - Small explicit conventions.
 - URL routing and controller methods are visible.
 - Reviewers can find HTTP input, business rules, SQL, API contracts, and tests in predictable places.
+- Review participation should not require deep familiarity with trendy architecture patterns before basic behavior can be checked.
 - OpenAPI and tests were added around the old shape.
 - Not a Laravel or Symfony competitor.
 
@@ -250,6 +257,7 @@ NeNe's first public outreach is successful if readers can quickly understand:
 - Who NeNe is for.
 - Why it keeps a legacy-style shape.
 - How it lowers review cost by keeping implementation patterns consistent.
+- Why it avoids making reviewer availability depend on specialized design-pattern fluency.
 - How to run it locally.
 - How to build a first feature.
 - Why it is intentionally smaller than mainstream frameworks.

--- a/docs/publication-strategy.md
+++ b/docs/publication-strategy.md
@@ -1,0 +1,256 @@
+# Publication Strategy
+
+This document records how NeNe should be introduced after the `v0.2.0` release.
+
+NeNe should not be presented as another general-purpose full-stack framework. Its strongest message is narrower and clearer:
+
+> NeNe is a tiny renovated legacy-style PHP framework for readable small services. It keeps visible URL routing, controller actions, Smarty pages, lightweight mappers, REST endpoints, OpenAPI, Docker, tests, and explicit security boundaries.
+
+The public angle should speak to a common developer pain:
+
+> Have you ever lost time in code review just trying to understand the writer's style? NeNe aims to lower that cost by keeping small-service changes in the same visible shape, whether they are written by a person or assisted by an AI tool.
+
+## Current Public State
+
+NeNe already has enough material for a first public introduction:
+
+- MIT license.
+- GitHub Releases for `v0.1.0` and `v0.2.0`.
+- Public sample deployment at `https://nene-php.com/`.
+- Docker local development with app, MySQL, phpMyAdmin, Swagger UI, and test commands.
+- Traditional Apache/PHP server install documentation.
+- Service tutorial for pages, REST endpoints, database work, OpenAPI, and tests.
+- AI-assisted development guidance focused on visible conventions, self-review, and lower human review cost.
+
+The main gap is not implementation depth. The main gap is discovery: README, GitHub repository metadata, Packagist metadata, and article entry points should make the project easier to understand from outside.
+
+## Positioning
+
+Use this positioning consistently:
+
+- Renovation, not rewrite.
+- Small-service framework, not enterprise full-stack framework.
+- Legacy-friendly, not legacy-bound.
+- Review-friendly first: human-written and AI-assisted changes should follow the same visible conventions.
+- Human-readable and AI-readable because conventions are stable and explicit.
+- Explicit URL routing and controller methods over hidden framework magic.
+- OpenAPI and tests around real endpoints, not documentation for its own sake.
+
+Avoid these messages:
+
+- Do not call NeNe a Laravel, Symfony, CodeIgniter, or Laminas replacement.
+- Do not overstate AI support. Say that NeNe is reviewable for human-written or AI-assisted changes.
+- Do not imply production readiness for large multi-team systems.
+- Do not hide that Smarty and URL-segment routing are intentional old-school choices.
+
+## Preparation Order
+
+### 1. GitHub Repository Face
+
+Before broad outreach, update the repository surface:
+
+- Set GitHub About description.
+- Set homepage to `https://nene-php.com/`.
+- Add repository topics:
+  - `php`
+  - `php-framework`
+  - `framework`
+  - `openapi`
+  - `smarty`
+  - `docker`
+  - `legacy-modernization`
+  - `micro-framework`
+- Confirm GitHub detects the MIT license.
+- Keep GitHub Releases synced with `docs/releases.md`.
+
+Suggested About description:
+
+```text
+A tiny renovated legacy-style PHP framework for reviewable small services: URL routing, Smarty, REST, OpenAPI, Docker, and tests.
+```
+
+### 2. README Public Entry
+
+The README should help a first-time visitor decide whether NeNe is relevant in less than one minute.
+
+Add or strengthen:
+
+- Demo link: `https://nene-php.com/`.
+- Latest release link.
+- License badge or visible MIT text.
+- Quick Start.
+- "What NeNe is" and "What NeNe is not".
+- A short review-cost message: "same visible shape for human-written and AI-assisted changes."
+- Link to the service tutorial.
+- Link to the AI self-review checklists.
+- Link to GitHub Releases.
+
+The README should stay concise. Detailed setup and design explanations belong in `docs/`.
+
+### 3. Composer and Packagist Metadata
+
+If NeNe should be discoverable as a PHP package, improve `composer.json` before Packagist registration:
+
+- Add a PHP requirement that matches the documented target.
+- Add `keywords`.
+- Add `homepage`.
+- Add `support.issues`.
+- Add `authors`.
+- Clarify whether NeNe is used as a package, an application skeleton, or a repository to clone.
+
+Packagist expectations should be explicit. If the recommended install path is still `git clone`, say that clearly in README and release notes.
+
+### 4. Reference Implementation
+
+Complete #145 before the widest outreach if possible.
+
+The reference implementation should show the expected shape for a small NeNe feature:
+
+- Page controller and Smarty template.
+- Method-specific REST endpoint.
+- Service/use-case boundary for business logic when needed.
+- Mapper/model use.
+- Transaction pattern when multiple database writes are involved.
+- OpenAPI update.
+- Focused tests.
+- AI self-review checklist usage.
+
+This gives articles a concrete feature to point at instead of only describing framework philosophy.
+
+## Japanese Article Strategy
+
+Use Zenn and Qiita for different purposes.
+
+### Zenn: Philosophy and Renovation Story
+
+Zenn is best for the project story.
+
+Possible title:
+
+```text
+10年前の自作PHPフレームワークを、PHP 8.4時代向けにリフォームした話
+```
+
+Recommended outline:
+
+1. Why not rewrite everything.
+2. Why keep `/{controller}/{action}` routing.
+3. Why keep Smarty and lightweight mappers.
+4. What was modernized: Composer, Docker, OpenAPI, PHPUnit, Phan, PHP CS Fixer.
+5. Security hardening: sessions, CSRF, password hashing, JSON-only responses.
+6. Why small explicit conventions reduce review cost for human-written and AI-assisted changes.
+7. What NeNe is not.
+8. Link to GitHub, demo, release, and tutorial.
+
+Tone:
+
+- Personal and honest.
+- Explain the target users.
+- Avoid sounding like a new mainstream framework launch.
+
+### Qiita: Hands-on Implementation Guide
+
+Qiita is best for practical steps.
+
+Possible title:
+
+```text
+NeNeで固定ページとREST APIを追加する
+```
+
+Recommended outline:
+
+1. Clone and Docker startup.
+2. Confirm top page and health check.
+3. Add a fixed page.
+4. Add method-specific REST handlers.
+5. Add mapper/model code.
+6. Add transaction boundary when needed.
+7. Update OpenAPI.
+8. Run tests and analysis.
+
+Use `docs/tutorials/building-a-service.md` as the source material.
+
+## English Outreach Strategy
+
+Start with low-pressure channels before posting to highly critical communities.
+
+### DEV Community
+
+Best first English article target.
+
+Possible title:
+
+```text
+Renovating a tiny legacy-style PHP framework for modern PHP
+```
+
+Core message:
+
+- Renovation, not rewrite.
+- Small explicit conventions.
+- URL routing and controller methods are visible.
+- Reviewers can find HTTP input, business rules, SQL, API contracts, and tests in predictable places.
+- OpenAPI and tests were added around the old shape.
+- Not a Laravel or Symfony competitor.
+
+### Hashnode or Personal Blog
+
+Use for a longer English version if continuing the story.
+
+Good angle:
+
+- "What I kept."
+- "What I modernized."
+- "What I intentionally did not add."
+
+### Reddit
+
+Use carefully, preferably after README and Packagist metadata are improved.
+
+Suggested framing:
+
+```text
+I renovated a tiny legacy-style PHP framework instead of rewriting it. Feedback welcome.
+```
+
+Post to `r/PHP` only when ready for direct technical criticism. Avoid promotional wording.
+
+### Hacker News
+
+Use only after the public entry is polished:
+
+- README is strong.
+- Demo works.
+- GitHub Release is visible.
+- Reference implementation exists.
+- Packagist or install story is clear.
+
+Suggested framing:
+
+```text
+Show HN: NeNe, a tiny renovated legacy-style PHP framework
+```
+
+## Suggested Execution TODO
+
+1. Improve GitHub repository metadata.
+2. Strengthen the README public entry.
+3. Improve Composer/Packagist metadata.
+4. Complete #145 reference implementation.
+5. Write the Zenn renovation story.
+6. Write the Qiita hands-on guide.
+7. Publish a short DEV Community English article.
+8. Consider Reddit or Hacker News after feedback from the first articles.
+
+## Success Criteria
+
+NeNe's first public outreach is successful if readers can quickly understand:
+
+- Who NeNe is for.
+- Why it keeps a legacy-style shape.
+- How it lowers review cost by keeping implementation patterns consistent.
+- How to run it locally.
+- How to build a first feature.
+- Why it is intentionally smaller than mainstream frameworks.
+- Where to find releases, docs, demo, and source code.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@ NeNe should continue to emphasize:
 - Smarty-based server rendering as the default HTML path.
 - Lightweight mapper/model classes instead of a heavy ORM.
 - Small, readable framework code over large abstractions.
-- Explicit conventions that make generated or hand-written changes reviewable in the same way.
+- Explicit conventions that reduce code review cost by making generated or hand-written changes follow the same shape.
 - A short path from `git clone` to local verification and small-service delivery.
 - Modern safety rails around the legacy shape: Docker, tests, OpenAPI, Phan, PHP CS Fixer, CSRF, password hashing, error catalogs, and safer output handling.
 
@@ -135,20 +135,24 @@ Future candidates:
 - Reduce legacy static-analysis baseline issues in focused cleanup PRs.
 - Revisit CI Docker runtime coverage when repository resources and runtime cost make it practical.
 
-## 6. AI-Readable Small-Service Delivery
+## 6. Reviewable Small-Service Delivery
 
 Status: next phase.
 
 Goal:
 
-NeNe already has several AI-era strengths: visible URL conventions, predictable controller and REST method names, small framework code, OpenAPI, and focused tests. Phase 6 should not turn "AI-readable" into a broad redesign goal. It should prove those existing strengths through repeatable examples and a delivery path that stays easy for humans to review.
+NeNe already has several review-cost strengths: visible URL conventions, predictable controller and REST method names, small framework code, OpenAPI, focused tests, and AI self-review checklists. Phase 6 should not turn "AI-readable" into a broad redesign goal. It should make the practical promise clearer: reduce the cost of understanding and reviewing small-service changes.
 
-This phase should strengthen NeNe as a small-service delivery framework: quick to clone, quick to run, quick to inspect, and safe enough by default for realistic small projects. AI assistance is useful when it produces changes that look like normal NeNe changes and remain practical for a human developer to review.
+This phase should strengthen NeNe as a small-service delivery framework where a reviewer does not need to decode each contributor's personal style before checking behavior. Whether code is written by a person or assisted by an AI agent, Controller, Service, Mapper, OpenAPI, error-code, and test changes should follow the same visible pattern.
+
+The legacy shape is a strength here. NeNe should preserve the old PHP framework habit of "look at the URL, find the controller, read the method," then add modern review aids around it: clear responsibility boundaries, self-review checklists, tests, OpenAPI, and secure defaults.
 
 Principles:
 
 - Prefer visible conventions over hidden framework magic.
+- Optimize for reviewability: a human should quickly know where to inspect HTTP input, business rules, SQL, API contracts, and tests.
 - Keep routing, controller names, REST method boundaries, configuration, and database setup easy to trace.
+- Keep Controller / Service / Mapper responsibilities stable enough that different humans and AI agents produce similar shapes.
 - Prefer working reference implementations over extra explanation when examples can show the expected shape.
 - Keep docs, OpenAPI contracts, and tests close to the behavior they describe.
 - Preserve a fast Docker-based local workflow and a clear traditional Apache/PHP server install path.
@@ -157,7 +161,10 @@ Principles:
 
 Future candidates:
 
-- #145: Add a small-service reference implementation that shows the expected shape of AI-assisted changes: page, REST endpoint, mapper, OpenAPI, and test.
+- #163: Reframe the next phase around reducing code review cost through consistent implementation conventions.
+- #164: Present NeNe publicly as a reviewable small-service PHP framework.
+- #165: Use the reference implementation to prove the reviewable Controller-Service-Mapper shape.
+- #145: Add a small-service reference implementation that shows the expected shape of page, REST endpoint, service/use-case, mapper, OpenAPI, and test changes.
 - Make the first-service tutorial even more repeatable from clone to local verification.
 - Improve comments and PHPDoc only where they help readers understand framework boundaries.
 - Add lightweight checklists for small-service delivery readiness, including environment, database, OpenAPI, tests, and production safety notes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -147,9 +147,12 @@ This phase should strengthen NeNe as a small-service delivery framework where a 
 
 The legacy shape is a strength here. NeNe should preserve the old PHP framework habit of "look at the URL, find the controller, read the method," then add modern review aids around it: clear responsibility boundaries, self-review checklists, tests, OpenAPI, and secure defaults.
 
+Modern design patterns and current coding styles are useful, but they can also concentrate review ability in the few people who have learned them deeply. NeNe should avoid making small-service delivery depend on specialist pattern fluency when a visible convention is enough.
+
 Principles:
 
 - Prefer visible conventions over hidden framework magic.
+- Prefer broadly reviewable patterns over fashionable patterns when both solve the same small-service problem.
 - Optimize for reviewability: a human should quickly know where to inspect HTTP input, business rules, SQL, API contracts, and tests.
 - Keep routing, controller names, REST method boundaries, configuration, and database setup easy to trace.
 - Keep Controller / Service / Mapper responsibilities stable enough that different humans and AI agents produce similar shapes.
@@ -164,6 +167,7 @@ Future candidates:
 - #163: Reframe the next phase around reducing code review cost through consistent implementation conventions.
 - #164: Present NeNe publicly as a reviewable small-service PHP framework.
 - #165: Use the reference implementation to prove the reviewable Controller-Service-Mapper shape.
+- #167: Explain how stable conventions help avoid reviewer scarcity caused by specialized pattern knowledge.
 - #145: Add a small-service reference implementation that shows the expected shape of page, REST endpoint, service/use-case, mapper, OpenAPI, and test changes.
 - Make the first-service tutorial even more repeatable from clone to local verification.
 - Improve comments and PHPDoc only where they help readers understand framework boundaries.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,10 +4,12 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Active
 
-- #160: Document AI self-review checklists and service-layer implementation standards.
+- #163: Reframe the next phase around reducing code review cost through consistent implementation conventions.
+- #162: Document the publication and outreach strategy for NeNe after `v0.2.0`.
 
 ## Recently Completed
 
+- #160: Document AI self-review checklists and service-layer implementation standards.
 - #158: Prepare the `v0.2.0` release notes and runtime version.
 - #154, #155, #156: Clean up release-blocking code quality concerns in `ControllerBase` and `DataMapperBase`.
 - #152: Add the canonical transaction pattern to the sample page tutorial.
@@ -63,7 +65,13 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
+- #164: Update the public entry to present NeNe as a reviewable small-service PHP framework.
+- #165: Prove the reviewable Controller-Service-Mapper shape through the reference implementation.
+- Prepare GitHub repository metadata: About, homepage, topics, and MIT license detection.
+- Strengthen the README public entry with demo, latest release, license, tutorial, and "what NeNe is not" links.
+- Improve Composer and Packagist metadata: PHP requirement, keywords, homepage, support, and authors.
 - #145: Add an AI-assisted small-service reference implementation covering page, REST, mapper, OpenAPI, and tests.
+- Write the Zenn renovation story and the Qiita hands-on guide after the public entry is ready.
 
 ## Backlog Candidates
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,6 +4,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Active
 
+- #167: Add the reviewer-scarcity angle around modern pattern learning costs.
 - #163: Reframe the next phase around reducing code review cost through consistent implementation conventions.
 - #162: Document the publication and outreach strategy for NeNe after `v0.2.0`.
 


### PR DESCRIPTION
## Summary
- Phase 6 を `Reviewable Small-Service Delivery` として、レビューコスト削減軸に再整理
- `docs/milestones/README.md` と `docs/todo/current.md` を #163 / #164 / #165 に合わせて更新
- `docs/publication-strategy.md` を追加し、README・GitHub metadata・記事公開の順序と訴求軸を整理

## Test plan
- `composer analyze`
- `git diff --check`

Closes #162
Closes #163

Made with [Cursor](https://cursor.com)