### PR TITLE
docs(smarty): smarty-plugins.md を新設して plugin authoring 手順を documentation する (#343)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This file is the first document for AI agents and automation working on NeNe.
 - Error codes & response decoration: `docs/development/error-codes.md` (envelope + the "error-path early-exit trap" — relevant whenever framework-wide response headers are added)
 - Error rendering (REST vs HTML): `docs/development/error-rendering.md` (404 / 500 / domain failure / CSRF / auth / 405 — what the caller actually sees on each side)
 - Production deployment: `docs/development/production-deployment.md` (env-var matrix, `compose.prod.yaml` overlay, log surface, Secure-cookie caveat, deployment checklist)
+- Smarty custom plugins: `docs/development/smarty-plugins.md` (modifier / function / block authoring under `view/plugins/`)
 - AI self-review: `docs/ai/README.md`
 - Commit conventions: `docs/development/commit-conventions.md`
 - Roadmap: `docs/roadmap.md`

--- a/docs/development/smarty-plugins.md
+++ b/docs/development/smarty-plugins.md
@@ -1,0 +1,104 @@
+# Smarty Plugins
+
+How to add a project-specific Smarty modifier / function / block plugin to NeNe under `view/plugins/`.
+
+Audience: anyone authoring a small piece of template logic (a date formatter, an HTML escaper variant, a domain-specific helper) that does not belong in a controller or `View` method. Trial source: FT9 (`docs/field-trials/2026-05-field-trial-9.md`).
+
+## Where plugins live
+
+```
+view/plugins/
+    modifier.shout.php
+    function.greet.php
+    block.callout.php
+```
+
+One plugin per file. The filename encodes both the plugin kind and the name the template uses:
+
+| Filename             | Kind     | Used in template as     |
+| -------------------- | -------- | ----------------------- |
+| `modifier.shout.php` | modifier | `{$value\|shout}`       |
+| `function.greet.php` | function | `{greet name='world'}`  |
+| `block.callout.php`  | block    | `{callout}…{/callout}`  |
+
+`View::registerProjectPlugins()` (in `class/xion/View.php`) scans this directory at construction time and registers each matching file via `Smarty::registerPlugin()`. Files that do not match the `modifier.NAME.php` / `function.NAME.php` / `block.NAME.php` pattern are skipped silently.
+
+The directory is created by `init.sh` alongside `view/compile/` and `data/`.
+
+## Function signatures
+
+### Modifier
+
+```php
+<?php
+// view/plugins/modifier.shout.php
+
+function smarty_modifier_shout(string $input): string
+{
+    return strtoupper($input) . '!!!';
+}
+```
+
+The function name must be exactly `smarty_modifier_<filename-stem>`. The first argument is the value being modified; additional arguments correspond to modifier parameters in the template (`{$value|shout:'?'}` would pass `'?'` as the second argument).
+
+### Function
+
+```php
+<?php
+// view/plugins/function.greet.php
+
+function smarty_function_greet(array $params, Smarty\Template $template): string
+{
+    $name = $params['name'] ?? 'world';
+    return 'Hello, ' . htmlspecialchars($name, ENT_QUOTES, 'UTF-8') . '.';
+}
+```
+
+`$params` carries the named attributes from the template (`{greet name='FT9'}` → `$params['name'] === 'FT9'`). Return the rendered string. The second argument is the Smarty `Template` instance — useful when the plugin needs to read or write template variables.
+
+### Block
+
+```php
+<?php
+// view/plugins/block.callout.php
+
+function smarty_block_callout(array $params, ?string $content, Smarty\Template $template, bool &$repeat): string
+{
+    if ($repeat) {
+        return '';
+    }
+    $level = htmlspecialchars((string)($params['level'] ?? 'note'), ENT_QUOTES, 'UTF-8');
+    return '<aside class="callout callout--' . $level . '">' . ($content ?? '') . '</aside>';
+}
+```
+
+Blocks are called twice — once at the opening tag (`$repeat=true`, `$content=null`) and once at the closing tag (`$repeat=false`, `$content` is the rendered inner block). Return an empty string on the first pass, the wrapped content on the second.
+
+## Output escaping
+
+The framework calls `setEscapeHtml(true)` on every `View` instance, which auto-escapes `{$variable}` references. **Plugins return raw strings** — if the return value contains HTML you intend to render unescaped, the caller must use `{plugin nofilter}` or `{$value|shout nofilter}` to bypass the auto-escape. For untrusted input inside the plugin, escape with `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` as shown above.
+
+The same trade-off was surfaced earlier by FT4 around `|nl2br` — see `docs/frontend/assets.md` § "Smarty HTML Escaping" for the full pattern.
+
+## Compile-cache hygiene
+
+Smarty invalidates compiled templates when the **template source** changes, but **not** when a plugin source file changes. After adding a new plugin file (or editing an existing one), clear the compile cache:
+
+```bash
+docker compose exec app rm -rf /var/www/html/view/compile/*
+```
+
+Otherwise Smarty will reuse the previously-compiled template, which already resolved the modifier/function/block names — and you'll see `unknown modifier 'shout'` even though the file is now in place. This is the same hygiene point covered by `docs/frontend/assets.md` (PR #268).
+
+## Why `registerPlugin` instead of `addPluginsDir`
+
+NeNe historically defined `DIR_SMARTY_PLUGINS` but never registered it with Smarty (FT9 F-1). The straightforward Smarty 3/4 fix would have been `Smarty::addPluginsDir(DIR_SMARTY_PLUGINS)`, but that API is **deprecated in Smarty 5** and emits a `Deprecated:` notice on every `View` construction. With `display_errors` on (default for development), the notice gets echoed into the HTTP response *before* the response headers, breaking session and CSRF flow.
+
+The framework instead scans the directory once at `View` construction and calls `Smarty::registerPlugin()` for each discovered file. This matches Smarty 5's preferred API while preserving the simple "drop a file in `view/plugins/`" authoring shape contributors expect.
+
+## Related
+
+- `docs/frontend/assets.md` — Smarty escape behavior, asset auto-discovery, compile cache.
+- `docs/field-trials/2026-05-field-trial-9.md` — the trial that surfaced the missing wiring.
+- `class/xion/View.php` — `View::registerProjectPlugins()` is the auto-discovery entry point.
+- Upstream Smarty 5 docs: <https://smarty-php.github.io/smarty/api/extending/registering-plugins>

--- a/docs/frontend/assets.md
+++ b/docs/frontend/assets.md
@@ -172,7 +172,7 @@ Two safe patterns:
 
 Option 2 keeps the template trivial and the auto-escape contract intact, at the cost of one CSS rule. Prefer it unless you specifically need HTML output from a modifier (e.g. `{$markdown_html|nofilter}` for already-sanitized markup).
 
-When you write a custom Smarty plugin or chain another markup-emitting modifier (`replace` with HTML, `html_*` series, etc.), reach for `nofilter` in the same way and treat any HTML the plugin produces as already trusted.
+When you write a custom Smarty plugin or chain another markup-emitting modifier (`replace` with HTML, `html_*` series, etc.), reach for `nofilter` in the same way and treat any HTML the plugin produces as already trusted. The authoring conventions for those custom plugins are in `docs/development/smarty-plugins.md`.
 
 ## Recommended Shape
 


### PR DESCRIPTION
## Summary

FT9 F-3 + F-4 の docs-only fix。F-1 + F-2 の framework fix (#344) で \`view/plugins/\` が auto-discover されるようになった後の正攻法を 1 ページにまとめる。

新ファイル \`docs/development/smarty-plugins.md\` を追加し、以下を含む:

1. ディレクトリレイアウト (\`modifier.X.php\` / \`function.X.php\` / \`block.X.php\` = 1 plugin 1 file)
2. 各 plugin kind の function 署名
3. Output escaping (\`setEscapeHtml=true\` との関係、\`nofilter\` / \`htmlspecialchars\` の使い分け)
4. **plugin file 追加 / 編集後は \`view/compile/\` を clear が必要** (F-4 / FT4 #268 と同根)
5. なぜ \`addPluginsDir()\` でなく \`registerPlugin()\` を使ったかの背景 (Smarty 5 deprecation 経緯)
6. 関連 link

\`AGENTS.md\` "Read First" にも 1 行リンク追加。\`docs/frontend/assets.md\` の Smarty escape section からも cross-link。

Closes #343.

## Test plan

- [ ] markdown lint pass
- [ ] 既存テストへの影響なし (docs-only)