### PR TITLE
chore(docker): bind mount を git safe.directory に登録する (#227)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN apt-get update \
 
 WORKDIR /var/www/html
 
+# Mark the host bind-mounted working tree as safe so git invocations inside
+# the container do not print `dubious ownership` warnings for every command
+# when the host uid differs from the container's root uid.
+RUN git config --global --add safe.directory /var/www/html
+
 COPY composer.json composer.lock ./
 RUN composer install --no-interaction --prefer-dist --no-progress
 


### PR DESCRIPTION
## 概要

FT1 (F-5) で発見した friction への対応。`docker compose run --rm app composer ...` 実行ごとに次の警告が毎回出ていた:

\`\`\`text
The repository at \"/var/www/html\" does not have the correct ownership and git refuses to use it:

fatal: detected dubious ownership in repository at '/var/www/html'
To add an exception for this directory, call:

git config --global --add safe.directory /var/www/html
\`\`\`

Closes #227

## 原因

ホストの bind mount (\`.:/var/www/html\`) は host 側 uid 所有、コンテナ内 git は root で動くため uid 不一致を Git 2.35.2+ の \`safe.directory\` 保護機構が検出していた。実行はブロックされず composer / phpunit / phan は走るが、コンテナ越しの全コマンド出力にこのノイズが付与されていた。

## 修正

\`Dockerfile\` に 1 行追加:

\`\`\`dockerfile
# Mark the host bind-mounted working tree as safe so git invocations inside
# the container do not print \`dubious ownership\` warnings for every command
# when the host uid differs from the container's root uid.
RUN git config --global --add safe.directory /var/www/html
\`\`\`

\`WORKDIR\` 直後・\`composer install\` 前に配置することで、イメージビルド時の git 呼び出しも含めて全経路で警告を抑止できる。

## 検証 (trial clone でリビルド)

- \`docker compose build app\`: 成功
- \`docker compose run --rm app composer --version\`: 警告無しでクリーン出力
- \`docker compose exec -T -e NENE_HTTP_BASE_URL=http://localhost:80 app composer test:http\`: 20/21 通過 / 211 assertions (回帰なし)
- #224 で追加した CI runtime-smoke ジョブにも回帰影響無し見込み

## 関連

- FT1 (F-5): \`docs/field-trials/2026-05-field-trial-1.md\` (執筆中)
- 重要度: 低 (機能影響なし、開発体験のクリーンアップ)

## 補足: Git の保護機構を緩めることへの安全性

\`safe.directory\` は特定パスを明示的に許可する設定で、グローバルに保護を無効化するわけではない。NeNe の bind mount は CI / 開発両方で必ず \`/var/www/html\` 配下に来る前提なので、このパスのみを許可するのは妥当。