### PR TITLE
refactor(template): コントローラー直下テンプレート探索を廃止する

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -278,9 +278,6 @@ abstract class ControllerBase
         $controller = $this->ROUTE_CONTEXT->controller();
         $action = $this->ROUTE_CONTEXT->action();
         $template = 'common';
-        if (file_exists(sprintf('%s/%s.tpl', DIR_SMARTY_TEMPLATE, $controller))) {
-            $template = $controller;
-        }
         if (file_exists(sprintf('%s/%s.tpl', DIR_SMARTY_TEMPLATE, $controller . '/' . $template))) {
             $template = $controller . '/' . $template;
         }

--- a/docs/frontend/assets.md
+++ b/docs/frontend/assets.md
@@ -58,13 +58,7 @@ view/source/page/about.tpl
 
 If the action-specific template does not exist, NeNe falls back through broader templates. This keeps very small pages possible while still allowing action-specific templates when the page needs its own markup.
 
-The legacy controller-level template form is also supported:
-
-```text
-view/source/{controller}.tpl
-```
-
-Prefer `view/source/{controller}/common.tpl` for new shared controller markup. It keeps all templates for the same controller in one directory and makes the route-to-template relationship easier to scan.
+Use `view/source/{controller}/common.tpl` for shared controller markup. NeNe does not load `view/source/{controller}.tpl`; keeping templates inside the controller directory makes the route-to-template relationship easier to scan.
 
 Most new pages should extend the shared layout:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,6 +8,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 ## Recently Completed
 
+- #187: Remove the controller-level Smarty template fallback.
 - #185: Document Smarty template, CSS, and JavaScript placement conventions.
 - #177: Prepare the Zenn renovation-story article.
 - #176: Prepare Composer and Packagist-facing metadata for public discovery while keeping `git clone` as the recommended install path.


### PR DESCRIPTION
## Summary
- `ControllerBase::setTemplate()` から `view/source/{controller}.tpl` の探索を削除
- テンプレート規約を `common.tpl` / `{controller}/common.tpl` / `{controller}/{action}.tpl` に整理
- `docs/frontend/assets.md` と TODO を更新

## Test plan
- `git diff --check`
- `composer test`
- `composer analyze`
- `composer validate --no-check-publish`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff class/xion/ControllerBase.php`

## Notes
- `composer format:check` は既存の未変更ファイル `class/controller/TodoController.php`, `class/db/Todo.php`, `ini/xSiteIni.php` の整形差分で失敗するため、今回変更したPHPファイルに絞って確認しました。

Closes #187

Made with [Cursor](https://cursor.com)