### PR TITLE
docs(security): security-headers.md + review checklist + production-deployment + error-codes cross-link + AGENTS (#386)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This file is the first document for AI agents and automation working on NeNe.
 - Smarty custom plugins: `docs/development/smarty-plugins.md` (modifier / function / block authoring under `view/plugins/`)
 - File uploads: `docs/development/file-uploads.md` (`Request::getFile` / `UploadedFile::validate` / `ControllerBase::sendFile` + storage convention + security summary)
 - Email sending: `docs/development/email-sending.md` (`Nene\Xion\Mailer` + `MailMessage` + `NENE_MAIL_DSN` env + mailpit dev catcher; ADR-0006)
+- Security headers / cross-cutting decoration: `docs/development/security-headers.md` (`Nene\Xion\ResponseDecorator` + `NENE_SECURITY_*` env; ADR-0007 — resolves the FT7 F-6 / FT8 F-4 decoration trap)
 - AI self-review: `docs/ai/README.md`
 - Commit conventions: `docs/development/commit-conventions.md`
 - Roadmap: `docs/roadmap.md`

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -67,7 +67,7 @@ NeNe currently emits no framework-level decoration on top of the envelope (no se
 
 **Place cross-cutting response decoration in `Nene\Xion\HttpEmitter` (or wrap `HttpEmitter::emit()`) — not in `ControllerBase::run()`'s tail.** Decoration added at `run()`'s tail will not reach 401 / 403 / 404 / 405 / 500 responses, even though it reaches every 2xx.
 
-This is the PHP analogue of the nene2-python FT75 LIFO-middleware trap. The trap is currently silent (there is nothing to skip), but it must be respected the moment any framework-wide response header is added. Surveyed and confirmed in FT7 (`docs/field-trials/2026-05-field-trial-7.md` F-6).
+This is the PHP analogue of the nene2-python FT75 LIFO-middleware trap. Surveyed in FT7 (`docs/field-trials/2026-05-field-trial-7.md` F-6); FT8 F-4 (#331) addressed the access-log corner of it; **FT14 / ADR-0007** (`docs/adr/0007-response-decoration-boundary.md`) introduced `Nene\Xion\ResponseDecorator` as the canonical boundary class. New cross-cutting concerns now plug into `ResponseDecorator::headers()` (via env) or `ResponseDecorator::decorate()` / `sendHeaders()` (via code) — see `docs/development/security-headers.md`. The "trap" wording is preserved here for historical context; the resolution is `ResponseDecorator`.
 
 ## Related
 

--- a/docs/development/production-deployment.md
+++ b/docs/development/production-deployment.md
@@ -38,6 +38,11 @@ The full list of env vars NeNe reads at boot lives in `ini/xSystemIni.php`. The 
 | `NENE_POST_MAX_SIZE`     | unset → PHP default `8M`  | must be ≥ `NENE_UPLOAD_MAX_FILESIZE` (e.g. `12M`) | Drives PHP's `post_max_size`. PHP rejects multipart POSTs larger than this before any controller code runs. |
 | `NENE_MAIL_DSN`          | unset → `null://null` (framework code); `smtp://mailpit:1025` (compose dev) | `smtp://user:pass@relay.example.com:587?encryption=tls` or `sendmail://default` | Symfony Mailer DSN consumed by `Nene\Xion\Mailer` (#379, ADR-0006). The mailpit catcher is dev-only — production must point at a real SMTP relay. |
 | `NENE_MAIL_FROM`         | `noreply@nene.local` (compose); `noreply@localhost` (framework code) | Verified sender for the deploy's domain (DKIM/SPF-aligned) | Default `From:` address for `MailMessage` instances that do not set one explicitly. |
+| `NENE_SECURITY_CSP`      | unset                     | `default-src 'self'; img-src 'self' data: https:; ...` | Content-Security-Policy emitted by `ResponseDecorator` (#387, ADR-0007). See `docs/development/security-headers.md` for a starting cookbook. |
+| `NENE_SECURITY_FRAME_OPTIONS` | unset                | `DENY` (or `SAMEORIGIN`) | X-Frame-Options. Browsers honor CSP `frame-ancestors` when both are set. |
+| `NENE_SECURITY_REFERRER_POLICY` | unset              | `strict-origin-when-cross-origin` | Referrer-Policy. |
+| `NENE_SECURITY_HSTS`     | unset                     | `max-age=31536000; includeSubDomains` | Strict-Transport-Security. **Only** set after HTTPS termination is verified — HSTS over plain HTTP traps browsers in a broken state. |
+| `NENE_SECURITY_PERMISSIONS_POLICY` | unset           | `geolocation=(), microphone=(), camera=()` | Permissions-Policy. Deny by default; expand as features require. |
 
 **Important**: setting `NENE_APP_ENV=production` *alone* flips the safe defaults of `NENE_APP_DEBUG` (`0`) and `NENE_SESSION_SECURE` (`1`). If you set `NENE_APP_DEBUG=1` and forget `NENE_APP_ENV`, your "production" deploy will not have `Secure` cookies. The overlay `compose.prod.yaml` sets all three explicitly so this footgun is closed for the bundled deploy.
 

--- a/docs/development/security-headers.md
+++ b/docs/development/security-headers.md
@@ -1,0 +1,107 @@
+# Security Headers
+
+How NeNe adds cross-cutting response headers (security or otherwise) to every PHP-generated response. Pair with ADR-0007 (`docs/adr/0007-response-decoration-boundary.md`).
+
+Audience: anyone hardening a production deployment or wiring an observability concern that needs a header on every response. Trial source: FT14 (`docs/field-trials/2026-05-field-trial-14.md`). Predicted by FT7 F-6 + FT8 F-4 and resolved by FT14.
+
+## The pieces
+
+| What | Where |
+| --- | --- |
+| Decoration class | `Nene\Xion\ResponseDecorator` |
+| HttpEmitter hook | `HttpEmitter::emit()` calls `ResponseDecorator::decorate()` |
+| Smarty hook | `View::execute()` calls `ResponseDecorator::sendHeaders()` |
+| Env vars | `NENE_SECURITY_CSP`, `NENE_SECURITY_FRAME_OPTIONS`, `NENE_SECURITY_REFERRER_POLICY`, `NENE_SECURITY_HSTS`, `NENE_SECURITY_PERMISSIONS_POLICY` |
+| Always-on | `X-Content-Type-Options: nosniff` (no env var) |
+
+## Header set
+
+| Header | Default | Env var | Recommended starting value |
+| --- | --- | --- | --- |
+| `X-Content-Type-Options` | `nosniff` (always-on) | — | — |
+| `Content-Security-Policy` | unset | `NENE_SECURITY_CSP` | `default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none'` |
+| `X-Frame-Options` | unset | `NENE_SECURITY_FRAME_OPTIONS` | `DENY` (or `SAMEORIGIN` if the app needs same-origin embedding) |
+| `Referrer-Policy` | unset | `NENE_SECURITY_REFERRER_POLICY` | `strict-origin-when-cross-origin` |
+| `Strict-Transport-Security` | unset | `NENE_SECURITY_HSTS` | `max-age=31536000; includeSubDomains` (HTTPS terminator必須) |
+| `Permissions-Policy` | unset | `NENE_SECURITY_PERMISSIONS_POLICY` | `geolocation=(), microphone=(), camera=()` (deny by default; expand as features require) |
+
+Set values in `compose.prod.yaml` (or the equivalent overlay), one env var per header. NeNe ships **no** opinionated value — every CSP that ships is wrong for some deploy.
+
+## How decoration reaches every response
+
+`ResponseDecorator::decorate()` runs at the framework's output boundary in **two** places:
+
+1. **`HttpEmitter::emit()`** — catches every response that flows through `HttpTermination` (auth redirect, CSRF reject, 401 / 403 / 404 / 405 / 500), every `DomainException`, every top-level `\Throwable`, every REST 2xx, every `sendFile()` binary download (FT12 #368).
+2. **`View::execute()`** — Smarty's `display()` streams template output directly to stdout, bypassing `HttpEmitter`. The decorator's `sendHeaders()` runs **before** Smarty echoes so the headers go out first.
+
+That covers every PHP-generated response. The FT7 F-6 / FT8 F-4 trap (decoration added at `ControllerBase::run()`'s tail silently skips error paths) is closed: the decoration is at the lower boundary, not the controller layer.
+
+## Controller-set headers win
+
+When a controller writes its own header before responding, the decorator does **not** overwrite it. Match is case-insensitive — `'x-frame-options'` from the controller still beats `'X-Frame-Options'` from the decorator. Use this when one endpoint needs a different value than the deploy-wide default (e.g., an admin iframe page that needs `X-Frame-Options: SAMEORIGIN` while the rest of the app uses `DENY`).
+
+```php
+public function indexAction(): void
+{
+    // Just before render, override the decorator's X-Frame-Options:
+    header('X-Frame-Options: SAMEORIGIN');
+    $this->setTitle('Admin');
+}
+```
+
+## Apache-served static files
+
+The decorator only covers **PHP-generated** responses. Apache directly serves `htdocs/favicon.ico` and anything else under the document root without invoking PHP, so those responses do not carry the decorator's headers.
+
+If a production deploy needs CSP on static files too, add an Apache directive (the same pattern FT8 #330 used for `ServerTokens`):
+
+```apache
+# docker/apache/conf-available/zz-nene-static-headers.conf
+<FilesMatch "\.(ico|css|js|png|jpg|svg|webp)$">
+    Header set X-Content-Type-Options "nosniff"
+    Header set Cache-Control "public, max-age=86400"
+</FilesMatch>
+```
+
+then `a2enconf` it in `Dockerfile`. The `zz-` prefix is intentional (FT8 trap — must load after `security.conf`).
+
+## Testing
+
+```php
+use Nene\Xion\ResponseDecorator;
+
+protected function setUp(): void
+{
+    putenv('NENE_SECURITY_CSP');               // clear
+    ResponseDecorator::reset();
+}
+
+public function testFoo(): void
+{
+    putenv("NENE_SECURITY_CSP=default-src 'self'");
+    ResponseDecorator::reset();                  // rebuild from current env
+    // assertions ...
+}
+```
+
+`tests/Unit/Xion/ResponseDecoratorTest.php` shows the seven canonical cases (default, env opt-in, controller wins, case-insensitive match, cache + reset semantics).
+
+## Production deployment checklist
+
+- [ ] `NENE_SECURITY_CSP` is set (start with the value above; loosen per page if needed).
+- [ ] `NENE_SECURITY_HSTS` is set **only after** HTTPS termination is verified end-to-end.
+- [ ] `NENE_SECURITY_FRAME_OPTIONS` is set (`DENY` unless the app needs same-origin embedding).
+- [ ] `NENE_SECURITY_REFERRER_POLICY` is set.
+- [ ] Swagger UI (`http://localhost:8080/api-docs/` in dev) renders without CSP errors. (Swagger UI inlines styles/scripts; you may need `'unsafe-inline'` for `style-src`.)
+- [ ] Smarty pages render — check `docs/frontend/assets.md`'s `t_css` and `t_js` patterns work under the CSP.
+- [ ] No controller silently overrides a critical header. Grep for `header('X-Frame|Content-Security|Strict-Transport|Referrer-Policy|Permissions-Policy'`.
+
+## Related
+
+- `docs/adr/0007-response-decoration-boundary.md` — design rationale.
+- `docs/development/production-deployment.md` — full env-var matrix (the five `NENE_SECURITY_*` variables are listed).
+- `docs/development/error-codes.md` § "Response decoration and the error-path early-exit trap" — historical predictions (FT7 F-6 + FT8 F-4) now marked as resolved.
+- `docs/review/security-headers.md` — reviewer checklist.
+- `docs/field-trials/2026-05-field-trial-14.md` — the implementation trial.
+- `class/xion/ResponseDecorator.php` — the class.
+- MDN: [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) / [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) / [Permissions-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy).

--- a/docs/review/README.md
+++ b/docs/review/README.md
@@ -16,6 +16,7 @@ The format is borrowed from the sibling project NENE2's `docs/review/` and adapt
 | [`release-ci.md`](release-ci.md) | `.github/workflows/`, branch protection, auto-merge config, dependency upgrades. |
 | [`field-trial-report.md`](field-trial-report.md) | A new `docs/field-trials/YYYY-MM-field-trial-N.md` or its follow-up Issues. |
 | [`file-upload.md`](file-upload.md) | Endpoints that accept `multipart/form-data` uploads (`Request::getFile()` / `UploadedFile::validate()`). |
+| [`security-headers.md`](security-headers.md) | Changes to `ResponseDecorator`, `HttpEmitter`, `View::execute`, controllers that set their own security headers, or `NENE_SECURITY_*` env. |
 
 A single PR may invoke more than one checklist (a REST endpoint usually triggers `rest-controller.md` + `openapi-contract.md` + `database.md`). Reference the checklist(s) you used in the PR body.
 
@@ -37,6 +38,7 @@ The checklists link back to the canonical policy docs:
 - `docs/development/docker.md` — local environment + env vars
 - `docs/development/error-codes.md` — error catalog (post ADR-0003)
 - `docs/development/file-uploads.md` — upload helpers + storage convention + security notes (FT12)
+- `docs/development/security-headers.md` — cross-cutting response decoration (FT14, ADR-0007)
 - `docs/api/README.md` — OpenAPI policy
 - `docs/api/reference-client.md` — external consumer mechanics
 - `docs/tutorials/building-a-service.md` — full tutorial flow

--- a/docs/review/security-headers.md
+++ b/docs/review/security-headers.md
@@ -1,0 +1,47 @@
+# Security Headers Self-Review
+
+Use this checklist whenever a PR changes `class/xion/ResponseDecorator.php`, `compose.yaml`'s `NENE_SECURITY_*` env vars, `class/xion/HttpEmitter.php`, `class/xion/View.php::execute`, or any controller that calls `header('Content-Security-Policy' / 'Strict-Transport-Security' / 'X-Frame-Options' / 'Referrer-Policy' / 'Permissions-Policy' / 'X-Content-Type-Options' ...)`.
+
+Source policies:
+
+- `docs/development/security-headers.md` (env matrix, cookbook values, two-hook design)
+- `docs/adr/0007-response-decoration-boundary.md`
+- `docs/development/production-deployment.md` (env-var matrix incl. all five `NENE_SECURITY_*`)
+
+## Wiring checklist
+
+- [ ] The change does not introduce a **third** integration point. If decoration needs to apply somewhere new (e.g., a custom direct-`echo` path), prefer routing through `HttpEmitter::emit()` first.
+- [ ] If the change adds a new header to `ResponseDecorator::ALWAYS_ON`, the value is **zero-cost / universal** (like `nosniff`). If it could break a deploy, it should be env-opt-in instead.
+- [ ] If the change adds a new env var for a header, the name follows the `NENE_SECURITY_*` pattern, and the var is added to `compose.yaml` (empty default) **and** to the `docs/development/production-deployment.md` env-var matrix.
+- [ ] `ResponseDecorator::reset()` is called in the corresponding unit test's `setUp` / `tearDown` to avoid cache leakage across cases.
+
+## Controller-override checklist
+
+- [ ] If a controller intentionally overrides a decorator header, the override is documented in the controller's PHPDoc with the reason. (Silent overrides are a footgun.)
+- [ ] The override uses standard PHP `header(...)` and is set **before** any output begins (echo / Smarty display).
+- [ ] If the override is the same value as the decorator (no real difference), remove the override — the decorator already covers it.
+
+## CSP-specific checklist
+
+- [ ] The CSP value has been smoke-tested against the deploy's actual pages, including Smarty templates, Swagger UI (`/api-docs/`), and any inline `<style>` / `<script>` introduced by `view/source/layout/app.tpl` or asset auto-discovery (`htdocs/css/...`, `htdocs/js/...`).
+- [ ] If the policy requires `'unsafe-inline'` or `'unsafe-eval'`, the PR body justifies it (Swagger UI may need `style-src 'unsafe-inline'`; everything else should be tightened).
+- [ ] Frame-ancestors / frame-src are aligned with `NENE_SECURITY_FRAME_OPTIONS` (browsers prefer CSP `frame-ancestors` over the deprecated `X-Frame-Options` when both are set).
+
+## HSTS-specific checklist
+
+- [ ] `NENE_SECURITY_HSTS` is **only** set when the deploy has HTTPS termination verified end-to-end. Setting HSTS over plain HTTP locks browsers into a broken state.
+- [ ] `max-age` is at least one year (`31536000`) for production. Shorter values are fine during initial HTTPS rollout.
+- [ ] `includeSubDomains` is set only if every subdomain of the deploy can serve HTTPS.
+- [ ] `preload` (in the header value) is **not** added without a separate decision — preload-list inclusion is hard to undo.
+
+## Operator checklist
+
+- [ ] The `compose.prod.yaml` overlay (or equivalent production config) sets every `NENE_SECURITY_*` env var the deploy needs. Empty defaults are not "off by accident".
+- [ ] Reverse-proxy / CDN does not strip the headers added by NeNe. Verify with `curl -i` against the actual production hostname.
+- [ ] If Apache directly serves static files (CSS, JS, images, favicon), those files have their own header set in `docker/apache/conf-available/zz-nene-static-headers.conf` (or equivalent). The `ResponseDecorator` does not reach static files.
+
+## Test plan checklist
+
+- [ ] Unit: every code path through `ResponseDecorator::decorate` and `::sendHeaders` is exercised in `tests/Unit/Xion/ResponseDecoratorTest.php`.
+- [ ] HTTP smoke: the relevant new endpoint (if any) carries the expected headers per `composer test:http`.
+- [ ] Live: `curl -sS -i http://localhost:8080/health` shows the configured headers.


### PR DESCRIPTION
## Summary

FT14 の docs-only fix。#387 (ADR-0007 + ResponseDecorator) merged 後の最新状態を 1 ページに集約 + 既存 docs から cross-link。

### New files

- **\`docs/development/security-headers.md\`** — env matrix / cookbook 推奨値 / 2 integration point 解説 / controller-wins / static file caveat / production checklist / test pattern
- **\`docs/review/security-headers.md\`** — 5 セクション checklist (Wiring / Controller-override / CSP / HSTS / Operator / Test plan)

### Updates

- \`docs/development/production-deployment.md\` env matrix に 5 行 (CSP / FRAME_OPTIONS / REFERRER_POLICY / HSTS / PERMISSIONS_POLICY)
- \`docs/development/error-codes.md\` "Response decoration..." section に **resolved by FT14 / ADR-0007** の cross-link (F-5)
- \`AGENTS.md\` "Read First" に security-headers.md
- \`docs/review/README.md\` When-to-use 表 + policy references

Framework code 変更なし。

## Test plan

- [ ] markdown lint pass
- [ ] 既存テストへの影響なし (docs-only)

Closes #386.