### PR TITLE
feat(ini): NENE_LOG_PATH で LOG_PATH を env override 可能にする (#332)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,7 @@ services:
       NENE_DB_PASS: "${NENE_DB_PASS:-nene}"
       NENE_SAMPLE_ADMIN_PASSWORD: "${NENE_SAMPLE_ADMIN_PASSWORD:-admin}"
       NENE_LOGOUT_URI: "${NENE_LOGOUT_URI:-/}"
+      NENE_LOG_PATH: "${NENE_LOG_PATH:-}"
     ports:
       - "${NENE_PORT:-8080}:80"
     volumes:

--- a/ini/xSystemIni.php
+++ b/ini/xSystemIni.php
@@ -156,6 +156,21 @@ define('DB_HOST', $getEnv('NENE_DB_HOST', 'localhost'));
 define('DB_PORT', $getEnv('NENE_DB_PORT', '3306'));
 define('DB_NAME', $getEnv('NENE_DB_NAME', 'nene-php'));
 
+/*
+ * Logs.
+ *
+ * `NENE_LOG_PATH` lets a production deploy point logs at a directory outside
+ * the project tree (for example a Docker named volume or `/var/log/<app>/`).
+ * The default keeps logs inside the project tree, matching pre-PR-336 behavior.
+ * The Docker init script creates this directory and grants write permissions
+ * for the web server user. If logs fail in local development, check directory
+ * ownership.
+ */
+define('LOG_PATH', rtrim($getEnv('NENE_LOG_PATH', DIR_ROOT . 'log'), '/') . '/');
+define('APP_LOG_PATH', LOG_PATH . 'debug.log');
+define('ACCESS_LOG_PATH', LOG_PATH . 'access.log');
+define('ERROR_LOG_PATH', LOG_PATH . 'error.log');
+
 unset($getEnv);
 
 /*
@@ -186,18 +201,6 @@ const DB_IS_PHYSICAL_DELETE = true;
  */
 const JSON_OUTPUT = true;
 const ERROR_CODE_PATH = DIR_ROOT . 'config/error_codes.php';
-
-/*
- * Logs.
- *
- * The Docker init script creates this directory and grants write permissions
- * for the web server user. If logs fail in local development, check directory
- * ownership before changing these constants.
- */
-const LOG_PATH = DIR_ROOT . 'log/';
-const APP_LOG_PATH = LOG_PATH . 'debug.log';
-const ACCESS_LOG_PATH = LOG_PATH . 'access.log';
-const ERROR_LOG_PATH = LOG_PATH . 'error.log';
 
 /*
  * Smarty view paths.


### PR DESCRIPTION
## Summary

FT8 F-8 (Issue #332) の fix。

\`LOG_PATH\` が \`DIR_ROOT . 'log/'\` で hard-coded だったので、FT5 #284 (\`NENE_LOGOUT_URI\`) と同じ pattern で \`NENE_LOG_PATH\` を導入し、production で \`/var/log/<app>/\` や Docker named volume にログを置けるようにする。

### Changes

- \`ini/xSystemIni.php\`: \`LOG_PATH\` / \`APP_LOG_PATH\` / \`ACCESS_LOG_PATH\` / \`ERROR_LOG_PATH\` を \`const → define()\` に切り替え、\`$getEnv('NENE_LOG_PATH', DIR_ROOT . 'log')\` で読む。trailing slash を rtrim → '/' で正規化。
- 定義位置を \`unset($getEnv);\` (line 159) より前に移動 (db define ブロックの直後)。const のままでは \`$getEnv\` がスコープ外。
- \`compose.yaml\`: \`environment:\` に \`NENE_LOG_PATH\` を追加 (default 空 → ini 側 default にフォールバック)。

### Operator note

\`NENE_LOG_PATH\` で外部パスを指定した場合、そのディレクトリは事前に作成して www-data が write できる perm を設定しておく必要がある。本 PR では \`/tmp/nene-logs\` (world-writable parent) で live verify したので Monolog 側が自動 mkdir した。\`/var/log/...\` のような root 専用パスを使うときは pre-create を deployment 側で。\`docs/development/production-deployment.md\` (#333) で詳述する。

## Test plan

- [x] \`composer test\` (50/50)
- [x] \`composer test:http\` (23/23, 1 expected skip)
- [x] live verify: default で \`log/access-*.log\` 出力、\`NENE_LOG_PATH=/tmp/nene-logs\` 起動で \`/tmp/nene-logs/access-*.log\` 出力

Closes #332.