### PR TITLE
ci: HTTP smoke の health 待機を 120s に引き上げる

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,13 @@ jobs:
           # Require healthStatus=ok (not just HTTP 200), because /health returns
           # 200 even when the database is degraded — letting smoke tests run too
           # early and fail with SQLSTATE[HY000] [2002] Connection refused.
-          for i in $(seq 1 60); do
+          #
+          # 120s budget: the app container's init does composer install +
+          # ./init.sh + apache startup, which can take 60-90s on a cold GitHub
+          # Actions runner. MySQL is also still finishing its first-boot init at
+          # the start of this window. Don't reduce below ~90s without checking
+          # tail-end runs on actually-slow runners.
+          for i in $(seq 1 120); do
             status=$(curl -fsS http://localhost:8080/health/index 2>/dev/null | jq -r '.Data.healthStatus // "unknown"')
             if [ "$status" = "ok" ]; then
               echo "App became healthy (healthStatus=ok) after ${i}s"
@@ -61,7 +67,7 @@ jobs:
             fi
             sleep 1
           done
-          echo "App did not reach healthStatus=ok within 60s" >&2
+          echo "App did not reach healthStatus=ok within 120s" >&2
           docker compose logs app | tail -100 >&2
           docker compose logs mysql | tail -50 >&2
           exit 1


### PR DESCRIPTION
## Summary
- \`.github/workflows/tests.yml\` の "Wait for /health to report healthStatus=ok" 待機 budget を 60s → 120s。
- PR #284 の CI が 60s timeout で fail した実例があったため。MySQL 初回 init + app composer install + apache 起動が cold runner で 60-90s かかる場合あり。
- コメントに「90s 未満に減らす時は実 runner で要確認」を追記。

## Test plan
- [x] このPRのCIが green になることで動作確認
- [x] 既存 PRs (#284 等) を rebase / push 不要、次の CI 走で恩恵を受ける

🤖 Generated with [Claude Code](https://claude.com/claude-code)