### PR TITLE
feat(xion): DIR_SMARTY_PLUGINS を View::__construct で Smarty に登録する (#342)

### DIFF
--- a/class/xion/View.php
+++ b/class/xion/View.php
@@ -70,7 +70,51 @@ class View
         $this->smarty->setTemplateDir(DIR_SMARTY_TEMPLATE);     // TEMPLATE DIR
         $this->smarty->setCompileDir(DIR_SMARTY_COMPILE);       // TEMPLATE COMPILE DIR
         $this->smarty->setConfigDir(DIR_SMARTY_CONFIG);         // CONFIG DIR
+        $this->registerProjectPlugins(DIR_SMARTY_PLUGINS);
         $this->smarty->setEscapeHtml(true);
+    }
+
+    /**
+     * Register project-specific Smarty plugins from a directory.
+     *
+     * Scans the directory for files matching Smarty 5's conventional plugin
+     * filename layout (`modifier.{name}.php`, `function.{name}.php`,
+     * `block.{name}.php`), requires each one once, and calls
+     * `Smarty::registerPlugin()` so the plugin becomes available in
+     * templates. Skips silently when the directory is missing.
+     *
+     * Using `registerPlugin` instead of the legacy `addPluginsDir` follows
+     * Smarty 5's deprecation guidance (the old API still works but emits a
+     * deprecation notice, which break HTTP responses while `display_errors`
+     * is on).
+     *
+     * @param string $dir Plugin directory absolute path.
+     *
+     * @return void
+     */
+    private function registerProjectPlugins(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $kinds = [
+            'modifier' => Smarty::PLUGIN_MODIFIER,
+            'function' => Smarty::PLUGIN_FUNCTION,
+            'block' => Smarty::PLUGIN_BLOCK,
+        ];
+        foreach (scandir($dir) ?: [] as $entry) {
+            if (!preg_match('/^(modifier|function|block)\.([A-Za-z0-9_]+)\.php$/', $entry, $matches)) {
+                continue;
+            }
+            $kind = $matches[1];
+            $name = $matches[2];
+            $callback = 'smarty_' . $kind . '_' . $name;
+            require_once $dir . DIRECTORY_SEPARATOR . $entry;
+            if (!function_exists($callback)) {
+                continue;
+            }
+            $this->smarty->registerPlugin($kinds[$kind], $name, $callback);
+        }
     }
 
     /**

--- a/init.sh
+++ b/init.sh
@@ -5,10 +5,11 @@ set -eu
 mkdir -p ./data 2>/dev/null
 mkdir -p ./view/config 2>/dev/null
 mkdir -p ./view/compile 2>/dev/null
+mkdir -p ./view/plugins 2>/dev/null
 mkdir -p ./log 2>/dev/null
 
 if id www-data >/dev/null 2>&1; then
-    chown -R www-data:www-data ./data ./view/compile ./log
+    chown -R www-data:www-data ./data ./view/compile ./view/plugins ./log
 fi
 
-chmod 775 ./data ./view/compile ./log
+chmod 775 ./data ./view/compile ./view/plugins ./log


### PR DESCRIPTION
## Summary

FT9 F-1 (high) + F-2 (low) の fix。

### Problem

\`ini/xSystemIni.php:214\` で \`DIR_SMARTY_PLUGINS\` 定数が定義されているのに、\`View::__construct\` で Smarty インスタンスに **何も渡していなかった**。さらに \`init.sh\` がそのディレクトリ自体を作らないので fresh install では \`view/plugins/\` も存在しない。コントリビュータが Smarty 標準の \`modifier.X.php\` を置いても silent に無視される (FT9 で 500 + \`unknown modifier 'X'\` を live で確認)。

### Why \`addPluginsDir()\` ではなく \`registerPlugin()\`

最初は trial clone と同じく \`addPluginsDir(DIR_SMARTY_PLUGINS)\` を 1 行追加で済ませようとしたが、Smarty 5 でこの API は deprecated。\`display_errors\` が dev で on のときに deprecation notice が response 前に echo されてヘッダ送信が壊れる (\`composer test:http\` が 22 件 error した)。

代わりに \`registerProjectPlugins()\` private メソッドを追加し、\`view/plugins/\` を scandir で走査して Smarty 5 標準の filename convention (\`modifier.{name}.php\` / \`function.{name}.php\` / \`block.{name}.php\`) に合うファイルを個別に \`require_once\` + \`Smarty::registerPlugin()\` で登録する形にした。Smarty 5 の正攻法。

### Changes

- \`class/xion/View.php\`:
  - \`__construct\` に \`$this->registerProjectPlugins(DIR_SMARTY_PLUGINS)\` を追加 (\`setEscapeHtml\` の直前)
  - 新 private method \`registerProjectPlugins(string $dir): void\`。ディレクトリ不在時は silent skip。
- \`init.sh\`: \`view/plugins\` を \`data\` / \`view/compile\` / \`log\` と同じく mkdir + chown + chmod。

## Test plan

- [x] \`composer test\` (50/50)
- [x] \`composer test:http\` (23/23, 1 expected skip)
- [x] live verify in FT9 clone: \`view/plugins/modifier.shout.php\` (modifier) と \`function.greet.php\` (function plugin) 両方が template から呼べる

Closes #342.