### PR TITLE
refactor(xion): 型宣言を追加・整理する

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -176,7 +176,7 @@ abstract class ControllerBase
      *
      * @return void
      */
-    final public function run()
+    final public function run(): void
     {
         $controller = $this->ROUTE_CONTEXT->controller();
         $action = $this->ROUTE_CONTEXT->action();

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -118,7 +118,7 @@ abstract class DataMapperBase
         $values = [];
         $column = $this->getTableColumn(static::KEY_SID, DB_COLUMN_TIMESTAMP, $targetClassName);
         foreach ($column as $key => $var) {
-            $key = preg_replace('/^' . DB_NUM_PREFIX . '/', '', $key);
+            $key = (string)preg_replace('/^' . DB_NUM_PREFIX . '/', '', $key);
             $fields[] = $key;
             $values[] = ':' . $key;
         }
@@ -150,7 +150,7 @@ abstract class DataMapperBase
                 );
             }
             foreach ($column as $key => $var) {
-                $col = preg_replace('/^' . DB_NUM_PREFIX . '/', '', $key);
+                $col = (string)preg_replace('/^' . DB_NUM_PREFIX . '/', '', $key);
                 $stmt->bindValue(':' . $col, $row->$key);
             }
             $this->execute($stmt);
@@ -390,7 +390,7 @@ abstract class DataMapperBase
         $searchKey = str_replace(',', ' ', $searchKey);
         $searchKey = str_replace('、', ' ', $searchKey);
         $searchKey = str_replace('　', ' ', $searchKey);
-        $searchKey = preg_replace('/\s(?=\s)/', '', $searchKey);
+        $searchKey = (string)preg_replace('/\s(?=\s)/', '', $searchKey);
         $searchKey = trim($searchKey);
         $searchArray = explode(' ', $searchKey);
         return $searchArray;

--- a/class/xion/DataModelBase.php
+++ b/class/xion/DataModelBase.php
@@ -148,7 +148,7 @@ abstract class DataModelBase
      *
      * @return DataModelBase
      */
-    public function setParam(string $prop, mixed $val)
+    public function setParam(string $prop, mixed $val): static
     {
         if (!$this->validate($prop, $val)) {
             throw new \Exception('Parameter ' . $prop . ' is a validation error. (value : ' . $val . ')');
@@ -167,7 +167,7 @@ abstract class DataModelBase
      *
      * @return DataModelBase
      */
-    public function setParamPostString(string $prop, string $postProp = '')
+    public function setParamPostString(string $prop, string $postProp = ''): static
     {
         $postProp = $postProp == '' ? $prop : $postProp;
         return $this->setParam($prop, (string)filter_input(INPUT_POST, $postProp));
@@ -183,7 +183,7 @@ abstract class DataModelBase
      *
      * @return DataModelBase
      */
-    public function setParamPostInt(string $prop, string $postProp = '')
+    public function setParamPostInt(string $prop, string $postProp = ''): static
     {
         $postProp = $postProp == '' ? $prop : $postProp;
         return $this->setParam($prop, (int)filter_input(INPUT_POST, $postProp));

--- a/class/xion/Initialize.php
+++ b/class/xion/Initialize.php
@@ -35,7 +35,7 @@ class Initialize
      *
      * @return void
      */
-    final public static function init()
+    final public static function init(): void
     {
         require_once dirname(__FILE__) . '/../../ini/xSystemIni.php';       // SYSTEM INITIALIZE
         require_once dirname(__FILE__) . '/../../ini/xSiteIni.php';         // SITE INITIALIZE

--- a/class/xion/Request.php
+++ b/class/xion/Request.php
@@ -70,13 +70,13 @@ class Request
      *
      * @return mixed
      */
-    final public function getPost(?string $key = null)
+    final public function getPost(?string $key = null): mixed
     {
         if ($key == null) {
             return $this->post->get();
         }
         if ($this->post->has($key) == false) {
-            return;
+            return null;
         }
         return $this->post->get($key);
     }
@@ -89,13 +89,13 @@ class Request
      *
      * @return mixed
      */
-    public function getQuery(?string $key = null)
+    public function getQuery(?string $key = null): mixed
     {
         if ($key == null) {
             return $this->query->get();
         }
         if ($this->query->has($key) == false) {
-            return;
+            return null;
         }
         return $this->query->get($key);
     }
@@ -108,13 +108,13 @@ class Request
      *
      * @return mixed
      */
-    public function getParam(?string $key = null)
+    public function getParam(?string $key = null): mixed
     {
         if ($key == null) {
             return $this->param->get();
         }
         if ($this->param->has($key) == false) {
-            return;
+            return null;
         }
         return $this->param->get($key);
     }

--- a/class/xion/RequestVariables.php
+++ b/class/xion/RequestVariables.php
@@ -56,7 +56,7 @@ abstract class RequestVariables
      *
      * @return mixed value [string or array]
      */
-    public function get(?string $key = null)
+    public function get(?string $key = null): mixed
     {
         $ret = null;
         if ($key == null) {

--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -310,7 +310,7 @@ class View
      *
      * @return void
      */
-    final public function execute()
+    final public function execute(): void
     {
         self::$instance
             ->setCSS()


### PR DESCRIPTION
Closes #205

## 変更内容

**A: `preg_replace` に `(string)` キャストを追加**
- `DataMapperBase::insert()` の 2 箇所
- `DataMapperBase::getSearchARRAY()`

**B: 欠けていた戻り型宣言を追加**
- `Initialize::init()` → `: void`
- `ControllerBase::run()` → `: void`
- `View::execute()` → `: void`
- `RequestVariables::get()` → `: mixed`
- `Request::getPost/getQuery/getParam()` → `: mixed`
- 合わせて bare `return;` を `return null;` に修正

**C: メソッドチェーン戻り型**
- `DataModelBase::setParam/setParamPostString/setParamPostInt()` → `: static`

## テスト

- `composer test` 43/43 pass
- `composer analyze` 警告なし