### PR TITLE
ci(workflow): Phan + format:check + checkout v4 + Docker buildx cache (#403)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -19,6 +19,14 @@ jobs:
           php-version: "8.4"
           tools: composer:v2
           coverage: none
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/composer
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
@@ -32,18 +40,43 @@ jobs:
       - name: Confirm HTTP tests skip without runtime
         run: composer test:http
 
+      # Static analysis + formatting check were defined in composer.json
+      # (`composer check`) but historically never wired into CI; #403 plugged
+      # the gap so baseline regressions surface on every PR.
+      - name: Run static analysis (Phan)
+        run: composer analyze
+
+      - name: Check code formatting
+        run: composer format:check
+
   runtime-smoke:
     name: HTTP runtime smoke (Docker)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
+
+      # buildx + gha cache so the second-and-later runs reuse the composer
+      # install / apt layers instead of rebuilding from scratch (#403).
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Prepare environment
         run: cp .env.example .env
 
-      - name: Build app image
-        run: docker compose build app
+      - name: Build app image with layer cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: nene-app:ci
+          cache-from: type=gha,scope=app
+          cache-to: type=gha,mode=max,scope=app
+
+      - name: Tag image for docker compose
+        # `docker compose build` would otherwise rebuild — pre-tag the buildx
+        # output so the running container reuses the cached image.
+        run: docker tag nene-app:ci nene-app
 
       - name: Start app
         run: docker compose up -d app

--- a/class/controller/TodoController.php
+++ b/class/controller/TodoController.php
@@ -35,7 +35,7 @@ class TodoController extends ControllerBase
         $userId = $this->getLoginUserId();
         $todoMapper = new Database\TodoMapper();
         return $this->API_RESPONSE->success([
-            'todos' => $this->normalizeRows($todoMapper->findRowsByUserId($userId))
+            'todos' => $this->normalizeRows($todoMapper->findRowsByUserId($userId)),
         ]);
     }
 
@@ -53,7 +53,7 @@ class TodoController extends ControllerBase
         }
         $todoMapper = new Database\TodoMapper();
         return $this->API_RESPONSE->success([
-            'todo' => $this->normalizeRow($todoMapper->createForUser($userId, $title))
+            'todo' => $this->normalizeRow($todoMapper->createForUser($userId, $title)),
         ]);
     }
 
@@ -75,7 +75,7 @@ class TodoController extends ControllerBase
             return $this->API_RESPONSE->failure('TODO-NOT-FOUND');
         }
         return $this->API_RESPONSE->success([
-            'todo' => $this->normalizeRow($todo)
+            'todo' => $this->normalizeRow($todo),
         ]);
     }
 
@@ -106,7 +106,7 @@ class TodoController extends ControllerBase
             return $this->API_RESPONSE->failure('TODO-NOT-FOUND');
         }
         return $this->API_RESPONSE->success([
-            'todo' => $this->normalizeRow($todo)
+            'todo' => $this->normalizeRow($todo),
         ]);
     }
 
@@ -127,7 +127,7 @@ class TodoController extends ControllerBase
             return $this->API_RESPONSE->failure('TODO-NOT-FOUND');
         }
         return $this->API_RESPONSE->success([
-            'id' => $id
+            'id' => $id,
         ]);
     }
 
@@ -172,7 +172,7 @@ class TodoController extends ControllerBase
             'title' => (string)$row['title'],
             'is_completed' => (bool)$row['is_completed'],
             'created_at' => (string)$row['created_at'],
-            'updated_at' => (string)$row['updated_at']
+            'updated_at' => (string)$row['updated_at'],
         ];
     }
 }

--- a/class/db/Todo.php
+++ b/class/db/Todo.php
@@ -36,7 +36,7 @@ class Todo extends DataModelBase
         'user_id'      => parent::INTEGER,
         'title'        => parent::STRING,
         'is_completed' => parent::BOOLEAN,
