### PR TITLE
fix(xion): ControllerBase::location() の URI 連結を正規化して double-slash を防ぐ (#264)

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -390,7 +390,7 @@ abstract class ControllerBase
     final protected function location(string $uri, bool $flag = true): never
     {
         if ($flag) {
-            $uri = URI_ROOT . $uri;
+            $uri = rtrim(URI_ROOT, '/') . '/' . ltrim($uri, '/');
         }
         throw new Xion\HttpTermination(Xion\HttpResponse::redirect($uri));
     }


### PR DESCRIPTION
## Summary
- \`class/xion/ControllerBase::location()\` の \`URI_ROOT . \$uri\` 単純連結を \`rtrim/ltrim\` で正規化。
- 典型的な Docker 開発環境 (\`URI_ROOT='/'\`) で leading slash 付き URI を渡すと Location ヘッダーが \`//path\` になる FT4 finding F-2 への対応。
- ブラウザ挙動は不変 (どちらも正常 follow)、見栄えと自動 test の assert が綺麗になる。
- 唯一の内部 caller (\`location(LOGOUT_URI)\` at line 337) を含めて呼び出し側コードは無修正で動作。

## Test plan
- [x] FT4 trial clone で manual 動作確認: POST /note/index → \`Location: //note/item/id_X\` だった
- [x] \`grep -rn 'location(' class/ tests/\` で 1 件の内部 caller のみ確認、他に影響なし
- [x] 既存 \`composer test\` 45/45 grep 経路で location() を assert していない
- [ ] このPRのCIが green (HTTP smoke が POST → redirect 経路を持っていない限り変化を検知しないが、回帰は出ないはず)

🤖 Generated with [Claude Code](https://claude.com/claude-code)