### PR TITLE
refactor(controller-base): undocumented "debug" controller guard を削除する (#406)

### DIFF
--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -182,17 +182,15 @@ abstract class ControllerBase
     {
         $controller = $this->ROUTE_CONTEXT->controller();
         $action = $this->ROUTE_CONTEXT->action();
-        if ($controller != 'debug') {
-            $_SESSION['global']['referer']['controller']    = $controller;
-            $_SESSION['global']['referer']['action']        = $action;
-            $this->ACCESS_LOGGER->info(
-                'ACCESS : ' . $controller . '::' . $action,
-                [
-                    $_SERVER['HTTP_USER_AGENT'] ?? '',
-                    $_SERVER['HTTP_REFERER'] ?? '',
-                ]
-            );
-        }
+        $_SESSION['global']['referer']['controller']    = $controller;
+        $_SESSION['global']['referer']['action']        = $action;
+        $this->ACCESS_LOGGER->info(
+            'ACCESS : ' . $controller . '::' . $action,
+            [
+                $_SERVER['HTTP_USER_AGENT'] ?? '',
+                $_SERVER['HTTP_REFERER'] ?? '',
+            ]
+        );
         if ($this->ROUTE_CONTEXT->isRest() && in_array($this->method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
             $this->REQUEST_JSON = Xion\JsonResponder::inputJsonToArray();
         } elseif ($this->ROUTE_CONTEXT->isAction()) {


### PR DESCRIPTION
評価レポート #401 § 1 Architecture 指摘の **undocumented magic string** の解消。

### 調査

\`\`\`bash
git log --all --oneline -S \"'debug'\" -- class/xion/ControllerBase.php
\`\`\`
→ \`2e13c6d (2020-03-01) "add : Add controller base class."\` 初版から存在。**6 年前からの dead path**。

- \`DebugController\` クラスは存在しない
- docs にも記載なし
- 文書化も使用も無いまま放置

### Decision

**Case A: 削除** を採用。理由:
- 6 年使われていない、削除しても何も壊れない
- 1 行の guard 削除で済む (再導入も容易)
- 将来 debug controller が必要になったら hook 経由で導入 (新 ADR / convention) すれば良い

### Change

\`ControllerBase::run()\` の \`if (\$controller != 'debug')\` guard 撤去のみ。access log + session referer 記録は常時実行に。

## Test plan

- [x] composer test 99/99
- [x] composer test:http 24/24 (1 expected skip)
- [x] composer analyze (Phan) exit 0
- [x] composer format:check exit 0

Closes #406.