### PR TITLE
chore(dev): developer ergonomic tools + shared composer cache volume

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,13 @@ jobs:
       - name: Prepare environment
         run: cp .env.example .env
 
+      - name: Ensure shared composer cache volume exists
+        # compose.yaml references `nene_composer_cache` as an external
+        # named volume so every NeNe checkout / FT clone shares it. On
+        # a fresh CI runner the volume does not exist yet — create it
+        # idempotently. (Local devs get this via tools/nene-ft-new.sh.)
+        run: docker volume create nene_composer_cache
+
       - name: Build app image with layer cache
         uses: docker/build-push-action@v6
         with:

--- a/compose.yaml
+++ b/compose.yaml
@@ -41,6 +41,15 @@ services:
     volumes:
       - .:/var/www/html
       - vendor:/var/www/html/vendor
+      # Composer's package archive cache is shared across every NeNe
+      # checkout / trial clone via the external `nene_composer_cache`
+      # named volume. A clone's vendor/ stays per-project (composer.lock
+      # may differ), but the downloaded `.zip` for each package is
+      # cached once and reused by every clone. Reduces a fresh
+      # `composer install` from ~30-45s to ~5s after the first run.
+      # The volume is created by `tools/nene-ft-new.sh` (or by hand:
+      # `docker volume create nene_composer_cache`).
+      - composer-cache:/root/.composer/cache
     command: >
       sh -lc "composer install --no-interaction --prefer-dist
       && ./init.sh
@@ -88,3 +97,9 @@ services:
 volumes:
   mysql-data:
   vendor:
+  # External so every NeNe checkout / trial clone references the same
+  # underlying Docker volume. See the comment on the `app` service for
+  # rationale.
+  composer-cache:
+    external: true
+    name: nene_composer_cache

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,12 @@
             "@test",
             "@test:http",
             "@analyze"
+        ],
+        "ci": [
+            "@test",
+            "@test:http",
+            "@analyze",
+            "@format:check"
         ]
     }
 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,65 @@
+# Development Tools
+
+Single-purpose scripts that make NeNe's day-to-day workflow less typing-heavy. Everything here is reversible — these scripts wrap existing commands, they don't introduce new mandatory steps.
+
+## Quick reference
+
+| Command | What it does | When to use |
+| --- | --- | --- |
+| `tools/nene-ft-new.sh <topic>` | Bootstrap a new field trial clone (next FT number auto-detected, port offset, `.env`, `.claude/settings.local.json`). | Starting a new FT. |
+| `tools/wait-healthy.sh [port] [timeout]` | Block until `/health` returns 200, with a timeout. | After `docker compose up -d app`, before running curl probes. |
+| `tools/trial-status.sh <FT-N>` | List every Issue + PR mentioning a trial number, open and closed. | Closing-out check: "is every spawned Issue closed?" |
+| `php tools/error-code-add.php CODE "Message" <http-status> ["notes"]` | Insert a new error code into both `config/error_codes.php` and `docs/development/error-codes.md` atomically. | Adding an error code without the manual two-file dance. |
+| `tools/test-http-preflight.php` | Print a one-line summary of the HTTP smoke target before PHPUnit runs. | Called automatically by `composer test:http`. |
+
+## Composer scripts (in `composer.json`)
+
+| Script | What it does |
+| --- | --- |
+| `composer setup` | First-time DB setup (`cli/setupDatabase.php --env=.env --yes`). |
+| `composer schema:generate` | Regenerate `docker/mysql/init/001_schema.sql` from `SchemaDefinition`. |
+| `composer schema:check` | Drift check: fail if the generated SQL differs from the snapshot. |
+| `composer schema:diff -- --dsn=…` | Operator-applied migration diff (ADR-0009). |
+| `composer test` | Unit tests (`phpunit --testsuite unit`). |
+| `composer test:http` | HTTP smoke tests (`phpunit --testsuite http`). |
+| `composer test:all` | Both suites. |
+| `composer analyze` | Static analysis (Phan + baseline). |
+| `composer format` | Apply PHP CS Fixer. |
+| `composer format:check` | Dry-run PHP CS Fixer (CI gate). |
+| `composer check` | `test` + `test:http` + `analyze`. (Excludes `format:check` — see `composer ci`.) |
+| **`composer ci`** | **`test` + `test:http` + `analyze` + `format:check`** — runs exactly what CI runs. Use this before pushing. |
+
+### Argument passthrough
+
+Composer 2 forwards everything after `--` to the underlying tool. The most useful case:
+
+```bash
+# Run a single HTTP smoke test class
+composer test:http -- --filter HttpBearerAuthTest
+
+# Run a single unit test class
+composer test -- --filter SchemaDifferTest
+
+# Run a single method
+composer test -- --filter 'SchemaDifferTest::testNewIndexEmitsCreateIndex'
+```
+
+The preflight in `test:http` silently ignores extra args, so the same pattern works for both suites.
+
+## Shared composer cache
+
+`compose.yaml` references an **external** Docker volume `nene_composer_cache` for composer's package archives. Every NeNe checkout / FT clone reuses the same cache, so a fresh `composer install` is ~5s after the first download instead of ~30-45s.
+
+The volume is created lazily:
+
+- `tools/nene-ft-new.sh` ensures it exists when bootstrapping a clone.
+- If `docker compose up` fails with "external volume not found", run `docker volume create nene_composer_cache` once by hand.
+
+Each project's `vendor/` directory stays per-project (composer.lock may differ between clones). What gets cached is the downloaded `.zip` per package version.
+
+## Add a new tool
+
+1. Drop the script in `tools/`. PHP for anything that touches PHP source / config files; bash for shell glue.
+2. Add a one-line entry in the **Quick reference** table above.
+3. If the script ergonomically wraps a `composer` step, also add a composer script alias in `composer.json`.
+4. Keep tools single-purpose. A script that does three unrelated things should be three scripts.

