### PR TITLE
chore(composer): 公開向けメタ情報を整える

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ composer install
 
 Composer is used after cloning to install dependencies and build autoloading. NeNe is not currently positioned as a library that should be added to an existing application with `composer require`.
 
+The Composer package metadata uses `type: project` for public discovery and future Packagist compatibility. The recommended install story remains repository clone unless a later release changes the distribution model.
+
 ## Docker Quick Start
 
 ```sh

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,29 @@
 {
     "name": "hideyukimori/nene",
-    "description": "Simple web application framework",
+    "description": "A tiny renovated legacy-style PHP framework for reviewable small services",
+    "type": "project",
     "license": "MIT",
+    "homepage": "https://nene-php.com/",
+    "keywords": [
+        "php",
+        "framework",
+        "php-framework",
+        "openapi",
+        "smarty",
+        "docker",
+        "legacy-modernization",
+        "micro-framework"
+    ],
+    "authors": [
+        {
+            "name": "Hideyuki MORI",
+            "email": "info@ayane.co.jp"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/hideyukiMORI/NeNe/issues",
+        "source": "https://github.com/hideyukiMORI/NeNe"
+    },
     "autoload": {
 		"psr-4": {
 			"Nene\\Init\\"      : "class/init/",

--- a/docs/publication-strategy.md
+++ b/docs/publication-strategy.md
@@ -119,13 +119,11 @@ The README should stay concise. Detailed setup and design explanations belong in
 
 NeNe's current recommended install path is `git clone`, then `composer install`. Treat the repository as a small-service base, not as a library that is added to an existing application with `composer require`.
 
-If NeNe should become discoverable on Packagist later, improve `composer.json` before registration:
+If NeNe should become discoverable on Packagist later, keep `composer.json` metadata useful for readers and search:
 
-- Add a PHP requirement that matches the documented target.
-- Add `keywords`.
-- Add `homepage`.
-- Add `support.issues`.
-- Add `authors`.
+- Keep `type: project` unless a later release changes NeNe into an installable library.
+- Keep `keywords`, `homepage`, `support`, and `authors` useful for public discovery.
+- Add a Composer PHP requirement only when the local/CI Composer runtime and lock-file workflow are ready to enforce it consistently.
 - Keep the README clear that the primary install path is still repository clone unless a later Issue changes the distribution model.
 
 Packagist expectations should be explicit. Packagist can help discovery, but it should not imply that NeNe is currently a drop-in library for existing applications.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,10 +4,11 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Active
 
-- #176: Prepare Composer and Packagist-facing metadata for public discovery while keeping `git clone` as the recommended install path.
+- #177: Prepare the Zenn renovation-story article.
 
 ## Recently Completed
 
+- #176: Prepare Composer and Packagist-facing metadata for public discovery while keeping `git clone` as the recommended install path.
 - #174: Clarify that `git clone` is the recommended install path for now.
 - #172: Clarify that the review-cost message is about implementation-style variance, not outside reviewer scarcity.
 - #164: Update the public entry to present NeNe as a reviewable small-service PHP framework.
@@ -71,7 +72,6 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Next
 
-- #177: Prepare the Zenn renovation-story article.
 - #178: Prepare the Qiita hands-on implementation tutorial article.
 - #179: Prepare the DEV Community English introduction article.
 - #180: Decide on Reddit/Hacker News only after the first article feedback.


### PR DESCRIPTION
## Summary
- `composer.json` に `type: project`、homepage、keywords、authors、support を追加
- description を公開向けに更新
- README に Composer metadata は発見性/将来のPackagist互換のためで、推奨導入は引き続き `git clone` であることを追記
- 公開戦略ドキュメントで Packagist は将来の発見性として位置づけ直し
- TODO を #176 完了予定、次のActiveを #177 に更新

## Test plan
- `git diff --check`
- `composer validate --strict --no-check-publish`
- `composer install --dry-run`
- `composer test`

Closes #176

Made with [Cursor](https://cursor.com)