### PR TITLE
docs(database): schema が 3 箇所に重複していることを明文化する (#295)

### DIFF
--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -175,12 +175,13 @@ NENE_DB_TYPE=SQLite3 NENE_DB_FILE=nene.db docker compose up --build app
 
 ## Schema Parity Between SQLite and MySQL
 
-NeNe initializes two separate development databases through two separate scripts:
+NeNe initializes the sample database through **three** independent code paths:
 
-- `cli/initSQLite.php` — PHP code that creates SQLite tables and `updated_at` triggers when the SQLite3 fallback is used.
 - `docker/mysql/init/001_schema.sql` — declarative SQL applied by the MySQL container on first boot under Docker Compose.
+- `cli/initSQLite.php` — legacy PHP CLI that creates SQLite tables and `updated_at` triggers. Maintained for backwards compatibility; new deployment guides should prefer `cli/setupDatabase.php`.
+- `class/xion/DatabaseInstaller.php` — the generic installer invoked by `cli/setupDatabase.php`. Holds inline CREATE TABLE statements for both MySQL and SQLite paths. This is the canonical installation path.
 
-These files **do not share a source of truth**. Nothing in CI enforces parity between them. When a contributor adds or alters a table, both files must be edited in the same change, and both runtimes must be verified locally.
+These three sites **do not share a source of truth**. Nothing in CI enforces parity. When a contributor adds or alters a table, **all three** must be edited in the same change, and both runtimes verified locally.
 
 When in doubt about whether the two paths agree, compare the table sets:
 

--- a/docs/review/database.md
+++ b/docs/review/database.md
@@ -10,7 +10,7 @@ Source policies:
 
 ## Checklist
 
-- [ ] Schema changes are mirrored in **both** `docker/mysql/init/001_schema.sql` **and** `cli/initSQLite.php`. The two files do not share a source of truth; CI does not enforce parity.
+- [ ] Schema changes are mirrored in **all three** locations: `docker/mysql/init/001_schema.sql`, `cli/initSQLite.php`, and `class/xion/DatabaseInstaller.php` (used by `cli/setupDatabase.php`). The three sites do not share a source of truth; CI does not enforce parity.
 - [ ] SQLite path includes an `..._updated_at_trigger` to mirror MySQL's `ON UPDATE CURRENT_TIMESTAMP`.
 - [ ] Foreign keys cascade-delete or restrict deliberately; the choice matches the entity lifecycle.
 - [ ] Per-user tables expose `user_id` as a `BIGINT UNSIGNED` FK to `users.id`, indexed (`KEY ..._user_id_index`).


### PR DESCRIPTION
## Summary
- \`docs/development/docker.md\` の "Schema Parity" セクションを 2-site → **3-site** に拡張。\`class/xion/DatabaseInstaller.php\` (\`cli/setupDatabase.php\` の本体) を追加し、各 site の役割を明示。
- \`docs/review/database.md\` self-review checklist の対応項目を "all three" に更新。
- 既存 FT2 F-7 / PR #240 の延長 (FT6 で 3 site の重複を発見、本 PR で docs を整合)。
- FT6 finding F-2 への対応 (closes #295)。

## Test plan
- [x] markdown rendering で section / list 構造が崩れない
- [x] 3 site 全ての存在を grep で再確認: \`grep -rl 'CREATE TABLE.*users' docker/mysql/init/ cli/ class/xion/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)