### PR TITLE
fix(cli): setupDatabase.php で --env=PATH 指定時にファイル不在を error にする (#297)

### DIFF
--- a/cli/setupDatabase.php
+++ b/cli/setupDatabase.php
@@ -31,7 +31,15 @@ if (isset($options['help'])) {
     return 0;
 }
 
-$envPath = resolveEnvPath(is_string($options['env'] ?? null) ? $options['env'] : '.env');
+$envOptionRaw = $options['env'] ?? null;
+$envExplicit = is_string($envOptionRaw);
+$envPath = resolveEnvPath($envExplicit ? $envOptionRaw : '.env');
+
+if ($envExplicit && !is_file($envPath)) {
+    fwrite(STDERR, 'Specified env file not found: ' . $envPath . PHP_EOL);
+    return 1;
+}
+
 $loadedEnv = EnvLoader::loadIfExists($envPath);
 
 Initialize::init();


### PR DESCRIPTION
## Summary
- \`cli/setupDatabase.php\` で \`--env=PATH\` を明示的に渡したのに PATH が存在しない場合、STDERR にエラーメッセージ + exit 1 で抜けるよう変更。
- \`--env=\` 省略時の "default \`.env\` を try、無ければ silent fallback" は既存挙動のまま (intent が無い場合は厳格化しない)。
- production deployment script で \`--env=PATH\` を typo した際の silent failure を防ぐ。FT6 finding F-4 への対応 (closes #297)。

## Test plan (実機確認済)
- [x] \`php cli/setupDatabase.php --env=/tmp/missing.env --yes\` → "Specified env file not found: /tmp/missing.env" + exit 1
- [x] \`php cli/setupDatabase.php --env=/var/www/html/.env --yes\` → 既存挙動 (load + proceed)
- [x] \`php cli/setupDatabase.php --yes\` → 既存挙動 (default \`.env\` を try、なければ process env)

self-review: \`docs/review/release-ci.md\` (CLI 挙動変更は手動 smoke test → 確認済)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)