### PR TITLE
test(http): composer test:http に preflight 表示を追加する (#225)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
     },
     "scripts": {
         "test": "phpunit --testsuite unit",
-        "test:http": "phpunit --testsuite http",
+        "test:http": [
+            "@php tools/test-http-preflight.php",
+            "phpunit --testsuite http"
+        ],
         "test:all": "phpunit",
         "analyze": "phan --allow-polyfill-parser --load-baseline .phan/baseline.php",
         "format": "php-cs-fixer fix --config=.php-cs-fixer.dist.php",

--- a/tools/test-http-preflight.php
+++ b/tools/test-http-preflight.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Preflight for `composer test:http`.
+ *
+ * Prints a single line to stderr describing the HTTP smoke target before
+ * PHPUnit runs, so the developer can tell at a glance whether the suite is
+ * about to execute against a real runtime or skip every test silently.
+ *
+ * Exit code is always 0 so the surrounding composer script behavior is
+ * unchanged. The goal is visibility, not enforcement.
+ *
+ * See:
+ *   - docs/development/testing.md (HTTP smoke workflow)
+ *   - #225 (background)
+ */
+
+$baseUrl = getenv('NENE_HTTP_BASE_URL');
+$errorBaseUrl = getenv('NENE_HTTP_ERROR_BASE_URL');
+
+$line = static function (string $text): void {
+    fwrite(STDERR, $text . PHP_EOL);
+};
+
+$line('');
+$line('[test:http] HTTP smoke preflight');
+
+if ($baseUrl === false || $baseUrl === '') {
+    $line('  NENE_HTTP_BASE_URL is not set.');
+    $line('  Every HTTP test will be reported as Skipped. The PHPUnit summary');
+    $line('  will still print "OK, but some tests were skipped!" — this is the');
+    $line('  expected output when the runtime is not exercised.');
+    $line('  To actually run the suite, see docs/development/testing.md.');
+} else {
+    $line('  NENE_HTTP_BASE_URL = ' . $baseUrl);
+    if ($errorBaseUrl === false || $errorBaseUrl === '') {
+        $line('  NENE_HTTP_ERROR_BASE_URL is not set (the error-exposure test will be skipped).');
+    } else {
+        $line('  NENE_HTTP_ERROR_BASE_URL = ' . $errorBaseUrl);
+    }
+}
+
+$line('');


### PR DESCRIPTION
## 概要

FT1 (F-3) で発見した「`composer test:http` が全件 skip でも OK 表記で誤読される」問題への対応。

Closes #225

## アプローチの選択

Issue 本文の選択肢 A (全件 skip を失敗扱い) / B (ラッパーで thresholding) / C (警告メッセージ追加) のうち、**C を採用**した。理由:

- 既存 CI ワークフローの「Confirm HTTP tests skip without runtime」ステップ (\`.github/workflows/Tests\`) は `composer test:http` を skip 成功で通る前提で書かれている
- A / B を採ると CI を同時に変更する必要があり、PR スコープが #225 を超えて #224 (CI runtime job 追加) と混ざる
- #224 で CI 構造を正面から扱う際に、必要なら test:http の strict 化も再検討できる

#225 のスコープは「ユーザーが目視で気付ける」レベルの改善に絞った。

## 変更内容

### 新規: `tools/test-http-preflight.php`

PHPUnit 実行前に stderr に短いブロックを印字するだけの PHP スクリプト。exit code は常に 0 で、後続の PHPUnit 動作には一切手を加えない。

- `NENE_HTTP_BASE_URL` 未設定時: 「全件 skip される」「`OK ...skipped` は想定出力」「実行手順は `docs/development/testing.md`」を明示
- `NENE_HTTP_BASE_URL` 設定時: 対象 URL を表示。`NENE_HTTP_ERROR_BASE_URL` の有無も併記して、`HttpErrorExposureTest` 単独 skip の理由が分かるようにする

### 更新: `composer.json`

\`test:http\` を 2 ステップ配列に変更:

\`\`\`json
\"test:http\": [
    \"@php tools/test-http-preflight.php\",
    \"phpunit --testsuite http\"
]
\`\`\`

\`composer check\` も `@test:http` 経由で同じ preflight を踏む。

## 検証

Docker (trial clone) で 2 ケース動作確認:

**env 未設定:**
\`\`\`text
[test:http] HTTP smoke preflight
  NENE_HTTP_BASE_URL is not set.
  Every HTTP test will be reported as Skipped. The PHPUnit summary
  will still print \"OK, but some tests were skipped!\" — this is the
  expected output when the runtime is not exercised.
  To actually run the suite, see docs/development/testing.md.

PHPUnit 10.5.63 by Sebastian Bergmann and contributors.
...
OK, but some tests were skipped!
Tests: 21, Assertions: 0, Skipped: 21.
\`\`\`

**env 設定済み:**
\`\`\`text
[test:http] HTTP smoke preflight
  NENE_HTTP_BASE_URL = http://localhost:80
  NENE_HTTP_ERROR_BASE_URL is not set (the error-exposure test will be skipped).

PHPUnit 10.5.63 by Sebastian Bergmann and contributors.
...
S....................                                             21 / 21 (100%)
OK, but some tests were skipped!
Tests: 21, Assertions: 211, Skipped: 1.
\`\`\`

## 関連

- FT1 (F-3): `docs/field-trials/2026-05-field-trial-1.md` (執筆中)
- #224: CI HTTP runtime smoke job 追加 (構造的解決はそちらで)
- #226: NENE_HTTP_BASE_URL のドキュメント整備 (#228 でマージ済み)