### PR TITLE
test(http): OpenApiRuntimeContractTest を自己発見型にする (#252)

### DIFF
--- a/tests/Http/OpenApiRuntimeContractTest.php
+++ b/tests/Http/OpenApiRuntimeContractTest.php
@@ -10,11 +10,27 @@ require_once __DIR__ . '/HttpRuntimeTestCase.php';
 
 final class OpenApiRuntimeContractTest extends HttpRuntimeTestCase
 {
+    private const PATH_PARAM_SENTINEL = '999999999';
+    private const SKIP_EXTENSION = 'x-nene-runtime-probe';
+    private const SKIP_VALUE = 'skip';
+
     /*
      * This is still a runtime smoke check rather than a full OpenAPI validator:
-     * documented REST operations should exist, and observed HTTP statuses
-     * should be listed in the contract. symfony/yaml is used so this test reads
-     * the contract as structured data instead of depending on indentation.
+     * every documented REST operation should be probeable, and the observed
+     * HTTP status should be listed in the contract. symfony/yaml is used so
+     * this test reads the contract as structured data instead of depending on
+     * indentation.
+     *
+     * Each operation is exercised with a fresh client (no shared cookie or
+     * CSRF state), so state-changing endpoints that require auth typically
+     * land on the documented 401 / 403 branch — that is the intent. The
+     * probe verifies the contract for failure paths; the dedicated per-entity
+     * tests (TodoTest, MemoAuthTest, etc.) cover happy paths.
+     *
+     * Adding a new endpoint to docs/api/openapi.yaml automatically adds it to
+     * this test. To opt an operation out (e.g. one with destructive side
+     * effects that should not be probed), set the OpenAPI vendor extension
+     * `x-nene-runtime-probe: skip` on the operation.
      */
     public function testDocumentedRestOperationsRespondWithDocumentedStatuses(): void
     {
@@ -22,32 +38,35 @@ final class OpenApiRuntimeContractTest extends HttpRuntimeTestCase
         $openApi = $this->parseOpenApi($openApiResponse->body());
         $operations = $this->documentedOperations($openApi);
 
-        $examples = [
-            ['GET', '/health/index', '/health/index', null],
-            ['POST', '/session/login', '/session/login', ['user_id' => 'admin', 'user_pass' => 'admin']],
-            ['POST', '/session/logout', '/session/logout', []],
-            ['GET', '/todo/index', '/todo/index', null],
-            ['POST', '/todo/index', '/todo/index', ['title' => self::TEST_TODO_PREFIX . 'contract']],
-            ['PUT', '/todo/item/id_{id}', '/todo/item/id_1', ['is_completed' => true]],
-            ['DELETE', '/todo/item/id_{id}', '/todo/item/id_1', null],
-        ];
+        self::assertNotEmpty($operations, 'OpenAPI document contains no operations to probe.');
 
-        foreach ($examples as [$method, $documentedPath, $runtimePath, $body]) {
-            self::assertContains(
-                [$method, $documentedPath],
-                $operations,
-                $method . ' ' . $documentedPath . ' is missing from OpenAPI.'
-            );
+        foreach ($operations as $operation) {
+            [$method, $documentedPath, $operationObject] = $operation;
+
+            if ($this->isSkipped($operationObject)) {
+                continue;
+            }
+
+            $runtimePath = $this->materializePath($documentedPath, $operationObject);
+            $body = $this->extractExampleBody($operationObject);
 
             $client = $this->newClient();
             $response = is_array($body)
                 ? $client->json($method, $runtimePath, $body)
                 : $client->request($method, $runtimePath);
 
+            $documentedStatuses = $this->documentedStatuses($openApi, $documentedPath, $method);
             self::assertContains(
                 (string)$response->statusCode(),
-                $this->documentedStatuses($openApi, $documentedPath, $method),
-                $method . ' ' . $documentedPath . ' returned undocumented status ' . $response->statusCode()
+                $documentedStatuses,
+                sprintf(
+                    '%s %s probed at %s returned undocumented status %d (documented: %s).',
+                    $method,
+                    $documentedPath,
+                    $runtimePath,
+                    $response->statusCode(),
+                    implode(', ', $documentedStatuses)
+                )
             );
         }
     }
@@ -66,7 +85,7 @@ final class OpenApiRuntimeContractTest extends HttpRuntimeTestCase
     /**
      * @param array<string,mixed> $openApi Parsed OpenAPI document.
      *
-     * @return array<int,array{0:string,1:string}>
+     * @return array<int,array{0:string,1:string,2:array<string,mixed>}>
      */
     private function documentedOperations(array $openApi): array
     {
@@ -79,9 +98,11 @@ final class OpenApiRuntimeContractTest extends HttpRuntimeTestCase
                 continue;
             }
             foreach (['get', 'post', 'put', 'patch', 'delete'] as $method) {
-                if (array_key_exists($method, $pathItem)) {
-                    $operations[] = [strtoupper($method), $path];
+                if (!array_key_exists($method, $pathItem)) {
+                    continue;
                 }
+                $operationObject = is_array($pathItem[$method]) ? $pathItem[$method] : [];
+                $operations[] = [strtoupper($method), $path, $operationObject];
             }
         }
         return $operations;
@@ -98,5 +119,74 @@ final class OpenApiRuntimeContractTest extends HttpRuntimeTestCase
         self::assertIsArray($responses);
 
         return array_map('strval', array_keys($responses));
+    }
+
+    /**
+     * Substitute path parameters with a sentinel value (defaults to 999999999),
+     * so destructive probes hit the documented 404 branch rather than a real
+     * row. Per-parameter examples in the OpenAPI document take priority when
+     * present.
+     *
+     * @param array<string,mixed> $operationObject
+     */
+    private function materializePath(string $documentedPath, array $operationObject): string
+    {
+        $runtimePath = $documentedPath;
+        $parameters = isset($operationObject['parameters']) && is_array($operationObject['parameters'])
+            ? $operationObject['parameters']
+            : [];
+
+        foreach ($parameters as $parameter) {
+            if (!is_array($parameter) || ($parameter['in'] ?? null) !== 'path') {
+                continue;
+            }
+            $name = (string)($parameter['name'] ?? '');
+            if ($name === '') {
+                continue;
+            }
+            $value = $parameter['example'] ?? self::PATH_PARAM_SENTINEL;
+            $runtimePath = str_replace('{' . $name . '}', (string)$value, $runtimePath);
+        }
+
+        // Generic fallback for any unresolved {placeholder}.
+        return (string)preg_replace('/\{[^}]+\}/', self::PATH_PARAM_SENTINEL, $runtimePath);
+    }
+
+    /**
+     * Extract the first JSON example from the operation's request body, if any.
+     * Returns null when the operation has no body (typical for GET / DELETE).
+     *
+     * @param array<string,mixed> $operationObject
+     *
+     * @return array<string,mixed>|null
+     */
+    private function extractExampleBody(array $operationObject): ?array
+    {
+        $jsonContent = $operationObject['requestBody']['content']['application/json'] ?? null;
+        if (!is_array($jsonContent)) {
+            return null;
+        }
+
+        if (isset($jsonContent['examples']) && is_array($jsonContent['examples'])) {
+            foreach ($jsonContent['examples'] as $example) {
+                if (is_array($example) && isset($example['value']) && is_array($example['value'])) {
+                    return $example['value'];
+                }
+            }
+        }
+
+        if (isset($jsonContent['example']) && is_array($jsonContent['example'])) {
+            return $jsonContent['example'];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string,mixed> $operationObject
+     */
+    private function isSkipped(array $operationObject): bool
+    {
+        return ($operationObject[self::SKIP_EXTENSION] ?? null) === self::SKIP_VALUE;
     }
 }


### PR DESCRIPTION
## Summary
- \`testDocumentedRestOperationsRespondWithDocumentedStatuses\` をハードコード probe 配列ベースから \`\$openApi['paths']\` の自動 iterate ベースに書き換える。OpenAPI に新規 endpoint を追加すると自動で probe 対象に入る。
- path parameter は \`parameters[].example\` を優先しつつ、なければ sentinel 値 \`999999999\` で materialize (実在しない id を狙って documented 404 経路へ着地する想定)。
- request body は \`requestBody.content['application/json'].examples\` の最初のエントリ → \`.example\` → 空オブジェクト の順で抽出。
- 副作用が大きい等で probe したくない operation 用に OpenAPI 拡張 \`x-nene-runtime-probe: skip\` を opt-out marker としてサポート。
- 各 operation は \`newClient()\` で auth state を共有しないため、state-changing endpoint は documented 401 (SESSION-CLOSED) / 200 経路に着地する (happy path は per-entity test = TodoTest / MemoAuthTest 側でカバー)。FT3 finding F-2 への対応 (closes #252)。

## Test plan
- [x] \`composer test\`: 45 / 45, 129 assertions
- [x] \`composer test:http\`: 21 / 21, 205 assertions (1 expected skip)
- [x] 既存 7 operations (health/session×2/todo index GET+POST/todo item PUT+DELETE) は全て documented status に着地して green
- [x] opt-out marker (\`x-nene-runtime-probe: skip\`) のコード経路は \`isSkipped\` で1行判定、unit テストで明示的に exercise はしていない (extension が付いた endpoint が現状ない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)