### PR TITLE
docs: document ext-intl requirement and install in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git unzip libsqlite3-dev \
-    && docker-php-ext-install pdo_mysql pdo_sqlite \
+    && apt-get install -y --no-install-recommends git unzip libsqlite3-dev libicu-dev \
+    && docker-php-ext-install pdo_mysql pdo_sqlite intl \
     && a2enmod rewrite headers \
     && echo "ServerName localhost" > /etc/apache2/conf-available/servername.conf \
     && a2enconf servername \

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ URL parameters are passed in the `key_value` segment form (for example `/todo/it
 
 - The Docker development target is PHP 8.4.
 - Composer is required for dependency installation and autoloading.
+- **`ext-intl`** is required for bare-metal PHP installs. Dev dependencies (Symfony String, PHP-CS-Fixer, and related tooling) fail at bootstrap without it. The Docker image installs `intl`; on WSL or host PHP, enable the extension before `composer install` (for example `apt install php8.4-intl` on Debian/Ubuntu).
 
 ## Recommended Install Path
 

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -9,6 +9,8 @@ NeNe can run locally with Docker Compose.
 
 The application container uses PHP 8.4 as the Docker development target.
 
+The image installs `pdo_mysql`, `pdo_sqlite`, and **`intl`**. The `intl` extension matches the bare-metal requirement documented in the root README—dev dependencies such as Symfony String expect it during Composer bootstrap.
+
 ## Start
 
 ```sh


### PR DESCRIPTION
## Summary

- Document **`ext-intl`** in README Requirements for bare-metal / WSL PHP installs
- Install `intl` in the PHP 8.4 Docker development image for parity with documented requirements
- Note bundled extensions in `docs/development/docker.md`

## Context

nene-mcp Field Trial 1 — **F-1**: fresh `composer install` on PHP 8.4 without `intl` fails when Symfony String autoloads.

Closes #309

## Test plan

- [x] Docs-only + Dockerfile extension install
- [ ] `docker compose build` succeeds with `intl` enabled
- [ ] README Requirements readable for bare-metal integrators

Cross-repo: filed from nene-mcp FT1; NeNe maintainer to review and merge.

Made with [Cursor](https://cursor.com)