### PR TITLE
fix(tools): nene-ft-new.sh が trial clone 内から実行されるのを検出して止める (#276)

### DIFF
--- a/tools/nene-ft-new.sh
+++ b/tools/nene-ft-new.sh
@@ -54,6 +54,36 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FRAMEWORK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Sanity check: the script must run from the NeNe framework repo, not from a
+# trial clone copy. Trial clones also contain tools/nene-ft-new.sh (since they
+# are git clones of the framework), so running the script via its in-clone path
+# would silently compute FRAMEWORK_ROOT as the clone — and FT_ROOT below would
+# point at a nonexistent nested dir.
+#
+# Two checks: the marker files must exist (catches non-framework dirs), and
+# FRAMEWORK_ROOT must not be located under a `NeNe-FT/` parent (catches the
+# trial-clone case, since trial clones contain the same marker files).
+case "$FRAMEWORK_ROOT" in
+    */NeNe-FT/*)
+        echo "ERROR: this script appears to run from inside a trial clone." >&2
+        echo "       FRAMEWORK_ROOT resolved to: $FRAMEWORK_ROOT" >&2
+        echo "       Trial clones are git clones of the framework and contain a copy of" >&2
+        echo "       this script, but running it from there would create nested wrong dirs." >&2
+        echo "       Hint: cd /path/to/NeNe && tools/nene-ft-new.sh $*" >&2
+        exit 1
+        ;;
+esac
+if [ ! -f "$FRAMEWORK_ROOT/class/xion/ControllerBase.php" ] \
+    || [ ! -d "$FRAMEWORK_ROOT/docs/field-trials" ]; then
+    echo "ERROR: this script must run from the NeNe framework repo." >&2
+    echo "       FRAMEWORK_ROOT resolved to: $FRAMEWORK_ROOT" >&2
+    echo "       Expected marker files were not found:" >&2
+    [ ! -f "$FRAMEWORK_ROOT/class/xion/ControllerBase.php" ] && echo "         - $FRAMEWORK_ROOT/class/xion/ControllerBase.php" >&2
+    [ ! -d "$FRAMEWORK_ROOT/docs/field-trials" ] && echo "         - $FRAMEWORK_ROOT/docs/field-trials/" >&2
+    exit 1
+fi
+
 FT_ROOT="${NENE_FT_ROOT:-$FRAMEWORK_ROOT/../NeNe-FT}"
 
 mkdir -p "$FT_ROOT"


### PR DESCRIPTION
## Summary
- \`tools/nene-ft-new.sh\` の冒頭に二段 sanity check を追加。
- 第一段: FRAMEWORK_ROOT path に \`/NeNe-FT/\` が含まれていれば trial clone 内実行とみなして exit 1。
- 第二段: marker file (\`class/xion/ControllerBase.php\` / \`docs/field-trials/\`) が無ければ exit 1。
- どちらも復旧 hint を stderr に表示。FT5 finding F-1 への対応 (closes #276)。

## Test plan
- [x] framework dir から普通に走る: 既存挙動不変、N=次番号で clone される
- [x] simulated clone path (\`/tmp/fake-clone/NeNe-FT/clone-A/tools/nene-ft-new.sh\`) から走る: ERROR + exit 1 + hint 表示
- [x] \`bash -n\` syntax OK
- [x] FT5 で踏んだ実害 (\`NeNe-FT/NeNe-FT/ft1-...\`) は今後発生しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)