### PR TITLE
refactor(xion): singleton $instance に ?self 型、IndexController に : void、Dispatcher PHPDoc を修正する

### DIFF
--- a/class/controller/IndexController.php
+++ b/class/controller/IndexController.php
@@ -40,7 +40,7 @@ class IndexController extends ControllerBase
      *
      * @return void
      */
-    public function indexAction()
+    public function indexAction(): void
     {
         $this->setTitle('NeNe - Simple Legacy PHP Framework');
         $this->VIEW->addJS('https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js')

--- a/class/xion/AuthSession.php
+++ b/class/xion/AuthSession.php
@@ -25,9 +25,9 @@ class AuthSession
     /**
      * Instance to pass as a singleton.
      *
-     * @var AuthSession
+     * @var AuthSession|null
      */
-    private static $instance;
+    private static ?self $instance = null;
 
     /**
      * CONSTRUCTOR.

--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -195,7 +195,7 @@ class Dispatcher
      *
      * @param string $controller Controller name.
      *
-     * @return ControllerBase $ControllerBase Controller alias specified by argument.
+     * @return ControllerBase Controller alias specified by argument.
      */
     private function getControllerInstance(string $controller): ControllerBase
     {

--- a/class/xion/ErrorCode.php
+++ b/class/xion/ErrorCode.php
@@ -25,9 +25,9 @@ class ErrorCode
     /**
      * Instance to pass as a singleton.
      *
-     * @var ErrorCode
+     * @var ErrorCode|null
      */
-    private static $instance;
+    private static ?self $instance = null;
 
     /**
      * Error code array.

--- a/class/xion/Log.php
+++ b/class/xion/Log.php
@@ -33,9 +33,9 @@ class Log
     /**
      * Instance to pass as a singleton.
      *
-     * @var Log
+     * @var Log|null
      */
-    private static $instance;
+    private static ?self $instance = null;
 
     /**
      * Logger class for access log

--- a/class/xion/PdoConnection.php
+++ b/class/xion/PdoConnection.php
@@ -30,9 +30,9 @@ class PdoConnection
     /**
      * Instance to pass as a singleton.
      *
-     * @var PdoConnection
+     * @var PdoConnection|null
      */
-    private static $instance;
+    private static ?self $instance = null;
 
     /**
      * Database connect object

--- a/class/xion/RouteContext.php
+++ b/class/xion/RouteContext.php
@@ -25,9 +25,9 @@ class RouteContext
     /**
      * Instance to pass as a singleton.
      *
-     * @var RouteContext
+     * @var RouteContext|null
      */
-    private static $instance;
+    private static ?self $instance = null;
 
     /**
      * Controller name.

--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -29,9 +29,9 @@ class View
     /**
      * Instance to pass as a singleton.
      *
-     * @var View
+     * @var View|null
      */
-    private static $instance;
+    private static ?self $instance = null;
 
     /**
      * Smarty object


### PR DESCRIPTION
Closes #217

## 変更内容

**A. singleton の `static $instance` に native 型宣言を追加 (6クラス)**
`private static ?self $instance = null;` に統一。
対象: `View`, `PdoConnection`, `RouteContext`, `Log`, `AuthSession`, `ErrorCode`

**B. `IndexController::indexAction()` に `: void` を追加**

**C. `Dispatcher::getControllerInstance()` の PHPDoc 修正**
`@return ControllerBase $ControllerBase` → `@return ControllerBase`

## テスト

- `composer test` 43/43 pass
- `composer analyze` 警告なし