### PR TITLE
docs(adr): ADR 0002 で field trial methodology の採用を記録する (#246)

### DIFF
--- a/docs/adr/0002-adopt-field-trial-methodology.md
+++ b/docs/adr/0002-adopt-field-trial-methodology.md
@@ -1,0 +1,53 @@
+# ADR 0002: Adopt Field Trial Methodology
+
+## Status
+
+Accepted
+
+## Context
+
+NeNe positions itself as a small, AI-readable, renovation-style PHP framework. Its value depends on what a fresh-clone external developer (human or AI agent) actually experiences when building a small service against it. That experience cannot be observed from inside the repository — internal tests, static analysis, and code review all assume an author who already knows the conventions.
+
+Two sibling projects by the same maintainer (`hideyukiMORI/NENE2` and `hideyukiMORI/nene2-python`) had already converged on a "field trial" practice: build a small realistic service in an external clone, record every point of friction with a stable identifier, file each finding as a focused Issue, and only run the next trial after every previous Issue is closed. Across those two projects roughly 150 trials had been completed before NeNe adopted the same shape.
+
+The first NeNe trials (FT1 and FT2, both 2026-05-20) immediately validated the model:
+
+- FT1 surfaced a runtime fatal that the existing CI workflow had been declaring green (fixed in PR #223), and the upstream cause — CI never starts a runtime — was closed by PR #230, which added a Docker-based HTTP smoke job.
+- FT2 surfaced a missing path for converting domain errors to JSON 4xx responses from inside `TransactionManager::run()`, which was addressed by PR #244 by introducing `Nene\Xion\DomainException`.
+
+Both trials also drove documentation improvements that were not visible from inside the repo (PR #228, #229, #231, #238, #239, #240).
+
+The methodology itself was introduced in PR #221 with `docs/field-trials/README.md` and `docs/templates/field-trial-report.md`, but its adoption as an ongoing practice — including the friction-kind taxonomy, the decision categories, the clone layout, and the close-all-Issues-before-next-FT cadence — is an architectural-process decision that should be recorded here.
+
+## Decision
+
+NeNe adopts the field trial methodology as documented in `docs/field-trials/README.md` as a continuous quality practice rather than a one-off exercise.
+
+Specifically:
+
+- Trials are run from a fresh `git clone` placed under `../NeNe-FT/ft{N}-{topic}/`. The trial directory is independent, its `.git` / `.env` / generated artifacts stay local, and nothing from it is committed back into the framework repository except the final report.
+- Trial reports live at `docs/field-trials/YYYY-MM-field-trial-{N}.md` and follow the skeleton at `docs/templates/field-trial-report.md`. Each trial gets exactly one report file; subsequent work is tracked through Issues, not by re-editing the report.
+- Friction is recorded with a stable identifier (`F-N`) inline as it occurs, and consolidated in a Friction Summary table with severity (high / medium / low), kind, and decision.
+- The friction-kind taxonomy includes `legacy-preserved` (a NeNe-specific category for intentionally retained legacy shapes whose fix is documentation, never a redesign) alongside `docs-gap`, `feature-gap`, `design-trade-off`, and `process-gap`.
+- The decision taxonomy includes `keep-legacy` (paired with `legacy-preserved` kind) alongside `fix-in-framework`, `document`, and `defer`.
+- Each finding worth acting on is filed as a focused GitHub Issue and addressed in its own PR. The loop is closed when every actionable Issue from a trial is merged or closed with a recorded rationale.
+- The next trial does not start until the previous trial's Issues are closed. This keeps each trial's findings attributable to the surface it actually exercised, not to leftover friction from a previous one.
+
+This decision does not change framework code by itself. It commits the project to running, recording, and closing field trials as part of its quality practice.
+
+## Consequences
+
+- A continuous evidence channel exists for documentation gaps, missing reference patterns, and runtime regressions that internal tests cannot detect. Findings come from real construction work, not speculation.
+- CI and review processes are pushed to cover the surfaces that field trials exercise. FT1 directly produced the runtime-smoke CI job in PR #230, which now blocks an entire class of regressions at the PR boundary.
+- The bar for new framework features rises slightly: each one is expected to be validated against an external trial within a reasonable time after merge, rather than remaining untested in real construction.
+- PR cadence during the post-trial improvement window can spike. Trials typically generate three to seven follow-up Issues that should be closed before the next trial; merging them sequentially can produce ten-plus PRs in a short window. Reviewers should expect this rhythm and may want to bundle non-conflicting follow-ups when the trial's findings cluster.
+- Disk usage grows under `../NeNe-FT/` while trials are active. Trial directories should be deleted once their work closes, unless a specific clone has independent reference value.
+- The `legacy-preserved` kind and `keep-legacy` decision make it explicit that not every friction is a defect. NeNe stays a renovation, not a redesign, and findings that reveal an intentional legacy shape end in documentation rather than code change.
+- A future trial may surface a friction that the methodology itself produced (for example, report-writing overhead or false-positive findings). When that happens, update `docs/field-trials/README.md` and reference this ADR in a follow-up ADR.
+
+## Related
+
+- PR #221 — introduced `docs/field-trials/README.md` and `docs/templates/field-trial-report.md`.
+- `docs/field-trials/2026-05-field-trial-1.md`, `docs/field-trials/2026-05-field-trial-2.md` — first two trials executed under this methodology.
+- ADR 0001 — recording architecture decisions.
+- `docs/roadmap.md` Phase 7 — Field Trials as a continuous quality gate.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,3 +24,4 @@ Create an ADR when a change affects:
 ## Index
 
 - `0001-record-architecture-decisions.md`: Start recording architecture decisions.
+- `0002-adopt-field-trial-methodology.md`: Adopt the field trial methodology as a continuous quality practice.


### PR DESCRIPTION
## 概要

2026-05-20 に PR #221 で導入した field trial methodology は、その後の FT1 / FT2 を通じて runtime fatal の hotfix・CI 構造変更・新規例外クラス追加・複数のドキュメント整備に波及した。これらの broad な変更を後追いで把握しやすくし、かつ methodology 自体を「外部消費者視点を継続的に framework に強制注入するプロセス的意思決定」として durable に記録するため、ADR を追加する。

Closes #246

## 変更内容

### 新規

\`docs/adr/0002-adopt-field-trial-methodology.md\` を ADR 0001 と同じ形式 (Status / Context / Decision / Consequences) で作成。

- **Status**: Accepted
- **Context**: NeNe のポジショニング (small / AI-readable / renovation) と FT の必要性、姉妹リポジトリ (NENE2 / nene2-python) での蓄積、FT1 / FT2 が実際に生んだ具体的成果 (#223 hotfix, #230 CI 構造改善, #244 DomainException 追加, 多数のドキュメント PR)
- **Decision**:
  - クローン配置 \`../NeNe-FT/ft{N}-{topic}/\` の規約化
  - 報告書配置 \`docs/field-trials/YYYY-MM-field-trial-{N}.md\` の規約化
  - \`F-N\` 識別子・Friction Summary 表・severity 3 段階の運用
  - friction-kind 5 種 (\`docs-gap\` / \`feature-gap\` / \`design-trade-off\` / \`legacy-preserved\` / \`process-gap\`)、特に \`legacy-preserved\` は NeNe 固有
  - decision 4 種 (\`fix-in-framework\` / \`document\` / \`keep-legacy\` / \`defer\`)
  - Issue ベース管理 + 「次トライアル前に全 Issue 解消」ループ規約
- **Consequences**: 良点 (continuous evidence channel、CI 押し上げ効果、legacy-preserved スタンスの明文化)、留意点 (PR 連投時のレビュー負荷、disk 使用量)、将来 methodology 自身が trial で改訂対象になる可能性

### 更新

\`docs/adr/README.md\` Index に ADR 0002 行を追加。

## 検証

ドキュメントのみの追加。コード変更なし、回帰なし。

## 関連

- PR #221 (方法論本体導入)
- \`docs/field-trials/2026-05-field-trial-1.md\`、\`-2.md\` (FT1 / FT2 報告書)
- \`docs/roadmap.md\` Phase 7
- ADR 0001 (本 ADR フォーマットの源)