### PR TITLE
refactor(xion): 残りのベースクラスプロパティに native 型宣言を追加する

### DIFF
--- a/class/db/Todo.php
+++ b/class/db/Todo.php
@@ -29,7 +29,7 @@ class Todo extends DataModelBase
      *
      * @var array
      */
-    protected static $schema = [
+    protected static array $schema = [
         'id'           => parent::INTEGER,
         'created_at'   => parent::DATETIME,
         'updated_at'   => parent::DATETIME,

--- a/class/db/User.php
+++ b/class/db/User.php
@@ -29,7 +29,7 @@ class User extends DataModelBase
      *
      * @var array
      */
-    protected static $schema = [
+    protected static array $schema = [
         'id'         => parent::INTEGER,
         'created_at' => parent::DATETIME,
         'updated_at' => parent::DATETIME,

--- a/class/xion/ApiResponse.php
+++ b/class/xion/ApiResponse.php
@@ -27,7 +27,7 @@ class ApiResponse
      *
      * @var ErrorCode
      */
-    private $errorCode;
+    private ErrorCode $errorCode;
 
     /**
      * CONSTRUCTOR.

--- a/class/xion/DataMapperBase.php
+++ b/class/xion/DataMapperBase.php
@@ -36,28 +36,28 @@ abstract class DataMapperBase
      *
      * @var PDO
      */
-    protected $DB;
+    protected PDO $DB;
 
     /**
      * Logger
      *
      * @var Logger
      */
-    protected $LOGGER;
+    protected Logger $LOGGER;
 
     /**
      * Class name.
      *
      * @var string
      */
-    protected $CLASS;
+    protected string $CLASS;
 
     /**
      * Error code
      *
      * @var ErrorCode
      */
-    protected $ERROR_CODE;
+    protected ErrorCode $ERROR_CODE;
 
     protected const MODEL_CLASS = 'Nene\Xion\DataModelBase';
     protected const TARGET_TABLE = '';

--- a/class/xion/DataModelBase.php
+++ b/class/xion/DataModelBase.php
@@ -47,35 +47,35 @@ abstract class DataModelBase
      *
      * @var array
      */
-    protected $data    = [];
+    protected array $data = [];
 
     /**
      * Table schema
      *
      * @var array
      */
-    protected static $schema  = [];
+    protected static array $schema = [];
 
     /**
      * Logger
      *
      * @var Logger
      */
-    protected $LOGGER;
+    protected Logger $LOGGER;
 
     /**
      * Class name
      *
      * @var string
      */
-    protected $CLASS;
+    protected string $CLASS;
 
     /**
      * Error code
      *
      * @var ErrorCode
      */
-    protected $ERROR_CODE;
+    protected ErrorCode $ERROR_CODE;
 
     /**
      * CONSTRUCTOR.

--- a/class/xion/ErrorCode.php
+++ b/class/xion/ErrorCode.php
@@ -34,7 +34,7 @@ class ErrorCode
      *
      * @var array
      */
-    public $ERROR_CODE;
+    public array $ERROR_CODE;
 
     /**
      * CONSTRUCTOR

--- a/class/xion/Log.php
+++ b/class/xion/Log.php
@@ -42,21 +42,21 @@ class Log
      *
      * @var Logger
      */
-    public $accessLog;
+    public Logger $accessLog;
 
     /**
      * Logger class for information log
      *
      * @var Logger
      */
-    public $informationLog;
+    public Logger $informationLog;
 
     /**
      * Logger class for error log
      *
      * @var Logger
      */
-    public $errorLog;
+    public Logger $errorLog;
 
     /**
      * CONSTRUCTOR

--- a/class/xion/ModelBase.php
+++ b/class/xion/ModelBase.php
@@ -33,28 +33,28 @@ abstract class ModelBase
      *
      * @var Logger
      */
-    protected $LOGGER;
+    protected Logger $LOGGER;
 
     /**
      * Class name.
      *
      * @var string
      */
-    protected $CLASS;
+    protected string $CLASS;
 
     /**
      * Error code
      *
      * @var ErrorCode
      */
-    protected $ERROR_CODE;
+    protected ErrorCode $ERROR_CODE;
 
     /**
      * Authentication session boundary.
      *
      * @var AuthSession
      */
-    protected $AUTH_SESSION;
+    protected AuthSession $AUTH_SESSION;
 
     /**
      * CONSTRUCTOR.

--- a/class/xion/RouteContext.php
+++ b/class/xion/RouteContext.php
@@ -34,28 +34,28 @@ class RouteContext
      *
      * @var string
      */
-    private $controller = 'index';
+    private string $controller = 'index';
 
     /**
      * Action name.
      *
      * @var string
      */
-    private $action = 'index';
+    private string $action = 'index';
 
     /**
      * Action mode.
      *
      * @var string
      */
-    private $mode = 'Action';
+    private string $mode = 'Action';
 
     /**
      * Controller method name.
      *
      * @var string
      */
-    private $method = 'indexAction';
+    private string $method = 'indexAction';
 
     /**
      * CONSTRUCTOR.

--- a/class/xion/TransactionManager.php
+++ b/class/xion/TransactionManager.php
@@ -30,7 +30,7 @@ class TransactionManager
      *
      * @var PDO
      */
-    private $pdo;
+    private PDO $pdo;
 
     /**
      * CONSTRUCTOR.


### PR DESCRIPTION
Closes #212

## 変更内容

`ControllerBase` (#207) に続き、残りの `class/xion/` ベースクラスおよび関連クラスの全プロパティに PHP ネイティブ型宣言を追加。

| クラス | 変更プロパティ |
|---|---|
| `ModelBase` | `Logger`, `string`, `ErrorCode`, `AuthSession` |
| `DataMapperBase` | `PDO`, `Logger`, `string`, `ErrorCode` |
| `DataModelBase` | `array`, `array(static)`, `Logger`, `string`, `ErrorCode` |
| `RouteContext` | `string` × 4 |
| `TransactionManager` | `PDO` |
| `ApiResponse` | `ErrorCode` |
| `Log` | `Logger` × 3 |
| `ErrorCode` | `array` |

**波及修正**
`DataModelBase::$schema` に `array` を追加したことで、サブクラス `Todo`/`User` の `$schema` 宣言も `array` に更新（型の互換性維持）。

## テスト

- `composer test` 43/43 pass
- `composer analyze` 警告なし