### PR TITLE
feat(xion): must-call CSRF helper requireCsrfFromPost() を追加する (#316)

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -402,7 +402,7 @@ abstract class ControllerBase
      *
      * In REST controllers, the token is automatically verified against the
      * `X-CSRF-Token` header by the framework dispatcher; HTML actions must
-     * embed it in a hidden field and call {@see verifyCsrfFromPost()}.
+     * embed it in a hidden field and call {@see requireCsrfFromPost()}.
      *
      * @return string Session CSRF token.
      */
@@ -414,15 +414,10 @@ abstract class ControllerBase
     /**
      * Verify the CSRF token submitted via a POST form field.
      *
-     * Pairs with {@see csrfToken()}: the template emits the token as a hidden
-     * input, and the handler calls this method before performing any
-     * state-changing work.
-     *
-     *     if (!$this->verifyCsrfFromPost()) {
-     *         http_response_code(403);
-     *         // render an error template
-     *         return;
-     *     }
+     * Low-level helper: returns a boolean. Prefer {@see requireCsrfFromPost()}
+     * in new code — it cannot be silently ignored if the caller forgets to
+     * branch on the return value. Reach for this method only when the handler
+     * needs to recover from a CSRF failure rather than terminate.
      *
      * @param string $field POST field name carrying the token (default `csrf_token`).
      *
@@ -432,6 +427,50 @@ abstract class ControllerBase
     {
         $token = (string)($this->request->getPost($field) ?? '');
         return $this->AUTH_SESSION->verifyCsrfToken($token);
+    }
+
+    /**
+     * Verify the CSRF token from POST and terminate the request on failure.
+     *
+     * Pairs with {@see csrfToken()}: the template emits the token as a hidden
+     * input, and the handler calls this method before performing any
+     * state-changing work:
+     *
+     *     public function deleteAction(): void
+     *     {
+     *         if ($this->method !== 'POST') {
+     *             return;
+     *         }
+     *         $this->requireCsrfFromPost();
+     *         // ... safe to perform the destructive write
+     *     }
+     *
+     * On failure the response is emitted directly and the dispatch is
+     * terminated via `HttpTermination`:
+     *
+     * - REST callers receive a 403 `CSRF-TOKEN-INVALID` JSON envelope (matching
+     *   the automatic check in {@see run()} for `*Rest` handlers).
+     * - HTML callers receive a 403 page from `csrf.html` at the project root.
+     *
+     * Use {@see verifyCsrfFromPost()} directly only when the handler needs to
+     * react to the failure (e.g. re-render the form with field-level errors)
+     * instead of terminating.
+     *
+     * @param string $field POST field name carrying the token (default `csrf_token`).
+     *
+     * @return void
+     */
+    final protected function requireCsrfFromPost(string $field = 'csrf_token'): void
+    {
+        if ($this->verifyCsrfFromPost($field)) {
+            return;
+        }
+        if ($this->ROUTE_CONTEXT->isRest()) {
+            Xion\JsonResponder::outputArray($this->API_RESPONSE->failure('CSRF-TOKEN-INVALID'));
+        }
+        throw new Xion\HttpTermination(
+            Xion\HttpResponse::html((string)file_get_contents(DIR_ROOT . '/csrf.html'), 403)
+        );
     }
 
     /**

--- a/csrf.html
+++ b/csrf.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>403 Invalid CSRF Token</title>
+	</head>
+	<body>
+		<h1>Invalid CSRF Token</h1>
+		<p>The form submission could not be verified. Please reload the page and try again.</p>
+	</body>
+</html>

--- a/docs/review/html-controller.md
+++ b/docs/review/html-controller.md
@@ -15,7 +15,7 @@ Source policies:
 - [ ] Side-effect actions (`createAction`, `deleteAction`, `logoutAction`, ...) guard with `$this->method !== 'POST'` before performing any write; GET on a side-effect URL must not trigger the side effect.
 - [ ] Form POST handlers read input via `$this->request->getPost($key)`, not `$_POST` directly.
 - [ ] Validation failure re-renders the same form using `$this->VIEW->setTemplate('xxx/yyy.tpl')` (the auto-template would be the list, not the form).
-- [ ] Authenticated state-changing forms use the CSRF helpers: controller sets `t_csrf_token` via `$this->csrfToken()`, template emits `<input type="hidden" name="csrf_token" value="{$t_csrf_token}">`, handler calls `$this->verifyCsrfFromPost()` before the write.
+- [ ] Authenticated state-changing forms use the CSRF helpers: controller sets `t_csrf_token` via `$this->csrfToken()`, template emits `<input type="hidden" name="csrf_token" value="{$t_csrf_token}">`, handler calls `$this->requireCsrfFromPost()` before the write. Reach for the lower-level `$this->verifyCsrfFromPost()` (returns `bool`) only when the handler must recover from a CSRF failure rather than terminate with a flat 403.
 - [ ] Post-write redirects use `$this->location('/path')` (the post/redirect/get pattern); URI normalization is handled by `location()` (no leading-slash double-up — see PR #269).
 - [ ] `SESSION_CHECK = false` is set in `preAction()` only for public pages (`/auth/login` etc.). Protected pages keep the default.
 - [ ] Per-controller redirect targets (e.g. admin pages → `/admin/login`) use the `unauthorizedRedirect()` hook (ADR-0004), not by editing `LOGOUT_URI` or re-implementing `sessionCheck()`.

--- a/docs/tutorials/building-a-service.md
+++ b/docs/tutorials/building-a-service.md
@@ -210,7 +210,7 @@ When a server-rendered form submits state-changing data behind a login (creating
 | Helper | Use in | What it does |
 | --- | --- | --- |
 | `$this->csrfToken()` | controller (GET form action) | returns the session's CSRF token to embed in a hidden field |
-| `$this->verifyCsrfFromPost()` | controller (POST handler) | reads `csrf_token` from `$_POST` and verifies it against the session token |
+| `$this->requireCsrfFromPost()` | controller (POST handler) | reads `csrf_token` from `$_POST`, verifies it, and on failure terminates the dispatch with a 403 — REST callers get the `CSRF-TOKEN-INVALID` JSON envelope, HTML callers get the `csrf.html` page |
 
 Skeleton:
 
@@ -226,13 +226,7 @@ class PrivateNoteController extends ControllerBase
     public function indexAction(): void
     {
         if ($this->method === 'POST') {
-            if (!$this->verifyCsrfFromPost()) {
-                http_response_code(403);
-                $this->VIEW
-                    ->setString('t_detail', 'CSRF token check failed. Reload the form and try again.')
-                    ->setTemplate('error/forbidden.tpl');
-                return;
-            }
+            $this->requireCsrfFromPost();
             // ... do the protected write, then redirect ...
             return;
         }
@@ -253,11 +247,12 @@ Form template emits the hidden field:
 </form>
 ```
 
-The default field name is `csrf_token`. To use a different name, pass it to both sides: `$this->verifyCsrfFromPost('my_token')` and `<input type="hidden" name="my_token" value="...">`.
+The default field name is `csrf_token`. To use a different name, pass it to both sides: `$this->requireCsrfFromPost('my_token')` and `<input type="hidden" name="my_token" value="...">`.
 
-Two notes:
+Three notes:
 
-- The session token comes from `AuthSession::csrfToken()`. It is created at login and remains stable for the lifetime of the session, so the same `csrfToken()` value works across all forms in the same login. After logout (or session expiry) the token is regenerated on the next login and old hidden fields stop validating — surface that as a `403` and let the user reload.
+- The session token comes from `AuthSession::csrfToken()`. It is created at login and remains stable for the lifetime of the session, so the same `csrfToken()` value works across all forms in the same login. After logout (or session expiry) the token is regenerated on the next login and old hidden fields stop validating — `requireCsrfFromPost()` surfaces that as a `403` automatically.
+- `requireCsrfFromPost()` is the recommended shape. There is also a low-level `verifyCsrfFromPost(): bool` that returns the verification result without terminating; reach for it only when the handler needs to recover (for example, re-render the form with field-level errors) instead of returning a flat 403 page.
 - The helpers do not change REST behavior. REST handlers (`indexPostRest` etc.) still go through the automatic framework gate that validates the `X-CSRF-Token` header.
 
 ## Add a REST Endpoint
@@ -654,13 +649,7 @@ class AuthController extends ControllerBase
             $this->location('/auth/login');
             return;
         }
-        if (!$this->verifyCsrfFromPost()) {
-            http_response_code(403);
-            $this->VIEW
-                ->setString('t_detail', 'CSRF token check failed. Reload the page and try again.')
-                ->setTemplate('error/forbidden.tpl');
-            return;
-        }
+        $this->requireCsrfFromPost();
         $this->AUTH_SESSION->logout(true);
         $this->location('/auth/login');
     }


### PR DESCRIPTION
## Summary

FT7 F-5 (Issue #316, severity high) の本体 fix。

### 何を直したか

\`verifyCsrfFromPost(): bool\` は戻り値を if し忘れると bad CSRF token でも 200 が返ってしまう silent CSRF accept の足元だった。FT7 で probe controller で再現済み。

新 helper \`requireCsrfFromPost(string $field = 'csrf_token'): void\` を \`ControllerBase\` に追加し、検証失敗時は \`HttpTermination\` を投げて dispatch を終了させる:

- **REST mode** → \`CSRF-TOKEN-INVALID\` JSON envelope (403)、\`ControllerBase::run()\` 内の自動チェックと同じ shape
- **HTML mode** → repo root の \`csrf.html\` (403)、\`404.html\` と同じ static-file パターン

### Backward compatibility

- \`verifyCsrfFromPost(): bool\` は残す。advanced 用途 (フォーム再表示 with field-level error 等で recover したい場合) で必要なため
- PHPDoc で「new code では requireCsrfFromPost を使え」と明記
- tutorial / review checklist を新 helper 推奨に swap

### Test plan

- [x] \`composer test\` (45/45)
- [x] \`composer test:http\` (21/21, 1 expected skip)
- [x] live verify (logged-in REST POST with bad CSRF → 403 CSRF-TOKEN-INVALID envelope)
- HTML 側は framework main に CSRF を使う HTML controller が無いため manual live verify は FT7 clone で実施済み (FINDINGS.md 参照)

Closes #316.