### PR TITLE
refactor(ControllerBase): デッドプロパティ $controller と $action を削除する

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -45,20 +45,6 @@ abstract class ControllerBase
     protected $method;
 
     /**
-     * Controller name.
-     *
-     * @var string
-     */
-    protected $controller = 'index';
-
-    /**
-     * Action name.
-     *
-     * @var string
-     */
-    protected $action = 'index';
-
-    /**
      * Site title.
      *
      * @var string


### PR DESCRIPTION
## 目的

`ControllerBase` に宣言されていた `protected $controller` と `protected $action` はコンストラクタ以降に更新されず、常に初期値 `'index'` のまま固定されていた。

`run()` 配下の全メソッドはルート情報を `$this->ROUTE_CONTEXT->controller()` / `->action()` から取得しており、これら2プロパティは読まれていない。`class/controller/` のサブクラスでも使用箇所なし。

## 変更内容

- `class/xion/ControllerBase.php`: `protected $controller = 'index'` を削除
- `class/xion/ControllerBase.php`: `protected $action = 'index'` を削除

## 検証

- `composer test`: 43 tests, 125 assertions — OK

## 関連

Closes #193