### PR TITLE
refactor(xion): class/xion/ の型宣言と Phan baseline を改善する

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -246,9 +246,9 @@ abstract class ControllerBase
      * preAction
      * Executed before the main process of run.
      *
-     * @return mixed
+     * @return void
      */
-    protected function preAction()
+    protected function preAction(): void
     {
     }
 

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -170,6 +170,7 @@ abstract class DataMapperBase
     public function update(mixed $data): void
     {
         $column = $this->getTableColumn(static::KEY_SID, DB_COLUMN_TIMESTAMP);
+        $param = [];
         foreach ($column as $key => $val) {
             $key = preg_replace('/^' . DB_NUM_PREFIX . '/', '', $key);
             $param[] = $key . '=:' . $key;
@@ -336,11 +337,10 @@ abstract class DataMapperBase
     final public function executeQuery(string $query): PDOStatement
     {
         try {
-            $stmt = $this->DB->query($query);
+            return $this->DB->query($query);
         } catch (\PDOException $e) {
             $this->handleDatabaseException($e);
         }
-        return $stmt;
     }
 
     /**

--- a/class/xion/ModelBase.php
+++ b/class/xion/ModelBase.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace Nene\Xion;
 
 use Monolog\Logger;
-use Nene\Model;
 use Nene\Xion as Xion;
 
 /**
@@ -79,7 +78,7 @@ abstract class ModelBase
      *
      * @return boolean
      */
-    final protected function checkLogin()
+    final protected function checkLogin(): bool
     {
         return $this->AUTH_SESSION->isLoggedIn();
     }


### PR DESCRIPTION
## 目的

Phan baseline に残っている既知の問題のうち、コード変更で解消できるものを修正する。

## 変更内容

- `ModelBase`: 未使用の `use Nene\Model` を削除 (PhanUnreferencedUseNormal)
- `DataMapperBase::update()`: `$param` を明示的に初期化 (PhanPossiblyUndeclaredVariable 他)
- `DataMapperBase::executeQuery()`: `return` を早期脱出に変更して未定義変数警告を解消
- `ControllerBase::preAction()`: `@return mixed` → `@return void` + native 型宣言
- `ModelBase::checkLogin()`: native 戻り値型 `: bool` を追加

## 検証

- `composer test`: 43 tests, 125 assertions — OK

## 関連

Closes #189