### PR TITLE
refactor(ModelBase): accessLog を Monolog に統一する

### DIFF
--- a/class/xion/ModelBase.php
+++ b/class/xion/ModelBase.php
@@ -103,13 +103,12 @@ abstract class ModelBase
      *
      * @return void
      */
-    final protected function accessLog(string $API = '')
+    final protected function accessLog(string $API = ''): void
     {
-        $log = date('[Y-m-d H:i:s]') . ' ' .
-            $this->AUTH_SESSION->userIdentifier() . ' ' .
-            Xion\RouteContext::getInstance()->controller() . '   ' .
-            Xion\RouteContext::getInstance()->action() . '   ' .
-            $API . PHP_EOL;
-        file_put_contents(ACCESS_LOG_PATH, $log, FILE_APPEND);
+        $routeContext = Xion\RouteContext::getInstance();
+        $this->LOGGER->info(
+            'ACCESS : ' . $routeContext->controller() . '::' . $routeContext->action() . ($API !== '' ? ' ' . $API : ''),
+            ['user' => $this->AUTH_SESSION->userIdentifier()]
+        );
     }
 }


### PR DESCRIPTION
Closes #206

## 変更内容

`ModelBase::accessLog()` の `file_put_contents(ACCESS_LOG_PATH, ...)` による直接ファイル書き込みを廃止し、既存の `$this->LOGGER->info()` を使用するよう統一。

- `ACCESS_LOG_PATH` 定数への依存を除去
- `: void` 戻り型を追加
- `RouteContext::getInstance()` の二重呼び出しを変数にまとめて整理

## テスト

- `composer test` 43/43 pass
- `composer analyze` 警告なし