### PR TITLE
docs(observability): observability.md + ADR-0007 second-use-case + matrix + getenv idiom note + AGENTS (#392)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This file is the first document for AI agents and automation working on NeNe.
 - File uploads: `docs/development/file-uploads.md` (`Request::getFile` / `UploadedFile::validate` / `ControllerBase::sendFile` + storage convention + security summary)
 - Email sending: `docs/development/email-sending.md` (`Nene\Xion\Mailer` + `MailMessage` + `NENE_MAIL_DSN` env + mailpit dev catcher; ADR-0006)
 - Security headers / cross-cutting decoration: `docs/development/security-headers.md` (`Nene\Xion\ResponseDecorator` + `NENE_SECURITY_*` env; ADR-0007 — resolves the FT7 F-6 / FT8 F-4 decoration trap)
+- Observability (request-id + future cross-cutting concerns): `docs/development/observability.md` (`Nene\Xion\RequestId` + `X-Request-ID` header + Monolog `extra.request_id` + recipe for future per-request decorations)
 - AI self-review: `docs/ai/README.md`
 - Commit conventions: `docs/development/commit-conventions.md`
 - Roadmap: `docs/roadmap.md`

--- a/docs/adr/0007-response-decoration-boundary.md
+++ b/docs/adr/0007-response-decoration-boundary.md
@@ -64,3 +64,16 @@ Neutral:
 
 - The framework ships **no** opinionated CSP / HSTS values. The doc surfaces a starting cookbook; operators tune.
 - Pre-existing reverse proxy / load balancer headers (e.g., `X-Forwarded-For`) are unaffected. The decorator only adds; it never removes.
+
+## Addendum: Second use case landed (FT15)
+
+Field Trial 15 (`docs/field-trials/2026-05-field-trial-15.md`) added **request-id / correlation-id** as the first non-security concern via this decorator. The change was scoped to `ResponseDecorator` internals (splitting `headers()` into a cached `staticHeaders()` plus per-call augmentation that queries `RequestId::current()`). **`HttpEmitter::emit()` and `View::execute()` did not need to change** — the boundary held under a fresh use case.
+
+The recipe future concerns follow:
+
+1. Add a static helper (in the FT15 case `Nene\Xion\RequestId`) that resolves the per-request value once.
+2. Extend `ResponseDecorator::headers()` to fold the value in under the configured header name.
+3. Optionally extend `Log::__construct()` to push a Monolog processor that injects the value into `record->extra`.
+4. Add env-var rows to `compose.yaml`, `docs/development/production-deployment.md`, and the relevant `docs/development/*.md` doc.
+
+See `docs/development/observability.md` for the full request-id walkthrough.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -228,6 +228,19 @@ The error code must already exist in `config/error_codes.php`. Throwing an unkno
 
 For purely pre-flight input validation (no DB writes), prefer returning `$this->API_RESPONSE->failure($code)` directly from the controller before opening the transaction. `DomainException` is for cases where the validation must run alongside the writes, for example a row-existence check whose target may change between the validation and the write.
 
+## Environment-variable defaults
+
+When reading `NENE_*` env vars, do **not** use the `getenv('X') ?: 'default'` short-circuit. PHP's `?:` coerces both `'0'` and `''` to falsy, so an operator who explicitly sets `NENE_FOO=0` (turn off) or `NENE_FOO=` (empty = explicit "no value") silently gets the default instead.
+
+Use the explicit `=== false` check instead:
+
+```php
+$raw = getenv('NENE_FOO');
+$value = $raw === false ? 'default' : (string)$raw;
+```
+
+The footgun bit `RequestId::trustsInbound()` (FT15 F-1) — `NENE_REQUEST_ID_TRUST_INBOUND=0` was silently being treated as "trust = on". Existing helpers that use the `?:` idiom for env vars where `'0'` is not a meaningful value (`Mailer` DSN, `Log` file path, etc.) are dormant, but new helpers should follow the explicit pattern.
+
 ## Testing and Static Analysis
 
 - At minimum, run PHP syntax checks for changed PHP files.

--- a/docs/development/observability.md
+++ b/docs/development/observability.md
@@ -1,0 +1,130 @@
+# Observability
+
+How NeNe tags every request with a stable identifier, propagates it into logs and response headers, and how future observability concerns (server-timing, OpenTelemetry, audit fingerprints) plug into the same boundary.
+
+Audience: anyone debugging across multiple log lines that should belong to the same request, anyone configuring NeNe behind a reverse proxy / load balancer, anyone adding a new cross-cutting concern. Trial source: FT15 (`docs/field-trials/2026-05-field-trial-15.md`). Boundary: ADR-0007.
+
+## Request-id (correlation id)
+
+Every PHP-generated response carries an `X-Request-ID` header. Every log record carries a matching `request_id` in its `extra` block. Operators grep one id and see exactly the lines for one request.
+
+```
+$ curl -i http://localhost:8080/health | grep X-Request-ID
+X-Request-ID: 82ad54e03eabb286aad4e020d5bae21e
+
+$ grep 82ad54e03eabb286aad4e020d5bae21e log/access-*.log log/error-*.log
+log/access-2026-05-22.log:[...] Nene.INFO: ACCESS : health::index [...] {"request_id":"82ad54e03eabb286aad4e020d5bae21e"}
+```
+
+### Resolution order
+
+`Nene\Xion\RequestId::current()` resolves the id once per request, in this order:
+
+1. If `NENE_REQUEST_ID_TRUST_INBOUND` is truthy (default `1`), read the header named by `NENE_REQUEST_ID_HEADER` (default `X-Request-ID`). If the value passes `isValid()`, honor it.
+2. Otherwise generate a fresh value via `bin2hex(random_bytes(16))` (32 hex chars).
+
+The result is cached for the duration of the request. Subsequent `current()` calls — from the response header decorator and from every log processor — see the same value.
+
+### Validation
+
+A request-id that survives validation is safe to embed in log files and response headers without further escaping.
+
+| Rule | Value |
+| --- | --- |
+| Allowed charset | `[A-Za-z0-9_\-\.:]+` (alphanumeric plus `_`, `-`, `.`, `:`) |
+| Max length | 128 characters |
+| Empty | rejected (treated as missing) |
+
+Anything that fails validation is silently replaced by a generated id. This blocks:
+
+- Log poisoning (no newlines / control chars survive).
+- Unbounded length (no log-line bloat).
+- Header injection (no CR / LF / colon shenanigans).
+
+The strict policy is intentional. If your upstream proxy uses a different shape, override `NENE_REQUEST_ID_HEADER` (e.g. set it to your proxy's existing name) and ensure the proxy emits a valid value.
+
+### Env vars
+
+| Variable | Default | Production-safe value | What it controls |
+| --- | --- | --- | --- |
+| `NENE_REQUEST_ID_HEADER` | `X-Request-ID` | `X-Request-ID` (or your proxy's name) | Header name read on inbound and emitted on outbound. Empty string disables outbound emission (logs still tag). |
+| `NENE_REQUEST_ID_TRUST_INBOUND` | `1` | `1` behind a trusted proxy; `0` when the public boundary is the app itself | Whether to honor an inbound header value. Generates fresh when `0`. |
+
+## Log integration
+
+`Nene\Xion\Log::__construct()` pushes a Monolog processor onto every Logger (access / information / error) that adds `request_id` to each record's `extra` array:
+
+```php
+$requestIdProcessor = static function (\Monolog\LogRecord $record): \Monolog\LogRecord {
+    return $record->with(extra: array_merge($record->extra, ['request_id' => RequestId::current()]));
+};
+```
+
+`extra` (not `context`) is the right slot for processor-appended fields:
+
+- `context` is reserved for caller-supplied data passed to `$log->info('msg', $context)`.
+- `extra` is for cross-cutting metadata added by processors.
+
+Monolog's default formatter renders `extra` at the end of each line as a JSON object, which keeps `request_id` consistent across access / error / info logs and friendly to `grep` / `jq`.
+
+## ResponseDecorator integration
+
+`Nene\Xion\ResponseDecorator::headers()` returns the env-driven `NENE_SECURITY_*` headers plus the per-request request-id, in this shape:
+
+```php
+public static function headers(): array {
+    $headers = self::staticHeaders();  // cached process-wide
+    if (RequestId::headerName() !== '') {
+        $headers[RequestId::headerName()] = RequestId::current();
+    }
+    return $headers;
+}
+```
+
+The split between cached (`staticHeaders()`) and per-call (`headers()`) is intentional: env-driven security headers do not change within a process, but the request-id does change per request. Splitting keeps both costs at the right level.
+
+## Future cross-cutting concerns
+
+ADR-0007 introduced the decoration boundary; FT15 validated it by adding the first non-security concern. Future concerns follow the same recipe:
+
+| Concern | Likely env var(s) | Likely shape |
+| --- | --- | --- |
+| `Server-Timing` | `NENE_SERVER_TIMING_ENABLED` | Per-request, computed from `microtime()` checkpoints. Add to `headers()` via a `ServerTiming::current()` analogue. |
+| OpenTelemetry `traceparent` / `tracestate` | `NENE_OTEL_*` | Parse inbound `traceparent`, generate fresh when absent (same resolution shape as request-id). Plug into `headers()` and Monolog. |
+| Audit fingerprint / actor hash | `NENE_AUDIT_*` | Per-request hash of `(user_id, ip, user-agent)`. Plug into Monolog processor for tamper-evident audit logs. |
+
+Each follows the FT15 recipe: a static helper resolves the per-request value, `ResponseDecorator::headers()` appends it, `Log` processor injects it into `extra`. No changes to `HttpEmitter::emit()` or `View::execute()` should be needed.
+
+## Behind a reverse proxy
+
+When NeNe runs behind nginx / HAProxy / a CDN, the proxy is typically the one generating `X-Request-ID`. Keep `NENE_REQUEST_ID_TRUST_INBOUND=1` (default) so NeNe honors the proxy's value, and the same id propagates to NeNe's logs.
+
+Configure the proxy to set the header on every inbound request:
+
+```nginx
+# nginx
+proxy_set_header X-Request-ID $request_id;
+```
+
+```
+# HAProxy
+http-request set-header X-Request-ID %[uuid()]
+```
+
+Verify with `curl -i` against the public URL — the response should echo a stable id per request.
+
+## Standalone (no proxy)
+
+When the app is the boundary, the inbound header is untrusted. Either:
+
+- Set `NENE_REQUEST_ID_TRUST_INBOUND=0` to always generate (recommended unless you actively want clients to set their own id).
+- Keep the default `1` but rely on `isValid()` to reject anything malformed (the typical case — clients rarely send the header at all).
+
+## Related
+
+- `docs/adr/0007-response-decoration-boundary.md` — the decoration boundary.
+- `docs/development/security-headers.md` — first use case (security headers).
+- `docs/development/production-deployment.md` — full env-var matrix, including the two `NENE_REQUEST_ID_*` rows.
+- `docs/development/coding-standards.md` § "Environment-variable defaults" — the `getenv() ?:` falsy-trap note (FT15 F-1).
+- `docs/field-trials/2026-05-field-trial-15.md` — the trial.
+- `class/xion/RequestId.php` — implementation.

--- a/docs/development/production-deployment.md
+++ b/docs/development/production-deployment.md
@@ -43,6 +43,8 @@ The full list of env vars NeNe reads at boot lives in `ini/xSystemIni.php`. The 
 | `NENE_SECURITY_REFERRER_POLICY` | unset              | `strict-origin-when-cross-origin` | Referrer-Policy. |
 | `NENE_SECURITY_HSTS`     | unset                     | `max-age=31536000; includeSubDomains` | Strict-Transport-Security. **Only** set after HTTPS termination is verified — HSTS over plain HTTP traps browsers in a broken state. |
 | `NENE_SECURITY_PERMISSIONS_POLICY` | unset           | `geolocation=(), microphone=(), camera=()` | Permissions-Policy. Deny by default; expand as features require. |
+| `NENE_REQUEST_ID_HEADER` | `X-Request-ID` (compose default) | `X-Request-ID` or the proxy's existing name | Response header that carries the per-request id (#393). Empty string disables emission (logs still tag). See `docs/development/observability.md`. |
+| `NENE_REQUEST_ID_TRUST_INBOUND` | `1` (compose default)   | `1` behind a trusted proxy; `0` when the app is the public boundary | Whether to honor an inbound request-id. Generates fresh when `0`. |
 
 **Important**: setting `NENE_APP_ENV=production` *alone* flips the safe defaults of `NENE_APP_DEBUG` (`0`) and `NENE_SESSION_SECURE` (`1`). If you set `NENE_APP_DEBUG=1` and forget `NENE_APP_ENV`, your "production" deploy will not have `Secure` cookies. The overlay `compose.prod.yaml` sets all three explicitly so this footgun is closed for the bundled deploy.
 

--- a/docs/development/security-headers.md
+++ b/docs/development/security-headers.md
@@ -36,6 +36,8 @@ Set values in `compose.prod.yaml` (or the equivalent overlay), one env var per h
 
 That covers every PHP-generated response. The FT7 F-6 / FT8 F-4 trap (decoration added at `ControllerBase::run()`'s tail silently skips error paths) is closed: the decoration is at the lower boundary, not the controller layer.
 
+**Other cross-cutting concerns**: the same `ResponseDecorator` hosts non-security headers. The first non-security use case is `X-Request-ID` (per-request correlation id, FT15) — see `docs/development/observability.md` for the recipe and how future concerns (Server-Timing, OpenTelemetry, audit fingerprint) plug in the same way.
+
 ## Controller-set headers win
 
 When a controller writes its own header before responding, the decorator does **not** overwrite it. Match is case-insensitive — `'x-frame-options'` from the controller still beats `'X-Frame-Options'` from the decorator. Use this when one endpoint needs a different value than the deploy-wide default (e.g., an admin iframe page that needs `X-Frame-Options: SAMEORIGIN` while the rest of the app uses `DENY`).


### PR DESCRIPTION
## Summary

FT15 の docs-only fix。#393 (RequestId helper) merged 後の最新状態を集約。

### New file

- **\`docs/development/observability.md\`** — request-id 概要 + resolution order + env matrix + Log 統合 + ResponseDecorator 統合 + future concerns (Server-Timing / OTel / audit) + reverse proxy 構成例

### Updates

- \`docs/adr/0007-response-decoration-boundary.md\` Consequences に **"Second use case landed (FT15)"** addendum + recipe (1-4 step)
- \`docs/development/production-deployment.md\` env matrix に 2 行
- \`docs/development/security-headers.md\` の "How decoration reaches every response" に forward link (observability.md)
- \`docs/development/coding-standards.md\` に新 subsection **"Environment-variable defaults"**: \`getenv() ?: 'default'\` の \`'0'\` / \`''\` falsy trap (FT15 F-1)
- \`AGENTS.md\` "Read First" に observability.md

Framework code 変更なし。

## Test plan

- [ ] markdown lint pass
- [ ] 既存テストへの影響なし (docs-only)

Closes #392.