### PR TITLE
docs(strategy): レビューコスト訴求の誤読を避ける

### DIFF
--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -90,14 +90,14 @@ Context: NeNe's next phase should build on the renovated legacy foundation. The 
 
 The legacy inheritance matters. Older PHP frameworks often made control flow easy to trace because the route, controller, action, and mapper were visible. This milestone keeps that readability, then adds modern review aids so different humans and different AI tools still produce code that looks like normal NeNe code.
 
-Modern patterns remain useful, but this milestone should avoid making review participation depend on specialist pattern knowledge. For small services, a simple visible convention is often more valuable than a cooler abstraction if it lets more people review changes confidently.
+Modern patterns remain useful, but this milestone should avoid making every review depend on understanding a different author's preferred architecture. For small services, a simple visible convention is often more valuable than a cooler abstraction if it lets reviewers focus on behavior confidently.
 
 Positioning:
 
 - Review-cost reduction as the practical value of explicit conventions.
 - AI-readable as an outcome of stable human-reviewable patterns, not as a separate architecture goal.
 - Human-friendly and review-friendly, not magic-heavy.
-- Modern safety rails without requiring fashionable architecture-pattern fluency for ordinary reviews.
+- Modern safety rails without requiring reviewers to decode a different architecture style for ordinary changes.
 - Fast for small services, not a replacement for large enterprise frameworks.
 - Secure by default for realistic local development and small deployments.
 
@@ -118,7 +118,7 @@ Completion criteria:
 - #163 defines the review-cost-reduction framing for Phase 6.
 - #164 updates the public entry message around reviewable small-service delivery.
 - #165 and #145 define a concrete reference implementation for the expected Controller, Service, Mapper, OpenAPI, and test workflow.
-- #167 explains how stable conventions help avoid reviewer scarcity caused by specialized design-pattern knowledge.
+- #167 explains how stable conventions reduce review load caused by highly variable implementation styles.
 - Local Docker setup remains simple, including app, MySQL, phpMyAdmin, Swagger UI, and test commands.
 - Production-facing docs continue to warn about secrets, debug output, local Docker credentials, phpMyAdmin exposure, and database initialization.
 - New examples do not introduce hidden routing, heavy ORM behavior, or broad framework abstractions.

--- a/docs/publication-strategy.md
+++ b/docs/publication-strategy.md
@@ -16,7 +16,9 @@ The public angle should speak to a common developer pain:
 
 Another useful angle:
 
-> Modern design patterns and fashionable coding styles can be powerful. But when only a few people have learned those patterns deeply enough to review them, a project can slow down because reviewers become scarce. NeNe favors visible, repeatable conventions so more developers can participate in review without first learning a large framework-specific style.
+> Modern design patterns and fashionable coding styles can be powerful. But when implementation style is left completely open, review can slow down because every change requires reviewers to decode a different personal architecture. NeNe favors visible, repeatable conventions so reviewers can focus on behavior instead of first learning each contributor's preferred style.
+
+This is not a claim that NeNe needs more outside reviewers. The point is structural: by narrowing ordinary implementation choices, NeNe reduces the number of design decisions a reviewer must understand before checking a small-service change.
 
 ## Current Public State
 
@@ -64,7 +66,7 @@ Use this positioning consistently:
 Avoid these messages:
 
 - Do not call NeNe a Laravel, Symfony, CodeIgniter, or Laminas replacement.
-- Do not attack modern design patterns. Explain that NeNe optimizes for small-service reviewability when the team does not want reviewer availability to depend on specialist pattern knowledge.
+- Do not attack modern design patterns. Explain that NeNe optimizes for small-service reviewability when a team does not want every review to start by decoding a different personal architecture.
 - Do not overstate AI support. Say that NeNe is reviewable for human-written or AI-assisted changes.
 - Do not imply production readiness for large multi-team systems.
 - Do not hide that Smarty and URL-segment routing are intentional old-school choices.
@@ -217,7 +219,7 @@ Core message:
 - Small explicit conventions.
 - URL routing and controller methods are visible.
 - Reviewers can find HTTP input, business rules, SQL, API contracts, and tests in predictable places.
