### PR TITLE
feat(dispatcher): 404 を Accept header で content-negotiation する (#312)

### DIFF
--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -225,11 +225,64 @@ class Dispatcher
     /**
      * Build the shared 404 response.
      *
+     * Returns the ADR-0003 `NOT-FOUND` JSON envelope when the request's
+     * `Accept` header prefers `application/json`; otherwise returns the
+     * static `404.html` page. The header is read from the current request
+     * so this method is environment-aware without needing it injected.
+     *
      * @return HttpResponse 404 response.
      */
     private function notFoundResponse(): HttpResponse
     {
+        if ($this->wantsJson($_SERVER['HTTP_ACCEPT'] ?? '')) {
+            $response = JsonResponder::responseArray((new ApiResponse())->failure('NOT-FOUND'));
+            return $response;
+        }
         $body = file_get_contents(DIR_ROOT . '/404.html');
         return HttpResponse::html(is_string($body) ? $body : '404 Not Found', 404);
+    }
+
+    /**
+     * Decide whether the request's `Accept` header prefers a JSON response.
+     *
+     * A header is treated as JSON-preferring when `application/json` (or a
+     * compatible wildcard like `application/...`) appears with a `q` value at
+     * least as high as any `text/html` entry. Requests with no `Accept`
+     * header, or a generic catch-all wildcard, are treated as HTML callers
+     * (real browsers send `text/html` explicitly; only curl-style clients
+     * default to `*` of `*`).
+     *
+     * @param string $acceptHeader Raw `Accept` request header.
+     *
+     * @return boolean Whether to prefer a JSON-shaped response.
+     */
+    public function wantsJson(string $acceptHeader): bool
+    {
+        if ($acceptHeader === '') {
+            return false;
+        }
+        $jsonQuality = -1.0;
+        $htmlQuality = -1.0;
+        foreach (explode(',', $acceptHeader) as $entry) {
+            $parts = explode(';', trim($entry));
+            $mediaType = strtolower(trim($parts[0] ?? ''));
+            if ($mediaType === '') {
+                continue;
+            }
+            $quality = 1.0;
+            for ($i = 1; $i < count($parts); $i++) {
+                $param = trim($parts[$i]);
+                if (str_starts_with($param, 'q=')) {
+                    $quality = (float)substr($param, 2);
+                    break;
+                }
+            }
+            if ($mediaType === 'application/json' || $mediaType === 'application/*') {
+                $jsonQuality = max($jsonQuality, $quality);
+            } elseif ($mediaType === 'text/html' || $mediaType === 'text/*') {
+                $htmlQuality = max($htmlQuality, $quality);
+            }
+        }
+        return $jsonQuality > 0 && $jsonQuality >= $htmlQuality;
     }
 }

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -19,6 +19,10 @@ return [
         'message' => 'The HTTP method is not allowed for this endpoint.',
         'httpStatus' => 405,
     ],