-        'is_deleted'   => parent::BOOLEAN
+        'is_deleted'   => parent::BOOLEAN,
     ];
 
     /**
@@ -48,6 +48,6 @@ class Todo extends DataModelBase
         'user_id'      => ['required' => true],
         'title'        => ['required' => true, 'maxlength' => 255],
         'is_completed' => ['required' => true, 'bool' => true],
-        'is_deleted'   => ['required' => true, 'bool' => true]
+        'is_deleted'   => ['required' => true, 'bool' => true],
     ];
 }

--- a/cli/generateSchemaSql.php
+++ b/cli/generateSchemaSql.php
@@ -63,13 +63,13 @@ $body = $header . $ddl . ($seeds !== '' ? $seeds : ($seedMarker . PHP_EOL));
 
 if (isset($options['check'])) {
     if ($existing === $body) {
-        echo "OK: docker/mysql/init/001_schema.sql matches generated output." . PHP_EOL;
+        echo 'OK: docker/mysql/init/001_schema.sql matches generated output.' . PHP_EOL;
         exit(0);
     }
-    echo "DRIFT: docker/mysql/init/001_schema.sql does not match generated output." . PHP_EOL;
-    echo "Run `composer schema:generate` to refresh." . PHP_EOL;
+    echo 'DRIFT: docker/mysql/init/001_schema.sql does not match generated output.' . PHP_EOL;
+    echo 'Run `composer schema:generate` to refresh.' . PHP_EOL;
     exit(1);
 }
 
 file_put_contents($schemaPath, $body);
-echo "Wrote " . $schemaPath . PHP_EOL;
+echo 'Wrote ' . $schemaPath . PHP_EOL;

--- a/ini/xSiteIni.php
+++ b/ini/xSiteIni.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * AYANE : ayane.co.jp
  * powered by NENE.

--- a/tests/Unit/Xion/BearerAuthTest.php
+++ b/tests/Unit/Xion/BearerAuthTest.php
@@ -29,7 +29,7 @@ final class BearerAuthTest extends TestCase
 
     public function testAcceptsMultipleWhitespaceBetweenSchemeAndToken(): void
     {
-        self::assertSame('abc-123', BearerAuth::extractToken("Bearer  abc-123"));
+        self::assertSame('abc-123', BearerAuth::extractToken('Bearer  abc-123'));
         self::assertSame('abc-123', BearerAuth::extractToken("Bearer\tabc-123"));
     }
 

--- a/tests/Unit/Xion/MailerTest.php
+++ b/tests/Unit/Xion/MailerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Nene\Tests\Unit\Xion;
 
-use Nene\Xion\MailMessage;
 use Nene\Xion\Mailer;
+use Nene\Xion\MailMessage;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Mailer as SymfonyMailer;

--- a/tests/Unit/Xion/RequestIdTest.php
+++ b/tests/Unit/Xion/RequestIdTest.php
@@ -110,7 +110,7 @@ final class RequestIdTest extends TestCase
     {
         self::assertFalse(RequestId::isValid("abc\ndef"));
         self::assertFalse(RequestId::isValid("abc\tdef"));
-        self::assertFalse(RequestId::isValid("abc def"));
+        self::assertFalse(RequestId::isValid('abc def'));
     }
 
     public function testIsValidAcceptsAllowedCharset(): void


### PR DESCRIPTION
## Summary

評価レポート (#401 § 6 DevOps/CI) 指摘の通り、\`composer.json\` で \`composer check\` が定義されているのに CI で呼ばれていなかった問題を解消。

### Workflow

- \`actions/checkout@v6\` → \`actions/checkout@v4\` (**v6 は実在しない**)
- **unit job**: composer cache (\`actions/cache@v4\`) + \"Run static analysis (Phan)\" + \"Check code formatting\" steps
- **runtime-smoke job**: \`docker/setup-buildx-action@v3\` + \`docker/build-push-action@v6\` + **gha cache** scope=app

### Cleanup

CI に \`format:check\` を有効化するため、既存 main の format violation 7 件を \`composer format\` で auto-fix:
- \`class/controller/TodoController.php\`, \`class/db/Todo.php\`, \`cli/generateSchemaSql.php\`, \`ini/xSiteIni.php\`
- \`tests/Unit/Xion/{Mailer,RequestId,BearerAuth}Test.php\`

CS Fixer の single-quote / trailing-comma 揃え、挙動変化なし。

## Test plan

- [x] \`composer test\` 99/99
- [x] \`composer test:http\` 23/23 (1 expected skip)
- [x] \`composer analyze\` (Phan) exit 0
- [x] \`composer format:check\` exit 0 (0/80 files)
- [ ] CI 初回 run で all green (Phan + format:check + Docker cache が動く)

Closes #403.