### PR TITLE
feat(error-handling): HTML controller の DomainException を template で render する (#314)

### DIFF
--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -43,6 +43,15 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 3. If the code is referenced from a new OpenAPI endpoint, the endpoint's failure response references the shared `ApiFailureEnvelope` — no per-code schema is added. The endpoint MAY include an `example` showing the specific `errorCode` value it produces.
 4. The contract test (`tests/Http/OpenApiRuntimeContractTest`) automatically discovers new endpoints and asserts that observed statuses appear in the documented status list. No test changes are needed for a new error code on an existing endpoint.
 
+## HTML rendering of domain failures
+
+When a controller throws `Nene\Xion\DomainException` from inside an HTML `*Action()` method, the top-level catch in `htdocs/index.php` branches on `RouteContext::isRest()`:
+
+- REST callers receive the JSON `ApiFailureEnvelope` carrying the thrown `errorCode`, with HTTP status from the catalog (no change from prior behavior).
+- HTML callers receive the static `domain-error.html` page at the project root with `{{errorCode}}` and `{{errorMessage}}` placeholders substituted by `htmlspecialchars`-escaped values from the catalog. HTTP status still comes from the catalog (e.g. `TODO-NOT-FOUND` → 404).
+
+The HTML rendering uses a static file and simple `strtr()` substitution rather than Smarty so the catch path does not need to bootstrap a view layer. Replace the template at the project root to rebrand or extend the markup.
+
 ## Response decoration and the error-path early-exit trap
 
 NeNe currently emits no framework-level decoration on top of the envelope (no security headers, no request IDs). If a future change adds such decoration, the *placement* matters because several error paths exit before `ControllerBase::run()` returns:

--- a/domain-error.html
+++ b/domain-error.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>{{errorCode}}</title>
+	</head>
+	<body>
+		<h1>{{errorCode}}</h1>
+		<p>{{errorMessage}}</p>
+	</body>
+</html>

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -41,9 +41,18 @@ try {
     Xion\HttpEmitter::emit($termination->response());
 } catch (Xion\DomainException $domainException) {
     $apiResponse = new Xion\ApiResponse();
-    Xion\HttpEmitter::emit(
-        Xion\JsonResponder::responseArray($apiResponse->failure($domainException->errorCode()))
-    );
+    $failure = $apiResponse->failure($domainException->errorCode());
+    if (Xion\RouteContext::getInstance()->isRest()) {
+        Xion\HttpEmitter::emit(Xion\JsonResponder::responseArray($failure));
+    } else {
+        $template = (string)file_get_contents(DIR_ROOT . '/domain-error.html');
+        $body = strtr($template, [
+            '{{errorCode}}' => htmlspecialchars((string)$failure['errorCode'], ENT_QUOTES, 'UTF-8'),
+            '{{errorMessage}}' => htmlspecialchars((string)$failure['errorMessage'], ENT_QUOTES, 'UTF-8'),
+        ]);
+        $status = Xion\ErrorCode::getInstance()->getHttpStatus($domainException->errorCode());
+        Xion\HttpEmitter::emit(Xion\HttpResponse::html($body, $status));
+    }
 } catch (\Throwable $throwable) {
     Xion\Log::getInstance('error')->error('Unhandled application error.', ['exception' => $throwable]);
     if (Xion\RouteContext::getInstance()->isRest()) {


### PR DESCRIPTION
## Summary

FT7 F-3 (Issue #314) の本体 fix。

### 何を直したか

\`htdocs/index.php\` の \`DomainException\` catch は常に JSON envelope を emit していて、HTML \`*Action()\` から \`throw new DomainException('TODO-NOT-FOUND')\` するとブラウザに JSON が飛んでいた。

\`RouteContext::getInstance()->isRest()\` で分岐:

- **REST** → JSON envelope (現状維持)
- **HTML** → repo root の \`domain-error.html\` を \`strtr\` で \`{{errorCode}}\` / \`{{errorMessage}}\` (htmlspecialchars escape) に置換して emit

HTTP status は \`ErrorCode catalog\` から逆引きするので、TODO-NOT-FOUND であれば従来どおり 404 が返る (catalog の \`httpStatus\` が source of truth)。

### なぜ Smarty ではなく static + strtr か

DomainException catch path で Smarty を bootstrap (constants, paths, plugins, compile dir) するのは index.php の責務として重い。404.html / 500.html / csrf.html の static-file pattern と揃え、template/strtr で済ませた。リブランド / マークアップ拡張は \`domain-error.html\` を編集するだけで完結する。

### Test plan

- [x] \`composer test\` (50/50)
- [x] \`composer test:http\` (23/23, 1 expected skip)
- [x] live verify: temp DomprobeController で REST/HTML 両方の分岐を確認
  - REST: \`HTTP 404 / application/json\` + TODO-NOT-FOUND envelope (unchanged)
  - HTML: \`HTTP 404 / text/html\` + \`<title>TODO-NOT-FOUND</title>\` + body に errorMessage

### Doc updates

- \`docs/development/error-codes.md\` に「HTML rendering of domain failures」 section を追加

Closes #314.