### PR TITLE
feat(ini): LOGOUT_URI を NENE_LOGOUT_URI で env override 可能にする (#277)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -20,6 +20,7 @@ services:
       NENE_DB_USER: "${NENE_DB_USER:-nene}"
       NENE_DB_PASS: "${NENE_DB_PASS:-nene}"
       NENE_SAMPLE_ADMIN_PASSWORD: "${NENE_SAMPLE_ADMIN_PASSWORD:-admin}"
+      NENE_LOGOUT_URI: "${NENE_LOGOUT_URI:-/}"
     ports:
       - "${NENE_PORT:-8080}:80"
     volumes:

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -70,6 +70,14 @@ Use another phpMyAdmin port if needed:
 NENE_PHPMYADMIN_PORT=8083 docker compose up --build
 ```
 
+Override the unauthenticated redirect target if your app has a custom login page:
+
+```sh
+NENE_LOGOUT_URI=/auth/login docker compose up --build
+```
+
+`LOGOUT_URI` is used by `ControllerBase::sessionCheck()` when an unauthenticated visitor hits an HTML page that requires login. The default `/` sends them to the site root; set this to your login URL (e.g. `/auth/login`) so they land on a useful page instead of the index splash.
+
 ## Session Cookie Settings
 
 The app explicitly configures PHP session Cookie attributes before `session_start()`:

--- a/ini/xSystemIni.php
+++ b/ini/xSystemIni.php
@@ -122,7 +122,7 @@ define('SESSION_COOKIE_LIFETIME', (int)$getEnv('NENE_SESSION_LIFETIME', '0'));
 const OWN_DOMAIN = 'localhost';
 const URI_ROOT = '/';
 const LAYERS_NUM = 0;
-const LOGOUT_URI = (getenv('NENE_LOGOUT_URI') !== false) ? (string)getenv('NENE_LOGOUT_URI') : '/';
+define('LOGOUT_URI', $getEnv('NENE_LOGOUT_URI', '/'));
 
 /*
  * Public assets.

--- a/ini/xSystemIni.php
+++ b/ini/xSystemIni.php
@@ -122,7 +122,7 @@ define('SESSION_COOKIE_LIFETIME', (int)$getEnv('NENE_SESSION_LIFETIME', '0'));
 const OWN_DOMAIN = 'localhost';
 const URI_ROOT = '/';
 const LAYERS_NUM = 0;
-const LOGOUT_URI = '/';
+const LOGOUT_URI = (getenv('NENE_LOGOUT_URI') !== false) ? (string)getenv('NENE_LOGOUT_URI') : '/';
 
 /*
  * Public assets.


### PR DESCRIPTION
## Summary
- \`ini/xSystemIni.php\` の \`const LOGOUT_URI = '/';\` を env-override 可能に: \`getenv('NENE_LOGOUT_URI')\` があれば使う、無ければ default \`/\`。
- \`compose.yaml\` の app environment に \`NENE_LOGOUT_URI: "\${NENE_LOGOUT_URI:-/}"\` を追加。
- \`docs/development/docker.md\` の Environment Variables section に使用例を追記 (\`/auth/login\` 等)。
- default \`/\` 維持なので既存 deployment 無変更。FT5 finding F-2 への対応 (closes #277)。

## Test plan
- [x] env 未設定 → \`LOGOUT_URI\` = \`/\` (既存挙動)
- [x] \`NENE_LOGOUT_URI=/auth/login\` → \`LOGOUT_URI\` = \`/auth/login\`
- [x] markdown 更新: section 構造 + コード block 整合確認
- [x] FT5 trial clone で同等の手動書き換えが動作していた実績あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)