### PR TITLE
chore: .gitignore・コメント・roadmap の小さな整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 tags
 vendor
+package-lock.json
 .env
 .env.*
 !.env.example

--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -276,7 +276,7 @@ class View
     /**
      * Set data object.
      *
-     * @param array $dataArray Pass the data to vue.js.
+     * @param array $dataArray Data to expose as a JavaScript variable in the template.
      *
      * @return View
      */

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,12 +162,15 @@ Principles:
 - Treat security defaults, explicit errors, CSRF, password hashing, session settings, and dependency hygiene as part of the developer experience.
 - Avoid adding large abstractions that make the code harder for humans or AI agents to understand.
 
+Completed:
+
+- #163: Reframed the next phase around reducing code review cost through consistent implementation conventions.
+- #164: Updated the public entry to present NeNe as a reviewable small-service PHP framework.
+- #167: Added the review-cost angle around modern pattern learning and implementation-style variance.
+
 Future candidates:
 
-- #163: Reframe the next phase around reducing code review cost through consistent implementation conventions.
-- #164: Present NeNe publicly as a reviewable small-service PHP framework.
 - #165: Use the reference implementation to prove the reviewable Controller-Service-Mapper shape.
-- #167: Explain how stable conventions reduce review load caused by highly variable implementation styles.
 - #145: Add a small-service reference implementation that shows the expected shape of page, REST endpoint, service/use-case, mapper, OpenAPI, and test changes.
 - Make the first-service tutorial even more repeatable from clone to local verification.
 - Improve comments and PHPDoc only where they help readers understand framework boundaries.


### PR DESCRIPTION
## 目的

未管理ファイルの放置、削除済みフレームワークへの言及残存、完了済み Issue のロードマップ残留を整理する。

## 変更内容

- `.gitignore` に `package-lock.json` を追加
- `View::setDataObject()` の PHPDoc から削除済み Vue.js への言及を削除
- `docs/roadmap.md` Phase 6 の完了済み Issue (#163・#164・#167) を Completed セクションに移動

## 検証

- `composer test`: 43 tests, 125 assertions — OK

## 関連

Closes #190