### PR TITLE
docs(adr): index に 0003-0008 を追加する (#404)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,5 +23,11 @@ Create an ADR when a change affects:
 
 ## Index
 
-- `0001-record-architecture-decisions.md`: Start recording architecture decisions.
-- `0002-adopt-field-trial-methodology.md`: Adopt the field trial methodology as a continuous quality practice.
+- [`0001-record-architecture-decisions.md`](0001-record-architecture-decisions.md) (Accepted): Start recording architecture decisions.
+- [`0002-adopt-field-trial-methodology.md`](0002-adopt-field-trial-methodology.md) (Accepted): Adopt the field trial methodology as a continuous quality practice.
+- [`0003-openapi-failure-envelope-shape.md`](0003-openapi-failure-envelope-shape.md) (Accepted, FT3 #256): Use a single generic `ApiFailureEnvelope` schema for every REST failure status.
+- [`0004-controllerbase-unauthorized-redirect-hook.md`](0004-controllerbase-unauthorized-redirect-hook.md) (Accepted, FT5 #287): Add `unauthorizedRedirect()` hook so HTML controllers can override the global `LOGOUT_URI` per-section.
+- [`0005-schema-php-single-source.md`](0005-schema-php-single-source.md) (Accepted, FT11 #358): Make `class/xion/SchemaDefinition.php` the canonical schema source; `SchemaCompiler` generates MySQL + SQLite DDL.
+- [`0006-symfony-mailer-as-mail-dep.md`](0006-symfony-mailer-as-mail-dep.md) (Accepted, FT13 #379): Adopt `symfony/mailer` for the framework's mail surface; `Mailer` + `MailMessage` helpers; `null://null` default keeps CI offline.
+- [`0007-response-decoration-boundary.md`](0007-response-decoration-boundary.md) (Accepted, FT14 #387): `Nene\Xion\ResponseDecorator` at the `HttpEmitter::emit()` (and `View::execute()`) boundary hosts every cross-cutting response concern; closes the FT7 F-6 / FT8 F-4 decoration trap.
+- [`0008-optional-bearer-for-agent-routes.md`](0008-optional-bearer-for-agent-routes.md) (Accepted, FT16 #399): Optional `Authorization: Bearer` for stateless agent / MCP clients (`Nene\Xion\BearerAuth`); browser cookie+CSRF flow unchanged.


### PR DESCRIPTION
Source: \`REPORT_project_evaluation.md\` § 5 (Documentation) — PR #401 で指摘された ADR index 不整合の fix。

\`docs/adr/README.md\` index に **0003-0008** を Status + FT 由来 + 一行 summary 付きで明示。各エントリを clickable link 化。

## Test plan

- [ ] markdown lint pass
- [ ] 各 ADR への relative link が valid

Closes #404.