### PR TITLE
test(error-code): catalog と markdown 表の drift を unit test で検出する (#352)

### DIFF
--- a/tests/Unit/Xion/ErrorCodeTest.php
+++ b/tests/Unit/Xion/ErrorCodeTest.php
@@ -46,4 +46,31 @@ final class ErrorCodeTest extends TestCase
     {
         self::assertSame(500, ErrorCode::getInstance()->getHttpStatus('UNKNOWN-CODE'));
     }
+
+    /**
+     * The runtime catalog (`config/error_codes.php`) and the operator-facing
+     * markdown table (`docs/development/error-codes.md`) must stay in sync.
+     * FT10 surfaced that there is no CI check catching drift between the two:
+     * a new code only added to the PHP file silently ships undocumented.
+     */
+    public function testEveryRuntimeCodeAppearsInDocsMarkdownTable(): void
+    {
+        $catalog = require dirname(__DIR__, 3) . '/config/error_codes.php';
+        $markdown = (string)file_get_contents(dirname(__DIR__, 3) . '/docs/development/error-codes.md');
+
+        $missing = [];
+        foreach (array_keys($catalog) as $code) {
+            // The markdown row uses backtick-quoted code at the start of the cell.
+            if (!str_contains($markdown, '`' . $code . '`')) {
+                $missing[] = $code;
+            }
+        }
+
+        self::assertSame(
+            [],
+            $missing,
+            'These config/error_codes.php codes are not documented in docs/development/error-codes.md: '
+                . implode(', ', $missing)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

FT10 F-5 の fix。新しい error code を \`config/error_codes.php\` に足したのに \`docs/development/error-codes.md\` の表に書かれない drift を CI で catchable にする。

\`tests/Unit/Xion/ErrorCodeTest.php\` に \`testEveryRuntimeCodeAppearsInDocsMarkdownTable\` を追加。catalog の全 key が markdown ファイルにバッククォート (\`CODE\`) で登場するかチェックする。fail 時は missing 一覧を assertion message で出す。

## Test plan

- [x] \`composer test\` 51/51 green
- [x] 試しに \`PROBE-DRIFT-DETECTED\` を catalog に追加すると新 test だけが fail (message: \`These config/error_codes.php codes are not documented...: PROBE-DRIFT-DETECTED\`)
- [x] 復元後再び green

Closes #352.