### PR TITLE
fix(controller): preAction() オーバーライドに戻り値型宣言を追加する

### DIFF
--- a/class/controller/IndexController.php
+++ b/class/controller/IndexController.php
@@ -29,7 +29,7 @@ class IndexController extends ControllerBase
      *
      * @return void
      */
-    protected function preAction()
+    protected function preAction(): void
     {
         $this->SESSION_CHECK = false;
     }

--- a/class/controller/SessionController.php
+++ b/class/controller/SessionController.php
@@ -30,7 +30,7 @@ class SessionController extends ControllerBase
      *
      * @return void
      */
-    protected function preAction()
+    protected function preAction(): void
     {
         $this->SESSION_CHECK = false;
     }


### PR DESCRIPTION
## 目的

#189 で `ControllerBase::preAction()` に `: void` を追加したことで、
`IndexController` と `SessionController` のオーバーライドが Phan の
`PhanParamSignatureRealMismatchReturnType` エラーになっていた。

## 変更内容

- `IndexController::preAction()` に `: void` を追加
- `SessionController::preAction()` に `: void` を追加

## 検証

- `composer test`: 43 tests, 125 assertions — OK
- `composer analyze`: エラーなし

## 関連

Closes #199