### PR TITLE
fix(deps): bump symfony/yaml to v6.4.40 (CVE-2026-45305 / CVE-2026-45133) (#378)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5521,16 +5521,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.38",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "f8d2f4af29053842c01b4cae6bd4c2c3191fc63c"
+                "reference": "68dcd1f1602dac9d9221e25729683e0ce8733f3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8d2f4af29053842c01b4cae6bd4c2c3191fc63c",
-                "reference": "f8d2f4af29053842c01b4cae6bd4c2c3191fc63c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/68dcd1f1602dac9d9221e25729683e0ce8733f3b",
+                "reference": "68dcd1f1602dac9d9221e25729683e0ce8733f3b",
                 "shasum": ""
             },
             "require": {
@@ -5573,7 +5573,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.38"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -5593,7 +5593,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-05T06:55:40+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
## Summary

FT13 F-3 で \`composer audit\` が報告した pre-existing CVE 2 件の解消:

- **CVE-2026-45305** — \`Parser::cleanup()\` の ReDoS via catastrophic backtracking
- **CVE-2026-45133** — 無制限 nesting 経由の stack exhaustion

\`symfony/yaml\` v6.4.38 → v6.4.40 (composer.json の constraint \`^6.4\` のまま、lockfile のみ更新)。

## Test plan

- [x] \`composer audit\` → \`No security vulnerability advisories found.\`
- [x] \`composer test\` 70/70
- [x] \`composer test:http\` 23/23 (1 expected skip)
- [x] OpenAPI YAML parsing (docs/api/openapi.yaml) 影響なし

Closes #378.