### PR TITLE
build(docker): Apache ServerTokens Prod / ServerSignature Off で server banner を最小化する (#330)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,13 @@ RUN apt-get update \
     && sed -ri 's!AllowOverride None!AllowOverride All!g' /etc/apache2/apache2.conf \
     && rm -rf /var/lib/apt/lists/*
 
+# Apache hardening drop-in: ServerTokens Prod + ServerSignature Off to keep
+# the production-mode Server header minimal (no version, no OS). The `zz-`
+# prefix forces alphabetical load order after Debian's `security.conf`,
+# which otherwise sets `ServerTokens OS` and `ServerSignature On`.
+COPY docker/apache/conf-available/zz-nene-hardening.conf /etc/apache2/conf-available/zz-nene-hardening.conf
+RUN a2enconf zz-nene-hardening
+
 # PHP ini drop-ins (NeNe production-mode overrides — currently: expose_php Off
 # to suppress X-Powered-By in HTTP responses). Loaded last in conf.d/ so it
 # wins over any earlier ini.

--- a/docker/apache/conf-available/zz-nene-hardening.conf
+++ b/docker/apache/conf-available/zz-nene-hardening.conf
@@ -1,0 +1,5 @@
+# NeNe Apache hardening drop-in.
+# Loaded via a2enconf from the Dockerfile. Production-mode defaults.
+
+ServerTokens Prod
+ServerSignature Off


### PR DESCRIPTION
## Summary

FT8 F-3 (Issue #330) の fix。

Debian image default で \`Server: Apache/2.4.67 (Debian)\` が出ていたので production 想定の \`Server: Apache\` (version / OS 無し) に絞る。

- \`docker/apache/conf-available/zz-nene-hardening.conf\` 新規作成 (\`ServerTokens Prod\` + \`ServerSignature Off\`)
- \`Dockerfile\` で \`COPY\` + \`a2enconf zz-nene-hardening\`

### Note: \`zz-\` prefix

Debian image の \`/etc/apache2/conf-available/security.conf\` が既に \`ServerTokens OS\` / \`ServerSignature On\` を設定している。Apache は conf-enabled を alphabetical 順にロードするので、\`nene-hardening.conf\` のままだと \`security.conf\` が後勝ちで override される (作業中に踏んだ罠)。\`zz-\` prefix で確実に最後にロードされるようにした。\`#329\` の PHP ini drop-in と同じ理由。

## Test plan

- [x] \`composer test\` (50/50)
- [x] \`composer test:http\` (23/23, 1 expected skip)
- [x] live verify: \`curl -i http://127.0.0.1:8080/health\` の Server header が \`Apache\` 単独 (version / OS 無し)

Closes #330.