### PR TITLE
docs(coding-standards): junction-table mapper の指針を追加する (#239)

### DIFF
--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -140,6 +140,20 @@ Mapper responsibilities:
 - Do not know about HTTP request shape, templates, or `ApiResponse`.
 - Do not start transactions for every statement; leave transaction boundaries to service/use-case code.
 
+### Junction tables (many-to-many)
+
+`DataMapperBase` assumes a single-column primary key (the `KEY_SID` constant) and exposes id-centric helpers such as `find($sid)`, `update($model)`, and `delete($model)`. These helpers are **not** designed for many-to-many junction tables like `article_tags (article_id, tag_id)`, where the natural primary key is composite.
+
+For junction tables:
+
+- Still inherit from `DataMapperBase` to keep PDO acquisition (`$this->DB`) and the logger (`$this->LOGGER`) consistent with the rest of the codebase.
+- Leave `KEY_SID` unset — do not invent a synthetic id just to satisfy the base class.
+- Do not use `find()` / `update()` / `delete()` from the base class; they assume single-column PK.
+- Write the relation operations (find ids by left, replace tag set, clear all rows for one parent) as small raw prepared statements through `$this->execute($stmt)`.
+- Keep schema-level cascade behavior (`ON DELETE CASCADE` in MySQL / `FOREIGN KEY ... ON DELETE CASCADE` in SQLite) on the junction table so the relation rows disappear when either side is hard-deleted.
+- When the parent uses soft delete (`is_deleted = 1`), the cascade does not fire automatically; clear the junction rows explicitly inside the same `TransactionManager::run()` block as the parent's soft-delete write.
+- Callers (controllers or service code) own the transaction boundary when more than one statement must commit atomically — for example a parent update that re-syncs the relation set.
+
 ## OpenAPI
 
 New public HTTP APIs should be documented with OpenAPI.


### PR DESCRIPTION
## 概要

FT2 (F-6) で発見した friction への対応。\`Nene\\Xion\\DataMapperBase\` は単一カラム主キーを前提とする設計だが、M:N 結合表 (複合主キー) にはヘルパーが適用できない。その判断基準がどこにも明文化されておらず、新規参入者または AI agent が罠を踏みやすかった。

Closes #239

## 変更内容

\`docs/development/coding-standards.md\` の Mapper responsibilities 直後に「**Junction tables (many-to-many)**」サブセクションを追加。

ガイダンス:

- \`DataMapperBase\` を継承して \`\$this->DB\` / \`\$this->LOGGER\` の経路は揃える
- \`KEY_SID\` は未設定にし、id-centric ヘルパー (\`find()\` / \`update()\` / \`delete()\`) は使わない
- 関係操作は raw prepared statement で書く
- スキーマレベルの \`ON DELETE CASCADE\` を junction に張る
- 親が soft-delete の場合は cascade が発火しないため、同じ \`TransactionManager::run()\` ブロック内で junction を明示的にクリアする
- multi-statement の atomic 操作は controller/service 側で \`TransactionManager\` を所有する

## 検証

ドキュメントのみの変更。コード変更なし、回帰なし。

## 関連

- FT2 (F-6): \`docs/field-trials/2026-05-field-trial-2.md\`
- FT2 trial dir の参照実装: \`/home/xi/github/NeNe-FT/ft2-bookmark-tag/class/db/BookmarkTagMapper.php\` (将来 bundled sample に昇格する候補)
- \`class/xion/DataMapperBase.php\` (id-centric ヘルパーの実装)