### PR TITLE
docs(field-trials): defer された FT findings の follow-up リストを追加する (#248)

### DIFF
--- a/docs/field-trials/README.md
+++ b/docs/field-trials/README.md
@@ -102,9 +102,10 @@ When in doubt, omit. A trial report is more valuable as a small, safe record tha
 After a trial:
 
 1. Open one GitHub Issue per actionable finding. Reference the report file and the `F-N` row.
-2. Update `docs/todo/current.md` with a short "FT{N}" block linking the Issues.
-3. Update `docs/roadmap.md` if the trial moved a phase forward.
-4. Delete the trial clone under `../NeNe-FT/` when its work is done, unless it has independent value (for example as a future public sample).
+2. Append `defer` and unfiled `legacy-preserved` findings to `docs/field-trials/follow-ups.md` so they remain searchable when a later trial revisits the same surface.
+3. Update `docs/todo/current.md` with a short "FT{N}" block linking the Issues.
+4. Update `docs/roadmap.md` if the trial moved a phase forward.
+5. Delete the trial clone under `../NeNe-FT/` when its work is done, unless it has independent value (for example as a future public sample).
 
 The trial is finished when its Issues are merged or closed with a recorded rationale. A trial does not need to "succeed" — recording friction is the success condition.
 

--- a/docs/field-trials/follow-ups.md
+++ b/docs/field-trials/follow-ups.md
@@ -1,0 +1,59 @@
+# Field Trial Follow-ups
+
+This file consolidates findings from past field trial reports that were recorded as `defer` or `legacy-preserved` and were therefore **not filed as their own GitHub Issue**. Reports themselves are frozen at completion time, so this file is the durable index that future trials should check before recording the same friction.
+
+Methodology reference: `docs/field-trials/README.md`. Decision authority: ADR 0002.
+
+## How to Use This File
+
+When a new trial surfaces friction that looks similar to an entry here:
+
+1. Read the entry's *Re-evaluation trigger* line.
+2. If the trigger condition is met (second occurrence, materially worse, or scope changed), escalate: file a focused GitHub Issue, remove the entry from this file, and reference the Issue in the next trial report.
+3. If the trigger condition is not met, just add a back-reference from the new trial report's Friction Summary so the link between sightings stays visible.
+
+Entries are grouped by trial of origin. Once an entry is escalated to an Issue and that Issue is merged or closed with a rationale, remove the entry from this file with a short note in the next trial report.
+
+## From FT1 (2026-05-20)
+
+Source: `2026-05-field-trial-1.md`.
+
+### Host-side WSL setup (F-0a / F-0b / F-0c, consolidated)
+
+- **Friction**: On WSL 2 with a stock Ubuntu image, three preconditions were necessary before any NeNe command could run: PHP unavailable at the target 8.4 version on default apt, Docker Desktop's WSL integration not enabled for the distro, and the user not in the `docker` group. Each was a one-action fix, but the NeNe Docker Quick Start did not flag any of them as prerequisites.
+- **Decision in FT1**: `defer` (host-side, not NeNe's fault).
+- **Re-evaluation trigger**: a second trial on a different WSL host (or on a non-WSL Linux host) re-discovers any of the three. Once confirmed as a pattern rather than a single host quirk, add a short "WSL Prerequisites" subsection to `docs/development/docker.md` covering all three preconditions.
+- **ADR likely?**: No. This is documentation, not architecture.
+
+## From FT2 (2026-05-21)
+
+Source: `2026-05-field-trial-2.md`.
+
+### F-2 — Soft-delete + unique constraint test isolation
+
+- **Friction**: `tags.name` was marked `UNIQUE` while the table used soft delete (`is_deleted = 1`). The second test run could not recreate a tag with the same name because the soft-deleted row from the first run still held the unique key. FT2 fixed it in tests by namespacing every tag name with a per-run prefix; the framework convention is unspecified.
+- **Decision in FT2**: `defer` (workaround applied inside the trial).
+- **Re-evaluation trigger**: a future trial again hits a unique-constraint conflict caused by soft-deleted rows, or a new bundled sample adopts a unique column that needs the same workaround. At that point the choice is an ADR-class decision:
+  - (a) keep `is_deleted` + `UNIQUE`, document the namespacing pattern for tests;
+  - (b) drop soft delete on rarely-deleted lookup tables;
+  - (c) replace the constraint with a partial unique index on `(name) WHERE is_deleted = 0` (SQLite) and `(name, is_deleted)` (MySQL) or equivalent.
+- **ADR likely?**: Yes, if escalated.
+
+### F-4 — `TransactionManager` reference implementation in `class/controller/`
+
+- **Friction**: `Nene\Xion\TransactionManager` is documented in `docs/development/coding-standards.md` and demonstrated in `docs/tutorials/building-a-service.md`, but no controller in `class/controller/` actually uses it. Source-only search (grep for `TransactionManager` in `class/controller/`) returns nothing, so contributors who skip the tutorial may miss the pattern.
+- **Decision in FT2**: `defer` (tutorial coverage exists; full reference implementation would be Issue #145 scope).
+- **Re-evaluation trigger**: Issue #145 (small-service reference implementation) lands and continues to skip `TransactionManager`, OR a trial uncovers a contributor who reached for an ad-hoc PDO transaction because the canonical pattern was not findable.
+- **ADR likely?**: No. The decision was already made (ADR-class behavior is in coding standards). This is a sample-implementation gap.
+
+### F-5 — OpenAPI per-error-code envelope boilerplate
+
+- **Friction**: The existing TODO contract defines a separate envelope schema per error code (`TodoNotFoundEnvelope`, `TodoIdRequiredEnvelope`, `TodoTitleRequiredEnvelope`, ...). Adding two new entities in FT2 would have required seven additional per-code envelopes; FT2 used a single generic `ApiFailureEnvelope` instead to keep the trial in scope.
+- **Decision in FT2**: `defer` (FT2 made an executive call locally; long-term shape is undecided).
+- **Re-evaluation trigger**: a third entity gets added to the OpenAPI contract and the decision repeats, OR a contributor proposes a generic envelope migration for the existing per-code schemas. Either way, the open question is whether per-code envelopes stay canonical (richer documentation, more boilerplate) or are migrated to a generic shape (less boilerplate, weaker per-code documentation).
+- **ADR likely?**: Yes, if escalated. This is a public OpenAPI shape decision.
+
+## Notes
+
+- `legacy-preserved` findings (FT2 F-3 — URL parameter `key_value` format) were closed in PR #241 via documentation, not deferred, so they do not appear here. The `legacy-preserved` kind itself does not imply deferral; it means the fix is documentation rather than redesign.
+- The longer this file becomes without entries getting escalated or removed, the more it suggests that NeNe's friction surface is stable. The shorter it stays, the more it suggests every trial is actionable.


### PR DESCRIPTION
## 概要

FT1 / FT2 報告書には actionable Issue 化しなかった \`defer\` 項目 (および unfiled \`legacy-preserved\` 項目) が含まれている。報告書本体は完了済みドキュメントで更新しないため、これらを集約した durable な索引が無いと次トライアル時の escalation 判断が遅くなる。

Closes #248

## 抽出元と内容

### FT1 (\`2026-05-field-trial-1.md\`)

- F-0a / F-0b / F-0c (WSL host PHP / Docker integration / docker group) — defer (host-side, not NeNe's fault)

### FT2 (\`2026-05-field-trial-2.md\`)

- F-2 — Soft-delete + \`UNIQUE\` 制約の test isolation pattern (workaround は trial 内で適用済み、framework 規約は未決)
- F-4 — \`TransactionManager\` の参照実装が \`class/controller/\` 内に無い (チュートリアル文書では言及済み、grep で発見不能)
- F-5 — OpenAPI per-error-code envelope の boilerplate (FT2 は generic envelope で代用、long-term shape 未決)

各項目に:

- 元 FT 報告書へのリンク
- defer 理由
- **Re-evaluation trigger** 条件 (どんな再観測で escalate するか)
- ADR 必要性の目安

を併記している。

## 運用

新規 \`docs/field-trials/follow-ups.md\` を作成し、\`docs/field-trials/README.md\` の Aftermath セクションのステップ 2 として「defer / unfiled legacy-preserved findings を follow-ups.md に追加する」を組み込んだ。

次トライアル (FT3+) で同じ surface を当たった時、follow-ups.md の re-evaluation trigger を見て escalate するか判断する。escalate された項目はファイルから削除し、次トライアル報告にその経緯を記録する。

## 関連

- ADR 0002 (FT methodology の正式採用)
- \`docs/field-trials/2026-05-field-trial-1.md\`、\`-2.md\`
- 該当 PR (FT1: #223 / #228 / #229 / #230 / #231 / #233、FT2: #236 / #241 / #242 / #243 / #244)