### PR TITLE
chore(ci): actions/checkout を v4 から v6 に更新する

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## 目的

`actions/checkout` を現在の最新 major バージョン v6 に更新する。

## 変更内容

- `.github/workflows/tests.yml`: `actions/checkout@v4` → `actions/checkout@v6`

## 検証

- PR の unit チェックが通ること

## 関連

Closes #195