### PR TITLE
トップページにレビューしやすさの訴求を追加する

### DIFF
--- a/htdocs/js/index/index.js
+++ b/htdocs/js/index/index.js
@@ -21,6 +21,10 @@ document.addEventListener('DOMContentLoaded', function() {
         {
             title: 'Modernization',
             text: 'Add tests, OpenAPI, and safer conventions without losing the legacy shape.'
+        },
+        {
+            title: 'Reviewable Code',
+            text: 'Modern patterns are useful, but NeNe favors visible conventions so more reviewers can check small-service changes.'
         }
     ];
 
@@ -256,6 +260,7 @@ document.addEventListener('DOMContentLoaded', function() {
             ),
             e('div', { className: 'tutorial__intro' },
                 e('p', null, 'NeNe keeps the old-school URL and controller shape familiar to CodeIgniter or Zend Framework 1 users, then adds modern safety rails around it: JSON-only REST, OpenAPI, tests, Docker, and explicit error catalogs.'),
+                e('p', null, 'The goal is not to chase fashionable architecture patterns. The goal is to keep small-service changes reviewable by many people: HTTP input, business rules, SQL, API contracts, and tests should live in predictable places.'),
                 e('div', { className: 'tutorial__links' },
                     e('a', {
                         className: 'tutorial__doc-link',

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -41,6 +41,8 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertStringContainsString('/health/index', $response->body());
         self::assertStringContainsString('php cli/setupDatabase.php --env=.env --yes', $response->body());
         self::assertStringContainsString('class/xion as framework core', $response->body());
+        self::assertStringContainsString('Reviewable Code', $response->body());
+        self::assertStringContainsString('reviewable by many people', $response->body());
         self::assertStringContainsString('TransactionManager::run', $response->body());
         self::assertStringContainsString('Environment: ', $response->body());
         self::assertStringContainsString("health.environment === 'development'", $response->body());


### PR DESCRIPTION
## Summary
- トップページのカードに `Reviewable Code` を追加
- 小規模サービスチュートリアルに、流行パターンよりレビューしやすい配置を優先するメッセージを追加
- HTTP smoke test でトップページJSに訴求文言が含まれることを確認

## Test plan
- `php -l htdocs/js/index/index.js`
- `php -l tests/Http/HttpSmokeTest.php`
- `composer test`
- `composer analyze`

Related #164

Made with [Cursor](https://cursor.com)