### PR TITLE
docs(bearer): agent-bearer-auth.md + matrix + reference-client + FT README cross-repo pattern + AGENTS (#398)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This file is the first document for AI agents and automation working on NeNe.
 - Email sending: `docs/development/email-sending.md` (`Nene\Xion\Mailer` + `MailMessage` + `NENE_MAIL_DSN` env + mailpit dev catcher; ADR-0006)
 - Security headers / cross-cutting decoration: `docs/development/security-headers.md` (`Nene\Xion\ResponseDecorator` + `NENE_SECURITY_*` env; ADR-0007 — resolves the FT7 F-6 / FT8 F-4 decoration trap)
 - Observability (request-id + future cross-cutting concerns): `docs/development/observability.md` (`Nene\Xion\RequestId` + `X-Request-ID` header + Monolog `extra.request_id` + recipe for future per-request decorations)
+- Agent / MCP Bearer auth: `docs/development/agent-bearer-auth.md` (`Nene\Xion\BearerAuth` + `NENE_AGENT_BEARER_TOKEN` env + mod_php Authorization quirk; ADR-0008 — cross-repo handoff from nene-mcp)
 - AI self-review: `docs/ai/README.md`
 - Commit conventions: `docs/development/commit-conventions.md`
 - Roadmap: `docs/roadmap.md`

--- a/docs/api/reference-client.md
+++ b/docs/api/reference-client.md
@@ -104,6 +104,32 @@ If you implement a server-rendered login form rather than calling REST `/session
 
 For the full error catalog, see `config/error_codes.php`.
 
+## Bearer for non-browser callers
+
+Stateless clients (MCP servers, scripted agents, internal tooling) can skip the cookie+CSRF dance by sending an `Authorization: Bearer <token>` header. The token value must match the server's `NENE_AGENT_BEARER_TOKEN` env, and the token authenticates as the user identified by `NENE_AGENT_BEARER_USER` (default `admin`). See ADR-0008 and `docs/development/agent-bearer-auth.md`.
+
+Minimal example — the entire client flow is one curl per request:
+
+```bash
+TOKEN=$NENE_AGENT_BEARER_TOKEN
+BASE=http://nene.example.com
+
+# list
+curl -H "Authorization: Bearer $TOKEN" "$BASE/todo/index"
+
+# create — no X-CSRF-Token, no cookie
+curl -X POST \
+     -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"title":"Hello from MCP"}' \
+     "$BASE/todo/index"
+
+# read one
+curl -H "Authorization: Bearer $TOKEN" "$BASE/todo/item/id_42"
+```
+
+`X-CSRF-Token` is intentionally not used on Bearer requests — the Bearer header itself is the proof of intent, and CSRF protects only browser flows. The browser session-cookie + CSRF flow above is unchanged for browsers.
+
 ## See also
 
 - `docs/tutorials/building-a-service.md` — authoring side: how to write a controller that enforces this flow.

--- a/docs/development/agent-bearer-auth.md
+++ b/docs/development/agent-bearer-auth.md
@@ -1,0 +1,113 @@
+# Agent Bearer Authentication
+
+How NeNe accepts an optional `Authorization: Bearer <token>` for stateless agent / MCP clients, alongside the existing browser session-cookie + CSRF flow. Pair with **ADR-0008** (`docs/adr/0008-optional-bearer-for-agent-routes.md`).
+
+Audience: anyone integrating NeNe with an MCP server (e.g. `nene-mcp`), a script, an automation agent, or anything else that cannot maintain a cookie jar. Trial source: FT16 (`docs/field-trials/2026-05-field-trial-16.md`), driven by the cross-repo handoff from nene-mcp Issue #380.
+
+## TL;DR
+
+```bash
+# 1. set the env vars on the NeNe container
+NENE_AGENT_BEARER_TOKEN=<long random secret>
+NENE_AGENT_BEARER_USER=admin   # default
+
+# 2. call NeNe with the token; no cookie, no CSRF
+curl -H "Authorization: Bearer <long random secret>" \
+     http://nene.example.com/todo/index
+```
+
+Browser users continue to log in with `POST /session/login` and use the resulting `PHPSESSID` cookie plus `X-CSRF-Token` header. Both flows coexist; neither blocks the other.
+
+## How it works
+
+1. `htdocs/index.php` calls `Nene\Xion\BearerAuth::resolve()` immediately after `session_start()`.
+2. `resolve()` reads the inbound `Authorization` header through a four-layer fallback (see "mod_php quirk" below).
+3. If the token matches `NENE_AGENT_BEARER_TOKEN` (via `hash_equals` — constant-time), the helper looks up the user identified by `NENE_AGENT_BEARER_USER` (default `admin`) and calls `AuthSession::bindBearer($userRow)`.
+4. From this point in the request, `AUTH_SESSION->isLoggedIn()` returns `true`, `AUTH_SESSION->user()` returns the bearer-bound user, and `AUTH_SESSION->isBearerAuthenticated()` returns `true`.
+5. `CsrfProtectionPolicy::requiresToken()` sees the bearer flag and returns `false`, so state-changing requests do not need `X-CSRF-Token`.
+6. The next request starts from scratch — Bearer authentication is **stateless** on the server side, the bearer user is **not** stored in `$_SESSION`, and the PHP session cookie is never touched.
+
+When `NENE_AGENT_BEARER_TOKEN` is empty (the default), `resolve()` is a no-op — the cookie+CSRF path runs unchanged.
+
+## Env vars
+
+| Variable | Default | Production-safe value | What it controls |
+| --- | --- | --- | --- |
+| `NENE_AGENT_BEARER_TOKEN` | empty (feature off) | a long random secret (≥32 bytes of entropy) | The expected Bearer value. Empty disables the feature. Rotate by changing the value. |
+| `NENE_AGENT_BEARER_USER` | `admin` | the `user_id` of the user the Bearer should act as | Identity the token maps to. Must exist in the `users` table. |
+
+The integrator side (e.g. nene-mcp) reads its own env (e.g. `NENE_MCP_BEARER_TOKEN`) and forwards the value as `Authorization: Bearer ...`. The two env names are independent — only the **values** must match.
+
+## mod_php Authorization quirk
+
+Apache `mod_php` strips the `Authorization` header from `$_SERVER['HTTP_AUTHORIZATION']` by default (the "security" hardening Apache ships with). `apache_request_headers()` / `getallheaders()` still see it.
+
+`BearerAuth::readAuthorizationHeader()` handles this with a four-layer fallback:
+
+1. `$_SERVER['HTTP_AUTHORIZATION']`
+2. `$_SERVER['REDIRECT_HTTP_AUTHORIZATION']` (mod_rewrite path)
+3. `apache_request_headers()` (case-insensitive)
+4. `getallheaders()` (case-insensitive)
+
+No Apache configuration change is required. The same recipe is useful for any other future framework helper that reads inbound headers — keep this pattern in mind when adding helpers that touch `Authorization`, `X-Api-Key`, or similar.
+
+## In-memory binding, per request
+
+`AuthSession::bindBearer()` stores the bearer-bound user in a private instance field, **not** in `$_SESSION`. This is intentional:
+
+- The PHP session cookie is not generated or rotated for Bearer requests.
+- Two concurrent requests with the same Bearer get fresh authenticate-per-request — no shared state.
+- The next request from the same client must re-authenticate (re-send the header). This is the correct stateless property.
+
+`isLoggedIn()` / `user()` / `userId()` return the bearer-bound user with precedence over any `$_SESSION` content, so an agent request that happens to carry both a Bearer header and a stale `PHPSESSID` cookie sees the Bearer user (the request's intent).
+
+## CSRF behavior
+
+`CsrfProtectionPolicy::requiresToken()` short-circuits to `false` when `$isBearerAuthenticated` is true. Rationale:
+
+- CSRF protects against cross-site form submission, which is a browser-only attack surface.
+- A Bearer token in `Authorization` cannot be auto-attached by a third-party site to a victim's request (browsers do not auto-send `Authorization` headers across origins).
+- Forcing CSRF on Bearer requests would require server-side state (cookie jar + token mint), which contradicts the stateless property.
+
+Browser flows are unaffected — `Authorization` is absent on browser POSTs, so `isBearerAuthenticated()` is false and CSRF runs normally.
+
+## OpenAPI
+
+The TODO sample app's operations carry two security alternatives:
+
+```yaml
+security:
+  - sessionCookie: []
+    csrfToken: []
+  - bearerAuth: []
+```
+
+Either path authenticates the request. New endpoints that should accept agents add `bearerAuth: []` as a sibling alternative. Endpoints that are **browser-only** (e.g. HTML form-rendering routes) keep `sessionCookie + csrfToken` only.
+
+## Security notes
+
+- **Choose a long random token.** Minimum recommendation: 32 bytes of entropy (`openssl rand -hex 32`). The framework does not validate token strength.
+- **Do not log the token.** The framework logs the resolved user identity, never the token bytes. Avoid `print_r($_SERVER)` or similar diagnostic dumps in custom controllers.
+- **Rotate by changing env.** No graceful overlap window — when the env changes, the old token immediately invalidates. Coordinate with the integrator before flipping the value.
+- **Token == admin.** The current design maps one env token to one user. Anyone with the token has that user's full read/write surface. A real multi-integrator deploy needs per-user personal-access-tokens (future ADR).
+- **HTTPS in production.** A Bearer token sent over plain HTTP is captured by anyone on the network path. Always deploy NeNe behind an HTTPS terminator.
+
+## Future direction: per-user personal access tokens
+
+ADR-0008's chosen shape (Option C) is a minimum viable Bearer surface. The natural extension (Option B in the ADR's table) is a `personal_access_tokens` table storing hashed token + scope + expiry + audit metadata per token. The helper's public surface (`BearerAuth::resolve()`) does not change — only the lookup step (`hash_equals` against an env value → DB hash comparison + scope check) changes.
+
+A future trial may pick this up when:
+
+- A real deploy needs more than one integrator with distinct audit trails.
+- Token rotation needs an overlap window (old + new valid simultaneously).
+- Per-route or per-scope authorization is needed beyond "is this the admin?".
+
+## Related
+
+- `docs/adr/0008-optional-bearer-for-agent-routes.md` — design rationale.
+- `docs/api/openapi.yaml` — `bearerAuth` security scheme + TODO operations.
+- `docs/api/reference-client.md` — non-browser caller flows (Bearer pattern).
+- `docs/development/production-deployment.md` — env matrix, including `NENE_AGENT_BEARER_TOKEN` and `NENE_AGENT_BEARER_USER`.
+- `docs/field-trials/2026-05-field-trial-16.md` — the trial that built this.
+- `class/xion/BearerAuth.php` — implementation.
+- nene-mcp project (`https://github.com/hideyukiMORI/nene-mcp`) — the sister MCP server that originated this requirement.

