### PR TITLE
docs(routing): URL parameter (key_value 形式) を forward-facing に文書化する (#238)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The dispatcher resolves the URL to:
 
 The legacy `{action}Rest` fallback remains only for compatibility. New REST endpoints should use method-specific handlers.
 
+URL parameters are passed in the `key_value` segment form (for example `/todo/item/id_42`), not REST `{id}` templates. See `docs/development/coding-standards.md` for the full convention.
+
 ## Requirements
 
 - The Docker development target is PHP 8.4.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -82,6 +82,37 @@ REST endpoints should make accepted HTTP methods explicit.
 - Define error code messages and HTTP status values in the server-side catalog at `config/error_codes.php`; controllers should reference codes, not inline messages or direct HTTP status headers.
 - Treat browser-visible error-code assets as exports or compatibility files, not the source of truth.
 
+## URL Parameter Format
+
+NeNe encodes URL parameters as `key_value` path segments after the controller and action, separated by underscores. This is a legacy-preserved convention — NeNe intentionally keeps the older PHP framework shape rather than adopting modern REST `{id}` templates.
+
+For example, the route `/todo/item/id_42` resolves to:
+
+- Controller: `TodoController`
+- Action: `item` → method `itemGetRest` / `itemPutRest` / `itemDeleteRest` depending on the HTTP method
+- URL parameter: `id = 42`
+
+Inside the controller method, read the value via `Request::getParam($key)`:
+
+```php
+$id = $this->request->getParam('id');
+if ($id === null || !ctype_digit((string)$id)) {
+    return $this->API_RESPONSE->failure('TODO-ID-REQUIRED');
+}
+$id = (int)$id;
+```
+
+Multiple parameters use additional `key_value` segments. `/foo/bar/page_3/sort_name` resolves to `page = 3` and `sort = name`.
+
+A few consequences worth flagging when generating routes (by hand or with an AI agent):
+
+- The path on the wire is `/{controller}/{action}/id_X`, not `/{controller}/{action}/{id}`.
+- OpenAPI `paths` keys use the literal underscore form (`/todo/item/id_{id}`) so the documented and runtime paths stay aligned.
+- Query strings (`?key=value`) still work via `Request::getQuery($key)` when filter-style parameters are needed instead.
+- A REST client written against a `{id}` template will hit 404 because the dispatcher takes only the first two URL segments as controller and action.
+
+When in doubt, read `class/xion/UrlParameter.php` for the parsing logic and existing samples in `class/controller/TodoController.php`.
+
 ## Service and Use-Case Logic
 
 Controllers are HTTP boundaries. Keep business decisions in service/use-case code once a controller method does more than simple request parsing, mapper delegation, and response selection.


### PR DESCRIPTION
## 概要

FT2 (F-3) で発見した friction への対応。URL パラメータの \`key_value\` 形式 (例: \`/todo/item/id_42\`) は legacy-preserved な NeNe の意図的設計だが、forward-facing ドキュメントに記載が無く、新規参入者または AI agent が現代的 REST 規約の \`/{controller}/{action}/{id}\` を期待してコードを書く罠があった。

Closes #238

## 変更内容

- \`docs/development/coding-standards.md\` の REST Controllers 節の直後に「**URL Parameter Format**」節を追加。
  - \`/todo/item/id_42\` の解決例 (controller / action / parameter の対応)
  - \`\$this->request->getParam('id')\` の使い方サンプルコード
  - 複数パラメータ \`/foo/bar/page_3/sort_name\` の例
  - OpenAPI 上の表記 (\`/todo/item/id_{id}\`) と実 URL の整合性
  - query string (\`?key=value\`) との使い分け
  - REST \`{id}\` template との違いと AI agent 向けの注意点
- \`README.md\` の Routing セクションに 1 行追加し、coding-standards.md への導線を確保。

## 検証

ドキュメントのみの変更。コード変更なし、回帰なし。

## 関連

- FT2 (F-3): \`docs/field-trials/2026-05-field-trial-2.md\`
- \`class/xion/UrlParameter.php\` (実装ソース)
- \`docs/tutorials/building-a-service.md\` (既に \`id_X\` 例を使用)