### PR TITLE
fix(cli): initSQLite.php に --yes / --help flag を追加する (#296)

### DIFF
--- a/cli/initSQLite.php
+++ b/cli/initSQLite.php
@@ -23,17 +23,33 @@ ini_set('display_errors', '1');
 error_reporting(E_ALL);
 date_default_timezone_set('Asia/Tokyo');
 
+$options = getopt('', ['yes', 'help']) ?: [];
+if (isset($options['help'])) {
+    echo <<<'TEXT'
+Usage:
+  php cli/initSQLite.php [--yes] [--help]
+
+Options:
+  --yes   Run without the confirmation prompt.
+  --help  Show this help.
+
+TEXT;
+    return 0;
+}
+
 Initialize::init();
 
 echo 'Welcome NeNe-PHP CLI!' . PHP_EOL . PHP_EOL;
 echo 'This command initializes the SQLite database used by the fallback sample runtime.' . PHP_EOL;
 echo 'Target file: ' . DB_DIR . DB_FILE . PHP_EOL . PHP_EOL;
-echo 'Do you want to initialize SQLite? (Y/N)' . PHP_EOL;
 
-$answer = trim((string)fgets(STDIN));
-if (!in_array(strtolower($answer), ['y', 'yes'], true)) {
-    echo 'OK. Bye!' . PHP_EOL;
-    return 0;
+if (!isset($options['yes'])) {
+    echo 'Do you want to initialize SQLite? (Y/N)' . PHP_EOL;
+    $answer = trim((string)fgets(STDIN));
+    if (!in_array(strtolower($answer), ['y', 'yes'], true)) {
+        echo 'OK. Bye!' . PHP_EOL;
+        return 0;
+    }
 }
 
 try {


### PR DESCRIPTION
## Summary
- \`cli/initSQLite.php\` に \`--yes\` と \`--help\` flag を追加。
- \`setupDatabase.php\` と同じ \`getopt\` パターンで実装、挙動も対応:
  - \`--help\` → usage 表示 + exit 0
  - \`--yes\` → 確認 prompt を skip
  - flag なし → 既存の Y/N prompt 挙動 (後方互換)
- noninteractive 実行 (CI / docker compose run) で \`echo "Y" \|\` workaround が不要に。
- FT6 finding F-3 への対応 (closes #296)。

## Test plan (実機確認済)
- [x] \`--help\` で usage 表示 + exit 0
- [x] \`--yes\` で prompt skip + DB 作成
- [x] flag なしで既存 Y/N 挙動 (互換性確認)
- [x] N 入力時の "OK. Bye!" exit 0 経路も健在

🤖 Generated with [Claude Code](https://claude.com/claude-code)