--- a/docs/development/production-deployment.md
+++ b/docs/development/production-deployment.md
@@ -45,6 +45,8 @@ The full list of env vars NeNe reads at boot lives in `ini/xSystemIni.php`. The 
 | `NENE_SECURITY_PERMISSIONS_POLICY` | unset           | `geolocation=(), microphone=(), camera=()` | Permissions-Policy. Deny by default; expand as features require. |
 | `NENE_REQUEST_ID_HEADER` | `X-Request-ID` (compose default) | `X-Request-ID` or the proxy's existing name | Response header that carries the per-request id (#393). Empty string disables emission (logs still tag). See `docs/development/observability.md`. |
 | `NENE_REQUEST_ID_TRUST_INBOUND` | `1` (compose default)   | `1` behind a trusted proxy; `0` when the app is the public boundary | Whether to honor an inbound request-id. Generates fresh when `0`. |
+| `NENE_AGENT_BEARER_TOKEN` | empty (feature off) | a long random secret (e.g. `openssl rand -hex 32`) | Optional `Authorization: Bearer` for stateless agent / MCP clients (#399, ADR-0008). Empty disables the feature. See `docs/development/agent-bearer-auth.md`. |
+| `NENE_AGENT_BEARER_USER` | `admin` (compose default) | the `user_id` the Bearer maps to | Identity the token authenticates as. Must exist in the `users` table. |
 
 **Important**: setting `NENE_APP_ENV=production` *alone* flips the safe defaults of `NENE_APP_DEBUG` (`0`) and `NENE_SESSION_SECURE` (`1`). If you set `NENE_APP_DEBUG=1` and forget `NENE_APP_ENV`, your "production" deploy will not have `Secure` cookies. The overlay `compose.prod.yaml` sets all three explicitly so this footgun is closed for the bundled deploy.
 

--- a/docs/field-trials/README.md
+++ b/docs/field-trials/README.md
@@ -117,6 +117,22 @@ After a trial:
 
 The trial is finished when its Issues are merged or closed with a recorded rationale. A trial does not need to "succeed" — recording friction is the success condition.
 
+### Cross-repo Issue reuse
+
+When a sister project (NENE2, nene-mcp, nene2-python) opens an Issue against NeNe with concrete acceptance criteria — e.g. "with `NENE_*` set, this curl should return 200 — and the sister will run a confirmation FT once it merges" — **use that Issue directly as the trial Issue**. Do not open a new one.
+
+Rationale:
+
+- The cross-repo trace stays clean: the sister's FT report links to the same Issue NeNe's PR closes, so reviewers in either project see one timeline.
+- The acceptance criteria are already authoritative; restating them in a new Issue invites drift between the two versions.
+- The sister's confirmation FT is gated on that exact Issue closing, so referencing it in the trial report's "Trial Issue" field is unambiguous.
+
+Examples in this repo's history:
+
+- FT16 (`docs/field-trials/2026-05-field-trial-16.md`) reused Issue #380 (cross-repo handoff from nene-mcp FT204 / FT215 / FT225–FT419). The PR body's `Closes #380` triggered nene-mcp's confirmation FT.
+
+When the trial closes, comment on the original Issue with a short status update so the sister-side reader sees the outcome without having to dig into PR descriptions.
+
 ## Templates and Tools
 
 - Report skeleton: `docs/templates/field-trial-report.md`


### PR DESCRIPTION
## Summary

FT16 の docs-only fix。#399 (BearerAuth + ADR-0008) が merged 後の状態を集約 + cross-repo Issue reuse pattern を FT methodology の正式項目に。

### New file

- **\`docs/development/agent-bearer-auth.md\`** — env matrix / 4-layer Authorization fallback / in-memory bindBearer / CSRF skip 設計 / OpenAPI 反映 / Security notes / Future direction (per-user PAT)

### Updates

- \`docs/development/production-deployment.md\` env matrix に 2 行 (NENE_AGENT_BEARER_TOKEN / NENE_AGENT_BEARER_USER)
- \`docs/api/reference-client.md\` に "Bearer for non-browser callers" subsection (curl 3 例: list / create / read)
- **\`docs/field-trials/README.md\` に "Cross-repo Issue reuse" subsection** (F-5: 姉妹リポからの Issue を新 Issue 切らずに trial Issue として直接利用するパターンを methodology の正式項目化、FT16 #380 を例として明示)
- \`AGENTS.md\` "Read First"

Framework code 変更なし。

## Test plan

- [ ] markdown lint pass
- [ ] 既存テストへの影響なし (docs-only)

Closes #398.