### PR TITLE
ci(tests): HTTP runtime smoke ジョブを追加する (#224)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,3 +31,44 @@ jobs:
 
       - name: Confirm HTTP tests skip without runtime
         run: composer test:http
+
+  runtime-smoke:
+    name: HTTP runtime smoke (Docker)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare environment
+        run: cp .env.example .env
+
+      - name: Build app image
+        run: docker compose build app
+
+      - name: Start app
+        run: docker compose up -d app
+
+      - name: Wait for /health
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:8080/health > /dev/null 2>&1; then
+              echo "App became healthy after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "App did not become healthy within 60s" >&2
+          docker compose logs app | tail -100 >&2
+          exit 1
+
+      - name: Run HTTP smoke tests
+        run: |
+          docker compose exec -T -e NENE_HTTP_BASE_URL=http://localhost:80 app composer test:http
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker compose logs app | tail -200
+
+      - name: Stop containers
+        if: always()
+        run: docker compose down -v


### PR DESCRIPTION
## 概要

FT1 (F-2) で発見した CI 構造課題への対応。`PdoConnection::__destruct(): void`(#222 / #223 で hotfix 済み)のような **runtime でのみ顕在化するバグが CI を素通りした**根本原因が、`Tests` workflow の `Confirm HTTP tests skip without runtime` ステップが skip 確認のみで終わる設計にあった。

Closes #224

## 採用方針

Issue 本文の提案案 A (Docker Compose) / B (PHP built-in + SQLite) のうち **A を採用**。

### 採用理由

- README の Quick Start (\`docker compose up --build\`) と同じ経路を CI で再現できる
- \`/health\` の \`databaseType: MySQL\` ルートを実際に踏む → SQLite では検出できない MySQL 経路の不具合も拾える
- 60 秒程度の startup オーバーヘッドは品質ゲートとして許容範囲

### 既存ステップの扱い

\`Confirm HTTP tests skip without runtime\` は env 不在時の skip 保護動作確認として温存(Issue 本文の提案どおり)。本 PR は別ジョブ追加であり既存ステップの置き換えではない。

## ジョブ構成

新規 \`runtime-smoke\` ジョブ:

1. \`.env.example\` をコピー
2. \`docker compose build app\`
3. \`docker compose up -d app\` (MySQL コンテナも依存で起動)
4. \`/health\` が 200 を返すまで最大 60 秒待機 (1 秒間隔ポーリング)
5. \`docker compose exec\` で \`composer test:http\` を実行
6. 失敗時は \`docker compose logs app\` を末尾 200 行ダンプ
7. \`always()\` で \`docker compose down -v\` してリソース解放

## ローカル等価検証

trial clone (\`/home/xi/github/NeNe-FT/ft1-bookmarklog/\`) で同じ手順を実走:

\`\`\`text
[test:http] HTTP smoke preflight
  NENE_HTTP_BASE_URL = http://localhost:80
  NENE_HTTP_ERROR_BASE_URL is not set (the error-exposure test will be skipped).

PHPUnit 10.5.63 by Sebastian Bergmann and contributors.
S....................                                             21 / 21 (100%)

OK, but some tests were skipped!
Tests: 21, Assertions: 211, Skipped: 1.
\`\`\`

20/21 通過、211 assertions。残 1 件は \`NENE_HTTP_ERROR_BASE_URL\` 別 skip で想定どおり。

## この PR の意義

直近のバグ #222 のように runtime でのみ起きる回帰が、今後の PR でこの新ジョブによって CI 上で検出可能になる。具体的には:

- マジックメソッドへの不正な型宣言
- Smarty テンプレートの構文エラー
- PdoConnection 初期化時の例外
- Session 周りの runtime fatal
- Dispatcher の routing 解決時例外

これまでこれらは「手元で curl して気付くか、本番で気付くか」しか経路がなかった。

## 関連

- #222 / #223 — runtime fatal バグの実例(本 PR の動機)
- #225 (#229 でマージ済み) — test:http の skip UX 改善
- #226 (#228 でマージ済み) — NENE_HTTP_BASE_URL ドキュメント
- FT1 (F-2): \`docs/field-trials/2026-05-field-trial-1.md\` (執筆中)