### PR TITLE
refactor(xion): 残存 Phan baseline をさらに削減する (13件→6件)

### DIFF
--- a/.phan/baseline.php
+++ b/.phan/baseline.php
@@ -9,29 +9,14 @@
  */
 return [
     // # Issue statistics:
-    // PhanPossiblyUndeclaredVariable : 1 occurrence
     // PhanTypeMagicVoidWithReturn : 1 occurrence
     // PhanTypeMismatchArgument : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
     // PhanTypeMismatchDimFetch : 1 occurrence
     // PhanTypeMismatchForeach : 1 occurrence
-    // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
-    // PhanTypeMissingReturn : 1 occurrence
-    // PhanTypeSuspiciousStringExpression : 1 occurrence
     // PhanUndeclaredConstantOfClass : 1 occurrence
-    // PhanUndeclaredTypeThrowsType : 1 occurrence
-    // PhanUndeclaredVariableDim : 1 occurrence
-    // PhanUnreferencedUseNormal : 1 occurrence
 
     'file_suppressions' => [
-        'class/xion/ControllerBase.php' => [
-            'PhanTypeMissingReturn' => ['\\Nene\\Xion\\ControllerBase::preAction']
-        ],
-        'class/xion/DataMapperBase.php' => [
-            'PhanPossiblyUndeclaredVariable' => ['\\Nene\\Xion\\DataMapperBase::update'],
-            'PhanTypeSuspiciousStringExpression' => ['\\Nene\\Xion\\DataMapperBase::update'],
-            'PhanUndeclaredVariableDim' => ['\\Nene\\Xion\\DataMapperBase::update']
-        ],
         'class/xion/DataModelBase.php' => [
             'PhanTypeMagicVoidWithReturn' => ['\\Nene\\Xion\\DataModelBase::__set'],
             'PhanTypeMismatchArgument' => ['\\Nene\\Xion\\DataModelBase::validate'],
@@ -39,15 +24,8 @@ return [
             'PhanTypeMismatchDimFetch' => ['\\Nene\\Xion\\DataModelBase::validate'],
             'PhanTypeMismatchForeach' => ['\\Nene\\Xion\\DataModelBase::validate']
         ],
-        'class/xion/ModelBase.php' => [
-            'PhanUnreferencedUseNormal' => ['class/xion/ModelBase.php']
-        ],
         'class/xion/PdoConnection.php' => [
-            'PhanTypeMismatchPropertyProbablyReal' => ['\\Nene\\Xion\\PdoConnection::__destruct'],
             'PhanUndeclaredConstantOfClass' => ['\\Nene\\Xion\\PdoConnection::__construct']
-        ],
-        'class/xion/View.php' => [
-            'PhanUndeclaredTypeThrowsType' => ['\\Nene\\Xion\\View::__clone']
         ],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -172,7 +172,7 @@ abstract class DataMapperBase
         $column = $this->getTableColumn(static::KEY_SID, DB_COLUMN_TIMESTAMP);
         $param = [];
         foreach ($column as $key => $val) {
-            $key = preg_replace('/^' . DB_NUM_PREFIX . '/', '', $key);
+            $key = (string)preg_replace('/^' . DB_NUM_PREFIX . '/', '', $key);
             $param[] = $key . '=:' . $key;
         }
         $stmt = $this->DB->prepare(sprintf(
@@ -191,11 +191,11 @@ abstract class DataMapperBase
             } elseif (!$row->isValid()) {
                 throw new \InvalidArgumentException(
                     'DATA MAPPER ERROR. The specified "' .
-                        static::MODEL_CLASS . '.' . $row->isValid() . '" is in violation of validation'
+                        static::MODEL_CLASS . '.' . $row->validate() . '" is in violation of validation'
                 );
             }
             foreach ($column as $key => $var) {
-                $col = preg_replace('/^' . DB_NUM_PREFIX . '/', '', $key);
+                $col = (string)preg_replace('/^' . DB_NUM_PREFIX . '/', '', $key);
                 $stmt->bindValue(':' . $col, $row->$key);
             }
             $stmt->bindValue(':' . static::KEY_SID, $row->{static::KEY_SID});

--- a/class/xion/PdoConnection.php
+++ b/class/xion/PdoConnection.php
@@ -37,7 +37,7 @@ class PdoConnection
     /**
      * Database connect object
      *
-     * @var PDO
+     * @var PDO|null
      */
     public $connection;
 

--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -346,7 +346,7 @@ class View
     /**
      * Copy inhibit.
      *
-     * @throws RuntimeException If you try to duplicate it, it will throw an exception because it is a singleton.
+     * @throws \RuntimeException If you try to duplicate it, it will throw an exception because it is a singleton.
      *
      * @return  void
      */


### PR DESCRIPTION
## 目的

#189 作業後に残っていた Phan baseline 9 件のうち、コード変更で解消できる 3 件を対処し、baseline を 13 件 → 6 件まで削減する。

## 変更内容

- `View::__clone()`: `@throws RuntimeException` → `@throws \RuntimeException`（グローバル名前空間を明示）
- `PdoConnection`: `$connection` の `@var` を `PDO|null` に修正（デストラクタで `null` 代入するため）
- `DataMapperBase::update()`: `preg_replace` 戻り値を `(string)` キャスト（2 箇所）
- `DataMapperBase::update()`: エラーメッセージで `$row->isValid()` (bool) → `$row->validate()` に修正（`insert()` と同じ正しい呼び出しに統一）
- `.phan/baseline.php` を再生成（13 件 → 6 件）

残り 6 件（`DataModelBase` の magic method 系 5 件 + `PDO::MYSQL_ATTR_USE_BUFFERED_QUERY` 1 件）は変更コストが高いため今回は対象外。

## 検証

- `composer test`: 43 tests, 125 assertions — OK
- `composer analyze`: エラーなし

## 関連

Closes #201