### PR TITLE
docs(install): git clone推奨を明記する

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ The legacy `{action}Rest` fallback remains only for compatibility. New REST endp
 - The Docker development target is PHP 8.4.
 - Composer is required for dependency installation and autoloading.
 
+## Recommended Install Path
+
+For now, NeNe is intended to be cloned as a small-service base repository:
+
+```sh
+git clone git@github.com:hideyukiMORI/NeNe.git
+cd NeNe
+composer install
+```
+
+Composer is used after cloning to install dependencies and build autoloading. NeNe is not currently positioned as a library that should be added to an existing application with `composer require`.
+
 ## Docker Quick Start
 
 ```sh

--- a/docs/publication-strategy.md
+++ b/docs/publication-strategy.md
@@ -117,16 +117,18 @@ The README should stay concise. Detailed setup and design explanations belong in
 
 ### 3. Composer and Packagist Metadata
 
-If NeNe should be discoverable as a PHP package, improve `composer.json` before Packagist registration:
+NeNe's current recommended install path is `git clone`, then `composer install`. Treat the repository as a small-service base, not as a library that is added to an existing application with `composer require`.
+
+If NeNe should become discoverable on Packagist later, improve `composer.json` before registration:
 
 - Add a PHP requirement that matches the documented target.
 - Add `keywords`.
 - Add `homepage`.
 - Add `support.issues`.
 - Add `authors`.
-- Clarify whether NeNe is used as a package, an application skeleton, or a repository to clone.
+- Keep the README clear that the primary install path is still repository clone unless a later Issue changes the distribution model.
 
-Packagist expectations should be explicit. If the recommended install path is still `git clone`, say that clearly in README and release notes.
+Packagist expectations should be explicit. Packagist can help discovery, but it should not imply that NeNe is currently a drop-in library for existing applications.
 
 ### 4. Reference Implementation
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,11 +4,12 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Active
 
-- #172: Clarify that the review-cost message is about implementation-style variance, not outside reviewer scarcity.
+- #174: Clarify that `git clone` is the recommended install path for now.
 - #165: Prove the reviewable Controller-Service-Mapper shape through the reference implementation.
 
 ## Recently Completed
 
+- #172: Clarify that the review-cost message is about implementation-style variance, not outside reviewer scarcity.
 - #164: Update the public entry to present NeNe as a reviewable small-service PHP framework.
 - #169: Position the publication strategy document as a public OSS release case study.
 - #167: Add the review-cost angle around modern pattern learning and implementation-style variance.
@@ -70,7 +71,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- Improve Composer and Packagist metadata: PHP requirement, keywords, homepage, support, and authors.
+- Improve Composer and Packagist metadata for discovery after the `git clone` install story is clear.
 - #145: Add an AI-assisted small-service reference implementation covering page, REST, mapper, OpenAPI, and tests.
 - Write the Zenn renovation story and the Qiita hands-on guide after the public entry is ready.
 


### PR DESCRIPTION
## Summary
- README に現時点の推奨インストールは `git clone` + `composer install` であることを明記
- NeNe は既存アプリへ `composer require` するライブラリではなく、小規模サービスの土台として clone する方針を説明
- 公開戦略ドキュメントで Packagist を将来の発見性・メタ情報整備として位置づけ直し
- TODO を #172 完了済み、#174 Active として更新

## Test plan
- `git diff --check`
- `composer validate --no-check-publish`
- `composer test`

Closes #174

Made with [Cursor](https://cursor.com)