### PR TITLE
docs(tutorial): URL controller セグメントの命名規約 (kebab-case 不可) を明文化する (#280)

### DIFF
--- a/docs/tutorials/building-a-service.md
+++ b/docs/tutorials/building-a-service.md
@@ -106,6 +106,8 @@ The same three patterns apply to `htdocs/js/...` for JavaScript. Files are emitt
 
 The dispatcher resolves `/page/about` to `PageController::aboutAction()`. `ControllerBase` automatically chooses `view/source/page/about.tpl` when it exists.
 
+URL controller segments must be a **single lowercase word** (`page`, `note`, `bookmark`), not kebab-case (`private-note`, `bookmark-tag`). The dispatcher forms the class name via `ucfirst(strtolower($controller)) . 'Controller'`, and PHP class names cannot contain hyphens. Multi-word concepts should be joined: `/privatenote/index` → `PrivatenoteController::indexAction()`, not `/private-note/index`. Action segments follow the same rule.
+
 For the full template, CSS, JavaScript, and auto-loading rules, see `docs/frontend/assets.md`.
 
 ## Handle a Form POST


### PR DESCRIPTION
## Summary
- \`docs/tutorials/building-a-service.md\` の "Add a Fixed Page" section に URL controller 命名 rule を 1 段落追加。
- dispatcher が \`ucfirst(strtolower(\$controller)) . 'Controller'\` で class 名を形成 → ハイフン入り URL は invalid な PHP class 名を要求して 404 になる事実を明示。
- 「multi-word は連結 (\`/privatenote\`)」「kebab-case (\`/private-note\`) は使わない」を例付きで規定。
- FT5 finding F-5 への対応 (closes #280)。

## Test plan
- [x] markdown rendering で段落が他の content と論理的に並ぶ位置に入る
- [x] FT5 trial で \`/private-note\` が実際に 404 になり、\`/privatenote\` で動いた実走確認済

🤖 Generated with [Claude Code](https://claude.com/claude-code)