### PR TITLE
feat(dispatcher): pre-dispatch 404 / 405 / ROUTE-CONFLICT を access log に記録する (#331)

### DIFF
--- a/class/xion/Dispatcher.php
+++ b/class/xion/Dispatcher.php
@@ -44,6 +44,10 @@ class Dispatcher
         $action = $requestRoute['action'];
 
         $controllerInstance = $this->getControllerInstance($controller);
+        if ($controllerInstance === null) {
+            $this->logPreDispatchAccess($controller, $action, 404);
+            throw new HttpTermination($this->notFoundResponse());
+        }
 
         $route = $this->resolveActionRoute(
             $controllerInstance,
@@ -51,10 +55,13 @@ class Dispatcher
             $_SERVER['REQUEST_METHOD'] ?? 'GET'
         );
         if ($route['status'] === 404) {
+            $this->logPreDispatchAccess($controller, $action, 404);
             throw new HttpTermination($this->notFoundResponse());
         } elseif ($route['status'] === 405) {
+            $this->logPreDispatchAccess($controller, $action, 405);
             $this->outputJsonFailure('METHOD-NOT-ALLOWED', ['Allow' => implode(', ', $route['allowed'])]);
         } elseif ($route['status'] === 500) {
+            $this->logPreDispatchAccess($controller, $action, 500);
             Log::getInstance('error')->error('Route conflict detected.', [
                 'controller' => $controller,
                 'action' => $action,
@@ -63,6 +70,34 @@ class Dispatcher
         }
         RouteContext::getInstance()->set($controller, $action, $route['mode'], $route['method']);
         $controllerInstance->run();
+    }
+
+    /**
+     * Emit an ACCESS log entry for a request that fails before
+     * {@see ControllerBase::run()} runs (404 / 405 / ROUTE-CONFLICT).
+     *
+     * `run()` writes its own ACCESS entry for successful dispatch; this method
+     * covers the pre-dispatch holes that would otherwise leave the request
+     * invisible to production operators. The shape (`controller::action` from
+     * the URL) intentionally mirrors `run()`'s entry plus an extra HTTP-status
+     * field so operators can grep for 404 spam.
+     *
+     * @param string  $controller URL-derived controller segment.
+     * @param string  $action     URL-derived action segment.
+     * @param integer $status     HTTP status that will be emitted.
+     *
+     * @return void
+     */
+    private function logPreDispatchAccess(string $controller, string $action, int $status): void
+    {
+        Log::getInstance('access')->info(
+            'ACCESS : ' . $controller . '::' . $action,
+            [
+                'status' => $status,
+                'userAgent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
+                'referer' => $_SERVER['HTTP_REFERER'] ?? '',
+            ]
+        );
     }
 
     /**
@@ -190,22 +225,23 @@ class Dispatcher
     }
 
     /**
-     * Determine the class file name from the controller name passed as an argument,
-     * generate an instance, and return.
+     * Determine the controller class name from the URL segment, instantiate
+     * it, and return the instance — or `null` when the class does not exist
+     * so the caller can decide how to surface the 404 (log + emit, not just
+     * throw).
      *
      * @param string $controller Controller name.
      *
-     * @return ControllerBase Controller alias specified by argument.
+     * @return ControllerBase|null Controller instance, or null when missing.
      */
-    private function getControllerInstance(string $controller): ControllerBase
+    private function getControllerInstance(string $controller): ?ControllerBase
     {
         $className = ucfirst(strtolower($controller)) . 'Controller';
         $className = '\\Nene\\Controller\\' . $className;
         if (!class_exists($className)) {
-            throw new HttpTermination($this->notFoundResponse());
+            return null;
         }
-        $controllerInstance = new $className();
-        return $controllerInstance;
+        return new $className();
     }
 
     /**


### PR DESCRIPTION
## Summary

FT8 F-4 (Issue #331) の fix。

\`Dispatcher::dispatch()\` の早期 exit (404 / 405 / 500) は \`ControllerBase::run()\` を呼ばずに \`HttpTermination\` を throw するため、\`run()\` 内で書かれていた ACCESS log entry を踏まなかった。結果として \`/no-such-controller/foo\` のような route resolution 失敗が \`access-*.log\` に**全く残らない** (FT8 で 88 ACCESS entries に対し 404 試行 4 回 → 0 件で確認)。

production operator が「どの URL が 404 で叩かれているか」を見られない visibility gap。

### Changes

- \`Dispatcher::dispatch()\` で 4 つの早期 exit 直前に \`logPreDispatchAccess()\` を呼ぶ:
  - \`getControllerInstance\` が null (controller class 無し) → 404
  - \`resolveActionRoute\` status 404 (action 無し) → 404
  - \`resolveActionRoute\` status 405 (METHOD-NOT-ALLOWED) → 405
  - \`resolveActionRoute\` status 500 (ROUTE-CONFLICT) → 500
- \`logPreDispatchAccess\` は \`run()\` の ACCESS log と同じ shape (\`ACCESS : <controller>::<action>\`) + 追加 context (\`status\` / \`userAgent\` / \`referer\`)。grep しやすい統一フォーマット。
- \`getControllerInstance\` を「class が無いと throw」から「null を返す」に refactor。caller (\`dispatch()\`) が log + throw を担う。private method なので外部影響なし。

### Note: cross-cutting decoration の根本対策ではない

これは FT7 F-6 と FT8 F-4 が共通して指摘する「dispatcher → run() 境界で cross-cutting concerns が一律 skip される」構造の access-log layer の応急処置。将来 security headers / request IDs を一律乗せる時には dispatcher 側に hook を作る ADR-class の検討が必要 (本 PR scope 外)。

## Test plan

- [x] \`composer test\` (50/50)
- [x] \`composer test:http\` (23/23, 1 expected skip)
- [x] live verify: \`curl /no-such-controller/foo\` → \`ACCESS : no-such-controller::foo {"status":404,...}\` が access log に出る、\`curl /session/login\` (GET) → \`ACCESS : session::login {"status":405,...}\` が出る

Closes #331.