### PR TITLE
docs(testing): NENE_HTTP_BASE_URL の在処と in-container 実行形を明記する (#226)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,11 @@ NENE_DB_FILE=nene.db
 
 # Optional SQLite initializer sample password override. The value is hashed before insert.
 NENE_SAMPLE_ADMIN_PASSWORD=admin
+
+# HTTP smoke test target (consumed by `composer test:http`).
+# Leave unset to skip the HTTP suite; set to a reachable NeNe instance to run it.
+#   From the host: http://localhost:8080
+#   From inside the running app container: http://localhost:80
+# See docs/development/testing.md for the full workflow.
+# NENE_HTTP_BASE_URL=http://localhost:8080
+# NENE_HTTP_ERROR_BASE_URL=http://localhost:8081

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ SQLite database files under `data/` are generated locally and are not committed.
 composer test
 ```
 
+`composer test` runs the unit suite. HTTP smoke tests (`composer test:http`) are conditional on `NENE_HTTP_BASE_URL` — see `docs/development/testing.md` for the runtime workflow.
+
 ## License
 
 MIT.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -66,26 +66,49 @@ docker compose run --rm app sh -lc "composer install --no-interaction --prefer-d
 
 HTTP runtime tests exercise the Docker-served application through real HTTP requests. They cover the top page, explicit URL routing, Swagger UI, session login/logout, TODO CRUD, REST method handling, and the JSON-only REST response policy.
 
+These tests are conditional. They require `NENE_HTTP_BASE_URL` to point to a running NeNe instance, and they are all skipped when the variable is empty or the target is unreachable. This keeps `composer test` fast and independent from Docker, while keeping `composer test:http` available for full runtime verification on demand.
+
+### Required environment variables
+
+| Variable | Purpose | Example |
+| --- | --- | --- |
+| `NENE_HTTP_BASE_URL` | Base URL the HTTP smoke suite targets. | `http://localhost:8080` (from the host) or `http://localhost:80` (from inside the running `app` container) |
+| `NENE_HTTP_ERROR_BASE_URL` | Optional base URL for the error-exposure suite (see *Error Exposure Check* below). | `http://localhost:8081` |
+
+If neither variable is set, `composer test:http` will report `OK` while skipping every test. The summary line `Tests: N, Skipped: N` is the signal that the suite was not actually run.
+
+### Run from the host
+
 Start the Docker environment first:
 
 ```sh
 docker compose up --build -d
 ```
 
-Then run:
+Then run from the host shell:
 
 ```sh
 NENE_HTTP_BASE_URL=http://localhost:8080 composer test:http
 ```
 
-If `NENE_HTTP_BASE_URL` is not configured, or the target server is unreachable, the HTTP test suite is skipped. This keeps normal unit testing fast and independent from Docker.
-
-For a full local runtime check:
+For a full local runtime check together with unit tests and static analysis:
 
 ```sh
 docker compose up --build -d
 NENE_HTTP_BASE_URL=http://localhost:8080 composer check
 ```
+
+### Run from inside the `app` container
+
+When the runtime is exercised from inside the same `app` container, the base URL is the container-local port (`80`), not the host port:
+
+```sh
+docker compose exec -T -e NENE_HTTP_BASE_URL=http://localhost:80 app composer test:http
+```
+
+This is the form used by Field Trial workflows (see `docs/field-trials/README.md`) and by future CI jobs that boot the runtime in the same step that runs the suite.
+
+### Cleanup behavior
 
 HTTP tests use a test title prefix and clean up matching TODO rows before each runtime test. Tests that create TODOs also register them for cleanup during teardown, so failed tests should not leave long-lived sample data behind.
 


### PR DESCRIPTION
## 概要

FT1(`F-4`)から起票した #226 への対応。コード変更なしのドキュメント PR。

Closes #226

## Issue 起票内容の訂正

Issue 本文では「変数名がドキュメントに無い」と書いたが、精査すると `docs/development/testing.md` 内には既に記載があった(line 78 / 87)。

実際のギャップは次の 3 点に絞られる:

1. `.env.example` に test-only env の言及が無い → 新規参入者が変数の存在に気付きにくい。
2. `testing.md` の例が host 視点(`http://localhost:8080`)のみで、`docker compose exec` でコンテナ内から走らせる場合の `http://localhost:80` 形が無い。FT 実走時、および将来の CI runtime job(#224)で実際に必要となる形式。
3. `README.md` に `composer test` の 1 行は載っているが、`composer test:http` への導線が無い。

## 変更内容

- `docs/development/testing.md`:
  - 「Required environment variables」表(変数名・用途・例)を新設。
  - host 経由と `docker compose exec` 内実行の両方を別々に明示。
  - 全件 skip の見分け方(`Tests: N, Skipped: N`)を明記。
- `.env.example`: HTTP smoke 用 env(`NENE_HTTP_BASE_URL` / `NENE_HTTP_ERROR_BASE_URL`)のコメントブロックを追加(コメントアウトしたサンプル付き)。
- `README.md`: Testing セクションから `testing.md` への 1 行リンク。

## 検証

ドキュメント変更のみ。

## 関連

- FT1(F-4): `docs/field-trials/2026-05-field-trial-1.md`(執筆中)
- #224(CI runtime job): こちらのドキュメント整備が前提となる
- #225(test:http skip UX): 同じ HTTP smoke 周りの友引