### PR TITLE
refactor(xion): __clone() に : never、__destruct() に : void、__get() に : mixed を追加する

### DIFF
--- a/.phan/baseline.php
+++ b/.phan/baseline.php
@@ -9,19 +9,19 @@
  */
 return [
     // # Issue statistics:
+    // PhanTypeArraySuspicious : 1 occurrence
     // PhanTypeMagicVoidWithReturn : 1 occurrence
-    // PhanTypeMismatchArgument : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
-    // PhanTypeMismatchDimFetch : 1 occurrence
+    // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanTypeMismatchForeach : 1 occurrence
     // PhanUndeclaredConstantOfClass : 1 occurrence
 
     'file_suppressions' => [
         'class/xion/DataModelBase.php' => [
+            'PhanTypeArraySuspicious' => ['\\Nene\\Xion\\DataModelBase::validate'],
             'PhanTypeMagicVoidWithReturn' => ['\\Nene\\Xion\\DataModelBase::__set'],
-            'PhanTypeMismatchArgument' => ['\\Nene\\Xion\\DataModelBase::validate'],
             'PhanTypeMismatchArgumentInternal' => ['\\Nene\\Xion\\DataModelBase::validate'],
-            'PhanTypeMismatchDimFetch' => ['\\Nene\\Xion\\DataModelBase::validate'],
+            'PhanTypeMismatchArgumentNullableInternal' => ['\\Nene\\Xion\\DataModelBase::setNow'],
             'PhanTypeMismatchForeach' => ['\\Nene\\Xion\\DataModelBase::validate']
         ],
         'class/xion/PdoConnection.php' => [

--- a/class/xion/AuthSession.php
+++ b/class/xion/AuthSession.php
@@ -191,9 +191,9 @@ class AuthSession
     /**
      * Copy inhibit.
      *
-     * @return void
+     * @return never
      */
-    final public function __clone()
+    final public function __clone(): never
     {
         throw new \RuntimeException('Clone is not allowed against ' . get_class($this));
     }

--- a/class/xion/DataModelBase.php
+++ b/class/xion/DataModelBase.php
@@ -99,7 +99,7 @@ abstract class DataModelBase
      *
      * @return string|null
      */
-    public function __get(string $prop)
+    public function __get(string $prop): mixed
     {
         if (isset($this->data[$prop])) {
             return $this->data[$prop];

--- a/class/xion/ErrorCode.php
+++ b/class/xion/ErrorCode.php
@@ -92,9 +92,9 @@ class ErrorCode
     /**
      * Copy inhibit.
      *
-     * @return void
+     * @return never
      */
-    final public function __clone()
+    final public function __clone(): never
     {
         throw new \RuntimeException('Clone is not allowed against ' . get_class($this));
     }

--- a/class/xion/Log.php
+++ b/class/xion/Log.php
@@ -100,9 +100,9 @@ class Log
     /**
      * Copy inhibit
      *
-     * @return void
+     * @return never
      */
-    final public function __clone()
+    final public function __clone(): never
     {
         throw new \RuntimeException('Clone is not allowed against ' . get_class($this));
     }

--- a/class/xion/PdoConnection.php
+++ b/class/xion/PdoConnection.php
@@ -84,7 +84,7 @@ class PdoConnection
     /**
      * DESTRUCTOR.
      */
-    final public function __destruct()
+    final public function __destruct(): void
     {
         $this->connection = null;
     }
@@ -105,9 +105,9 @@ class PdoConnection
     /**
      * Copy inhibit.
      *
-     * @return void
+     * @return never
      */
-    final public function __clone()
+    final public function __clone(): never
     {
         throw new \RuntimeException('Clone is not allowed against ' . get_class($this));
     }

--- a/class/xion/RouteContext.php
+++ b/class/xion/RouteContext.php
@@ -171,9 +171,9 @@ class RouteContext
     /**
      * Copy inhibit.
      *
-     * @return void
+     * @return never
      */
-    final public function __clone()
+    final public function __clone(): never
     {
         throw new \RuntimeException('Clone is not allowed against ' . get_class($this));
     }

--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -348,9 +348,9 @@ class View
      *
      * @throws \RuntimeException If you try to duplicate it, it will throw an exception because it is a singleton.
      *
-     * @return  void
+     * @return never
      */
-    final public function __clone()
+    final public function __clone(): never
     {
         throw new \RuntimeException('Clone is not allowed against ' . get_class($this));
     }


### PR DESCRIPTION
Closes #213

## 変更内容

**`__clone(): never` (6クラス)**
常に `RuntimeException` を投げる `__clone()` に `: never` を追加。
対象: `PdoConnection`, `View`, `RouteContext`, `ErrorCode`, `Log`, `AuthSession`

**`__destruct(): void`**
- `PdoConnection::__destruct()`

**`__get(): mixed`**
- `DataModelBase::__get()`

**Phan baseline 更新**
`__get()` の型宣言追加により `DataModelBase` の magic property システムの既存問題が 2 件新規検出されたため baseline に追加。合計件数は 6 件のまま。

## テスト

- `composer test` 43/43 pass
- `composer analyze` 警告なし