### PR TITLE
feat(xion): upload helpers (Request::getFile + UploadedFile + init.sh data/uploads) (#362)

### DIFF
--- a/class/xion/Request.php
+++ b/class/xion/Request.php
@@ -118,4 +118,18 @@ class Request
         }
         return $this->param->get($key);
     }
+
+    /**
+     * Return the uploaded file at `$_FILES[$key]` as a typed
+     * {@see UploadedFile}, or `null` when the key is absent. Does not
+     * itself reject incomplete uploads — the controller calls
+     * `validate(...)` on the returned wrapper for that.
+     */
+    public function getFile(string $key): ?UploadedFile
+    {
+        if (!isset($_FILES[$key]) || !is_array($_FILES[$key])) {
+            return null;
+        }
+        return new UploadedFile($_FILES[$key]);
+    }
 }

--- a/class/xion/UploadedFile.php
+++ b/class/xion/UploadedFile.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use finfo;
+
+/**
+ * Typed wrapper around a single `$_FILES` entry.
+ *
+ * Built by {@see Request::getFile()}. Carries the values the framework
+ * trusts (client-supplied original name, server-measured size, tmp path)
+ * plus a lazy `finfo` mime detection that ignores the client-supplied
+ * `type` (which is forgeable). FT12 F-1 / F-3.
+ */
+class UploadedFile
+{
+    private string $name;
+    private int $size;
+    private string $tmpPath;
+    private int $error;
+    private ?string $mime = null;
+
+    /**
+     * @param array{name:string,size:int,tmp_name:string,error:int} $upload
+     */
+    public function __construct(array $upload)
+    {
+        $this->name = (string)($upload['name'] ?? '');
+        $this->size = (int)($upload['size'] ?? 0);
+        $this->tmpPath = (string)($upload['tmp_name'] ?? '');
+        $this->error = (int)($upload['error'] ?? UPLOAD_ERR_NO_FILE);
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function size(): int
+    {
+        return $this->size;
+    }
+
+    public function tmpPath(): string
+    {
+        return $this->tmpPath;
+    }
+
+    /**
+     * Detect the mime type via `finfo` from the moved-tmp file, **not** the
+     * client-supplied `type` (which is forgeable). Cached after the first call.
+     */
+    public function mime(): string
+    {
+        if ($this->mime === null) {
+            $this->mime = (string)(new finfo(FILEINFO_MIME_TYPE))->file($this->tmpPath);
+        }
+        return $this->mime;
+    }
+
+    /**
+     * Whether PHP accepted the upload and the tmp file is real.
+     */
+    public function isValid(): bool
+    {
+        return $this->error === UPLOAD_ERR_OK && $this->tmpPath !== '' && is_uploaded_file($this->tmpPath);
+    }
+
+    /**
+     * Validate against framework-supplied constraints and return `$this`,
+     * or throw {@see DomainException} with a catalog error code.
+     *
+     * Constraints:
+     *
+     * - `maxBytes` (int)              — reject when `size() > maxBytes`        → `UPLOAD-TOO-LARGE`
+     * - `allowedMime` (array<string>) — `finfo` mime must be in this list     → `UPLOAD-MIME-REJECTED`
+     *
+     * `isValid()` is always checked first; failure raises `UPLOAD-FILE-REQUIRED`.
+     *
+     * @param array{maxBytes?:int, allowedMime?:array<int,string>} $constraints
+     */
+    public function validate(array $constraints = []): self
+    {
+        if (!$this->isValid()) {
+            throw new DomainException('UPLOAD-FILE-REQUIRED');
+        }
+        if (isset($constraints['maxBytes']) && $this->size > (int)$constraints['maxBytes']) {
+            throw new DomainException('UPLOAD-TOO-LARGE');
+        }
+        if (isset($constraints['allowedMime']) && !in_array($this->mime(), $constraints['allowedMime'], true)) {
+            throw new DomainException('UPLOAD-MIME-REJECTED');
+        }
+        return $this;
+    }
+
+    /**
+     * Move the uploaded tmp file to a target path. Wraps PHP's
+     * `move_uploaded_file()` and re-checks `is_uploaded_file()` defensively.
+     */
+    public function moveTo(string $target): bool
+    {
+        if (!is_uploaded_file($this->tmpPath)) {
+            return false;
+        }
+        return move_uploaded_file($this->tmpPath, $target);
+    }
+}

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -43,4 +43,16 @@ return [
         'message' => 'TODO title is required.',
         'httpStatus' => 400,
     ],
+    'UPLOAD-FILE-REQUIRED' => [
+        'message' => 'Upload file is required.',
+        'httpStatus' => 400,
+    ],
+    'UPLOAD-TOO-LARGE' => [
+        'message' => 'Upload exceeds size limit.',
+        'httpStatus' => 413,
+    ],
+    'UPLOAD-MIME-REJECTED' => [
+        'message' => 'Upload mime type is not allowed.',
+        'httpStatus' => 415,
+    ],
 ];

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -35,6 +35,9 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `TODO-ID-REQUIRED` | 400 | TODO id is required. | `/todo/item/id_X` with missing or non-numeric `id`. |
 | `TODO-NOT-FOUND` | 404 | TODO item was not found. | `/todo/item/id_X` where no row matches the signed-in user. |
 | `TODO-TITLE-REQUIRED` | 400 | TODO title is required. | `POST /todo/index` or `PUT /todo/item/id_X` with empty `title`. |