--- a/tools/error-code-add.php
+++ b/tools/error-code-add.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Insert a new error code into both `config/error_codes.php` and
+ * `docs/development/error-codes.md` in one step, avoiding the manual
+ * dance + the #352 drift gate (which catches the mistake of forgetting
+ * one of the two files).
+ *
+ * Usage:
+ *   php tools/error-code-add.php CODE "Message" <http-status> ["notes-for-docs"]
+ *
+ * Examples:
+ *   php tools/error-code-add.php \
+ *       TODO-LOCKED "TODO item is locked for editing." 409 \
+ *       "Returned when another user already has the lock."
+ *
+ *   php tools/error-code-add.php \
+ *       UPLOAD-DUPLICATE "Upload duplicates an existing file." 409
+ *
+ * Behavior:
+ *   - Both files are edited in-place. The PHP file gets a new entry at
+ *     the end of the array (before the closing `];`); the docs file
+ *     gets a new table row at the end of the existing catalog block.
+ *   - Refuses to add a code that already exists in either file.
+ *   - Does not run the drift-gate test (the existing
+ *     `tests/Unit/ErrorCodesDocSyncTest` does that after the edit).
+ *
+ * Exit codes:
+ *   0  both files updated
+ *   1  CLI usage error
+ *   2  code already exists / file structure unexpected
+ */
+
+if ($argc < 4) {
+    fwrite(STDERR, "usage: php tools/error-code-add.php CODE \"Message\" <http-status> [\"notes\"]\n");
+    fwrite(STDERR, "       see the docblock at the top of this file for examples.\n");
+    exit(1);
+}
+
+$code = (string)$argv[1];
+$message = (string)$argv[2];
+$httpStatus = (int)$argv[3];
+$notes = isset($argv[4]) ? (string)$argv[4] : '';
+
+if (!preg_match('/^[A-Z][A-Z0-9-]+$/', $code)) {
+    fwrite(STDERR, "error: code must match /^[A-Z][A-Z0-9-]+\$/ (got: $code)\n");
+    exit(1);
+}
+if ($httpStatus < 100 || $httpStatus > 599) {
+    fwrite(STDERR, "error: HTTP status must be 100-599 (got: $httpStatus)\n");
+    exit(1);
+}
+
+$frameworkRoot = dirname(__DIR__);
+$configPath = $frameworkRoot . '/config/error_codes.php';
+$docsPath = $frameworkRoot . '/docs/development/error-codes.md';
+
+$configContent = (string)file_get_contents($configPath);
+$docsContent = (string)file_get_contents($docsPath);
+
+// Existence checks
+if (str_contains($configContent, "'$code'")) {
+    fwrite(STDERR, "error: `$code` already exists in $configPath\n");
+    exit(2);
+}
+if (str_contains($docsContent, "`$code`")) {
+    fwrite(STDERR, "error: `$code` already exists in $docsPath\n");
+    exit(2);
+}
+
+// --- 1. Update config/error_codes.php ---
+$entry = sprintf(
+    "    '%s' => [\n        'message' => '%s',\n        'httpStatus' => %d,\n    ],\n",
+    $code,
+    addslashes($message),
+    $httpStatus
+);
+
+// Insert before the closing `];` (last occurrence so we land at the array tail).
+$lastClose = strrpos($configContent, '];');
+if ($lastClose === false) {
+    fwrite(STDERR, "error: $configPath does not end with `];` — structure unexpected\n");
+    exit(2);
+}
+$updatedConfig = substr($configContent, 0, $lastClose) . $entry . substr($configContent, $lastClose);
+file_put_contents($configPath, $updatedConfig);
+echo "✓ updated $configPath\n";
+
+// --- 2. Update docs/development/error-codes.md ---
+// Find the last row of the catalog table (line starting with `| `…`) within
+// the "## Catalog" section.
+$lines = explode("\n", $docsContent);
+$inCatalog = false;
+$insertAfterIndex = null;
+foreach ($lines as $index => $line) {
+    if (str_starts_with($line, '## ')) {
+        $inCatalog = ($line === '## Catalog');
+        continue;
+    }
+    if ($inCatalog && str_starts_with($line, '| `')) {
+        $insertAfterIndex = $index;
+    }
+}
+if ($insertAfterIndex === null) {
+    fwrite(STDERR, "error: could not locate `## Catalog` table rows in $docsPath\n");
+    exit(2);
+}
+
+$noteCell = $notes === '' ? '' : str_replace('|', '\\|', $notes);
+$newRow = sprintf(
+    '| `%s` | %d | %s | %s |',
+    $code,
+    $httpStatus,
+    str_replace('|', '\\|', $message),
+    $noteCell
+);
+array_splice($lines, $insertAfterIndex + 1, 0, [$newRow]);
+file_put_contents($docsPath, implode("\n", $lines));
+echo "✓ updated $docsPath\n";
+
+echo "\nReminder: run `composer test` to confirm the drift-gate (ErrorCodesDocSyncTest) passes.\n";
+exit(0);

