### PR TITLE
docs(field-trials): フィールドトライアル方法論を導入する (#220)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This file is the first document for AI agents and automation working on NeNe.
 - Roadmap: `docs/roadmap.md`
 - Current TODO: `docs/todo/current.md`
 - ADR index: `docs/adr/README.md`
+- Field trial methodology: `docs/field-trials/README.md`
 
 ## Operating Rules
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@ This directory contains project documentation for humans and AI agents.
 - `milestones/README.md`: Milestone management.
 - `adr/README.md`: Architecture decision records.
 - `api/README.md`: OpenAPI and API documentation policy.
+- `field-trials/README.md`: Field trial methodology and clone-based trial layout under `../NeNe-FT/`.
+- `templates/field-trial-report.md`: Report skeleton copied for each new trial.
 
 ## Source of Truth
 

--- a/docs/field-trials/README.md
+++ b/docs/field-trials/README.md
@@ -1,0 +1,120 @@
+# Field Trials
+
+A Field Trial (FT) is a small, time-boxed exercise where NeNe is used from a fresh clone to build a tiny realistic service. Every point of confusion or friction encountered during the trial is recorded with a stable identifier (`F-1`, `F-2`, ...) and converted into GitHub Issues that drive framework and documentation changes.
+
+The goal is not to ship the trial service. The goal is to surface what NeNe assumes but does not document, what its conventions actually feel like for a new project, and which legacy shapes need a clearer explanation rather than a redesign.
+
+## When to Run a Field Trial
+
+Run a new FT when one or more of the following is true:
+
+- A meaningful release or modernization step landed and external usability should be re-checked.
+- A documentation set was rewritten and should be verified by following it end to end.
+- A new convention was introduced (for example a new REST handler shape or template directory) and its real onboarding cost is unknown.
+- An ADR or roadmap phase explicitly schedules a trial.
+
+A single short trial is more valuable than a large list of speculative improvements. Keep each trial focused on one realistic small service.
+
+## Clone Layout
+
+All NeNe field trials are run from a fresh `git clone` placed under the `../NeNe-FT/` directory next to this repository. The directory structure is:
+
+```text
+~/github/
+├── NeNe/                  # this repository (framework)
+└── NeNe-FT/
+    ├── ft1-{topic}/       # FT1 clone (independent working tree)
+    ├── ft2-{topic}/       # FT2 clone
+    └── ...
+```
+
+Setup for a new trial:
+
+```sh
+mkdir -p ../NeNe-FT
+git clone git@github.com:hideyukiMORI/NeNe.git ../NeNe-FT/ft{N}-{topic}
+cd ../NeNe-FT/ft{N}-{topic}
+composer install
+```
+
+Each trial directory is independent. It is a real clone, so its own `.git`, `.env`, and `data/` live inside it. None of those artifacts are committed back into this framework repository.
+
+When a trial uncovers framework or documentation changes, those changes are made in this repository (`hideyukiMORI/NeNe`) through the normal Issue-driven workflow, not inside the trial directory. The trial directory exists only for the duration of the trial.
+
+## Naming and Numbering
+
+- Trial reports live in this directory and are named `YYYY-MM-field-trial-{N}.md`, where `N` is monotonically increasing across all trials (no resets).
+- Clone directories are named `ft{N}-{topic}` (lowercase, hyphenated topic). `N` matches the report number.
+- Each trial gets exactly one report file. Follow-up work that traces back to a trial is tracked through GitHub Issues, not by editing the report after the fact.
+
+## What to Record
+
+A trial report should be readable cold by someone who was not present for the trial. The required sections live in `docs/templates/field-trial-report.md`. The important parts are:
+
+- **Baseline**: which NeNe commit, tag, or release was cloned, PHP version, DB, and any other environmental facts that would change the result.
+- **Goal**: one or two sentences on what this trial is verifying.
+- **Steps Taken**: the actual flow of work, with `Finding (F-N)` notes embedded where friction occurred. Friction notes are the most valuable part of the report.
+- **Friction Summary**: a single table with one row per `F-N`, including location, severity (high / medium / low), kind, and decision.
+- **Recommendations**: grouped as immediate (documentation fix only), suggested (small framework or template change), and trade-off (changes that require an ADR or stakeholder discussion).
+- **Overall Impression**: a short paragraph. Useful for orienting future readers; not a marketing summary.
+
+### Friction Kinds
+
+Every `F-N` row should be tagged with one kind:
+
+| Kind | Meaning |
+| --- | --- |
+| `docs-gap` | The behavior is correct, but it is not documented or hard to find. |
+| `feature-gap` | A small extension or helper would noticeably reduce setup cost. |
+| `design-trade-off` | Behavior is intentional; the cost is worth flagging but should not change. |
+| `legacy-preserved` | A legacy shape that NeNe intentionally keeps. The fix is documentation, never a redesign. |
+| `process-gap` | The workflow, checklist, or tooling around the change is missing or unclear. |
+
+`legacy-preserved` is the kind that makes NeNe trials different from a generic framework usability study. NeNe is a renovation project, and many legacy shapes are kept on purpose. When a trial uncovers one, the right response is to document why it stays, not to redesign it.
+
+### Decisions
+
+Every `F-N` row should also carry a Decision:
+
+| Decision | Meaning |
+| --- | --- |
+| `fix-in-framework` | Change framework code or scripts. |
+| `document` | Add or improve documentation only. |
+| `keep-legacy` | No framework change; record the rationale. Often paired with a small documentation note. |
+| `defer` | Real friction, but not worth acting on yet. Recorded so it is not lost. |
+
+If a trial cannot recommend a Decision yet, mark the row `defer` and explain why in the recommendation section.
+
+## What Not to Record
+
+A field trial report is committed to a public repository. Do not include:
+
+- Secrets, tokens, API keys, or session cookies.
+- Local `.env` contents or credentials.
+- Production hostnames, internal URLs, customer data, or stack traces that leak private paths.
+- Confidential prompt text from a private collaboration.
+- Anything that violates the safety rules in `docs/CONTRIBUTING.md`.
+
+When in doubt, omit. A trial report is more valuable as a small, safe record than as a complete dump.
+
+## Aftermath
+
+After a trial:
+
+1. Open one GitHub Issue per actionable finding. Reference the report file and the `F-N` row.
+2. Update `docs/todo/current.md` with a short "FT{N}" block linking the Issues.
+3. Update `docs/roadmap.md` if the trial moved a phase forward.
+4. Delete the trial clone under `../NeNe-FT/` when its work is done, unless it has independent value (for example as a future public sample).
+
+The trial is finished when its Issues are merged or closed with a recorded rationale. A trial does not need to "succeed" — recording friction is the success condition.
+
+## Templates and Tools
+
+- Report skeleton: `docs/templates/field-trial-report.md`
+- Workflow: `docs/workflow.md`
+- Commit conventions: `docs/development/commit-conventions.md`
+- AI agent entry point: `AGENTS.md`
+
+## Index
+
+No trials have been recorded yet. The first trial should be `docs/field-trials/YYYY-MM-field-trial-1.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -175,3 +175,31 @@ Future candidates:
 - Make the first-service tutorial even more repeatable from clone to local verification.
 - Improve comments and PHPDoc only where they help readers understand framework boundaries.
 - Add lightweight checklists for small-service delivery readiness, including environment, database, OpenAPI, tests, and production safety notes.
+
+## 7. Field Trials
+
+Status: methodology adopted; first trial pending.
+
+Goal:
+
+Verify NeNe from the outside by cloning it into `../NeNe-FT/ft{N}-{topic}/` and building a small realistic service while recording every point of friction as a numbered finding (`F-1`, `F-2`, ...). Trials drive small framework and documentation Issues. Findings that turn out to be intentional legacy shapes are recorded as `legacy-preserved` with a documentation-only decision, rather than as defects.
+
+Field trials are a continuous quality gate rather than a single project. A new trial should run whenever a meaningful release, modernization step, or documentation rewrite lands and external usability should be re-checked.
+
+Principles:
+
+- One trial, one short report. Quantity does not matter; readable evidence does.
+- Use a fresh clone every time. The trial directory is independent and never committed back into this repository.
+- Record what surprised, blocked, or slowed down the work. Do not pad reports with speculative improvements.
+- Distinguish documentation gaps from intentional legacy shapes. NeNe is a renovation, not a redesign.
+- Each finding ends in a Decision: `fix-in-framework`, `document`, `keep-legacy`, or `defer`.
+
+Methodology and templates:
+
+- `docs/field-trials/README.md`: full methodology, clone layout, friction kinds, decisions, and safety rules.
+- `docs/templates/field-trial-report.md`: report skeleton copied per trial.
+
+Future candidates:
+
+- FT1: small service following `docs/tutorials/building-a-service.md` from a fresh clone, focused on the routing convention, REST method handlers, CSRF flow, and error catalog.
+- Subsequent trials should each target a different surface (Smarty rendering, OpenAPI workflow, database setup, deployment) rather than retesting the same paths.

--- a/docs/templates/field-trial-report.md
+++ b/docs/templates/field-trial-report.md
@@ -1,0 +1,95 @@
+# Field Trial {N} — {topic}
+
+Copy this skeleton to `docs/field-trials/YYYY-MM-field-trial-{N}.md` and fill it in. Keep it short. The full direction lives in `docs/field-trials/README.md`.
+
+Before committing, confirm the report contains no secrets, raw API keys, local `.env` contents, private customer data, production URLs, or confidential prompts.
+
+## Date
+
+YYYY-MM-DD
+
+## Baseline
+
+- NeNe ref: {tag or commit hash from the cloned working tree}
+- Clone path: `../NeNe-FT/ft{N}-{topic}/`
+- PHP: {version reported by `php -v`}
+- Database: {SQLite / MySQL / both, with version}
+- Other relevant tooling: {Composer, Docker image, browser, etc.}
+
+## Goal
+
+One or two sentences on what this trial is verifying. Anchor it to a release, an Issue, a rewritten docs section, or a new convention. Do not list speculative improvements here.
+
+## Service Built
+
+- Name: {service short name}
+- Domains: {entity list, e.g. `Memo`, `Tag`}
+- Surface: {number of pages, REST endpoints, OpenAPI operations}
+- DB tables: {list}
+
+## Steps Taken
+
+Number the steps in the order they actually happened. Embed `**Finding (F-N)**` notes inline at the point the friction occurred.
+
+### 1. {short step title}
+
+{what was attempted, what happened, code snippets if useful}
+
+**Finding (F-1)**: {one to three sentences describing the friction. Include the rough location in NeNe — file path, doc path, or convention name — when known.}
+
+### 2. {next step}
+
+...
+
+## Results
+
+| Scenario | Expectation | Actual | Status |
+| --- | --- | --- | --- |
+| {what was tried} | {what should have happened} | {what happened} | Pass / Partial / Blocked |
+
+Include only scenarios that the trial actually exercised. Do not pad the table with speculative checks.
+
+## Friction Summary
+
+| ID | Location | Severity | Kind | Decision |
+| --- | --- | --- | --- | --- |
+| F-1 | {file, doc, or convention} | high / medium / low | docs-gap / feature-gap / design-trade-off / legacy-preserved / process-gap | fix-in-framework / document / keep-legacy / defer |
+
+Severity guide:
+
+- **high** — a new project is likely to stall here until someone reads the framework source or asks a maintainer.
+- **medium** — a new project will lose time but can recover by trial and error.
+- **low** — a minor papercut, worth noting but not blocking.
+
+Use the kinds and decisions defined in `docs/field-trials/README.md`. When `Decision` is `keep-legacy`, write one sentence in the recommendations explaining why the legacy shape is intentional.
+
+## Recommendations
+
+### Immediate (documentation only)
+
+1. **{Finding ID} — {one-line title}**: {what to change, where to change it}.
+
+### Suggested (small framework or template change)
+
+1. **{Finding ID} — {one-line title}**: {what to change, where to change it. Include the smallest reasonable scope.}
+
+### Trade-offs (needs ADR or discussion)
+
+1. **{Finding ID} — {one-line title}**: {state the trade-off plainly. Do not pick a side here — that is what the ADR is for.}
+
+If a category has nothing in it, write "None." rather than removing the section. Future readers should be able to tell the difference between "no trade-offs surfaced" and "trade-offs section was forgotten."
+
+## Overall Impression
+
+Two to four sentences. What felt easy, what felt slow, and whether the trial changed your read on a current convention or release. This section is for orienting future readers, not for marketing language.
+
+## Follow-up Issues
+
+- [ ] {Finding ID} — {one-line summary} → Issue #...
+- [ ] {Finding ID} — {one-line summary} → Issue #...
+
+Update this checklist as Issues are opened. When all are merged or closed with a rationale, the trial is complete.
+
+## Reminder
+
+This report is committed to a public repository. Confirm it omits secrets, raw keys, production endpoints, and confidential prompts before opening the PR.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -92,6 +92,20 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 - #165: Prove the reviewable Controller-Service-Mapper shape through the reference implementation.
 - #145: Add an AI-assisted small-service reference implementation covering page, REST, mapper, OpenAPI, and tests.
 
+## Field Trials
+
+No trials have been run yet. The methodology is documented in `docs/field-trials/README.md` and `docs/templates/field-trial-report.md`. Trials are cloned into `../NeNe-FT/ft{N}-{topic}/`.
+
+When a trial is run, summarize it here with the format below, then move the block to `Recently Completed` once all follow-up Issues are merged or closed.
+
+```
+## FT{N} — {topic}
+
+- Report: `docs/field-trials/YYYY-MM-field-trial-{N}.md`
+- Baseline: {NeNe ref}
+- Findings: F-1 (severity / decision / Issue #), F-2 (...), ...
+```
+
 ## Backlog Candidates
 
 - Improve PHPDoc accuracy and native types across `class/xion/`, starting with shared base classes.


### PR DESCRIPTION
## 概要

NENE2 / nene2-python で運用されている Field Trial (FT) 方法論を NeNe に取り込む(Phase 0: 方法論ドキュメントのみ)。実際のトライアル実行は後続 Issue で扱う。

Closes #220

## 変更内容

### 新規

- `docs/field-trials/README.md` — FT 方法論、`../NeNe-FT/ft{N}-{topic}/` クローン展開規約、摩擦 5 種別(`docs-gap` / `feature-gap` / `design-trade-off` / `legacy-preserved` / `process-gap`)、Decision 4 種(`fix-in-framework` / `document` / `keep-legacy` / `defer`)、安全規則、アフターケア。
- `docs/templates/field-trial-report.md` — 報告書スケルトン(Baseline / Goal / Service Built / Steps Taken with `Finding (F-N)` / Results / Friction Summary / Recommendations 3 区分 / Overall Impression / Follow-up Issues / Reminder)。

### 更新

- `AGENTS.md` — Read First に `docs/field-trials/README.md` を追加。
- `docs/README.md` — Start Here に field-trials と templates を追加。
- `docs/roadmap.md` — 新セクション `## 7. Field Trials` を追加(継続的な品質ゲートとして位置付け)。
- `docs/todo/current.md` — `## Field Trials` 追跡フォーマット雛形を追加。

## NeNe 固有の調整

NENE2 からの主な差別化点:

- **配布モデル**: `composer require` ではなく **`git clone`** ベース。トライアルは `../NeNe-FT/ft{N}-{topic}/` へクローン展開する規約に統一。
- **摩擦種別 `legacy-preserved`**: NeNe の renovation 哲学に基づき、意図的に残すレガシー shape を「redesign せず文書化で解消」と分類できるようにした。
- **Decision `keep-legacy`**: 同上を結論として明示できる選択肢。

## 検証

文書のみの変更。`docs/CONTRIBUTING.md` / `docs/workflow.md` の規約と整合することを確認済み。コード変更なし、テスト・静的解析・OpenAPI 影響なし。

## 後続作業

- FT1 の実走(別 Issue)— `docs/tutorials/building-a-service.md` を頼りに小サービスを `../NeNe-FT/ft1-{topic}/` で構築し、初回の摩擦点を記録する。