### PR TITLE
docs: file-uploads.md + file-upload review checklist を新設する (#366)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This file is the first document for AI agents and automation working on NeNe.
 - Error rendering (REST vs HTML): `docs/development/error-rendering.md` (404 / 500 / domain failure / CSRF / auth / 405 — what the caller actually sees on each side)
 - Production deployment: `docs/development/production-deployment.md` (env-var matrix, `compose.prod.yaml` overlay, log surface, Secure-cookie caveat, deployment checklist)
 - Smarty custom plugins: `docs/development/smarty-plugins.md` (modifier / function / block authoring under `view/plugins/`)
+- File uploads: `docs/development/file-uploads.md` (`Request::getFile` / `UploadedFile::validate` / `ControllerBase::sendFile` + storage convention + security summary)
 - AI self-review: `docs/ai/README.md`
 - Commit conventions: `docs/development/commit-conventions.md`
 - Roadmap: `docs/roadmap.md`

--- a/docs/development/file-uploads.md
+++ b/docs/development/file-uploads.md
@@ -1,0 +1,143 @@
+# File Uploads
+
+How NeNe accepts `multipart/form-data` file uploads end-to-end: the framework helpers, storage convention, env-driven size limits, and the security details that surfaced during FT12.
+
+Audience: anyone authoring an endpoint that receives a file. Trial source: FT12 (`docs/field-trials/2026-05-field-trial-12.md`).
+
+## The pieces
+
+| What | Where |
+| --- | --- |
+| Typed wrapper for one `$_FILES` entry | `Nene\Xion\UploadedFile` |
+| Read an uploaded file from the request | `Nene\Xion\Request::getFile(string $key): ?UploadedFile` |
+| Validate (size, mime) | `UploadedFile::validate(['maxBytes' => N, 'allowedMime' => [...]])` |
+| Move to a final destination | `UploadedFile::moveTo(string $target): bool` |
+| Send a stored file back as a binary response | `ControllerBase::sendFile(string $path, string $mime, ?string $downloadName = null): never` |
+| Suggested storage root | `data/uploads/` (mkdir'd by `init.sh`) |
+| Upload size env overrides | `NENE_UPLOAD_MAX_FILESIZE`, `NENE_POST_MAX_SIZE` |
+| Error codes | `UPLOAD-FILE-REQUIRED` (400), `UPLOAD-TOO-LARGE` (413), `UPLOAD-MIME-REJECTED` (415) |
+
+## Receiving a file
+
+```php
+class AttachmentController extends ControllerBase
+{
+    public function indexPostRest(): array
+    {
+        $userId = $this->getLoginUserId();
+
+        $file = $this->request->getFile('file')?->validate([
+            'maxBytes'    => 1_000_000,
+            'allowedMime' => ['image/png', 'image/jpeg', 'application/pdf'],
+        ]);
+        if ($file === null) {
+            return $this->API_RESPONSE->failure('UPLOAD-FILE-REQUIRED');
+        }
+
+        $dir = DIR_ROOT . 'data/uploads/' . $userId;
+        if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+            throw new \RuntimeException('Could not create upload directory.');
+        }
+
+        $ext  = match ($file->mime()) {
+            'image/png'       => 'png',
+            'image/jpeg'      => 'jpg',
+            'application/pdf' => 'pdf',
+        };
+        $name = bin2hex(random_bytes(8)) . '.' . $ext;
+        if (!$file->moveTo($dir . '/' . $name)) {
+            throw new \RuntimeException('Could not persist uploaded file.');
+        }
+
+        return $this->API_RESPONSE->success([
+            'attachment' => [
+                'id'   => $name,
+                'size' => $file->size(),
+                'mime' => $file->mime(),
+            ],
+        ]);
+    }
+}
+```
+
+`validate()` raises `DomainException` with the appropriate catalog code on failure; the top-level catch in `htdocs/index.php` turns that into the ADR-0003 JSON envelope automatically. Pre-validation, `getFile()` returns `null` when the form field is missing — surface that as `UPLOAD-FILE-REQUIRED` manually (the helper does not assume "missing field" means "client error" because some endpoints accept optional uploads).
+
+The mime detection inside `UploadedFile` uses `finfo` on the moved tmp file. **The client-supplied `$_FILES['file']['type']` is ignored** — it is forgeable and must not be trusted.
+
+## Returning a file
+
+REST handlers normally return arrays (`ControllerBase::run()` JSON-encodes them). For binary downloads use `sendFile()`:
+
+```php
+public function itemGetRest(): array
+{
+    $userId = $this->getLoginUserId();
+    $id     = (string)($this->request->getParam('id') ?? '');
+    if (!preg_match('/^[a-f0-9]{16}\.(png|jpg|pdf)$/', $id)) {
+        return $this->API_RESPONSE->failure('UPLOAD-FILE-REQUIRED');
+    }
+
+    $path = DIR_ROOT . 'data/uploads/' . $userId . '/' . $id;
+    $mime = match (pathinfo($id, PATHINFO_EXTENSION)) {
+        'png' => 'image/png',
+        'jpg' => 'image/jpeg',
+        'pdf' => 'application/pdf',
+    };
+
+    $this->sendFile($path, $mime); // never returns — emits HttpTermination
+}
+```
+
+`sendFile()` throws `HttpTermination` after building the response, so the `return $this->API_RESPONSE->...` line beneath it is unreachable (the function signature is annotated `never`). On a missing file it falls back to the framework's `notFound()` 404. Add `$downloadName` to switch from inline preview to `Content-Disposition: attachment` download.
+
+## Storage convention
+
+`init.sh` creates `data/uploads/` at every container start with `www-data:www-data` ownership and mode `775`. The framework does not enforce a sub-directory layout; the example above uses `data/uploads/<user_id>/<random>.<ext>` so files are scoped per user and collision-free. Other reasonable layouts:
+
+- `data/uploads/<entity>/<id>.<ext>` — when the upload always attaches to a single entity row.
+- `data/uploads/<yyyy>/<mm>/<random>.<ext>` — for date-bucketed retention.
+
+`data/uploads/` is inside the project tree (and inside the Docker bind mount in dev). In production, mount a volume there or point a `NENE_UPLOAD_PATH` analogue at it (future work — see FT11 follow-ups for the path-override pattern with `NENE_LOG_PATH`).
+
+## Size limits
+
+PHP defaults are `upload_max_filesize = 2M` / `post_max_size = 8M`. A 3 MB file silently 413's *before* the controller sees the request, with response shape outside ADR-0003. Override via env:
+
+```yaml
+# compose.prod.yaml (or .env at the project root)
+services:
+  app:
+    environment:
+      NENE_UPLOAD_MAX_FILESIZE: "10M"
+      NENE_POST_MAX_SIZE: "12M"
+```
+
+`init.sh` writes the values into `/usr/local/etc/php/conf.d/zz-nene-runtime.ini` on every container start. Constraint: `NENE_POST_MAX_SIZE` must be at least as large as `NENE_UPLOAD_MAX_FILESIZE`. See `docs/development/production-deployment.md` for the full env matrix.
+
+The controller-level `maxBytes` constraint on `UploadedFile::validate()` is a **separate** check that runs *after* PHP has accepted the request — use both: PHP-level limit as the hard wall, controller-level limit for per-endpoint policy.
+
+## Security checklist
+
+`docs/review/file-upload.md` carries the full checklist. The four-line summary:
+
+1. **`finfo` mime, not client mime.** `$_FILES[]['type']` is forgeable.
+2. **Server-derived extension.** Pick the extension from the validated mime, not from `$_FILES[]['name']`. Reject `.php` / `.phtml` / `.html` / `.htaccess` even if the mime is plausible.
+3. **Scope the storage path.** Include `<user_id>` (or another scope identifier) in the path so a future bug in id parsing cannot cross-pollinate two users' files.
+4. **Bound the retrieve id.** Match `id_<X>` against an allowlist regex (`^[a-f0-9]{16}\.(png|jpg|pdf)$` in the example above) before concatenating it into a filesystem path.
+
+The framework helper enforces #1 (`UploadedFile::mime()` uses `finfo`); the other three are the controller's responsibility because the right shape depends on the app.
+
+## OpenAPI
+
+Multipart endpoints document their request body as `multipart/form-data` with a `type: object` schema. The runtime contract test (`OpenApiRuntimeContractTest`) probes such operations with an empty body, so the documented `responses:` list must include the missing-file status (typically `400` `UPLOAD-FILE-REQUIRED`). Full example: `docs/tutorials/building-a-service.md` § "File upload (multipart) operations".
+
+## Related
+
+- `docs/development/error-codes.md` — `UPLOAD-*` catalog rows.
+- `docs/development/production-deployment.md` — `NENE_UPLOAD_MAX_FILESIZE` / `NENE_POST_MAX_SIZE` env matrix.
+- `docs/development/error-rendering.md` — how `DomainException('UPLOAD-...')` renders on REST vs HTML paths.
+- `docs/review/file-upload.md` — review checklist.
+- `docs/tutorials/building-a-service.md` § "Update OpenAPI" → "File upload (multipart) operations" — yaml shape.
+- `docs/field-trials/2026-05-field-trial-12.md` — the trial that surfaced every behavior above.
+- `class/xion/UploadedFile.php` — wrapper source.
+- `class/xion/ControllerBase.php::sendFile` — binary response helper.

--- a/docs/review/README.md
+++ b/docs/review/README.md
@@ -15,6 +15,7 @@ The format is borrowed from the sibling project NENE2's `docs/review/` and adapt
 | [`docs-and-adr.md`](docs-and-adr.md) | Policy doc edits, ADR additions, roadmap / milestones / TODO changes. |
 | [`release-ci.md`](release-ci.md) | `.github/workflows/`, branch protection, auto-merge config, dependency upgrades. |
 | [`field-trial-report.md`](field-trial-report.md) | A new `docs/field-trials/YYYY-MM-field-trial-N.md` or its follow-up Issues. |
+| [`file-upload.md`](file-upload.md) | Endpoints that accept `multipart/form-data` uploads (`Request::getFile()` / `UploadedFile::validate()`). |
 
 A single PR may invoke more than one checklist (a REST endpoint usually triggers `rest-controller.md` + `openapi-contract.md` + `database.md`). Reference the checklist(s) you used in the PR body.
 
@@ -35,6 +36,7 @@ The checklists link back to the canonical policy docs:
 - `docs/development/testing.md` — unit + HTTP runtime smoke tests
 - `docs/development/docker.md` — local environment + env vars
 - `docs/development/error-codes.md` — error catalog (post ADR-0003)
+- `docs/development/file-uploads.md` — upload helpers + storage convention + security notes (FT12)
 - `docs/api/README.md` — OpenAPI policy
 - `docs/api/reference-client.md` — external consumer mechanics
 - `docs/tutorials/building-a-service.md` — full tutorial flow

--- a/docs/review/file-upload.md
+++ b/docs/review/file-upload.md
@@ -1,0 +1,45 @@
+# File Upload Self-Review
+
+Use this checklist for any endpoint that accepts a `multipart/form-data` upload or serves binary file responses. Pairs with `rest-controller.md` (for the surrounding REST handler) or `html-controller.md` (for the HTML form).
+
+Source policies:
+
+- `docs/development/file-uploads.md` (helpers, storage convention, security summary)
+- `docs/development/error-codes.md` (`UPLOAD-FILE-REQUIRED`, `UPLOAD-TOO-LARGE`, `UPLOAD-MIME-REJECTED`)
+- `docs/development/production-deployment.md` (`NENE_UPLOAD_MAX_FILESIZE`, `NENE_POST_MAX_SIZE`)
+- `docs/review/openapi-contract.md` (multipart operations)
+- `docs/tutorials/building-a-service.md` § "Update OpenAPI" → "File upload (multipart) operations"
+
+## Receive checklist
+
+- [ ] Read the uploaded file via `$this->request->getFile('field-name')` — **not** `$_FILES['...']` directly.
+- [ ] Call `->validate(['maxBytes' => N, 'allowedMime' => [...]])` on the wrapper. Do not skip any of the three validations (presence, size, mime).
+- [ ] Treat `getFile()` returning `null` as "form field missing" — return `UPLOAD-FILE-REQUIRED` (or a per-endpoint code) explicitly.
+- [ ] Use `UploadedFile::mime()` (the `finfo` result), **never** `$_FILES['...']['type']` (forgeable, client-supplied).
+- [ ] Derive the stored-file extension from the validated mime (`match ($file->mime()) { 'image/png' => 'png', ... }`), not from `$_FILES['...']['name']`.
+- [ ] Reject executable extensions on the stored path even when the mime is plausible (`.php`, `.phtml`, `.html`, `.htaccess`, `.shtml`).
+- [ ] The save path includes the signed-in user (`data/uploads/<user_id>/...`) or another explicit scope identifier so a future id-parsing bug cannot leak files across users.
+- [ ] The stored filename is server-generated (e.g. `bin2hex(random_bytes(8))`) — never the client-supplied name verbatim.
+- [ ] `UploadedFile::moveTo($target)` is used (wraps `move_uploaded_file()` + re-checks `is_uploaded_file()`). Do not write the tmp file with `rename()` / `copy()`.
+- [ ] State-changing upload endpoints declare both `sessionCookie` and `csrfToken` security in OpenAPI (`POST` requires CSRF).
+
+## Serve / retrieve checklist
+
+- [ ] The retrieve URL parameter is validated against an allowlist regex *before* being concatenated into a filesystem path (e.g. `/^[a-f0-9]{16}\.(png|jpg|pdf)$/`). No `basename()` shortcut.
+- [ ] The resolved path stays under the per-user (or per-scope) storage directory. Adding `realpath()` and asserting `str_starts_with($real, $allowedBase)` is a good belt-and-suspenders extra.
+- [ ] Binary responses use `$this->sendFile($path, $mime[, $downloadName])`, not custom `echo file_get_contents(...)` (the helper sets `Content-Type` and routes through `HttpEmitter`).
+- [ ] Inline previews (`image`, `pdf`) omit `$downloadName`. Force-download endpoints pass it so browsers do not render arbitrary content.
+- [ ] Missing files surface as `UPLOAD-FILE-REQUIRED` or fall through `$this->notFound()` — never a 500.
+
+## OpenAPI checklist
+
+- [ ] The operation's `requestBody.content['multipart/form-data'].schema` is a `type: object` with the file field declared as `type: string, format: binary`.
+- [ ] Responses include the documented missing-file path (`400` with `UPLOAD-FILE-REQUIRED`) — the contract test probes multipart operations with an empty body and asserts the response status is documented.
+- [ ] Auth-required upload operations `$ref` `#/components/responses/SessionClosed` (401) and `#/components/responses/CsrfTokenInvalid` (403) instead of inlining.
+- [ ] Add `x-nene-runtime-probe: skip` only if the empty-body probe would do something destructive — for most uploads the validation rejection is the desired probe outcome and skip is unnecessary.
+
+## Limits checklist
+
+- [ ] PHP-level limit (`NENE_UPLOAD_MAX_FILESIZE` / `NENE_POST_MAX_SIZE`) covers the largest upload the deployment expects. `NENE_POST_MAX_SIZE >= NENE_UPLOAD_MAX_FILESIZE`.
+- [ ] Controller-level `validate(['maxBytes' => N])` matches or is stricter than the PHP-level limit. Document the per-endpoint policy in the operation's OpenAPI `description:`.
+- [ ] If the production deploy adds more upload endpoints with different per-endpoint maxima, each calls `validate()` with its own `maxBytes` rather than a global mutable constant.


### PR DESCRIPTION
## Summary

FT12 F-7 + F-8 を 1 PR にした集約 doc。F-1 (#362) / F-2 (#363) / F-5 (#364) / F-6 (#365) が landed した後の最新状態を 1 ページに集約する。

### New files

- **\`docs/development/file-uploads.md\`** — 上から下まで読めば file upload を author できる guide
  - 全 helper の概要表
  - Receiving a file (validate → mkdir scope → moveTo)
  - Returning a file (sendFile pattern + inline / attachment 切替)
  - storage convention
  - size limit (PHP level env + controller level maxBytes)
  - 4 行 security summary (finfo mime / server-derived ext / scope path / allowlist regex)
- **\`docs/review/file-upload.md\`** — 4 セクション checklist (Receive / Serve / OpenAPI / Limits)

### Cross-links

- \`AGENTS.md\` "Read First" に追加
- \`docs/review/README.md\` の When-to-use 表に row 追加 + policy ref に file-uploads.md 追加

Framework code 変更なし (docs only)。

## Test plan

- [ ] markdown lint pass
- [ ] 既存テストへの影響なし (docs-only)

Closes #366. これで FT12 follow-up 5 件全部クローズ。