### PR TITLE
docs(frontend): ページアセット配置規約を明文化する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This directory contains project documentation for humans and AI agents.
 - `development/commit-conventions.md`: Commit message rules.
 - `development/docker.md`: Docker local development.
 - `deployment/server-install.md`: Traditional Apache/PHP server installation after `git clone`.
+- `frontend/assets.md`: Smarty template, CSS, and JavaScript placement conventions.
 - `development/testing.md`: Testing strategy and commands.
 - `tutorials/building-a-service.md`: Practical guide for adding pages, REST endpoints, database-backed features, OpenAPI, and tests.
 - `ai/README.md`: AI-assisted implementation and self-review checklists.

--- a/docs/frontend/assets.md
+++ b/docs/frontend/assets.md
@@ -1,0 +1,162 @@
+# Templates and Page Assets
+
+NeNe keeps page presentation close to its legacy URL routing style. A URL segment selects a controller and action, and the matching Smarty template, CSS, and JavaScript files are discovered by convention.
+
+This is intentional. A reader should be able to move from `/page/about` to `PageController::aboutAction()`, then to `view/source/page/about.tpl`, `htdocs/css/page/about.css`, and `htdocs/js/page/about.js` without searching a route table or build manifest.
+
+## Directory Roles
+
+- `view/source/`: Smarty template source files.
+- `view/source/layout/`: Shared Smarty layouts.
+- `htdocs/css/`: Public CSS files.
+- `htdocs/js/`: Public JavaScript files.
+
+Do not place source templates under `htdocs/`. Templates are server-side files. CSS and JavaScript are public browser assets, so they live under `htdocs/`.
+
+## Page Naming Convention
+
+For this URL:
+
+```text
+GET /page/about
+```
+
+NeNe resolves the page to:
+
+```text
+class/controller/PageController.php
+PageController::aboutAction()
+```
+
+The matching presentation files are:
+
+```text
+view/source/page/about.tpl
+htdocs/css/page/about.css
+htdocs/js/page/about.js
+```
+
+Use lower-case directory and file names for the URL-facing parts. The controller class keeps the PHP class convention (`PageController`), while the presentation paths follow the route segments (`page/about`).
+
+## Template Auto Selection
+
+`ControllerBase` automatically selects a template from the current controller and action. New pages should normally use the action-specific directory style.
+
+The practical recommended paths are:
+
+```text
+view/source/common.tpl
+view/source/{controller}/common.tpl
+view/source/{controller}/{action}.tpl
+```
+
+For `/page/about`, the preferred template is:
+
+```text
+view/source/page/about.tpl
+```
+
+If the action-specific template does not exist, NeNe falls back through broader templates. This keeps very small pages possible while still allowing action-specific templates when the page needs its own markup.
+
+The legacy controller-level template form is also supported:
+
+```text
+view/source/{controller}.tpl
+```
+
+Prefer `view/source/{controller}/common.tpl` for new shared controller markup. It keeps all templates for the same controller in one directory and makes the route-to-template relationship easier to scan.
+
+Most new pages should extend the shared layout:
+
+```smarty
+{extends file='layout/app.tpl'}
+{block name='content'}
+                <section class="page-about">
+                    <h1>{$t_heading}</h1>
+                    <p>{$t_body}</p>
+                </section>
+{/block}
+```
+
+## CSS Auto Loading
+
+`ControllerBase` also discovers CSS files by convention.
+
+The lookup order is:
+
+```text
+htdocs/css/{controller}.css
+htdocs/css/{controller}/common.css
+htdocs/css/{controller}/{action}.css
+```
+
+For `/page/about`, these files are loaded when they exist:
+
+```text
+htdocs/css/page.css
+htdocs/css/page/common.css
+htdocs/css/page/about.css
+```
+
+Use `htdocs/css/{controller}/common.css` for styles shared by pages in the same controller. Use `htdocs/css/{controller}/{action}.css` for page-specific styles.
+
+## JavaScript Auto Loading
+
+JavaScript follows the same pattern as CSS.
+
+The lookup order is:
+
+```text
+htdocs/js/{controller}.js
+htdocs/js/{controller}/common.js
+htdocs/js/{controller}/{action}.js
+```
+
+For `/page/about`, these files are loaded when they exist:
+
+```text
+htdocs/js/page.js
+htdocs/js/page/common.js
+htdocs/js/page/about.js
+```
+
+Use JavaScript only when the page needs browser behavior. Server-rendered pages can omit JavaScript entirely.
+
+## Layout Output
+
+The shared layout receives the resolved assets as Smarty variables:
+
+```text
+$t_css
+$t_js
+```
+
+`view/source/layout/app.tpl` renders those arrays into `<link>` and `<script>` tags. Normal pages do not need to manually include their own CSS or JavaScript files when they follow the naming convention.
+
+## Cache Busting
+
+When a local CSS or JavaScript file exists, `View` appends its `filemtime()` as a query string:
+
+```text
+/css/page/about.css?1234567890
+/js/page/about.js?1234567890
+```
+
+This keeps browser caches from hiding local asset changes during development and small deployments.
+
+External URLs added through `View::addCSS()` or `View::addJS()` are passed through as-is.
+
+## Recommended Shape
+
+Prefer this shape for new server-rendered pages:
+
+```text
+class/controller/{Name}Controller.php
+view/source/{name}/{action}.tpl
+htdocs/css/{name}/{action}.css
+htdocs/js/{name}/{action}.js
+```
+
+Keep markup in Smarty templates, styling in CSS files, and browser behavior in JavaScript files. Avoid inline CSS or large inline scripts unless the page has a narrow, documented reason.
+
+This keeps NeNe's page layer easy to review: URL, controller action, template, CSS, and JavaScript all line up by name.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #185: Document Smarty template, CSS, and JavaScript placement conventions.
 - #177: Prepare the Zenn renovation-story article.
 - #176: Prepare Composer and Packagist-facing metadata for public discovery while keeping `git clone` as the recommended install path.
 - #174: Clarify that `git clone` is the recommended install path for now.

--- a/docs/tutorials/building-a-service.md
+++ b/docs/tutorials/building-a-service.md
@@ -103,6 +103,8 @@ htdocs/js/page/about.js
 
 The dispatcher resolves `/page/about` to `PageController::aboutAction()`. `ControllerBase` automatically chooses `view/source/page/about.tpl` when it exists.
 
+For the full template, CSS, JavaScript, and auto-loading rules, see `docs/frontend/assets.md`.
+
 ## Add a REST Endpoint
 
 Use method-specific REST handlers for JSON endpoints. Avoid new `{action}Rest()` handlers unless a compatibility reason is documented, because they accept every HTTP method through the legacy fallback.


### PR DESCRIPTION
## Summary
- Smartyテンプレート、CSS、JavaScriptの配置規約を `docs/frontend/assets.md` に追加
- テンプレートとページアセットの自動読み込み、共通/ページ固有ファイル、キャッシュ破りを説明
- `docs/README.md` とサービス実装チュートリアルから参照できるように更新

## Test plan
- `git diff --check`
- `composer validate --no-check-publish`
- `ReadLints` on edited docs

Closes #185

Made with [Cursor](https://cursor.com)