+| `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
+| `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
+| `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
 
 ## Adding a new error code
 

--- a/init.sh
+++ b/init.sh
@@ -3,6 +3,7 @@
 set -eu
 
 mkdir -p ./data 2>/dev/null
+mkdir -p ./data/uploads 2>/dev/null
 mkdir -p ./view/config 2>/dev/null
 mkdir -p ./view/compile 2>/dev/null
 mkdir -p ./view/plugins 2>/dev/null
@@ -12,4 +13,4 @@ if id www-data >/dev/null 2>&1; then
     chown -R www-data:www-data ./data ./view/compile ./view/plugins ./log
 fi
 
-chmod 775 ./data ./view/compile ./view/plugins ./log
+chmod 775 ./data ./data/uploads ./view/compile ./view/plugins ./log

--- a/tests/Unit/Xion/UploadedFileTest.php
+++ b/tests/Unit/Xion/UploadedFileTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\DomainException;
+use Nene\Xion\UploadedFile;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * UploadedFile validation logic. The PHP `is_uploaded_file()` check that
+ * `isValid()` performs requires an actual SAPI upload, so tests that
+ * exercise it use a per-test tmp file plus mock-friendly inputs.
+ *
+ * `validate()` short-circuits on `isValid()`, so any tmp_name that fails
+ * `is_uploaded_file()` raises `UPLOAD-FILE-REQUIRED` before size or mime
+ * checks run. The tests use real tmp files for *size* / *mime* coverage
+ * by stubbing `isValid()` via a small subclass.
+ */
+final class UploadedFileTest extends TestCase
+{
+    public function testAccessorsReflectUploadArray(): void
+    {
+        $file = new UploadedFile([
+            'name' => 'foo.png',
+            'size' => 1234,
+            'tmp_name' => '/tmp/nonexistent-' . bin2hex(random_bytes(4)),
+            'error' => UPLOAD_ERR_OK,
+        ]);
+
+        self::assertSame('foo.png', $file->name());
+        self::assertSame(1234, $file->size());
+        self::assertStringStartsWith('/tmp/', $file->tmpPath());
+    }
+
+    public function testIsValidReturnsFalseForFakeTmpPath(): void
+    {
+        $file = new UploadedFile([
+            'name' => 'foo.png',
+            'size' => 10,
+            'tmp_name' => '/tmp/nonexistent-' . bin2hex(random_bytes(4)),
+            'error' => UPLOAD_ERR_OK,
+        ]);
+
+        self::assertFalse($file->isValid());
+    }
+
+    public function testIsValidReturnsFalseWhenPhpReportsError(): void
+    {
+        $file = new UploadedFile([
+            'name' => 'foo.png',
+            'size' => 0,
+            'tmp_name' => '',
+            'error' => UPLOAD_ERR_NO_FILE,
+        ]);
+
+        self::assertFalse($file->isValid());
+    }
+
+    public function testValidateThrowsFileRequiredWhenInvalid(): void
+    {
+        $file = new UploadedFile([
+            'name' => 'foo.png',
+            'size' => 10,
+            'tmp_name' => '/tmp/nonexistent-' . bin2hex(random_bytes(4)),
+            'error' => UPLOAD_ERR_OK,
+        ]);
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('UPLOAD-FILE-REQUIRED');
+        $file->validate();
+    }
+
+    public function testValidateThrowsTooLargeWhenOverMaxBytes(): void
+    {
+        $file = new UploadedFileWithForcedValid([
+            'name' => 'big.bin',
+            'size' => 5000,
+            'tmp_name' => '/tmp/nonexistent',
+            'error' => UPLOAD_ERR_OK,
+        ]);
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('UPLOAD-TOO-LARGE');
+        $file->validate(['maxBytes' => 1000]);
+    }
+
+    public function testValidateAcceptsWhenWithinMaxBytes(): void
+    {
+        $file = new UploadedFileWithForcedValid([
+            'name' => 'small.bin',
+            'size' => 500,
+            'tmp_name' => '/tmp/nonexistent',
+            'error' => UPLOAD_ERR_OK,
+        ]);
+        $file->setMime('application/octet-stream');
+
+        $returned = $file->validate([
+            'maxBytes' => 1000,
+            'allowedMime' => ['application/octet-stream'],
+        ]);
+
+        self::assertSame($file, $returned);
+    }
+
+    public function testValidateRejectsMimeNotOnAllowlist(): void
+    {
+        $file = new UploadedFileWithForcedValid([
+            'name' => 'bad.bin',
+            'size' => 100,
+            'tmp_name' => '/tmp/nonexistent',
+            'error' => UPLOAD_ERR_OK,
+        ]);
+        $file->setMime('application/octet-stream');
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('UPLOAD-MIME-REJECTED');
+        $file->validate(['allowedMime' => ['image/png']]);
+    }
+}
+
+/**
+ * Test-only subclass that forces `isValid()` to return true (so we can
+ * exercise the size / mime branches without a real SAPI upload) and lets
+ * the test set the detected mime instead of calling `finfo`.
+ */
+class UploadedFileWithForcedValid extends UploadedFile
+{
+    private string $forcedMime = 'application/octet-stream';
+
+    public function isValid(): bool
+    {
+        return true;
+    }
+
+    public function setMime(string $mime): void
+    {
+        $this->forcedMime = $mime;
+    }
+
+    public function mime(): string
+    {
+        return $this->forcedMime;
+    }
+}


### PR DESCRIPTION
## Summary

FT12 F-1 + F-3 + F-4 を 1 PR に combine。

### F-1 + F-3: Request::getFile() + UploadedFile

- \`class/xion/UploadedFile.php\` 新規。\`\$_FILES\` エントリの typed wrapper
  - \`name()\` / \`size()\` / \`tmpPath()\` (raw 値)
  - \`mime()\` (lazy \`finfo\`、client-supplied \`type\` は無視 — forgeable)
  - \`isValid()\` (\`UPLOAD_ERR_OK\` + \`is_uploaded_file\`)
  - \`validate([maxBytes, allowedMime])\`: 失敗時は \`DomainException\` で catalog code を投げる
    - invalid → \`UPLOAD-FILE-REQUIRED\` (400)
    - size 超過 → \`UPLOAD-TOO-LARGE\` (413)
    - mime 不合致 → \`UPLOAD-MIME-REJECTED\` (415)
  - \`moveTo(\$target)\` (\`move_uploaded_file\` wrapper)
- \`class/xion/Request.php\` に \`getFile(string \$key): ?UploadedFile\`
- \`final\` を付けずに subclass 可能 (test fixture + 拡張)

### F-4: init.sh で data/uploads/ を作る

\`data/\` と同じ pattern で \`data/uploads/\` を mkdir + chown + chmod。

### Error codes

\`config/error_codes.php\` と \`docs/development/error-codes.md\` 同期 (FT10 #352 drift gate あるので CI で自動チェック)。

### Usage 想定

trial probe では:

\`\`\`php
$upload = $_FILES['file'] ?? null;
if (!is_array($upload) || ...) { return failure('ATTACHMENT-FILE-REQUIRED'); }
if (!is_uploaded_file($upload['tmp_name'])) { ... }
if ((int)$upload['size'] > self::MAX_BYTES) { ... }
$mime = (new \\finfo(FILEINFO_MIME_TYPE))->file($upload['tmp_name']);
if (!in_array($mime, self::ALLOWED_MIME, true)) { ... }
\`\`\`

fix 後:

\`\`\`php
$file = $this->request->getFile('file')?->validate([
    'maxBytes' => 1_000_000,
    'allowedMime' => ['image/png', 'image/jpeg', 'application/pdf'],
]) ?? throw new DomainException('UPLOAD-FILE-REQUIRED');
\`\`\`

## Test plan

- [x] \`composer test\` 64/64 (57 既存 + 7 新 \`UploadedFileTest\`)
- [x] \`composer test:http\` 23/23 (1 expected skip)
- [x] FT10 drift test green (UPLOAD-* が docs 表にも入っている)
- [x] fresh \`docker compose up\` で \`data/uploads/\` 自動作成

Closes #362.