### PR TITLE
build(docker): compose.prod.yaml overlay で --no-dev を入れる (#328)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,12 @@ WORKDIR /var/www/html
 RUN git config --global --add safe.directory /var/www/html
 
 COPY composer.json composer.lock ./
-RUN composer install --no-interaction --prefer-dist --no-progress
+
+# `NENE_NO_DEV=1` (passed via `--build-arg`, set by `compose.prod.yaml`) tells
+# the image build to skip dev composer packages. The default keeps dev
+# packages so the bundled image still runs `composer test` out of the box.
+ARG NENE_NO_DEV=
+RUN composer install --no-interaction --prefer-dist --no-progress ${NENE_NO_DEV:+--no-dev}
 
 COPY . .
 RUN ./init.sh

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,32 @@
+# Production overlay for compose.yaml.
+#
+# Usage:
+#   docker compose -f compose.yaml -f compose.prod.yaml up -d --build
+#
+# What this overlay does:
+#   - Flips the env-var defaults to production-safe values.
+#   - Adds `--no-dev` to the runtime composer install so phpunit / phan /
+#     php-cs-fixer (and their transitive deps) do not get installed inside
+#     the running container.
+#   - Adds `NENE_NO_DEV=1` as a build arg so the same flag is baked into the
+#     image's first composer install layer for operators who run the image
+#     directly (without `docker compose up`).
+#
+# The base `compose.yaml` keeps dev-friendly defaults so `composer test` and
+# `composer test:http` still work in CI and local development without
+# additional flags.
+
+services:
+  app:
+    build:
+      context: .
+      args:
+        NENE_NO_DEV: "1"
+    environment:
+      NENE_APP_ENV: "${NENE_APP_ENV:-production}"
+      NENE_APP_DEBUG: "${NENE_APP_DEBUG:-0}"
+      NENE_SESSION_SECURE: "${NENE_SESSION_SECURE:-1}"
+    command: >
+      sh -lc "composer install --no-interaction --prefer-dist --no-dev
+      && ./init.sh
+      && apache2-foreground"


### PR DESCRIPTION
## Summary

FT8 F-1 (Issue #328) の fix。

### Problem

\`Dockerfile\` の \`composer install\` と \`compose.yaml\` の startup \`command:\` 両方が \`--no-dev\` 無しで動き、phpunit / phan / friendsofphp/php-cs-fixer (+ transitive deps) が production 想定の running container にも入っていた。

### Design choice

Issue 本体で 3 案を挙げた中から **compose overlay** を採用:

- 案 a (採用): \`compose.prod.yaml\` overlay
- 案 b: multi-stage Dockerfile
- 案 c: build arg のみ

決め手:
- base \`compose.yaml\` を dev 用に保ったまま (composer test が引き続き走る)、\`docker compose -f compose.yaml -f compose.prod.yaml up\` で prod 起動できる
- 標準パターン (Docker Compose の "production overlay" は十分に conventional)
- 既存 dev workflow / CI / FT clone に何も影響しない

### Changes

- \`compose.prod.yaml\` 新規:
  - \`environment:\`: \`NENE_APP_ENV/APP_DEBUG/SESSION_SECURE\` の default を production 寄りに
  - \`command:\`: runtime \`composer install\` に \`--no-dev\`
  - \`build.args.NENE_NO_DEV: "1"\` で Dockerfile の image-level composer install にも \`--no-dev\`
- \`Dockerfile\`: \`ARG NENE_NO_DEV=\` + \`RUN composer install ... \${NENE_NO_DEV:+--no-dev}\`。空の場合は従来どおり全部入りで dev 互換。

### Operator usage

\`\`\`bash
# dev (今までどおり)
docker compose up -d

# prod
docker compose -f compose.yaml -f compose.prod.yaml up -d --build
\`\`\`

\`docs/development/production-deployment.md\` (#333) で詳述する。

## Test plan

- [x] prod overlay 起動: \`/health\` で \`"environment":"production"\` / \`composer show -i | grep -iE 'phpunit|phan|cs-fixer'\` が空
- [x] dev compose 起動: \`/health\` で \`"environment":"development"\` / dev packages 健在
- [x] dev compose で \`composer test\` (50/50) / \`composer test:http\` (23/23) 緑

Closes #328.