### PR TITLE
feat(api-docs): OpenAPI failure envelope を generic ApiFailureEnvelope に統一する (#251)

### DIFF
--- a/docs/adr/0003-openapi-failure-envelope-shape.md
+++ b/docs/adr/0003-openapi-failure-envelope-shape.md
@@ -1,0 +1,68 @@
+# ADR 0003: OpenAPI Failure Envelope Shape
+
+## Status
+
+Accepted
+
+## Context
+
+NeNe's REST contract returns failures in a standard envelope:
+
+```json
+{ "Result": true, "Data": { "status": "failure", "errorCode": "...", "errorMessage": "..." } }
+```
+
+`config/error_codes.php` is the runtime source of truth for error codes and their HTTP statuses. The OpenAPI contract under `docs/api/openapi.yaml` documents the shape consumers see.
+
+The initial TODO sample adopted a **per-error-code envelope schema** pattern: every error code (`TODO-NOT-FOUND`, `TODO-ID-REQUIRED`, `TODO-TITLE-REQUIRED`, `SESSION-CLOSED`, `LOGIN-FAILED`, `CSRF-TOKEN-INVALID`, `METHOD-NOT-ALLOWED`, ...) gets its own envelope schema in `#/components/schemas/` that pins `errorCode` and `errorMessage` to constants:
+
+```yaml
+TodoNotFoundEnvelope:
+  allOf:
+    - $ref: "#/components/schemas/ErrorEnvelope"
+    - properties:
+        Data:
+          properties:
+            errorCode:
+              const: TODO-NOT-FOUND
+            errorMessage:
+              const: TODO item was not found.
+```
+
+Each endpoint then references the specific envelope under each status. The shape is rich: consumers reading the OpenAPI see the exact error code and message constants for every documented failure.
+
+Field Trial 2 (`docs/field-trials/2026-05-field-trial-2.md`, F-5) flagged the boilerplate cost when adding two new entities (Bookmark + Tag). The trial used a single generic `ApiFailureEnvelope` instead and recorded the choice as `defer` pending a third sighting. Field Trial 3 (`docs/field-trials/2026-05-field-trial-3.md`, F-1) added a third entity (`Memo`) and again paid the per-code boilerplate, meeting the escalation trigger documented in `docs/field-trials/follow-ups.md`. Issue #251 escalated the decision to an ADR.
+
+## Decision
+
+NeNe adopts a **single generic `ApiFailureEnvelope` schema** as the canonical failure response shape across the OpenAPI contract. Per-error-code envelope schemas are removed.
+
+Specifically:
+
+- `docs/api/openapi.yaml` defines one `ApiFailureEnvelope` schema. Every documented failure response (`400`, `401`, `403`, `404`, `405`) references it directly or via a reusable `#/components/responses/` entry.
+- `errorCode` in `ApiFailureData` is typed `string` with no `const`. The OpenAPI document does not enumerate codes per endpoint.
+- The canonical list of error codes, their messages, and their HTTP statuses lives at `docs/development/error-codes.md`. `config/error_codes.php` remains the runtime source of truth; the markdown file restates it for consumers reading the contract.
+- When a new error code is added, the only documentation step is one row in `docs/development/error-codes.md`. No envelope schema additions, no per-endpoint enum updates.
+- `application/json` content for failure responses may include `examples` showing the specific `errorCode` value the endpoint actually returns, so the per-endpoint documentation is not lost — it just moves out of `schemas`.
+
+This decision applies to public OpenAPI shape only. The runtime catalog (`config/error_codes.php`) and the `ApiResponse::failure($code)` API are unchanged.
+
+## Consequences
+
+- The OpenAPI document shrinks materially. The 12 per-error-code envelope schemas (`TodoIdRequiredEnvelope`, `TodoNotFoundEnvelope`, `TodoTitleRequiredEnvelope`, `SessionClosedEnvelope`, `LoginFailedEnvelope`, `CsrfTokenInvalidEnvelope`, `MethodNotAllowedEnvelope`, plus FT3's three Memo envelopes) collapse to one shared `ApiFailureEnvelope`.
+- Adding a new entity becomes cheaper. Each new endpoint only needs success / request schemas; failure responses reuse the existing shape.
+- Per-code documentation moves from OpenAPI to `docs/development/error-codes.md`. Consumers who relied on Swagger UI to see the exact constants now click through to the markdown file. The trade-off is accepted because the runtime catalog (`config/error_codes.php`) was already the source of truth and the per-envelope constants in OpenAPI were duplicating it.
+- Endpoint responses may still include `examples` showing the actual `errorCode` value, so the link between an HTTP status and its likely error code stays visible per operation without being structurally enforced.
+- Existing consumers see no payload change: the JSON envelope shape (`Result` / `Data.status` / `Data.errorCode` / `Data.errorMessage`) is identical. Only the OpenAPI schema names change. Generated clients (which key off `operationId` and request/response schema names) will rename their failure types from `TodoNotFoundEnvelope` etc. to `ApiFailureEnvelope`.
+- The `OpenApiRuntimeContractTest` shape (PR #255) continues to work: it iterates documented operations and asserts the observed status is in the documented status list, which is independent of the envelope schema name.
+- A future trial may re-surface the documentation gap (a contributor adds a new error code but forgets to update `docs/development/error-codes.md`). Mitigation paths if that happens: (a) add a contributing check, (b) auto-generate the markdown file from `config/error_codes.php`, (c) re-evaluate the trade-off via another ADR.
+
+## Related
+
+- Issue #251 — escalation that produced this ADR.
+- `docs/field-trials/2026-05-field-trial-2.md` F-5 — original sighting.
+- `docs/field-trials/2026-05-field-trial-3.md` F-1 — third-sighting escalation.
+- `docs/field-trials/follow-ups.md` — the trigger rule that fired.
+- ADR 0002 — field-trial methodology that produced the escalation.
+- `config/error_codes.php` — runtime source of truth for error codes.
+- `docs/development/error-codes.md` — new canonical markdown reference.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -88,11 +88,11 @@ paths:
                         id: 1
                         user_id: admin
         "401":
-          description: Credentials were rejected.
+          description: Credentials were rejected (`LOGIN-FAILED`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LoginFailureEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
               examples:
                 failure:
                   value:
@@ -118,11 +118,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/BasicSuccessEnvelope"
         "403":
-          description: CSRF token was missing or invalid.
+          description: CSRF token was missing or invalid (`CSRF-TOKEN-INVALID`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CsrfTokenInvalidEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                csrfTokenInvalid:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: CSRF-TOKEN-INVALID
+                      errorMessage: Invalid CSRF token.
   /todo/index:
     get:
       tags:
@@ -139,11 +147,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/TodoListSuccessEnvelope"
         "401":
-          description: Session is missing or expired.
+          description: Session is missing or expired (`SESSION-CLOSED`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SessionClosedEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                sessionClosed:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: SESSION-CLOSED
+                      errorMessage: Session timeout. Please log in again.
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
     post:
@@ -172,23 +188,47 @@ paths:
               schema:
                 $ref: "#/components/schemas/TodoSuccessEnvelope"
         "401":
-          description: Session is missing or expired.
+          description: Session is missing or expired (`SESSION-CLOSED`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SessionClosedEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                sessionClosed:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: SESSION-CLOSED
+                      errorMessage: Session timeout. Please log in again.
         "400":
-          description: TODO title was missing.
+          description: TODO title was missing (`TODO-TITLE-REQUIRED`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TodoTitleRequiredEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                titleRequired:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: TODO-TITLE-REQUIRED
+                      errorMessage: TODO title is required.
         "403":
-          description: CSRF token was missing or invalid.
+          description: CSRF token was missing or invalid (`CSRF-TOKEN-INVALID`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CsrfTokenInvalidEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                csrfTokenInvalid:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: CSRF-TOKEN-INVALID
+                      errorMessage: Invalid CSRF token.
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
   /todo/item/id_{id}:
@@ -223,27 +263,56 @@ paths:
               schema:
                 $ref: "#/components/schemas/TodoSuccessEnvelope"
         "401":
-          description: Session is missing or expired.
+          description: Session is missing or expired (`SESSION-CLOSED`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SessionClosedEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                sessionClosed:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: SESSION-CLOSED
+                      errorMessage: Session timeout. Please log in again.
         "400":
-          description: TODO id or title was invalid.
+          description: TODO id or title was invalid (`TODO-ID-REQUIRED` / `TODO-TITLE-REQUIRED`).
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/TodoIdRequiredEnvelope"
-                  - $ref: "#/components/schemas/TodoTitleRequiredEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                idRequired:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: TODO-ID-REQUIRED
+                      errorMessage: TODO id is required.
+                titleRequired:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: TODO-TITLE-REQUIRED
+                      errorMessage: TODO title is required.
         "404":
           $ref: "#/components/responses/TodoNotFound"
         "403":
-          description: CSRF token was missing or invalid.
+          description: CSRF token was missing or invalid (`CSRF-TOKEN-INVALID`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CsrfTokenInvalidEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                csrfTokenInvalid:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: CSRF-TOKEN-INVALID
+                      errorMessage: Invalid CSRF token.
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
     delete:
@@ -264,25 +333,49 @@ paths:
               schema:
                 $ref: "#/components/schemas/TodoDeleteSuccessEnvelope"
         "401":
-          description: Session is missing or expired.
+          description: Session is missing or expired (`SESSION-CLOSED`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SessionClosedEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                sessionClosed:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: SESSION-CLOSED
+                      errorMessage: Session timeout. Please log in again.
         "400":
-          description: TODO id was missing or invalid.
+          description: TODO id was missing or invalid (`TODO-ID-REQUIRED`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TodoIdRequiredEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                idRequired:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: TODO-ID-REQUIRED
+                      errorMessage: TODO id is required.
         "404":
           $ref: "#/components/responses/TodoNotFound"
         "403":
-          description: CSRF token was missing or invalid.
+          description: CSRF token was missing or invalid (`CSRF-TOKEN-INVALID`).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CsrfTokenInvalidEnvelope"
+                $ref: "#/components/schemas/ApiFailureEnvelope"
+              examples:
+                csrfTokenInvalid:
+                  value:
+                    Result: true
+                    Data:
+                      status: failure
+                      errorCode: CSRF-TOKEN-INVALID
+                      errorMessage: Invalid CSRF token.
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
 components:
@@ -308,13 +401,21 @@ components:
         minimum: 1
   responses:
     TodoNotFound:
-      description: TODO item was not found for the signed-in user.
+      description: TODO item was not found for the signed-in user (`TODO-NOT-FOUND`).
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/TodoNotFoundEnvelope"
+            $ref: "#/components/schemas/ApiFailureEnvelope"
+          examples:
+            notFound:
+              value:
+                Result: true
+                Data:
+                  status: failure
+                  errorCode: TODO-NOT-FOUND
+                  errorMessage: TODO item was not found.
     MethodNotAllowed:
-      description: HTTP method is not allowed for this endpoint.
+      description: HTTP method is not allowed for this endpoint (`METHOD-NOT-ALLOWED`).
       headers:
         Allow:
           description: Comma-separated allowed HTTP methods.
@@ -323,7 +424,15 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/MethodNotAllowedEnvelope"
+            $ref: "#/components/schemas/ApiFailureEnvelope"
+          examples:
+            methodNotAllowed:
+              value:
+                Result: true
+                Data:
+                  status: failure
+                  errorCode: METHOD-NOT-ALLOWED
+                  errorMessage: The HTTP method is not allowed for this endpoint.
   schemas:
     JsonEnvelope:
       type: object
@@ -444,8 +553,6 @@ components:
                       $ref: "#/components/schemas/LoginUser"
                     csrfToken:
                       type: string
-    LoginFailureEnvelope:
-      $ref: "#/components/schemas/LoginFailedEnvelope"
     Todo:
       type: object
       required:
@@ -531,108 +638,15 @@ components:
                   properties:
                     id:
                       type: integer
-    ErrorEnvelope:
+    ApiFailureEnvelope:
+      description: |
+        Canonical failure envelope for every documented error response. The
+        specific `errorCode` and `errorMessage` values are not constrained
+        here; the catalog lives at `docs/development/error-codes.md`, and
+        each operation may include an `example` showing the code it returns.
       allOf:
         - $ref: "#/components/schemas/JsonEnvelope"
         - type: object
           properties:
             Data:
               $ref: "#/components/schemas/ApiFailureData"
-    SessionClosedEnvelope:
-      allOf:
-        - $ref: "#/components/schemas/ErrorEnvelope"
-        - type: object
-          properties:
-            Data:
-              allOf:
-                - $ref: "#/components/schemas/ApiFailureData"
-                - type: object
-                  properties:
-                    errorCode:
-                      const: SESSION-CLOSED
-                    errorMessage:
-                      const: Session timeout. Please log in again.
-    LoginFailedEnvelope:
-      allOf:
-        - $ref: "#/components/schemas/ErrorEnvelope"
-        - type: object
-          properties:
-            Data:
-              allOf:
-                - $ref: "#/components/schemas/ApiFailureData"
-                - type: object
-                  properties:
-                    errorCode:
-                      const: LOGIN-FAILED
-                    errorMessage:
-                      const: Wrong user ID or user PASS
-    CsrfTokenInvalidEnvelope:
-      allOf:
-        - $ref: "#/components/schemas/ErrorEnvelope"
-        - type: object
-          properties:
-            Data:
-              allOf:
-                - $ref: "#/components/schemas/ApiFailureData"
-                - type: object
-                  properties:
-                    errorCode:
-                      const: CSRF-TOKEN-INVALID
-                    errorMessage:
-                      const: Invalid CSRF token.
-    TodoIdRequiredEnvelope:
-      allOf:
-        - $ref: "#/components/schemas/ErrorEnvelope"
-        - type: object
-          properties:
-            Data:
-              allOf:
-                - $ref: "#/components/schemas/ApiFailureData"
-                - type: object
-                  properties:
-                    errorCode:
-                      const: TODO-ID-REQUIRED
-                    errorMessage:
-                      const: TODO id is required.
-    TodoNotFoundEnvelope:
-      allOf:
-        - $ref: "#/components/schemas/ErrorEnvelope"
-        - type: object
-          properties:
-            Data:
-              allOf:
-                - $ref: "#/components/schemas/ApiFailureData"
-                - type: object
-                  properties:
-                    errorCode:
-                      const: TODO-NOT-FOUND
-                    errorMessage:
-                      const: TODO item was not found.
-    TodoTitleRequiredEnvelope:
-      allOf:
-        - $ref: "#/components/schemas/ErrorEnvelope"
-        - type: object
-          properties:
-            Data:
-              allOf:
-                - $ref: "#/components/schemas/ApiFailureData"
-                - type: object
-                  properties:
-                    errorCode:
-                      const: TODO-TITLE-REQUIRED
-                    errorMessage:
-                      const: TODO title is required.
-    MethodNotAllowedEnvelope:
-      allOf:
-        - $ref: "#/components/schemas/ErrorEnvelope"
-        - type: object
-          properties:
-            Data:
-              allOf:
-                - $ref: "#/components/schemas/ApiFailureData"
-                - type: object
-                  properties:
-                    errorCode:
-                      const: METHOD-NOT-ALLOWED
-                    errorMessage:
-                      const: The HTTP method is not allowed for this endpoint.

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -1,0 +1,49 @@
+# Error Codes
+
+Catalog of NeNe REST API error codes. The runtime source of truth is `config/error_codes.php`; this file restates the catalog in a form OpenAPI consumers can read alongside `docs/api/openapi.yaml`.
+
+For the envelope shape rationale, see ADR 0003.
+
+## Envelope
+
+Every failure response uses the same envelope, documented in OpenAPI as `ApiFailureEnvelope`:
+
+```json
+{
+  "Result": true,
+  "Data": {
+    "status": "failure",
+    "errorCode": "TODO-NOT-FOUND",
+    "errorMessage": "TODO item was not found."
+  }
+}
+```
+
+`Result` stays `true` because the response was produced by the controller (a 5xx wraps a different shape). `Data.status` is always `failure` for the codes below. The HTTP status is set by the controller based on `httpStatus` in the runtime catalog.
+
+## Catalog
+
+| Error code | HTTP status | Message | Notes |
+| --- | --- | --- | --- |
+| `SESSION-CLOSED` | 401 | Session timeout. Please log in again. | Returned when an authenticated endpoint is called without a valid `PHPSESSID` cookie. |
+| `LOGIN-FAILED` | 401 | Wrong user ID or user PASS | Returned by `POST /session/login` for rejected credentials. |
+| `CSRF-TOKEN-INVALID` | 403 | Invalid CSRF token. | Returned when a state-changing request from a logged-in client is missing or has a wrong `X-CSRF-Token` header. |
+| `METHOD-NOT-ALLOWED` | 405 | The HTTP method is not allowed for this endpoint. | Returned with the `Allow` response header listing valid methods. |
+| `ROUTE-CONFLICT` | 500 | Route configuration conflict. | Internal — surfaces when controller dispatch is ambiguous. |
+| `TODO-ID-REQUIRED` | 400 | TODO id is required. | `/todo/item/id_X` with missing or non-numeric `id`. |
+| `TODO-NOT-FOUND` | 404 | TODO item was not found. | `/todo/item/id_X` where no row matches the signed-in user. |
+| `TODO-TITLE-REQUIRED` | 400 | TODO title is required. | `POST /todo/index` or `PUT /todo/item/id_X` with empty `title`. |
+
+## Adding a new error code
+
+1. Add the entry to `config/error_codes.php` with `message` and `httpStatus`.
+2. Add a row to the table above. Match the order of the runtime file so the two are easy to diff.
+3. If the code is referenced from a new OpenAPI endpoint, the endpoint's failure response references the shared `ApiFailureEnvelope` — no per-code schema is added. The endpoint MAY include an `example` showing the specific `errorCode` value it produces.
+4. The contract test (`tests/Http/OpenApiRuntimeContractTest`) automatically discovers new endpoints and asserts that observed statuses appear in the documented status list. No test changes are needed for a new error code on an existing endpoint.
+
+## Related
+
+- `config/error_codes.php` — runtime catalog.
+- `docs/api/openapi.yaml` — OpenAPI contract; references `ApiFailureEnvelope` for every failure response.
+- `docs/api/reference-client.md` — failure-mode table for external consumers.
+- ADR 0003 — rationale for the generic envelope shape.


### PR DESCRIPTION
## Summary
- ADR-0003 を追加 — canonical failure envelope は単一の \`ApiFailureEnvelope\` に統一する判断を記録 (FT2 F-5 / FT3 F-1 のエスカレ受け、選択肢 b: generic 採用)。
- \`docs/api/openapi.yaml\` から per-error-code envelope schemas を全削除し \`ApiFailureEnvelope\` に統合。errorCode 別の可視性は endpoint 内 \`examples\` で残す。schemas 数 24 → 16 (-8)。
- \`docs/development/error-codes.md\` を新規追加。\`config/error_codes.php\` を runtime source of truth としつつ、OpenAPI 読者向けに code/HTTP/message を restate。
- 新 errorCode 追加時の追加作業は markdown 1 行のみ (envelope schema 不要)、新 entity 追加時の OpenAPI 行数は ~12 lines/errorCode 削減。
- JSON payload 不変。Generated client は failure 型名が \`TodoNotFoundEnvelope\` 等 → \`ApiFailureEnvelope\` にリネーム。Closes #251 / escalates FT2 F-5 (follow-ups.md は merge 時に削除予定)。

## Test plan
- [x] \`composer test\`: 45 / 45, 129 assertions
- [x] \`composer test:http\`: 21 / 21, 211 assertions (1 expected skip)
- [x] \`Symfony\\Yaml\` で openapi.yaml が構造として parse できる (paths=5, schemas=16, responses=2)
- [x] \`grep\` で per-code envelope への stale 参照が docs/openapi/コード上に残っていない (JsonResponderTest のメソッド名 \`testErrorEnvelope...\` は Xion 側の概念で OpenAPI とは無関係、変更なし)
- [x] Swagger UI で /todo/item/id_{id} の 400 / 404 / 403 が examples 経由で具体 errorCode を見せる

🤖 Generated with [Claude Code](https://claude.com/claude-code)