### PR TITLE
build(docker): expose_php = Off で X-Powered-By を抑止する (#329)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ RUN apt-get update \
     && sed -ri 's!AllowOverride None!AllowOverride All!g' /etc/apache2/apache2.conf \
     && rm -rf /var/lib/apt/lists/*
 
+# PHP ini drop-ins (NeNe production-mode overrides — currently: expose_php Off
+# to suppress X-Powered-By in HTTP responses). Loaded last in conf.d/ so it
+# wins over any earlier ini.
+COPY docker/php/conf.d/zz-nene.ini /usr/local/etc/php/conf.d/zz-nene.ini
+
 WORKDIR /var/www/html
 
 # Mark the host bind-mounted working tree as safe so git invocations inside

--- a/docker/php/conf.d/zz-nene.ini
+++ b/docker/php/conf.d/zz-nene.ini
@@ -1,0 +1,5 @@
+; NeNe production-mode PHP overrides.
+; This file is dropped into /usr/local/etc/php/conf.d/ inside the image so it
+; loads last (alphabetical order) and wins over any earlier ini.
+
+expose_php = Off


### PR DESCRIPTION
## Summary

FT8 F-2 (Issue #329) の fix。

PHP の \`expose_php\` default は On で \`X-Powered-By: PHP/8.4.21\` が全 response に乗る。production で PHP version を狙い撃ちされる情報源を削るため off にする。

- \`docker/php/conf.d/zz-nene.ini\` 新規作成 (\`expose_php = Off\`)
- \`Dockerfile\` で \`/usr/local/etc/php/conf.d/zz-nene.ini\` にコピー (\`zz-\` prefix で alphabetical に最後ロード)

## Test plan

- [x] \`composer test\` (50/50)
- [x] \`composer test:http\` (23/23, 1 expected skip)
- [x] live verify: \`curl -i http://127.0.0.1:8080/health\` の response に \`X-Powered-By\` header が無いことを確認

Closes #329.