### PR TITLE
refactor(xion): getLoginUserId() を ControllerBase に promote する (#348)

### DIFF
--- a/class/controller/TodoController.php
+++ b/class/controller/TodoController.php
@@ -124,16 +124,6 @@ class TodoController extends ControllerBase
     }
 
     /**
-     * Get the current login user's primary key.
-     *
-     * @return int User primary key.
-     */
-    private function getLoginUserId(): int
-    {
-        return (int)$this->AUTH_SESSION->userId();
-    }
-
-    /**
      * Normalize TODO rows for JSON output.
      *
      * @param array<int,array<string,mixed>> $rows TODO rows.

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -394,6 +394,20 @@ abstract class ControllerBase
     }
 
     /**
+     * Return the current login user's primary key.
+     *
+     * Convenience for controllers that read or write rows scoped to the
+     * authenticated user. Equivalent to `(int)$this->AUTH_SESSION->userId()`
+     * but shorter and centrally typed.
+     *
+     * @return int User primary key.
+     */
+    final protected function getLoginUserId(): int
+    {
+        return (int)$this->AUTH_SESSION->userId();
+    }
+
+    /**
      * Return the current session's CSRF token for embedding in an HTML form.
      *
      * Use this in an HTML action to pass the token to the template:


### PR DESCRIPTION
## Summary

FT10 F-1 の fix。\`TodoController\` 内 private だった \`getLoginUserId()\` を \`ControllerBase\` に move し、新 entity controller が \`\$this->getLoginUserId()\` を直接呼べるようにする。

trial で実証済みの摩擦: 新 entity controller を書くと \`Call to undefined method MemoController::getLoginUserId()\` で 500 を踏む。tutorial が TodoController を例にしてこの method を使っているので、contributor は素直に書いて NIN ハマる。

## Test plan

- [x] \`composer test\` (50/50)
- [x] \`composer test:http\` (23/23, 1 expected skip)

Closes #348.