### PR TITLE
docs(strategy): 公開準備の優先順を整理する

### DIFF
--- a/docs/publication-strategy.md
+++ b/docs/publication-strategy.md
@@ -265,14 +265,15 @@ Show HN: NeNe, a tiny renovated legacy-style PHP framework
 
 ## Suggested Execution TODO
 
-1. Improve GitHub repository metadata.
-2. Strengthen the README public entry.
-3. Improve Composer/Packagist metadata.
-4. Complete #145 reference implementation.
-5. Write the Zenn renovation story.
-6. Write the Qiita hands-on guide.
-7. Publish a short DEV Community English article.
-8. Consider Reddit or Hacker News after feedback from the first articles.
+1. Done: improve GitHub repository metadata.
+2. Done: strengthen the README public entry.
+3. Done: clarify that `git clone` is the recommended install path for now.
+4. #176: improve Composer/Packagist-facing metadata for discovery.
+5. #177: write the Zenn renovation story.
+6. #178: write the Qiita hands-on guide.
+7. #179: publish a short DEV Community English article.
+8. #180: consider Reddit or Hacker News after feedback from the first articles.
+9. #165/#145: continue the reviewable Controller-Service-Mapper reference implementation after the public-entry sequence.
 
 ## Success Criteria
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,11 +4,11 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Active
 
-- #174: Clarify that `git clone` is the recommended install path for now.
-- #165: Prove the reviewable Controller-Service-Mapper shape through the reference implementation.
+- #176: Prepare Composer and Packagist-facing metadata for public discovery while keeping `git clone` as the recommended install path.
 
 ## Recently Completed
 
+- #174: Clarify that `git clone` is the recommended install path for now.
 - #172: Clarify that the review-cost message is about implementation-style variance, not outside reviewer scarcity.
 - #164: Update the public entry to present NeNe as a reviewable small-service PHP framework.
 - #169: Position the publication strategy document as a public OSS release case study.
@@ -71,9 +71,12 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- Improve Composer and Packagist metadata for discovery after the `git clone` install story is clear.
+- #177: Prepare the Zenn renovation-story article.
+- #178: Prepare the Qiita hands-on implementation tutorial article.
+- #179: Prepare the DEV Community English introduction article.
+- #180: Decide on Reddit/Hacker News only after the first article feedback.
+- #165: Prove the reviewable Controller-Service-Mapper shape through the reference implementation.
 - #145: Add an AI-assisted small-service reference implementation covering page, REST, mapper, OpenAPI, and tests.
-- Write the Zenn renovation story and the Qiita hands-on guide after the public entry is ready.
 
 ## Backlog Candidates
 


### PR DESCRIPTION
## Summary
- 公開戦略の実行TODOを実際のIssue番号に合わせて整理
- GitHub metadata / README / git clone 推奨の完了状態を明記
- #176〜#180 を #165/#145 より前に並べ、記事化と公開準備を優先する流れに更新

## Test plan
- `git diff --check`

Closes #182