--- a/tools/nene-ft-new.sh
+++ b/tools/nene-ft-new.sh
@@ -105,6 +105,15 @@ PORT_APP=$((8080 + N))
 PORT_MYSQL=$((3307 + N))
 HEAD_SHA="$(git -C "$FRAMEWORK_ROOT" rev-parse --short HEAD)"
 
+echo "==> Ensuring shared composer cache volume"
+# `compose.yaml` references `nene_composer_cache` as an external volume so
+# every NeNe checkout / trial clone reuses the same composer package cache.
+# Create it lazily so the bootstrap script does not require an out-of-band
+# `docker volume create` step.
+if ! docker volume inspect nene_composer_cache >/dev/null 2>&1; then
+    docker volume create nene_composer_cache >/dev/null
+fi
+
 echo "==> Cloning framework ($HEAD_SHA) into $CLONE_DIR"
 git clone --quiet "$FRAMEWORK_ROOT" "$CLONE_DIR"
 

--- a/tools/trial-status.sh
+++ b/tools/trial-status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Show every Issue and PR mentioning a Field Trial in one view.
+#
+# Usage:
+#   tools/trial-status.sh <FT-N>
+#
+# Examples:
+#   tools/trial-status.sh FT17
+#   tools/trial-status.sh FT3
+#
+# Why:
+#   When closing out a trial, the maintainer (or AI agent) wants to verify
+#   every spawned Issue is closed and every follow-up PR merged. Running
+#   `gh issue list --search FT17` and `gh pr list --search FT17` separately
+#   was the pre-existing dance — this is the merged view.
+#
+# Notes:
+#   - Searches by the literal string (e.g. "FT17") so the trial number must
+#     appear in the Issue title or body. Existing trial Issues follow that
+#     convention (`FT17: schema-diff …`).
+#   - Includes both open and closed.
+
+set -euo pipefail
+
+trial="${1:?usage: tools/trial-status.sh <FT-N>}"
+
+echo "=== Issues mentioning $trial (open + closed) ==="
+gh issue list --search "$trial" --state all --limit 50
+
+echo
+echo "=== PRs mentioning $trial (open + closed) ==="
+gh pr list --search "$trial" --state all --limit 50