-- Review participation should not require deep familiarity with trendy architecture patterns before basic behavior can be checked.
+- Reviews should not require deep familiarity with each author's preferred architecture before basic behavior can be checked.
 - OpenAPI and tests were added around the old shape.
 - Not a Laravel or Symfony competitor.
 
@@ -277,7 +279,7 @@ NeNe's first public outreach is successful if readers can quickly understand:
 - Who NeNe is for.
 - Why it keeps a legacy-style shape.
 - How it lowers review cost by keeping implementation patterns consistent.
-- Why it avoids making reviewer availability depend on specialized design-pattern fluency.
+- Why it avoids making ordinary reviews depend on decoding each author's personal architecture.
 - How to run it locally.
 - How to build a first feature.
 - Why it is intentionally smaller than mainstream frameworks.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -147,12 +147,12 @@ This phase should strengthen NeNe as a small-service delivery framework where a 
 
 The legacy shape is a strength here. NeNe should preserve the old PHP framework habit of "look at the URL, find the controller, read the method," then add modern review aids around it: clear responsibility boundaries, self-review checklists, tests, OpenAPI, and secure defaults.
 
-Modern design patterns and current coding styles are useful, but they can also concentrate review ability in the few people who have learned them deeply. NeNe should avoid making small-service delivery depend on specialist pattern fluency when a visible convention is enough.
+Modern design patterns and current coding styles are useful, but very open implementation style can make each review start with a different architecture lesson. NeNe should avoid making small-service delivery depend on decoding every contributor's preferred pattern when a visible convention is enough.
 
 Principles:
 
 - Prefer visible conventions over hidden framework magic.
-- Prefer broadly reviewable patterns over fashionable patterns when both solve the same small-service problem.
+- Prefer broadly reviewable conventions over fashionable patterns when both solve the same small-service problem.
 - Optimize for reviewability: a human should quickly know where to inspect HTTP input, business rules, SQL, API contracts, and tests.
 - Keep routing, controller names, REST method boundaries, configuration, and database setup easy to trace.
 - Keep Controller / Service / Mapper responsibilities stable enough that different humans and AI agents produce similar shapes.
@@ -167,7 +167,7 @@ Future candidates:
 - #163: Reframe the next phase around reducing code review cost through consistent implementation conventions.
 - #164: Present NeNe publicly as a reviewable small-service PHP framework.
 - #165: Use the reference implementation to prove the reviewable Controller-Service-Mapper shape.
-- #167: Explain how stable conventions help avoid reviewer scarcity caused by specialized pattern knowledge.
+- #167: Explain how stable conventions reduce review load caused by highly variable implementation styles.
 - #145: Add a small-service reference implementation that shows the expected shape of page, REST endpoint, service/use-case, mapper, OpenAPI, and test changes.
 - Make the first-service tutorial even more repeatable from clone to local verification.
 - Improve comments and PHPDoc only where they help readers understand framework boundaries.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,13 +4,14 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Active
 
+- #172: Clarify that the review-cost message is about implementation-style variance, not outside reviewer scarcity.
 - #165: Prove the reviewable Controller-Service-Mapper shape through the reference implementation.
 
 ## Recently Completed
 
 - #164: Update the public entry to present NeNe as a reviewable small-service PHP framework.
 - #169: Position the publication strategy document as a public OSS release case study.
-- #167: Add the reviewer-scarcity angle around modern pattern learning costs.
+- #167: Add the review-cost angle around modern pattern learning and implementation-style variance.
 - #163: Reframe the next phase around reducing code review cost through consistent implementation conventions.
 - #162: Document the publication and outreach strategy for NeNe after `v0.2.0`.
 - #160: Document AI self-review checklists and service-layer implementation standards.


### PR DESCRIPTION
## Summary
- レビューコスト訴求が外部レビュアー不足の話に見えないよう表現を調整
- 実装スタイルのばらつきによってレビュー時の設計読解負荷が増える、という意図を明確化
- roadmap / milestones / TODO を #172 の文脈に同期

## Test plan
- ReadLints: `docs/publication-strategy.md`, `docs/roadmap.md`, `docs/milestones/README.md`, `docs/todo/current.md`

Closes #172

Made with [Cursor](https://cursor.com)