### PR TITLE
tools(field-trials): nene-ft-new.sh が .claude/CLAUDE.md skeleton も生成する

### DIFF
--- a/tools/nene-ft-new.sh
+++ b/tools/nene-ft-new.sh
@@ -142,6 +142,23 @@ cat > .claude/settings.local.json <<'EOF'
 }
 EOF
 
+echo "==> Writing .claude/CLAUDE.md (FT-specific notes for Claude Code sessions)"
+cat > .claude/CLAUDE.md <<EOF
+# FT${N} — ${TOPIC}
+
+Field trial clone. Original framework: \`${FRAMEWORK_ROOT}\`.
+
+- NeNe ref: \`${HEAD_SHA}\` (at clone time)
+- Host ports: app=${PORT_APP}, mysql=${PORT_MYSQL} (not the framework defaults 8080/3307)
+- HTTP tests: \`NENE_HTTP_BASE_URL=http://127.0.0.1:${PORT_APP} composer test:http\`
+- Trial Issue: (fill in after \`gh issue create\`)
+- Final report path (filed from framework branch, not from here): \`${FRAMEWORK_ROOT}/docs/field-trials/$(date +%Y-%m)-field-trial-${N}.md\`
+
+## Loop methodology
+
+See \`${FRAMEWORK_ROOT}/docs/field-trials/README.md\`. Nothing in this clone gets committed back to the framework except the final report (filed from a framework branch). Working notes live in \`FT${N}-PLAN.md\` here.
+EOF
+
 echo "==> Writing FT${N}-PLAN.md skeleton"
 cat > "FT${N}-PLAN.md" <<EOF
 # FT${N} — ${TOPIC}: Plan


### PR DESCRIPTION
## Summary
- \`tools/nene-ft-new.sh\` が clone 時に \`.claude/CLAUDE.md\` を追加生成する。
- 中身は最小: NeNe ref、port offset、HTTP test コマンド、Trial Issue placeholder、最終 report path、methodology link。
- Claude Code は \`.claude/CLAUDE.md\` を自動でコンテキスト取り込みするので、新規 FT clone から起動した別セッションが trial 固有情報を即座に持てる (ports が defaults と違う等の毎回ハマる点を最初に提示)。
- \`FT{N}-PLAN.md\` (人間が書く working note) と役割を分離。

## Test plan
- [x] \`bash -n tools/nene-ft-new.sh\` (syntax)
- [x] dry-run (\`NENE_FT_ROOT=\$(mktemp -d) bash tools/nene-ft-new.sh test-topic\`) で \`.claude/CLAUDE.md\` が ports/refs/path 全て展開された状態で生成されることを確認