+    'NOT-FOUND' => [
+        'message' => 'The requested resource was not found.',
+        'httpStatus' => 404,
+    ],
     'ROUTE-CONFLICT' => [
         'message' => 'Route configuration conflict.',
         'httpStatus' => 500,

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -433,6 +433,24 @@ components:
                   status: failure
                   errorCode: METHOD-NOT-ALLOWED
                   errorMessage: The HTTP method is not allowed for this endpoint.
+    NotFound:
+      description: |
+        Route resolves to no controller or no action. The framework returns
+        this JSON envelope only when the request's `Accept` header prefers
+        `application/json`; otherwise the static `404.html` page is returned
+        (`NOT-FOUND`).
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiFailureEnvelope"
+          examples:
+            notFound:
+              value:
+                Result: true
+                Data:
+                  status: failure
+                  errorCode: NOT-FOUND
+                  errorMessage: The requested resource was not found.
   schemas:
     JsonEnvelope:
       type: object

--- a/docs/api/reference-client.md
+++ b/docs/api/reference-client.md
@@ -100,6 +100,7 @@ If you implement a server-rendered login form rather than calling REST `/session
 | `401` `LOGIN-FAILED` | `/session/login` credentials rejected | Check `user_id` / `user_pass`. |
 | `403` `CSRF-TOKEN-INVALID` | Missing or wrong `X-CSRF-Token` on a state-changing request | Re-read `Data.csrfToken` from the most recent login response and resend. |
 | `405` `METHOD-NOT-ALLOWED` | Wrong HTTP method for the endpoint | Check `Allow` response header. |
+| `404` `NOT-FOUND` | Route resolves to no controller or no action | Returned with `application/json` only when the request `Accept` header prefers JSON; HTML callers still receive the static `404.html` page. |
 
 For the full error catalog, see `config/error_codes.php`.
 

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -29,6 +29,7 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `LOGIN-FAILED` | 401 | Wrong user ID or user PASS | Returned by `POST /session/login` for rejected credentials. |
 | `CSRF-TOKEN-INVALID` | 403 | Invalid CSRF token. | Returned when a state-changing request from a logged-in client is missing or has a wrong `X-CSRF-Token` header. |
 | `METHOD-NOT-ALLOWED` | 405 | The HTTP method is not allowed for this endpoint. | Returned with the `Allow` response header listing valid methods. |
+| `NOT-FOUND` | 404 | The requested resource was not found. | Emitted by the dispatcher when the route resolves to no controller or no action **and** the request's `Accept` header prefers `application/json`. HTML callers still receive the static `404.html` page. |
 | `ROUTE-CONFLICT` | 500 | Route configuration conflict. | Internal — surfaces when controller dispatch is ambiguous. |
 | `TODO-ID-REQUIRED` | 400 | TODO id is required. | `/todo/item/id_X` with missing or non-numeric `id`. |
 | `TODO-NOT-FOUND` | 404 | TODO item was not found. | `/todo/item/id_X` where no row matches the signed-in user. |

--- a/tests/Http/HttpSmokeTest.php
+++ b/tests/Http/HttpSmokeTest.php
@@ -124,6 +124,29 @@ final class HttpSmokeTest extends HttpRuntimeTestCase
         self::assertStringContainsString('expires=', strtolower($logoutCookie));
     }
 
+    public function testMissingRouteReturnsHtml404ByDefault(): void
+    {
+        $response = $this->client->request('GET', '/no-such-controller/foo');
+
+        self::assertSame(404, $response->statusCode());
+        self::assertStringContainsString('text/html', $response->headerLine('Content-Type'));
+        self::assertStringContainsString('Not Found', $response->body());
+    }
+
+    public function testMissingRouteReturnsJsonEnvelopeWhenAcceptIsJson(): void
+    {
+        $response = $this->client->request('GET', '/no-such-controller/foo', null, [
+            'Accept' => 'application/json',
+        ]);
+        $payload = $response->json();
+
+        self::assertSame(404, $response->statusCode());
+        self::assertStringContainsString('application/json', $response->headerLine('Content-Type'));
+        self::assertSame(true, $payload['Result']);
+        self::assertSame('failure', $payload['Data']['status']);
+        self::assertSame('NOT-FOUND', $payload['Data']['errorCode']);
+    }
+
     public function testLoginRestEndpointRejectsUnsupportedMethod(): void
     {
         $response = $this->client->request('GET', '/session/login');

--- a/tests/Unit/Xion/DispatcherTest.php
+++ b/tests/Unit/Xion/DispatcherTest.php
@@ -108,4 +108,31 @@ final class DispatcherTest extends TestCase
 
         self::assertSame(500, $route['status']);
     }
+
+    public function testWantsJsonReturnsFalseForEmptyAcceptHeader(): void
+    {
+        self::assertFalse((new Dispatcher())->wantsJson(''));
+    }
+
+    public function testWantsJsonReturnsFalseForBrowserDefaultAcceptHeader(): void
+    {
+        $browserAccept = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8';
+
+        self::assertFalse((new Dispatcher())->wantsJson($browserAccept));
+    }
+
+    public function testWantsJsonReturnsTrueForApplicationJson(): void
+    {
+        self::assertTrue((new Dispatcher())->wantsJson('application/json'));
+    }
+
+    public function testWantsJsonReturnsTrueWhenJsonOutranksHtml(): void
+    {
+        self::assertTrue((new Dispatcher())->wantsJson('text/html;q=0.5, application/json;q=1.0'));
+    }
+
+    public function testWantsJsonReturnsFalseForWildcardStar(): void
+    {
+        self::assertFalse((new Dispatcher())->wantsJson('*/*'));
+    }
 }


### PR DESCRIPTION
## Summary

FT7 F-1 (Issue #312) の本体 fix。

### 何を直したか

\`Dispatcher::notFoundResponse()\` は常に \`404.html\` (\`Content-Type: text/html\`) を返していて、REST client が \`Accept: application/json\` を付けても HTML が返る → ADR-0003 envelope の契約が 404 だけ守られていなかった。

新たに \`Dispatcher::wantsJson(string $acceptHeader): bool\` を導入し、JSON-preferring client (\`application/json\` または \`application/*\` で q-value が \`text/html\` を上回る) には新 error code \`NOT-FOUND\` の JSON envelope を返す。HTML caller (\`text/html\`, 空 header, ワイルドカードのみ等) は従来どおり \`404.html\`。

### 仕様

- 新 error code: \`NOT-FOUND\` (HTTP 404, \`The requested resource was not found.\`)
- 判定ロジック: q-value 比較で JSON が HTML 以上のときに JSON envelope を返す
- 既存 \`404.html\` は HTML caller 用に残す (UX 後退なし)

### Test plan

- [x] \`composer test\` 50/50 (新規 5 ケース: \`wantsJson()\` 単体)
- [x] \`composer test:http\` 23/23 (新規 2 ケース: Accept 無し → HTML 404, Accept: JSON → NOT-FOUND envelope)
- [x] live verify: \`curl http://127.0.0.1:8080/no-such-controller/foo\` → HTML / \`curl -H 'Accept: application/json' ...\` → JSON envelope

### Doc updates

- \`docs/development/error-codes.md\` — NOT-FOUND row
- \`docs/api/openapi.yaml\` — \`NotFound\` response component
- \`docs/api/reference-client.md\` — failure-mode row

Closes #312.