### PR TITLE
docs: link nene-mcp package for local MCP integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This file is the first document for AI agents and automation working on NeNe.
 - Current TODO: `docs/todo/current.md`
 - ADR index: `docs/adr/README.md`
 - Field trial methodology: `docs/field-trials/README.md`
+- MCP bridge (external package): [nene-mcp](https://github.com/hideyukiMORI/nene-mcp) — NeNe integration at `docs/integration/nene.md` in that repo; not part of NeNe core
 
 ## Operating Rules
 
@@ -24,6 +25,7 @@ This file is the first document for AI agents and automation working on NeNe.
 - Do not commit secrets, credentials, local `.env` files, generated logs, cache, or compiled templates.
 - Prefer explicit, typed, testable PHP over hidden behavior.
 - Preserve NeNe's small legacy framework character while gradually improving standards support.
+- MCP stdio servers belong in [nene-mcp](https://github.com/hideyukiMORI/nene-mcp), not in `class/xion/`. Link OpenAPI operations via app-owned `docs/mcp/tools.json` when adding MCP-facing docs or examples.
 
 ## Project Direction
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The goal is not to replace Laravel, Symfony, CodeIgniter, or Laminas. The goal i
 - Releases: `docs/releases.md`
 - Testing: `docs/development/testing.md`
 - AI agent guide: `AGENTS.md`
+- MCP bridge (external): [nene-mcp](https://github.com/hideyukiMORI/nene-mcp) — Composer plugin for local stdio MCP; see [MCP with NeNe](#mcp-with-nene) below
 
 ## Routing
 
@@ -115,6 +116,21 @@ composer test
 ```
 
 `composer test` runs the unit suite. HTTP smoke tests (`composer test:http`) are conditional on `NENE_HTTP_BASE_URL` — see `docs/development/testing.md` for the runtime workflow.
+
+## MCP with NeNe
+
+NeNe does **not** embed MCP in framework core. Use the sibling package **[nene-mcp](https://github.com/hideyukiMORI/nene-mcp)** to expose local OpenAPI-backed REST as MCP tools for Cursor, Claude Desktop, and other MCP hosts.
+
+```sh
+composer require hideyukimori/nene-mcp
+```
+
+Add a NENE2-compatible tool catalog (convention: `docs/mcp/tools.json`) aligned with `docs/api/openapi.yaml`, then point your MCP client at `vendor/bin/nene-mcp`. Integration details live in the nene-mcp repository:
+
+- [NeNe integration guide](https://github.com/hideyukiMORI/nene-mcp/blob/main/docs/integration/nene.md)
+- [Sample health catalog](https://github.com/hideyukiMORI/nene-mcp/blob/main/docs/example-ne-health-catalog.md)
+
+MCP stdio handling stays in `vendor/`; do not add MCP code under `class/xion/`.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,13 @@ This directory contains project documentation for humans and AI agents.
 - `field-trials/README.md`: Field trial methodology and clone-based trial layout under `../NeNe-FT/`.
 - `templates/field-trial-report.md`: Report skeleton copied for each new trial.
 
+## Related Packages
+
+NeNe keeps MCP out of framework core. For local stdio MCP over documented HTTP APIs, use the sibling Composer package **[nene-mcp](https://github.com/hideyukiMORI/nene-mcp)**:
+
+- NeNe integration: [nene-mcp/docs/integration/nene.md](https://github.com/hideyukiMORI/nene-mcp/blob/main/docs/integration/nene.md)
+- Project overview: [nene-mcp/docs/project.md](https://github.com/hideyukiMORI/nene-mcp/blob/main/docs/project.md)
+
 ## Source of Truth
 
 GitHub Issues and PRs are the source of truth for active work.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -49,6 +49,24 @@ Cookie-authenticated state-changing REST requests must send the `X-CSRF-Token` h
 
 For an external client implementation (curl, fetch, custom SDK) see [`docs/api/reference-client.md`](reference-client.md), which spells out the cookie + CSRF mechanics with runnable examples.
 
+## MCP Tool Catalogs
+
+NeNe does not ship an MCP server. When you want AI agents (Cursor, Claude Desktop, etc.) to call local REST endpoints as tools, add the sibling package **[nene-mcp](https://github.com/hideyukiMORI/nene-mcp)** via Composer and maintain a tool catalog alongside OpenAPI.
+
+Recommended layout:
+
+```text
+docs/api/openapi.yaml    # HTTP contract (NeNe source of truth)
+docs/mcp/tools.json      # MCP tool entries aligned with OpenAPI operations
+```
+
+Keep catalog `method`, `path`, and `operationId` values consistent with `openapi.yaml`. Sample and integration steps:
+
+- [nene-mcp NeNe integration](https://github.com/hideyukiMORI/nene-mcp/blob/main/docs/integration/nene.md)
+- [Sample health tools.json](https://github.com/hideyukiMORI/nene-mcp/blob/main/docs/example-ne-health-catalog.md)
+
+Do not add MCP stdio code to `class/xion/`. The bridge runs from `vendor/bin/nene-mcp`.
+
 ## Authentication Failure Status
 
 Authentication failures use HTTP `401 Unauthorized`. `LOGIN-FAILED` means submitted credentials were rejected, and `SESSION-CLOSED` means a cookie-authenticated endpoint was called without a valid login session.


### PR DESCRIPTION
## Summary

- Document the sibling [nene-mcp](https://github.com/hideyukiMORI/nene-mcp) Composer package as the intended MCP bridge for NeNe apps
- Clarify that MCP stdio code stays out of `class/xion/`; apps add `composer require hideyukimori/nene-mcp` and maintain `docs/mcp/tools.json` aligned with OpenAPI

Closes #306

## Changes

- `README.md` — new "MCP with NeNe" section with install snippet and links
- `docs/README.md` — "Related Packages" entry
- `docs/api/README.md` — MCP tool catalog policy next to OpenAPI
- `AGENTS.md` — pointer for agents; rule to keep MCP in nene-mcp

## Test plan

- [x] Docs-only change; no runtime impact
- [ ] Review links resolve on GitHub
- [ ] Wording matches nene-mcp integration docs


Made with [Cursor](https://cursor.com)