### PR TITLE
docs(openapi): SessionClosed / CsrfTokenInvalid を reusable response にする (#351)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -118,19 +118,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/BasicSuccessEnvelope"
         "403":
-          description: CSRF token was missing or invalid (`CSRF-TOKEN-INVALID`).
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiFailureEnvelope"
-              examples:
-                csrfTokenInvalid:
-                  value:
-                    Result: true
-                    Data:
-                      status: failure
-                      errorCode: CSRF-TOKEN-INVALID
-                      errorMessage: Invalid CSRF token.
+          $ref: "#/components/responses/CsrfTokenInvalid"
   /todo/index:
     get:
       tags:
@@ -147,19 +135,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/TodoListSuccessEnvelope"
         "401":
-          description: Session is missing or expired (`SESSION-CLOSED`).
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiFailureEnvelope"
-              examples:
-                sessionClosed:
-                  value:
-                    Result: true
-                    Data:
-                      status: failure
-                      errorCode: SESSION-CLOSED
-                      errorMessage: Session timeout. Please log in again.
+          $ref: "#/components/responses/SessionClosed"
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
     post:
@@ -188,19 +164,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/TodoSuccessEnvelope"
         "401":
-          description: Session is missing or expired (`SESSION-CLOSED`).
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiFailureEnvelope"
-              examples:
-                sessionClosed:
-                  value:
-                    Result: true
-                    Data:
-                      status: failure
-                      errorCode: SESSION-CLOSED
-                      errorMessage: Session timeout. Please log in again.
+          $ref: "#/components/responses/SessionClosed"
         "400":
           description: TODO title was missing (`TODO-TITLE-REQUIRED`).
           content:
@@ -216,19 +180,7 @@ paths:
                       errorCode: TODO-TITLE-REQUIRED
                       errorMessage: TODO title is required.
         "403":
-          description: CSRF token was missing or invalid (`CSRF-TOKEN-INVALID`).
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiFailureEnvelope"
-              examples:
-                csrfTokenInvalid:
-                  value:
-                    Result: true
-                    Data:
-                      status: failure
-                      errorCode: CSRF-TOKEN-INVALID
-                      errorMessage: Invalid CSRF token.
+          $ref: "#/components/responses/CsrfTokenInvalid"
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
   /todo/item/id_{id}:
@@ -263,19 +215,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/TodoSuccessEnvelope"
         "401":
-          description: Session is missing or expired (`SESSION-CLOSED`).
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiFailureEnvelope"
-              examples:
-                sessionClosed:
-                  value:
-                    Result: true
-                    Data:
-                      status: failure
-                      errorCode: SESSION-CLOSED
-                      errorMessage: Session timeout. Please log in again.
+          $ref: "#/components/responses/SessionClosed"
         "400":
           description: TODO id or title was invalid (`TODO-ID-REQUIRED` / `TODO-TITLE-REQUIRED`).
           content:
@@ -300,19 +240,7 @@ paths:
         "404":
           $ref: "#/components/responses/TodoNotFound"
         "403":
-          description: CSRF token was missing or invalid (`CSRF-TOKEN-INVALID`).
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiFailureEnvelope"
-              examples:
-                csrfTokenInvalid:
-                  value:
-                    Result: true
-                    Data:
-                      status: failure
-                      errorCode: CSRF-TOKEN-INVALID
-                      errorMessage: Invalid CSRF token.
+          $ref: "#/components/responses/CsrfTokenInvalid"
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
     delete:
@@ -333,19 +261,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/TodoDeleteSuccessEnvelope"
         "401":
-          description: Session is missing or expired (`SESSION-CLOSED`).
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiFailureEnvelope"
-              examples:
-                sessionClosed:
-                  value:
-                    Result: true
-                    Data:
-                      status: failure
-                      errorCode: SESSION-CLOSED
-                      errorMessage: Session timeout. Please log in again.
+          $ref: "#/components/responses/SessionClosed"
         "400":
           description: TODO id was missing or invalid (`TODO-ID-REQUIRED`).
           content:
@@ -363,19 +279,7 @@ paths:
         "404":
           $ref: "#/components/responses/TodoNotFound"
         "403":
-          description: CSRF token was missing or invalid (`CSRF-TOKEN-INVALID`).
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiFailureEnvelope"
-              examples:
-                csrfTokenInvalid:
-                  value:
-                    Result: true
-                    Data:
-                      status: failure
-                      errorCode: CSRF-TOKEN-INVALID
-                      errorMessage: Invalid CSRF token.
+          $ref: "#/components/responses/CsrfTokenInvalid"
         "405":
           $ref: "#/components/responses/MethodNotAllowed"
 components:
@@ -400,6 +304,34 @@ components:
         type: integer
         minimum: 1
   responses:
+    SessionClosed:
+      description: Session is missing or expired (`SESSION-CLOSED`).
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiFailureEnvelope"
+          examples:
+            sessionClosed:
+              value:
+                Result: true
+                Data:
+                  status: failure
+                  errorCode: SESSION-CLOSED
+                  errorMessage: Session timeout. Please log in again.
+    CsrfTokenInvalid:
+      description: CSRF token was missing or invalid (`CSRF-TOKEN-INVALID`).
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiFailureEnvelope"
+          examples:
+            csrfTokenInvalid:
+              value:
+                Result: true
+                Data:
+                  status: failure
+                  errorCode: CSRF-TOKEN-INVALID
+                  errorMessage: Invalid CSRF token.
     TodoNotFound:
       description: TODO item was not found for the signed-in user (`TODO-NOT-FOUND`).
       content:

--- a/docs/review/openapi-contract.md
+++ b/docs/review/openapi-contract.md
@@ -16,7 +16,7 @@ Source policies:
 - [ ] Path parameters use NeNe's `/path/item/id_{id}` form and document a `parameter` referenced from `#/components/parameters/...` (e.g. `TodoId`, `MemoId`).
 - [ ] Security requirements (`sessionCookie` / `csrfToken`) match the actual gate behavior. `GET` operations only declare `sessionCookie`; state-changing operations declare both.
 - [ ] `requestBody.content['application/json'].examples` includes at least one example. The runtime contract test (`OpenApiRuntimeContractTest`) auto-discovers operations and uses the first example as the probe body.
-- [ ] Reusable responses (`#/components/responses/MethodNotAllowed`, `#/components/responses/TodoNotFound`, ...) are used where multiple operations share the same response shape.
+- [ ] Reusable responses (`#/components/responses/MethodNotAllowed`, `#/components/responses/SessionClosed`, `#/components/responses/CsrfTokenInvalid`, `#/components/responses/TodoNotFound`, ...) are used where multiple operations share the same response shape. State-changing operations that require auth should `$ref` `SessionClosed` (401) and `CsrfTokenInvalid` (403) rather than inlining the envelope.
 - [ ] New error codes are added to `config/error_codes.php` **and** `docs/development/error-codes.md` table; OpenAPI references them via `examples` only.
 - [ ] Operations with destructive side effects that should not be auto-probed by the runtime contract test set `x-nene-runtime-probe: skip` (currently unused — first use will validate the opt-out path).
 - [ ] `symfony/yaml` parses the modified file (`docker compose exec -T app php -r 'Symfony\Component\Yaml\Yaml::parseFile("docs/api/openapi.yaml");'` returns without exception).


### PR DESCRIPTION
## Summary

FT10 F-4 の fix。auth-required な全 operation で SESSION-CLOSED (401) と CSRF-TOKEN-INVALID (403) failure response が毎度 \`~15 行ずつ inline\` されている状態を解消する。

### Changes

- \`docs/api/openapi.yaml\` の \`components.responses\` に:
  - \`SessionClosed\` (401 + SESSION-CLOSED envelope example)
  - \`CsrfTokenInvalid\` (403 + CSRF-TOKEN-INVALID envelope example)
  を追加 (既存 \`MethodNotAllowed\` / \`TodoNotFound\` / \`NotFound\` と同じ shape)
- \`paths.*\` 配下の inline 401 / 403 ブロックを \`\$ref: \"#/components/responses/...\"\` に置換 (全 op で sweep)
- \`docs/review/openapi-contract.md\` checklist を更新して新 reusable を推奨

### Impact

| Metric | Before | After |
| --- | --- | --- |
| \`openapi.yaml\` 行数 | 670 | 602 (\`-68 行\`) |
| auth-required op の inline failure-block | ~15 行 × 2 | \`\$ref\` 各 2 行 |
| 新 endpoint authoring | ~70 行 | ~30 行 |

## Test plan

- [x] \`symfony/yaml\` parse OK (\`Yaml::parseFile(...)\`)
- [x] \`composer test\` (50/50)
- [x] \`composer test:http\` (23/23, 1 expected skip) — OpenApiRuntimeContractTest auto-discover が \`\$ref\` を正しく解決
- [ ] Swagger UI で render 確認 (任意)

Closes #351.