### PR TITLE
feat(xion): ControllerBase::sendFile() で binary 応答を可能にする (#363, option c)

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -516,4 +516,33 @@ abstract class ControllerBase
     {
         throw new Xion\HttpTermination(Xion\HttpResponse::html((string)file_get_contents(DIR_ROOT . '/404.html'), 404));
     }
+
+    /**
+     * Send a binary file response and terminate dispatch.
+     *
+     * `*Rest` and `*Action` handlers normally return arrays or `void`;
+     * `ControllerBase::run()` then JSON-encodes or Smarty-renders the
+     * response. To serve a binary file (PDF, image, generated CSV)
+     * inline from a REST handler, call `$this->sendFile($path, $mime)`
+     * — it throws {@see Xion\HttpTermination} carrying a
+     * {@see Xion\HttpResponse::file()} that the top-level catch in
+     * `htdocs/index.php` emits unchanged.
+     *
+     * The file must exist and be readable. Pass `$downloadName` to add
+     * `Content-Disposition: attachment; filename=...`; omit it for inline
+     * rendering (browser previews PDFs / images instead of saving).
+     *
+     * See FT12 F-2 / ADR-N/A. Option (c) of the trial report.
+     *
+     * @return never
+     */
+    final protected function sendFile(string $path, string $mime, ?string $downloadName = null): never
+    {
+        if (!is_file($path) || !is_readable($path)) {
+            $this->notFound();
+        }
+        throw new Xion\HttpTermination(
+            Xion\HttpResponse::file((string)file_get_contents($path), $mime, $downloadName)
+        );
+    }
 }

--- a/class/xion/HttpResponse.php
+++ b/class/xion/HttpResponse.php
@@ -52,6 +52,34 @@ final class HttpResponse
         return new self($statusCode, array_merge($headers, ['Location' => $uri]));
     }
 
+    /**
+     * Build a binary file response (Content-Type set by `$mime`; optionally
+     * marks the response as a download with `Content-Disposition: attachment;
+     * filename="..."`). Used by {@see ControllerBase::sendFile()}.
+     *
+     * The body is the full file contents; callers requiring streamed delivery
+     * of multi-gigabyte files should reach for `readfile()` outside this value
+     * object (out of scope for the small-app surface NeNe targets).
+     *
+     * @param string      $body         Raw file contents.
+     * @param string      $mime         Response `Content-Type` (e.g. `image/png`).
+     * @param string|null $downloadName Optional filename for `Content-Disposition`.
+     * @param integer     $statusCode   HTTP status code (default 200).
+     */
+    final public static function file(
+        string $body,
+        string $mime,
+        ?string $downloadName = null,
+        int $statusCode = 200
+    ): self {
+        $headers = ['Content-Type' => $mime];
+        if ($downloadName !== null) {
+            $safe = str_replace(['"', "\r", "\n"], '', $downloadName);
+            $headers['Content-Disposition'] = 'attachment; filename="' . $safe . '"';
+        }
+        return new self($statusCode, $headers, $body);
+    }
+
     final public function statusCode(): int
     {
         return $this->statusCode;


### PR DESCRIPTION
## Summary

FT12 F-2 の fix。trial report で並べた 3 案のうち **option (c) sendFile helper** を採用。

### Why (c)

- (a) \`*Rest\` handler が \`HttpResponse\` を返せる: run() に \`instanceof HttpResponse\` 分岐を増やす、contract test の前提 (\"REST returns array\") に影響する可能性
- (b) 新 handler suffix \`*Binary\`: dispatcher / RouteContext mode 拡張が要る
- (c) \`sendFile()\` helper: \`notFound()\` / \`location()\` と同じ \`throw HttpTermination(...)\` pattern。run() / dispatcher / contract test に影響ゼロ。最小 surface

(c) は notFound() の親戚として位置付けるのが自然。

### Changes

- \`class/xion/HttpResponse.php\` に新 factory \`file(string \$body, string \$mime, ?string \$downloadName = null, int \$statusCode = 200): self\`
  - Content-Type は \$mime
  - \$downloadName 指定で \`Content-Disposition: attachment; filename=\"...\"\`、CR/LF/dquote は sanitize
- \`class/xion/ControllerBase.php\` に \`final protected sendFile(string \$path, string \$mime, ?string \$downloadName = null): never\`
  - is_file / is_readable 通らない時は \$this->notFound() に委譲
  - 通れば \`throw new HttpTermination(HttpResponse::file(...))\` で dispatch 終了

## Test plan

- [x] \`composer test\` 64/64
- [x] \`composer test:http\` 23/23 (1 expected skip)
- [x] live verify (一時 probe controller):
  - GET → \`Content-Type: image/png\` + PNG bytes 直送
  - GET → \`Content-Disposition: attachment; filename=\"hello.txt\"\` + text body
  - GET (missing file) → 404 via notFound()

Closes #363.