### PR TITLE
refactor(types): tighten $REQUEST_JSON + ApiResponse return shapes (#405)

### DIFF
--- a/class/xion/ApiResponse.php
+++ b/class/xion/ApiResponse.php
@@ -38,11 +38,18 @@ class ApiResponse
     }
 
     /**
-     * Build a success response.
+     * Build a success response envelope.
      *
-     * @param array<string,mixed> $data Response data.
+     * The returned array always includes `status: 'success'` and
+     * `errorCode: ''`; any keys supplied in `$data` are merged on top
+     * (caller-supplied keys win, since `array_merge` keeps the rightmost
+     * value for duplicate keys). The envelope is wrapped by
+     * `JsonResponder::responseArray()` so the final REST shape is
+     * `{ Result: true, Data: { status: 'success', errorCode: '', ... } }`.
      *
-     * @return array<string,mixed> API response.
+     * @param array<string,mixed> $data Domain-specific data to merge into the envelope.
+     *
+     * @return array<string,mixed> Success envelope with caller keys merged.
      */
     public function success(array $data = []): array
     {
@@ -53,11 +60,15 @@ class ApiResponse
     }
 
     /**
-     * Build a failure response.
+     * Build a failure response envelope.
      *
-     * @param string $errorCode Error code.
+     * The shape is exactly three keys — `status`, `errorCode`,
+     * `errorMessage` — and never carries caller-supplied data. The
+     * PHPDoc uses the array-shape form so static analysis can
+     * distinguish failure responses from success responses by the
+     * presence of `errorMessage` (#405, eval report PR #401 § 2).
      *
-     * @return array<string,string> API response.
+     * @return array{status: 'failure', errorCode: string, errorMessage: string}
      */
     public function failure(string $errorCode): array
     {

--- a/class/xion/ControllerBase.php
+++ b/class/xion/ControllerBase.php
@@ -129,9 +129,14 @@ abstract class ControllerBase
     private CsrfProtectionPolicy $csrfProtectionPolicy;
 
     /**
-     * Rest post
+     * Decoded JSON request body (REST POST / PUT / PATCH / DELETE only).
      *
-     * @var array
+     * Populated by `JsonResponder::inputJsonToArray()` for state-changing
+     * REST requests; an empty array otherwise. Parameterizing the type
+     * lets Phan / IDE follow value types through controller code
+     * (#405, eval report PR #401 § 2).
+     *
+     * @var array<string,mixed>
      */
     protected array $REQUEST_JSON = [];
 


### PR DESCRIPTION
評価レポート #401 § 2 Code Quality の 2 件を解消。

### \$REQUEST_JSON

\`ControllerBase::\$REQUEST_JSON\` の PHPDoc を \`array<string,mixed>\` に parameterize (native type は \`array\` のまま)。\`JsonResponder::inputJsonToArray\` の戻り PHPDoc と整合。

### ApiResponse return shape

- \`success()\`: \`@return array<string,mixed>\` 維持 + array_merge 振る舞いと caller keys win の説明を追記
- \`failure()\`: \`@return array{status: 'failure', errorCode: string, errorMessage: string}\` の **shape 形式** に変更 → 静的解析が failure 戻り値を success と shape で区別可能に

## Test plan

- [x] composer test 99/99
- [x] composer test:http 24/24 (1 expected skip)
- [x] composer analyze (Phan) exit 0 (baseline 不変)
- [x] composer format:check exit 0

Closes #405.