### PR TITLE
feat(error-handling): 未捕捉 Throwable を envelope/template にマッピングする (#313)

### DIFF
--- a/500.html
+++ b/500.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>500 Internal Server Error</title>
+	</head>
+	<body>
+		<h1>Internal Server Error</h1>
+		<p>The server encountered an unexpected condition. Please try again later.</p>
+	</body>
+</html>

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -23,6 +23,10 @@ return [
         'message' => 'The requested resource was not found.',
         'httpStatus' => 404,
     ],
+    'INTERNAL-ERROR' => [
+        'message' => 'An unexpected internal error occurred.',
+        'httpStatus' => 500,
+    ],
     'ROUTE-CONFLICT' => [
         'message' => 'Route configuration conflict.',
         'httpStatus' => 500,

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -30,6 +30,7 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `CSRF-TOKEN-INVALID` | 403 | Invalid CSRF token. | Returned when a state-changing request from a logged-in client is missing or has a wrong `X-CSRF-Token` header. |
 | `METHOD-NOT-ALLOWED` | 405 | The HTTP method is not allowed for this endpoint. | Returned with the `Allow` response header listing valid methods. |
 | `NOT-FOUND` | 404 | The requested resource was not found. | Emitted by the dispatcher when the route resolves to no controller or no action **and** the request's `Accept` header prefers `application/json`. HTML callers still receive the static `404.html` page. |
+| `INTERNAL-ERROR` | 500 | An unexpected internal error occurred. | Emitted by `htdocs/index.php` when an unhandled `\Throwable` reaches the top-level catch on a REST request. HTML callers receive the static `500.html` page instead. |
 | `ROUTE-CONFLICT` | 500 | Route configuration conflict. | Internal — surfaces when controller dispatch is ambiguous. |
 | `TODO-ID-REQUIRED` | 400 | TODO id is required. | `/todo/item/id_X` with missing or non-numeric `id`. |
 | `TODO-NOT-FOUND` | 404 | TODO item was not found. | `/todo/item/id_X` where no row matches the signed-in user. |

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -46,10 +46,18 @@ try {
     );
 } catch (\Throwable $throwable) {
     Xion\Log::getInstance('error')->error('Unhandled application error.', ['exception' => $throwable]);
-    Xion\HttpEmitter::emit(Xion\HttpResponse::text(
-        APP_DEBUG ? $throwable->getMessage() : 'Internal Server Error',
-        500
-    ));
+    if (Xion\RouteContext::getInstance()->isRest()) {
+        $apiResponse = new Xion\ApiResponse();
+        Xion\HttpEmitter::emit(
+            Xion\JsonResponder::responseArray($apiResponse->failure('INTERNAL-ERROR'))
+        );
+    } else {
+        $body = file_get_contents(DIR_ROOT . '/500.html');
+        Xion\HttpEmitter::emit(Xion\HttpResponse::html(
+            is_string($body) ? $body : 'Internal Server Error',
+            500
+        ));
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

FT7 F-2 (Issue #313) の本体 fix。

### 何を直したか

\`htdocs/index.php\` の top-level \`\Throwable\` catch は \`text/plain\` 500 を REST/HTML どちらにも返していて、ADR-0003 envelope も HTML template も使われない状態だった。さらに \`APP_DEBUG=1\` (non-prod default) では raw exception message が body に漏れていた。

\`Xion\RouteContext::getInstance()->isRest()\` で分岐:

- **REST** → \`ApiFailureEnvelope\` (\`errorCode: 'INTERNAL-ERROR'\`, HTTP 500)
- **HTML** → repo root の \`500.html\` (\`404.html\` / \`csrf.html\` と同じ static pattern)

### Backward compatibility

- 副作用として \`APP_DEBUG=1\` 時の raw exception message 露出は消える (envelope/template 移行の自然な結果)
- exception 情報を debug 用に露出したい用途は別 issue で議論する
- 既存の error log は変更なし (\`Xion\Log::getInstance('error')\`)

### Test plan

- [x] \`composer test\` (50/50)
- [x] \`composer test:http\` (23/23, 1 expected skip)
- [x] live verify: temp ThrowprobeController を main repo に置いて REST/HTML 両方の分岐を確認
  - REST: \`HTTP 500 / Content-Type: application/json\` + INTERNAL-ERROR envelope
  - HTML: \`HTTP 500 / Content-Type: text/html\` + 500.html
- 自動 regression test: dispatcher が controller を class/controller/ から PSR-4 autoload する制約があり、production code に probe controller を置かないと throw を再現できない。autoload-dev を追加する小 PR は別途 (本 PR の scope 外)。FT7 clone (`/home/xi/github/NeNe-FT/ft7-error-pages`) では既に Ft7probeController で同 fix 後の挙動を確認済み (FINDINGS.md 参照)。

Closes #313.