### PR TITLE
fix(xion): PdoConnection::__destruct() の : void return type を削除する (#222)

### DIFF
--- a/class/xion/PdoConnection.php
+++ b/class/xion/PdoConnection.php
@@ -84,7 +84,7 @@ class PdoConnection
     /**
      * DESTRUCTOR.
      */
-    final public function __destruct(): void
+    final public function __destruct()
     {
         $this->connection = null;
     }


### PR DESCRIPTION
## 概要

`class/xion/PdoConnection.php:87` の `__destruct(): void` を `__destruct()` に修正する。PHP は `__destruct()` への return type を一切許可しないため、現在の `main` では PdoConnection クラスを生成する経路すべてで PHP fatal が発生していた。

Closes #222

## 再現(修正前)

```sh
curl -sS -X POST -H 'Content-Type: application/json' \
  -d '{"user":"admin","password":"admin"}' http://localhost:8080/session/login
```

出力:

```text
<br />
<b>Fatal error</b>: Method Nene\Xion\PdoConnection::__destruct() cannot declare a return type
in <b>/var/www/html/class/xion/PdoConnection.php</b> on line <b>87</b><br />
```

## 原因

PR #213(\`refactor(xion): __clone() に : never、__destruct() に : void、__get() に : mixed を追加する\`)で `: void` を `__destruct()` に付与した部分のみが PHP 仕様違反だった。同 PR で追加された `__clone(): never` と `__get(): mixed` は問題ない(マジックメソッドの中で return type が許される対象)。

## 検証

トライアルクローン(`/home/xi/github/NeNe-FT/ft1-bookmarklog/`)に修正適用後、Docker Compose 上で再走行:

- `composer test`: **43/43 通過**
- `composer test:http`(`NENE_HTTP_BASE_URL=http://localhost:80`): **20/21 通過**(残 1 件は `ERROR_BASE_URL_ENV` 未設定の別 skip)
- `POST /session/login`: PHP fatal が消え、proper JSON response(`{\"Result\":true,\"Data\":{\"status\":\"failure\",\"errorCode\":\"LOGIN-FAILED\"...}}`)を返すように回復

## 後続課題(別 Issue 推奨)

今回の bug が CI を素通りした構造的原因は本 PR の対象外。NeNe フィールドトライアル FT1 で同時に発見した以下は別 Issue として起票する:

- F-2: CI workflow が HTTP runtime を一切起動しない(`Confirm HTTP tests skip without runtime` というステップ名が現状を表現している)
- F-3: `composer test:http` が全件 skip でも `OK` と表示される UX 問題
- F-4: `NENE_HTTP_BASE_URL` 環境変数の存在がドキュメント(`README.md` / `docs/development/testing.md` / `.env.example`)に無い