### PR TITLE
docs(docker): Smarty compile cache のクリア手順を追加する (#266)

### DIFF
--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -197,6 +197,16 @@ This note exists because adding or altering tables in only one path is a silent 
 docker compose down
 ```
 
+## Clearing the Smarty Compile Cache
+
+`view/compile/` is written by the container's `www-data` user, so a host-side `rm view/compile/*` fails with `Permission denied`. To force a full recompile of all templates during development:
+
+```sh
+docker compose exec -T app find view/compile -type f -delete
+```
+
+The cache is regenerated on the next page request. Smarty also recompiles automatically when a `.tpl` source file's mtime changes; the manual delete is only needed when the cache itself looks stale (e.g. after editing a Smarty plugin or config).
+
 ## Notes
 
 - The Apache document root is `htdocs/`.


### PR DESCRIPTION
## Summary
- \`docs/development/docker.md\` に "Clearing the Smarty Compile Cache" セクションを追加。
- \`view/compile/\` は container 内 www-data 所有なので host \`rm\` が失敗する事実 + \`docker compose exec -T app find view/compile -type f -delete\` の one-liner を明記。
- manual clear が必要なのは Smarty plugin / config 変更時等、template mtime 変化なら自動再コンパイルされる点も補足。
- FT4 finding F-4 への対応 (closes #266)。

## Test plan
- [x] markdown rendering で表示が崩れない
- [x] FT4 trial clone で実行コマンドが動作確認済