### PR TITLE
feat(composer): setup shortcut を scripts に追加する (#298)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "symfony/yaml": "^6.4"
     },
     "scripts": {
+        "setup": "@php cli/setupDatabase.php --env=.env --yes",
         "test": "phpunit --testsuite unit",
         "test:http": [
             "@php tools/test-http-preflight.php",


### PR DESCRIPTION
## Summary
- \`composer.json\` の \`scripts\` に \`setup\` を追加: \`"setup": "@php cli/setupDatabase.php --env=.env --yes"\`
- \`composer list\` / \`composer help\` から発見可能になり、fresh installer / AI agent が deployment docs を読まずに DB セットアップへ到達できる。
- FT6 finding F-5 への対応 (closes #298)。

## Test plan
- [x] \`composer validate --strict\` pass
- [x] \`@php\` プレフィックス pattern は既存 scripts (\`@php tools/test-http-preflight.php\`) と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)