### PR TITLE
docs(error-codes): error-path early-exit (decoration) trap を明文化する (#317)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This file is the first document for AI agents and automation working on NeNe.
 - Contributor guide: `docs/CONTRIBUTING.md`
 - Workflow: `docs/workflow.md`
 - Coding standards: `docs/development/coding-standards.md`
+- Error codes & response decoration: `docs/development/error-codes.md` (envelope + the "error-path early-exit trap" — relevant whenever framework-wide response headers are added)
 - AI self-review: `docs/ai/README.md`
 - Commit conventions: `docs/development/commit-conventions.md`
 - Roadmap: `docs/roadmap.md`

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -41,6 +41,20 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 3. If the code is referenced from a new OpenAPI endpoint, the endpoint's failure response references the shared `ApiFailureEnvelope` — no per-code schema is added. The endpoint MAY include an `example` showing the specific `errorCode` value it produces.
 4. The contract test (`tests/Http/OpenApiRuntimeContractTest`) automatically discovers new endpoints and asserts that observed statuses appear in the documented status list. No test changes are needed for a new error code on an existing endpoint.
 
+## Response decoration and the error-path early-exit trap
+
+NeNe currently emits no framework-level decoration on top of the envelope (no security headers, no request IDs). If a future change adds such decoration, the *placement* matters because several error paths exit before `ControllerBase::run()` returns:
+
+- `ControllerBase::sessionCheck()` emits the `SESSION-CLOSED` 401 envelope (or the `unauthorizedRedirect()` 302) and terminates.
+- `ControllerBase::run()`'s CSRF check emits the `CSRF-TOKEN-INVALID` 403 envelope and terminates.
+- `Dispatcher::outputJsonFailure()` emits the `METHOD-NOT-ALLOWED` 405 envelope and terminates before `ControllerBase::run()` is ever called.
+- `Dispatcher::notFoundResponse()` emits the 404 response before `ControllerBase::run()` is ever called.
+- The top-level `\Throwable` catch in `htdocs/index.php` runs *after* `run()` returned (or threw), but skips `run()`'s tail entirely.
+
+**Place cross-cutting response decoration in `Nene\Xion\HttpEmitter` (or wrap `HttpEmitter::emit()`) — not in `ControllerBase::run()`'s tail.** Decoration added at `run()`'s tail will not reach 401 / 403 / 404 / 405 / 500 responses, even though it reaches every 2xx.
+
+This is the PHP analogue of the nene2-python FT75 LIFO-middleware trap. The trap is currently silent (there is nothing to skip), but it must be respected the moment any framework-wide response header is added. Surveyed and confirmed in FT7 (`docs/field-trials/2026-05-field-trial-7.md` F-6).
+
 ## Related
 
 - `config/error_codes.php` — runtime catalog.


### PR DESCRIPTION
## Summary

FT7 F-6 (Issue #317) の docs-only fix。

\`sessionCheck\` / CSRF reject / \`outputJsonFailure\` / \`notFoundResponse\` / top-level \`Throwable\` catch は **いずれも \`ControllerBase::run()\` の tail を経由しない** ため、framework-wide response decoration (security headers, request IDs 等) を将来 \`run()\` の末尾に足すと、error path にだけ decoration が乗らない silent な事故になる (nene2-python FT75 LIFO trap の PHP 版)。

\`docs/development/error-codes.md\` に「response decoration は \`HttpEmitter\` 側に置くこと」と明文化し、\`AGENTS.md\` の "Read First" に 1 行リンクを追加した。

Closes #317.

## Test plan

- [ ] markdown lint pass
- [ ] 既存 test に影響なし (docs-only)