### PR TITLE
docs: TODO / roadmap / milestones を 2026-05-21 ループ後の状態に同期する

### DIFF
--- a/docs/milestones/README.md
+++ b/docs/milestones/README.md
@@ -84,6 +84,8 @@ Current status: `v0.1.0` is the first planned tag. It represents the point where
 
 ### reviewable-small-service-delivery
 
+Status: substantially complete as of 2026-05-21.
+
 Goal: make NeNe a small PHP framework that lowers code review cost by keeping human-written and AI-assisted small-service changes in the same visible implementation shape.
 
 Context: NeNe's next phase should build on the renovated legacy foundation. The framework should not grow into a large full-stack platform, and it does not need a broad redesign just to become "AI-readable." It already has visible `/{controller}/{action}` flow, predictable controller and REST method names, a small codebase, Docker setup, OpenAPI, tests, security defaults, and self-review checklists. The next step is to make those strengths reduce real review friction: a reviewer should quickly know where to inspect HTTP input, business rules, SQL, API contracts, and tests.
@@ -117,11 +119,38 @@ Completion criteria:
 - A first service can be built by following docs from page/controller through Service/use-case, REST endpoint, database access, OpenAPI, and tests.
 - #163 defines the review-cost-reduction framing for Phase 6.
 - #164 updates the public entry message around reviewable small-service delivery.
-- #165 and #145 define a concrete reference implementation for the expected Controller, Service, Mapper, OpenAPI, and test workflow.
+- ~~#165 and #145 define a concrete reference implementation~~ — both closed 2026-05-21; the FT3–FT6 trial-driven PRs, the tutorial extensions added during those trials, and the `docs/review/` self-review checklists (PR #291) deliver the same value through smaller reviewable changes.
 - #167 explains how stable conventions reduce review load caused by highly variable implementation styles.
 - Local Docker setup remains simple, including app, MySQL, phpMyAdmin, Swagger UI, and test commands.
 - Production-facing docs continue to warn about secrets, debug output, local Docker credentials, phpMyAdmin exposure, and database initialization.
 - New examples do not introduce hidden routing, heavy ORM behavior, or broad framework abstractions.
