### PR TITLE
docs(api): reference-client.md に session_regenerate_id 挙動 + HTML login note を追記する (#282)

### DIFF
--- a/docs/api/reference-client.md
+++ b/docs/api/reference-client.md
@@ -70,6 +70,28 @@ await call('POST', '/session/logout');
 - The session cookie (`PHPSESSID`) is `HttpOnly` and `SameSite=Lax`. JavaScript cannot read it; the browser handles it. Set `Secure` in production via `NENE_SESSION_SECURE=1`.
 - The CSRF token is returned in the JSON body — not a cookie — and the client is expected to hold it in memory for the duration of the session. Do not persist it to local storage or send it cross-origin; if the token leaks, an attacker with a valid session id can impersonate the user.
 
+## Session id regeneration on login
+
+`POST /session/login` calls `session_regenerate_id(true)` server-side. As a side effect, the response carries **two** `Set-Cookie: PHPSESSID=...` headers — first the old session id (immediately invalidated), then the newly regenerated one. Your client must keep the **last** `PHPSESSID=` value, not the first.
+
+Most HTTP clients handle this correctly because they update the cookie store as headers stream in. Hand-rolled clients that loop over headers manually — `curl -c jar` with custom parsing, raw `file_get_contents` + `$http_response_header`, low-level socket reads — must iterate `Set-Cookie` headers and take the last one with a matching name:
+
+```php
+// Hand-rolled cookie extraction: take the LAST PHPSESSID=, not the first.
+$latest = '';
+foreach ($http_response_header as $line) {
+    if (preg_match('/^Set-Cookie:\s*PHPSESSID=([^;]+)/i', $line, $m)) {
+        $latest = $m[1];
+    }
+}
+```
+
+Using the first `PHPSESSID=` keeps the old, already-invalidated session id and every subsequent request will appear unauthenticated.
+
+## Notes for HTML login (not REST)
+
+If you implement a server-rendered login form rather than calling REST `/session/login`, the same `AuthSession::login(array $user)` API is used internally. The `$user` array is the row returned by `UserMapper::findByCredentials($user_id, $user_pass)`; pass it through directly. The fields read by `AuthSession::login()` are `id`, `user_id`, `user_name`, and `e_mail` — any extra columns on the row are ignored. See `docs/tutorials/building-a-service.md` for the HTML login pattern.
+
 ## Failure modes
 
 | Response | Cause | Fix |


### PR DESCRIPTION
## Summary
- \`docs/api/reference-client.md\` に 2 つの new section:
  - **Session id regeneration on login**: \`session_regenerate_id(true)\` で login レスポンスに 2 つの \`Set-Cookie: PHPSESSID=\` が来る挙動、外部 client は最後の値を保存する必要、ハンドロール抽出のコード例。
  - **Notes for HTML login (not REST)**: HTML login form 独自実装時、\`AuthSession::login(\$user)\` の \$user は \`UserMapper::findByCredentials()\` 返り値そのまま、読まれるフィールドは id/user_id/user_name/e_mail。
- FT5 で test client が初版でハマった罠 (8 round 中 3 fail) を明示。FT5 finding F-8 への対応 (closes #282)。

## Test plan
- [x] markdown rendering で section 構造 + code block 整合
- [x] PHP コード例が \`$http_response_header\` パターンとして正しい (FT5 trial で動作実証済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)