### PR TITLE
ci: HTTP smoke の health 待機を healthStatus=ok まで強化する

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,17 +48,22 @@ jobs:
       - name: Start app
         run: docker compose up -d app
 
-      - name: Wait for /health
+      - name: Wait for /health to report healthStatus=ok
         run: |
+          # Require healthStatus=ok (not just HTTP 200), because /health returns
+          # 200 even when the database is degraded — letting smoke tests run too
+          # early and fail with SQLSTATE[HY000] [2002] Connection refused.
           for i in $(seq 1 60); do
-            if curl -fsS http://localhost:8080/health > /dev/null 2>&1; then
-              echo "App became healthy after ${i}s"
+            status=$(curl -fsS http://localhost:8080/health/index 2>/dev/null | jq -r '.Data.healthStatus // "unknown"')
+            if [ "$status" = "ok" ]; then
+              echo "App became healthy (healthStatus=ok) after ${i}s"
               exit 0
             fi
             sleep 1
           done
-          echo "App did not become healthy within 60s" >&2
+          echo "App did not reach healthStatus=ok within 60s" >&2
           docker compose logs app | tail -100 >&2
+          docker compose logs mysql | tail -50 >&2
           exit 1
 
       - name: Run HTTP smoke tests


### PR DESCRIPTION
## Summary
- 現状の \"Wait for /health\" は HTTP 200 が返れば次のステップに進むが、\`/health\` は database degraded (MySQL がまだ起動しきっていない等) でも 200 を返すので、smoke テストが DB 接続前に走るレースが残っていた。
- 直近の PR #255 でこの flake が発火 (\`SQLSTATE[HY000] [2002] Connection refused\` で 18 / 21 fail → 再走で復帰)。
- 待機条件を \`Data.healthStatus == ok\` 基準に変更し、失敗時は app + mysql 両方のログを tail。
- これで FT4 以降の auto-merge / 並走 PR が flake で止まらなくなる。

## Test plan
- [x] 既存 ubuntu-latest runner に jq は標準搭載 (確認済)
- [x] 既存 60s リトライ予算は維持
- [ ] このPRのCIが green になることで動作確認