### PR TITLE
docs(readme): 公開入口をレビューしやすさ軸で整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # NeNe
 
-Simple web application framework.
+Tiny renovated legacy-style PHP framework for reviewable small services.
+
+- Demo: <https://nene-php.com/>
+- Latest release: [`v0.2.0`](https://github.com/hideyukiMORI/NeNe/releases/tag/v0.2.0)
+- License: MIT
+- Service tutorial: `docs/tutorials/building-a-service.md`
+- AI self-review checklists: `docs/ai/README.md`
 
 NeNe is a renovated legacy PHP framework.
 
 The original idea is more than ten years old: keep a tiny front-controller framework that people familiar with older PHP frameworks can understand at a glance. This repository keeps that philosophy and structure, then updates the project for modern PHP development with Composer, Docker, tests, OpenAPI, explicit security defaults, and current stable packages.
 
-NeNe is intentionally much smaller than full-stack frameworks. Its visible conventions are meant to stay readable by both humans and AI agents, so code generated or edited with AI assistance can follow the same shape a developer would normally review.
+NeNe is intentionally much smaller than full-stack frameworks. Its visible conventions are meant to stay readable by both humans and AI agents, so code generated or edited with AI assistance can follow the same shape a developer would normally review. The goal is to lower code review cost for small services by keeping HTTP input, controller actions, service rules, mapper SQL, OpenAPI, and tests in predictable places.
 
 NeNe keeps only the parts needed to build small services:
 
@@ -17,6 +23,13 @@ NeNe keeps only the parts needed to build small services:
 - Session, CSRF, error catalog, logging, and testable boundaries.
 
 The goal is not to replace Laravel, Symfony, CodeIgniter, or Laminas. The goal is to give legacy-framework users a small codebase they can read, keep, safely modernize, and move from clone to a working small-service delivery path quickly.
+
+## What NeNe Is Not
+
+- Not a large enterprise full-stack framework.
+- Not a Laravel, Symfony, CodeIgniter, or Laminas replacement.
+- Not an ORM, plugin ecosystem, or SPA-first architecture.
+- Not an attempt to hide legacy-style URL routing behind a new router abstraction.
 
 ## Documentation
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,10 +4,12 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Active
 
-- #169: Position the publication strategy document as a public OSS release case study.
+- #165: Prove the reviewable Controller-Service-Mapper shape through the reference implementation.
 
 ## Recently Completed
 
+- #164: Update the public entry to present NeNe as a reviewable small-service PHP framework.
+- #169: Position the publication strategy document as a public OSS release case study.
 - #167: Add the reviewer-scarcity angle around modern pattern learning costs.
 - #163: Reframe the next phase around reducing code review cost through consistent implementation conventions.
 - #162: Document the publication and outreach strategy for NeNe after `v0.2.0`.
@@ -67,10 +69,6 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- #164: Update the public entry to present NeNe as a reviewable small-service PHP framework.
-- #165: Prove the reviewable Controller-Service-Mapper shape through the reference implementation.
-- Prepare GitHub repository metadata: About, homepage, topics, and MIT license detection.
-- Strengthen the README public entry with demo, latest release, license, tutorial, and "what NeNe is not" links.
 - Improve Composer and Packagist metadata: PHP requirement, keywords, homepage, support, and authors.
 - #145: Add an AI-assisted small-service reference implementation covering page, REST, mapper, OpenAPI, and tests.
 - Write the Zenn renovation story and the Qiita hands-on guide after the public entry is ready.


### PR DESCRIPTION
## Summary
- README冒頭に Demo / Latest release / License / service tutorial / AI self-review checklist の導線を追加
- NeNeを「レビューしやすい小規模サービス向けPHPフレームワーク」として説明する文脈を補強
- `What NeNe Is Not` を追加して、Laravel/Symfony等の置き換えではないことを明確化
- `docs/todo/current.md` を現在のIssue状態に合わせて更新
- GitHub repository metadata も更新済み: About description, homepage, topics

## Test plan
- `git diff --check`
- `composer validate --no-check-publish`
- `composer test`

Closes #164

Made with [Cursor](https://cursor.com)