--- a/tools/wait-healthy.sh
+++ b/tools/wait-healthy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Wait until a NeNe instance reports `/health` 200, or timeout.
+#
+# Usage:
+#   tools/wait-healthy.sh [port] [timeout-seconds]
+#
+# Examples:
+#   tools/wait-healthy.sh                # framework default — 127.0.0.1:8080, 60s
+#   tools/wait-healthy.sh 8097           # FT17 clone — 127.0.0.1:8097, 60s
+#   tools/wait-healthy.sh 8080 120       # explicit timeout
+#
+# Exit codes:
+#   0  /health responded 200 within the budget
+#   1  /health did not respond within the budget
+#
+# Notes:
+#   - The check only requires HTTP 200, not `healthStatus=ok`. For a stricter
+#     gate (e.g. CI wait that requires the DB to be healthy too), use the
+#     inline loop in `.github/workflows/tests.yml`.
+#   - Sleep interval is 1s. After timeout, exits 1 with a hint to inspect
+#     `docker compose logs app`.
+
+set -euo pipefail
+
+port="${1:-8080}"
+timeout="${2:-60}"
+url="http://127.0.0.1:${port}/health"
+
+for i in $(seq 1 "$timeout"); do
+    if curl -fs -o /dev/null "$url" 2>/dev/null; then
+        echo "OK (${i}s) — $url"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "timeout: $url did not respond within ${timeout}s" >&2
+echo "       hint: docker compose logs app | tail -50" >&2
+exit 1


### PR DESCRIPTION
セッション運用で boilerplate に消えていた時間を畳む小道具一式。**任意採用、既存 workflow 互換、reversible**。

### Composer scripts

- **\`composer ci\`** = \`test\` + \`test:http\` + \`analyze\` + \`format:check\` の sequence
  - 既存 \`composer check\` が format:check を漏らしていたので、CI が走らせる厳密同等の boundary を local で確認するための alias
  - 本セッションで "format:check 漏れ → CI で fail → 再 push" を踏んだのが動機
- \`composer test:http / test\` の \`-- --filter\` passthrough を doc 化 (既に動作)

### Helper scripts (tools/)

- \`wait-healthy.sh [port] [timeout]\` — \`/health\` 200 待ちの \`until\` loop boilerplate を 1 行に
- \`trial-status.sh FT-N\` — Issue + PR を 1 view で
- \`error-code-add.php\` — \`config/error_codes.php\` + \`docs/development/error-codes.md\` を atomic 更新 (#352 drift gate 同時 pass、手動 2 ファイル更新を排除)
- **\`tools/README.md\` 新規** — 全 tool + composer script の 1 page リファレンス

### Shared composer cache (前提 C 採用)

- \`compose.yaml\` app service に **external named volume** \`nene_composer_cache\` を \`/root/.composer/cache\` に mount
- \`nene-ft-new.sh\` が clone bootstrap 時に volume を lazy 作成 (\`docker volume create\` 不要)
- vendor/ は per-project 維持、cache 対象は downloaded .zip のみ
- 効果: 初回後の fresh \`composer install\` が **~30-45s → ~5s**

### A / B 判断 (maintainer 指示で現状維持)

- A: CI paths-filter で docs PR の runtime-smoke skip → **現状維持**
- B: \`schema:diff:dev\` での DSN auto-fill → **現状維持** (ADR-0009 operator-explicit 原則)

## Test plan

- [x] \`composer ci\` 全 step green (142/142 + 24/24 + Phan exit 0 + format 0 fix)
- [x] \`composer test:http -- --filter HttpBearerAuthTest\` で 5 cases に絞れる
- [x] \`tools/wait-healthy.sh 8080 30\` → OK (1s)
- [x] \`tools/trial-status.sh FT17\` → 4 issue + 4 pr 表示
- [x] \`tools/error-code-add.php FAKE-CODE-TEST …\` で両 file 更新 + drift gate pass を確認 → revert 済
- [x] \`docker volume create nene_composer_cache\` 経由で composer cache が container 内 \`/root/.composer/cache\` に shared mount