+
+Additional artifacts that consolidate this milestone:
+
+- ADR 0003 (canonical OpenAPI failure envelope shape).
+- ADR 0004 (`ControllerBase::unauthorizedRedirect()` hook for per-controller redirect targets).
+- `docs/review/` self-review checklists: REST controller, HTML controller, database, OpenAPI contract, docs/ADR, release/CI, field-trial report (PR #291, adapted from NENE2's pattern).
+- `docs/tutorials/building-a-service.md` now covers HTML form POST handling, Protect an Authenticated Form, HTML login form, asset auto-discovery convention, and URL controller naming, in addition to the original REST flow.
+- `docs/development/cli.md` (new) declares `cli/setupDatabase.php` as the canonical installer and `cli/initSQLite.php` as the legacy alternative.
+
+### field-trials-loop
+
+Status: continuous, running since 2026-05-20.
+
+Goal: keep external usability evidence-driven by running fresh-clone field trials (`tools/nene-ft-new.sh {topic}`) on different surfaces and closing every spawned Issue before the next trial starts.
+
+Context: methodology is documented in ADR 0002 and `docs/field-trials/README.md`. The loop is described as a continuous quality gate rather than a one-off project, so it lives as a rolling milestone instead of a closeable goal.
+
+Completion criteria:
+
+- The loop is **never** marked complete; it is alive as long as NeNe is maintained.
+- Each trial produces a report under `docs/field-trials/YYYY-MM-field-trial-{N}.md` from `docs/templates/field-trial-report.md`.
+- Each non-deferred finding is filed as a focused GitHub Issue with the `field-trial` label and closed by a merged PR before the next trial starts.
+- Deferred findings live in `docs/field-trials/follow-ups.md` with an explicit re-evaluation trigger.
+
+Completed trials (2026-05-20 → 2026-05-21): FT1, FT2, FT3, FT4, FT5, FT6.
+
+Linked Issues: every Issue carrying the `field-trial` label.
 
 ## Maintenance Rule
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -137,7 +137,14 @@ Future candidates:
 
 ## 6. Reviewable Small-Service Delivery
 
-Status: next phase.
+Status: substantially complete as of 2026-05-21. The phase's principles are now reinforced by the field-trial loop (Phase 7) plus four trial-driven artifacts:
+
+- ADR 0003 (canonical OpenAPI failure envelope shape) keeps API contracts uniform across endpoints.
+- ADR 0004 (`ControllerBase::unauthorizedRedirect()` hook) keeps auth-redirect behavior overridable per controller without breaking the dispatch invariant.
+- `docs/review/` self-review checklists (REST controller, HTML controller, database, OpenAPI contract, docs/ADR, release/CI, field-trial report) document the standard shape humans and AI agents should produce.
+- The tutorial `docs/tutorials/building-a-service.md` now covers HTML form POST, Protect an Authenticated Form, HTML login form, asset auto-discovery, URL controller naming, OpenAPI integration — the previously missing reference flows.
+
+The two "reference implementation" Issues that originally framed this phase (#145, #165) were closed on 2026-05-21 because the trial-driven work delivers the same value through smaller, reviewable PRs.
 
 Goal:
 
@@ -167,18 +174,19 @@ Completed:
 - #163: Reframed the next phase around reducing code review cost through consistent implementation conventions.
 - #164: Updated the public entry to present NeNe as a reviewable small-service PHP framework.
 - #167: Added the review-cost angle around modern pattern learning and implementation-style variance.
+- #145, #165 (closed 2026-05-21): the AI-assisted reference implementation and the reviewable Controller-Service-Mapper proof are delivered through the FT3–FT6 trial-driven PRs, tutorial extensions, and `docs/review/` checklists rather than a single dedicated reference-implementation Issue.
+- ADR 0003 — canonical OpenAPI failure envelope shape.
+- ADR 0004 — `ControllerBase::unauthorizedRedirect()` hook.
+- #271: imported NENE2's `docs/review/` self-review checklist shape, adapted to NeNe's surfaces.
 
 Future candidates:
 
-- #165: Use the reference implementation to prove the reviewable Controller-Service-Mapper shape.
-- #145: Add a small-service reference implementation that shows the expected shape of page, REST endpoint, service/use-case, mapper, OpenAPI, and test changes.
-- Make the first-service tutorial even more repeatable from clone to local verification.
 - Improve comments and PHPDoc only where they help readers understand framework boundaries.
-- Add lightweight checklists for small-service delivery readiness, including environment, database, OpenAPI, tests, and production safety notes.
+- Promote the project (#178 / #179 / #180) once the Phase 6 conventions are stable enough to demo externally.
 
 ## 7. Field Trials
 
-Status: methodology adopted; FT1 + FT2 complete; FT3 starting.
+Status: methodology adopted (ADR 0002). FT1–FT6 complete as of 2026-05-21.
 
 Goal:
 
@@ -201,10 +209,22 @@ Methodology and templates:
 
 Completed:
 
-- **FT1** — baseline trial from `ft1-bookmarklog`. The intended scope was a Bookmark+Tag CRUD service, but the baseline phase produced enough findings to fill the trial. Outcomes: a 1-line `main` hotfix (PR #223 closing a PHP fatal in `PdoConnection::__destruct()`), a new CI HTTP runtime smoke job (#230), three small UX and docs improvements (#228, #229, #231). Report: `docs/field-trials/2026-05-field-trial-1.md`.
-- **FT2** — Bookmark + Tag M:N CRUD trial from `ft2-bookmark-tag`. Two-entity REST service with transactional relation diff against the clean post-FT1 baseline. 7 findings; 4 filed as Issues for follow-up (TransactionManager domain-error path, URL parameter convention docs, junction-table guidance, schema parity note). Report: `docs/field-trials/2026-05-field-trial-2.md`.
+- **FT1** — baseline trial from `ft1-bookmarklog`. The intended scope was Bookmark+Tag CRUD, but the baseline phase produced enough findings to fill the trial. Outcomes: a 1-line `main` hotfix (PR #223 closing a PHP fatal in `PdoConnection::__destruct()`), a new CI HTTP runtime smoke job (#230), and three small UX / docs improvements (#228, #229, #231). Report: `docs/field-trials/2026-05-field-trial-1.md`.
+- **FT2** — Bookmark + Tag M:N CRUD from `ft2-bookmark-tag`. 7 findings; 4 filed as Issues (TransactionManager domain-error path, URL parameter convention docs, junction-table guidance, schema parity note). FT2 F-5 was later escalated in FT3 and resolved via ADR-0003. Report: `docs/field-trials/2026-05-field-trial-2.md`.
+- **FT3** — auth + CSRF REST trial from `ft3-authlog`. 6 findings; ADR-0003 (canonical OpenAPI failure envelope shape) born from F-1 (escalation of FT2 F-5). Report: `docs/field-trials/2026-05-field-trial-3.md`.
+- **FT4** — server-rendered HTML trial from `ft4-smarty-html`. 9 findings covering Smarty escape behavior, asset auto-discovery convention, HTML form POST handling, compile cache hygiene, and a small `location()` URI fix. Report: `docs/field-trials/2026-05-field-trial-4.md`.
+- **FT5** — auth × HTML cross trial from `ft5-protected-notes`. 10 findings; ADR-0004 (`ControllerBase::unauthorizedRedirect()` hook) born. The CI workflow's `Wait for /health` step was hardened to require `healthStatus=ok` with a 120s budget after a debugging mis-diagnosis. Report: `docs/field-trials/2026-05-field-trial-5.md`.
+- **FT6** — CLI installer trial from `ft6-cli-tooling` (first CLI-only trial). 7 findings; `composer setup` shortcut, `cli/setupDatabase.php` `--env=PATH` strict mode, `cli/initSQLite.php` `--yes` / `--help`, schema 3-way parity documentation, new `docs/development/cli.md` declaring `setupDatabase.php` canonical and `initSQLite.php` legacy. Report: `docs/field-trials/2026-05-field-trial-6.md`.
+
+Infrastructure landed alongside the trials:
+
+- `tools/nene-ft-new.sh` one-shot clone bootstrap (port offset, `.claude/settings.local.json`, `.claude/CLAUDE.md`, `FT{N}-PLAN.md` skeleton, sanity check that blocks accidental clone-cwd invocation).
+- `field-trial` GitHub label applied retroactively to historical trial-related Issues.
+- `main` branch protection with required status checks; the FT3–FT6 follow-up loops merged via `gh pr merge --auto`.
+- `docs/review/field-trial-report.md` self-review checklist referenced by the methodology.
+- `docs/field-trials/follow-ups.md` rules for deferred findings, with FT2 F-5 escalated and removed during FT3.
 
 Future candidates:
 
-- FT3 (after FT2 follow-up Issues close): a different surface — candidates are session/CSRF flow, Smarty rendering, OpenAPI workflow polish, or deployment.
-- Subsequent trials should each target a different surface rather than retesting the same paths.
+- **FT7+** — remaining FT-untouched surfaces: error pages (404 / 500 templates and the `htdocs/index.php` catch-all), production-mode deployment probe (`NENE_APP_ENV=production` + secure cookie + log rotation behavior), Smarty custom plugin authoring (`view/plugins/`), OpenAPI authoring workflow round-trip, schema source-of-truth consolidation (ADR-class, triggered when a future trial actually trips on the three-site drift surfaced by FT6 F-2).
+- Subsequent trials should each target a different surface rather than retesting paths already exercised by FT1–FT6.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,7 +6,36 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 - #178: Prepare the Qiita hands-on implementation tutorial article.
 
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously through 2026-05-21. As of that day's close: zero non-promotion Issues remain open, six trials (FT1–FT6) are complete, and four ADRs are in place (0001–0004). The framework is ready for the publication / outreach push (#178 → #179 → #180) which is the only currently active line of work.
+
 ## Recently Completed
+
+### 2026-05-21 — FT3 / FT4 / FT5 / FT6 + infra + checklists
+
+Single-day wave of trial-driven improvements across the framework, documentation, and process.
+
+**FT3 (authlog — REST auth + CSRF):** report PR #250; follow-ups #251–#253 → PR #254 (Reference Client docs), PR #255 (self-discovering contract test), PR #256 (ADR-0003 + generic `ApiFailureEnvelope` migration). All Issues closed.
+
+**FT4 (smarty-html — server-rendered HTML pages):** report PR #262; follow-ups #263–#267 → PR #268 (compile cache tip), #269 (`location()` URI normalize), #270 (asset auto-discovery convention), #272 (Smarty escape × `nl2br`), #273 (HTML form POST tutorial section). All Issues closed.
+
+**FT5 (protected-notes — auth × HTML cross):** report PR #275; follow-ups #276–#282 → PR #283 (bootstrap script sanity check), #284 (`LOGOUT_URI` env override), #285 (reference-client.md session-regen note), #286 (URL controller naming docs), #287 (ADR-0004 + `unauthorizedRedirect()` hook), #288 (CI health-wait timeout), #289 (HTML form CSRF helper), #290 (HTML login form tutorial). All Issues closed.
+
+**FT6 (cli-tooling — installer scripts):** report PR #293; follow-ups #294–#298 → PR #299 (`composer setup` shortcut), #300 (`--env=PATH` strict), #301 (`initSQLite.php` `--yes` / `--help`), #302 (schema 3-way parity docs), #303 (canonical / legacy CLI docs + new `docs/development/cli.md`). All Issues closed.
+
+**Process import:** PR #291 added `docs/review/` self-review checklists (8 files: REST controller, HTML controller, database, OpenAPI contract, docs/ADR, release/CI, field-trial report, README index) adapted from sibling NENE2's pattern. Referenced from `docs/workflow.md` and `docs/CONTRIBUTING.md`.
+
+**Stale Issue cleanup:** #234 (FT2 trial Issue, historically open), #145 (AI-readable reference implementation goal), #165 (reviewable Controller-Service-Mapper proof) — closed with explanatory comments. The goals these Issues encoded were effectively delivered through the FT3–FT6 tutorial additions, the `docs/review/` checklists, ADR-0003, and ADR-0004.
+
+**Infra changes that landed alongside the trial loops:**
+
+- `tools/nene-ft-new.sh` — one-shot FT clone bootstrap (port offset, `.claude/settings.local.json`, `.claude/CLAUDE.md`, PLAN skeleton). Sanity check (PR #283) blocks the "run-from-clone-cwd" footgun.
+- `field-trial` GitHub label — created and applied retroactively to 18 historical Issues.
+- `main` branch protection — required status checks (`unit`, `HTTP runtime smoke (Docker)`); the improvement loops were merged via `gh pr merge --auto`.
+- CI workflow — health-wait now requires `Data.healthStatus = ok` (not just HTTP 200) and the timeout is 120s (PR #259 / #288).
+- `~/.claude/settings.json` (developer-side) — broad dev-tool wildcards replaced the narrow per-command permission accumulation that had grown in `NeNe/.claude/settings.local.json`.
+- `jq` installed on the development host.
+
+### Earlier 2026-05
 
 - #217: Add `?self` type to singleton `$instance` in 6 classes; add `: void` to `IndexController::indexAction()`; fix `@return` PHPDoc in `Dispatcher`.
 - #212: Add native type declarations to all properties in remaining `class/xion/` base classes (ModelBase, DataMapperBase, DataModelBase, RouteContext, TransactionManager, ApiResponse, Log, ErrorCode); propagate `array` type to `Todo`/`User` subclass `$schema`.
@@ -89,8 +118,8 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 - #179: Prepare the DEV Community English introduction article.
 - #180: Decide on Reddit/Hacker News only after the first article feedback.
-- #165: Prove the reviewable Controller-Service-Mapper shape through the reference implementation.
-- #145: Add an AI-assisted small-service reference implementation covering page, REST, mapper, OpenAPI, and tests.
+
+The two earlier "AI-readable reference implementation" Issues (#145, #165) were closed on 2026-05-21 — the goals they encoded are now delivered through FT3–FT6 plus the tutorial and `docs/review/` checklists. New reference-implementation needs should be spawned as new field trials.
 
 ## Field Trials
 
@@ -109,12 +138,29 @@ When a trial is run, summarize it here with the format below, then move the bloc
 ### Recently Completed
 
 - **FT1** — baseline trial from `ft1-bookmarklog`. Pivoted from a Bookmark+Tag implementation when baseline phase produced enough findings to fill the trial on its own. Closed 5 Issues: #222 (PdoConnection runtime fatal hotfix), #224 (CI runtime smoke job), #225 (`composer test:http` preflight), #226 (`NENE_HTTP_BASE_URL` docs), #227 (Docker `safe.directory`). Report: `docs/field-trials/2026-05-field-trial-1.md`. The originally planned Bookmark+Tag scope shifts to FT2.
-- **FT2** — Bookmark + Tag M:N CRUD trial from `ft2-bookmark-tag`. Two-entity REST service with transactional relation diff, dual DB schema (SQLite + MySQL), OpenAPI extension, 6 new HTTP smoke tests. 7 findings recorded. Follow-up Issues (F-1 / F-3 / F-6 / F-7) tracked below. F-2 / F-4 / F-5 deferred. Report: `docs/field-trials/2026-05-field-trial-2.md`.
+- **FT2** — Bookmark + Tag M:N CRUD trial from `ft2-bookmark-tag`. Two-entity REST service with transactional relation diff, dual DB schema (SQLite + MySQL), OpenAPI extension, 6 new HTTP smoke tests. 7 findings. Follow-up Issues #237, #238, #239, #240, #241–#244 closed; F-5 escalated in FT3 and resolved via ADR-0003. Report: `docs/field-trials/2026-05-field-trial-2.md`.
+- **FT3** — auth-protected Memo CRUD from `ft3-authlog`. Session + CSRF flow against REST. 6 findings; 3 follow-up Issues #251–#253 closed by PRs #254 / #255 / #256. ADR-0003 (generic OpenAPI failure envelope) born from F-1 (escalation of FT2 F-5). Report: `docs/field-trials/2026-05-field-trial-3.md`.
+- **FT4** — server-rendered Note CRUD from `ft4-smarty-html`. Smarty + asset auto-discovery + HTML form POST. 9 findings; 5 follow-up Issues #263–#267 closed by PRs #268 / #269 / #270 / #272 / #273. Report: `docs/field-trials/2026-05-field-trial-4.md`.
+- **FT5** — protected-notes (auth × HTML cross) from `ft5-protected-notes`. HTML login form + CSRF helper + per-controller redirect target. 10 findings; 7 follow-up Issues #276–#282 closed by PRs #283 / #284 / #285 / #286 / #287 / #289 / #290 (#287 introduced ADR-0004 `unauthorizedRedirect()` hook). Side-effect: PR #288 bumped CI health-wait timeout to 120s. Report: `docs/field-trials/2026-05-field-trial-5.md`.
+- **FT6** — CLI installer tooling (`cli/initSQLite.php`, `cli/setupDatabase.php`) from `ft6-cli-tooling`. First CLI-only trial. 7 findings (5 actionable); 5 follow-up Issues #294–#298 closed by PRs #299 / #300 / #301 / #302 / #303 (including new `docs/development/cli.md` and `composer setup` shortcut). Report: `docs/field-trials/2026-05-field-trial-6.md`.
 
 ## Backlog Candidates
+
+### Next field trial themes (FT7+)
+
+FT1–FT6 covered REST, M:N relations, auth/CSRF, HTML rendering, auth × HTML cross, and CLI tooling. The remaining FT-untouched surfaces are:
+
+- **error pages** — 404 / 500 templates, the catch-all in `htdocs/index.php`, error rendering for HTML vs REST contexts. Small, well-bounded.
+- **production-mode deployment probe** — `NENE_APP_ENV=production` + `NENE_APP_DEBUG=0` + `NENE_SESSION_SECURE=1`, error display behavior, log file rotation. Medium surface.
+- **Smarty custom plugin authoring** — `view/plugins/` (referenced by `DIR_SMARTY_PLUGINS`), how to ship a project-specific Smarty modifier or function. Niche.
+- **OpenAPI authoring workflow** — now that ADR-0003 / the contract test / `docs/development/error-codes.md` / `docs/review/openapi-contract.md` are in place, a trial that adds a fresh small entity end-to-end and measures whether the documented workflow holds up.
+- **schema source-of-truth consolidation (ADR candidate)** — FT6 F-2 surfaced that schema lives in three sites (`docker/mysql/init/001_schema.sql`, `cli/initSQLite.php`, `class/xion/DatabaseInstaller.php`). Long-term consolidation into a single PHP source is ADR-class. Trigger this when a future trial actually trips on the drift.
+
+### General code-quality candidates
 
 - Improve PHPDoc accuracy and native types across `class/xion/`, starting with shared base classes.
 - Extract dispatcher route parsing and method resolution boundaries further if future tests need lower-level coverage.
 - Decide PHP minimum and target version policy in an ADR if support outside Docker PHP 8.4 becomes important.
 - Add CI coverage for Docker runtime checks when repository resources and runtime cost are acceptable.
 - Review GitHub Actions runtime deprecation warnings and update workflow actions when Node.js 24-ready versions are available.
+- Optionally deprecate `cli/initSQLite.php` toward a thin wrapper that delegates to `cli/setupDatabase.php` (would close the redundancy surfaced by FT6 F-1; held back for backwards-compat).


### PR DESCRIPTION
## Summary
2026-05-21 の単日改修 (FT3 → FT4 → FT5 → FT6 ループ + ADR-0003 / 0004 + docs/review/ checklists + bootstrap script + branch protection + auto-merge + CI improvements + global settings consolidation + stale Issue cleanup) を反映するため、project memory 3 ファイルを同期。

### docs/todo/current.md
- "Active" に Phase 6 / 7 が安定したサインを記載、currently active は #178 のみ。
- "Recently Completed" に 2026-05-21 単日ブロックを追加 (~30 PR、4 trials、2 ADR、8 checklist files、infra 5 件、stale 3 Issue close)。
- "Next" から #145 / #165 を除外 (closed)。
- "Backlog Candidates" に FT7+ テーマ候補 (error pages / production-mode probe / Smarty plugin / OpenAPI authoring round-trip / schema consolidation ADR) を明示。

### docs/roadmap.md
- Phase 6: "next phase" → "substantially complete (2026-05-21)" + ADR-0003 / 0004 / docs/review/ / tutorial 拡張による達成。
- Phase 7: FT1-6 complete + infra 整備 (bootstrap script, label, branch protection, auto-merge) + 次回テーマ候補 5 件を明示。
- 関連 Issue 状態 (#145, #165 close) を反映。

### docs/milestones/README.md
- reviewable-small-service-delivery: substantially complete 表示、補助 artifact (ADR-0003/4 + review checklists + tutorial 拡張 + cli.md) を完了条件下に明記。
- 新規 field-trials-loop milestone を rolling milestone として記述 ("never marked complete")。完了済 trial (FT1-6) と criteria を記載。

## Test plan
- [x] markdown rendering で見出し / list 構造が崩れない
- [x] 内部 Issue 番号と PR 番号がすべて実在する (gh issue/pr view で確認)
- [x] docs/review/ への back-link が PR #291 で landed したファイルと一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)