### PR TITLE
docs: normalize row pattern を tutorial と rest-controller review に追記する (#349)

### DIFF
--- a/docs/review/rest-controller.md
+++ b/docs/review/rest-controller.md
@@ -16,6 +16,7 @@ Source policies:
 - [ ] State-changing methods (`POST` / `PUT` / `PATCH` / `DELETE`) rely on the framework's automatic CSRF gate when the user is logged in; no per-handler CSRF re-implementation.
 - [ ] `SESSION_CHECK` is left at the default `true` for protected endpoints; only set to `false` in `preAction()` for public endpoints with a documented reason.
 - [ ] Success responses use `$this->API_RESPONSE->success([...])` with a stable `Data` shape.
+- [ ] Mapper rows are cast through a per-controller `normalizeRow()` (or equivalent) helper before returning. Never return raw `fetch(PDO::FETCH_ASSOC)` rows — every value is a string until the controller casts it (`(int)$row['id']`, `(bool)$row['is_X']`, ...). See `docs/tutorials/building-a-service.md` § "Normalize the row before returning".
 - [ ] Failure responses use `$this->API_RESPONSE->failure('ERROR-CODE')` with a code that exists in `config/error_codes.php`.
 - [ ] New error codes are added to `config/error_codes.php` **and** documented in `docs/development/error-codes.md` (catalog table).
 - [ ] Per-error envelope schemas are **not** added to `docs/api/openapi.yaml`; the contract uses the canonical generic `ApiFailureEnvelope` (ADR-0003) with per-endpoint `examples` showing specific codes.

--- a/docs/tutorials/building-a-service.md
+++ b/docs/tutorials/building-a-service.md
@@ -338,6 +338,50 @@ GET  /article/item/id_1 -> ArticleController::itemGetRest()
 
 State-changing REST requests such as `POST`, `PUT`, `PATCH`, and `DELETE` require a valid login session and `X-CSRF-Token` when the user is logged in. `/session/login` returns the token as `Data.csrfToken`.
 
+### Normalize the row before returning
+
+Mappers return raw `PDOStatement::fetch(PDO::FETCH_ASSOC)` rows. Every value is a `string` (or `null`) — PDO does not type-cast columns by default. Returning a raw row to JSON ships `"id": "1"`, `"is_completed": "0"`, and other loose types.
+
+Define a small per-controller `normalizeRow()` helper that casts each column to its intended PHP type, and use it on every row the controller returns:
+
+```php
+class ArticleController extends ControllerBase
+{
+    public function itemGetRest(): array
+    {
+        // ... resolve $id, fetch the row ...
+        return $this->API_RESPONSE->success([
+            'article' => $this->normalizeRow($article),
+        ]);
+    }
+
+    public function indexGetRest(): array
+    {
+        $mapper = new Database\ArticleMapper();
+        return $this->API_RESPONSE->success([
+            'articles' => array_map([$this, 'normalizeRow'], $mapper->findPublishedRows()),
+        ]);
+    }
+
+    private function normalizeRow(array $row): array
+    {
+        return [
+            'id' => (int)$row['id'],
+            'title' => (string)$row['title'],
+            'is_published' => (bool)$row['is_published'],
+            'created_at' => (string)$row['created_at'],
+        ];
+    }
+}
+```
+
+The helper is intentionally per-entity — each table has its own column list and cast intent. `TodoController::normalizeRow()` in the bundled sample app is the canonical example (`is_completed` cast to `bool`, IDs to `int`).
+
+Two reasons to do this even on a one-off endpoint:
+
+- JSON consumers (browsers, JS clients, the contract test) rely on declared types. `"is_published": "0"` evaluates truthy in JavaScript.
+- The OpenAPI schema you author (`type: integer`, `type: boolean`) does not reshape the response — it only describes the intended shape. The contract test asserts the wire data conforms.
+
 ## Keep Controllers Thin
 
 Small read-only or single-write endpoints may call a mapper directly from the controller. Move logic into a service/use-case class when a controller method starts to coordinate business decisions, multiple mappers, multiple SQL statements, or a transaction.


### PR DESCRIPTION
## Summary

FT10 F-2 の docs-only fix。Mapper の生 row (\`PDO::FETCH_ASSOC\` で全 string)をそのまま返すと JSON で loose 型 (\`\"id\": \"1\"\`, \`\"is_completed\": \"0\"\`) になる罠を documentation で塞ぐ。

- \`docs/tutorials/building-a-service.md\` § "Add a REST Endpoint" 直下に \"Normalize the row before returning\" subsection を追加
  - per-controller \`normalizeRow()\` の書き方 (単体・list)
  - なぜ必要か (PDO は型変換しない / OpenAPI schema は wire data を reshape しない / JS 側で \`\"0\"\` は truthy)
- \`docs/review/rest-controller.md\` checklist に「mapper row を normalize したか」を追加

framework code 変更なし。

Closes #349.

## Test plan

- [ ] markdown lint pass
- [ ] 既存テストへの影響なし (docs-only)