### PR TITLE
feat(xion): TransactionManager 内から domain error を JSON 4xx に変換する経路を追加する (#237)

### DIFF
--- a/class/xion/DomainException.php
+++ b/class/xion/DomainException.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use RuntimeException;
+
+/**
+ * Throwable that carries a NeNe error code to the top-level request handler.
+ *
+ * Application code may throw `DomainException` from inside a controller method,
+ * a service, a mapper, or a `TransactionManager::run()` callback when it needs
+ * to surface a domain-level failure (for example, a missing referenced row, a
+ * duplicate value, or a business-rule violation) without paying for a manual
+ * detour around `htdocs/index.php`'s generic 500 fallback.
+ *
+ * The top-level handler in `htdocs/index.php` catches this class and converts
+ * it to the standard `ApiResponse::failure($errorCode)` JSON envelope, picking
+ * up the HTTP status defined in `config/error_codes.php`. If thrown from inside
+ * a `TransactionManager::run()` callback, the transaction is rolled back first
+ * by `TransactionManager` itself, then the catch-all converts the exception to
+ * the JSON failure response.
+ *
+ * Error codes must already exist in `config/error_codes.php` so the HTTP status
+ * and message can be resolved. Throwing an unknown code produces an
+ * `Internal Server Error` style 500 fallback, which is intentional — domain
+ * errors are part of the API contract and must be registered first.
+ */
+final class DomainException extends RuntimeException
+{
+    /**
+     * Error code from `config/error_codes.php`.
+     */
+    private string $errorCode;
+
+    /**
+     * @param string $errorCode Error code declared in `config/error_codes.php`.
+     */
+    public function __construct(string $errorCode)
+    {
+        parent::__construct($errorCode);
+        $this->errorCode = $errorCode;
+    }
+
+    /**
+     * Error code declared in `config/error_codes.php`.
+     */
+    public function errorCode(): string
+    {
+        return $this->errorCode;
+    }
+}

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -183,6 +183,33 @@ The transaction manager commits when the callback succeeds and rolls back when i
 
 Do not create an alternate transaction helper for new features unless an Issue and ADR explain why `TransactionManager` is insufficient.
 
+### Surfacing domain errors from inside a transaction
+
+A `TransactionManager::run()` callback that throws a plain `Throwable` rolls back the transaction, but the exception then escapes to `htdocs/index.php`'s catch-all and produces a plain-text 500 response. That is the wrong shape for domain-level failures such as "referenced row not found" or "duplicate name".
+
+For these cases, throw `Nene\Xion\DomainException` with a registered error code. The top-level handler in `htdocs/index.php` catches it and converts to the standard JSON failure envelope with the HTTP status declared in `config/error_codes.php`:
+
+```php
+use Nene\Xion\DomainException;
+use Nene\Xion\TransactionManager;
+
+$transaction = new TransactionManager();
+$transaction->run(function () use ($bookmarkMapper, $junctionMapper, $tagIds): void {
+    foreach ($tagIds as $tagId) {
+        if (!$tagMapper->exists($tagId)) {
+            throw new DomainException('BOOKMARK-TAG-IDS-INVALID');
+        }
+    }
+    $junctionMapper->replaceTagsForBookmark($bookmarkId, $tagIds);
+});
+```
+
+When this throws, `TransactionManager` rolls back, the top-level handler emits `ApiResponse::failure('BOOKMARK-TAG-IDS-INVALID')`, and the client sees the normal JSON envelope plus the 400 (or whichever HTTP status the catalog declares) from `config/error_codes.php`.
+
+The error code must already exist in `config/error_codes.php`. Throwing an unknown code falls back to the generic 500 path, which is intentional — domain errors are part of the API contract and must be registered first.
+
+For purely pre-flight input validation (no DB writes), prefer returning `$this->API_RESPONSE->failure($code)` directly from the controller before opening the transaction. `DomainException` is for cases where the validation must run alongside the writes, for example a row-existence check whose target may change between the validation and the write.
+
 ## Testing and Static Analysis
 
 - At minimum, run PHP syntax checks for changed PHP files.

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -39,6 +39,11 @@ try {
     $dispatcher->dispatch();
 } catch (Xion\HttpTermination $termination) {
     Xion\HttpEmitter::emit($termination->response());
+} catch (Xion\DomainException $domainException) {
+    $apiResponse = new Xion\ApiResponse();
+    Xion\HttpEmitter::emit(
+        Xion\JsonResponder::responseArray($apiResponse->failure($domainException->errorCode()))
+    );
 } catch (\Throwable $throwable) {
     Xion\Log::getInstance('error')->error('Unhandled application error.', ['exception' => $throwable]);
     Xion\HttpEmitter::emit(Xion\HttpResponse::text(

--- a/tests/Unit/Xion/DomainExceptionTest.php
+++ b/tests/Unit/Xion/DomainExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\DomainException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Throwable;
+
+final class DomainExceptionTest extends TestCase
+{
+    public function testCarriesTheErrorCodeProvidedAtConstruction(): void
+    {
+        $exception = new DomainException('BOOKMARK-NOT-FOUND');
+
+        self::assertSame('BOOKMARK-NOT-FOUND', $exception->errorCode());
+        self::assertSame('BOOKMARK-NOT-FOUND', $exception->getMessage());
+    }
+
+    public function testIsAStandardThrowable(): void
+    {
+        $exception = new DomainException('TAG-NAME-DUPLICATE');
+
+        self::assertInstanceOf(Throwable::class, $exception);
+        self::assertInstanceOf(RuntimeException::class, $exception);
+    }
+}


### PR DESCRIPTION
## 概要

FT2 (F-1) で発見した friction への対応。\`TransactionManager::run()\` の callback 内から \`Throwable\` を投げると \`htdocs/index.php\` の catch-all に到達して plain text 500 になり、domain-level エラーを綺麗な JSON 4xx として返す方法が無かった。

Closes #237

## アプローチ

Issue 提案案 A (DomainException 経路) を採用。framework に \`Nene\\Xion\\DomainException\` を導入し、top-level handler でこれを catch して \`ApiResponse::failure(\$code)\` を JSON 出力する。

## 変更内容

### 新規

- \`class/xion/DomainException.php\` — \`RuntimeException\` 派生。\`config/error_codes.php\` に登録されたエラーコードを保持する小クラス。
- \`tests/Unit/Xion/DomainExceptionTest.php\` — コード保持と Throwable/RuntimeException 派生関係を確認する 2 テスト。

### 更新

- \`htdocs/index.php\` — \`HttpTermination\` catch の次、\`Throwable\` catch の前に \`DomainException\` catch を追加。\`ApiResponse::failure(\$code)\` を組み立てて \`JsonResponder::responseArray()\` で emit。HTTP status は \`config/error_codes.php\` から自動で引かれる。
- \`docs/development/coding-standards.md\` Database Transactions 節に「**Surfacing domain errors from inside a transaction**」サブセクションを追加:
  - 利用例 (Bookmark の tag 存在チェックを transaction 内で行うパターン)
  - 未登録コードを投げると 500 にフォールバックする挙動
  - pre-flight validation との使い分け

## 検証

- \`composer test\`: 45/45 (新規 \`DomainExceptionTest\` 2 件追加で 43→45)、129 assertions
- \`composer test:http\`: 27/27、243 assertions、1 expected skip、回帰なし

統合経路の確認 — trial clone で次の PHP スクリプトを直接実行:

\`\`\`php
\$tx = new \Nene\Xion\TransactionManager();
try {
    \$tx->run(function () {
        throw new \Nene\Xion\DomainException('BOOKMARK-TAG-IDS-INVALID');
    });
} catch (\Nene\Xion\DomainException \$e) {
    \$resp = \Nene\Xion\JsonResponder::responseArray((new \Nene\Xion\ApiResponse())->failure(\$e->errorCode()));
}
\`\`\`

結果:

\`\`\`text
Caught: BOOKMARK-TAG-IDS-INVALID
HTTP 400 body={\"Result\":true,\"Data\":{\"status\":\"failure\",\"errorCode\":\"BOOKMARK-TAG-IDS-INVALID\",\"errorMessage\":\"tag_ids must be an array of integers referring to existing tags.\"}}
\`\`\`

\`TransactionManager\` が rollback した上で、proper な JSON 4xx が返る。

## 関連

- FT2 (F-1): \`docs/field-trials/2026-05-field-trial-2.md\`
- \`class/xion/TransactionManager.php\` (既存の transaction boundary)
- \`config/error_codes.php\` (HTTP status と message の catalog)
- \`docs/development/coding-standards.md\` Database Transactions 節