### PR TITLE
chore(quality): resolve all 6 Phan baseline entries → empty baseline (#439)

### DIFF
--- a/.phan/baseline.php
+++ b/.phan/baseline.php
@@ -8,25 +8,8 @@
  * (can be combined with --load-baseline)
  */
 return [
-    // # Issue statistics:
-    // PhanTypeArraySuspicious : 1 occurrence
-    // PhanTypeMagicVoidWithReturn : 1 occurrence
-    // PhanTypeMismatchArgumentInternal : 1 occurrence
-    // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
-    // PhanTypeMismatchForeach : 1 occurrence
-    // PhanUndeclaredConstantOfClass : 1 occurrence
-
+    // This baseline has no suppressions
     'file_suppressions' => [
-        'class/xion/DataModelBase.php' => [
-            'PhanTypeArraySuspicious' => ['\\Nene\\Xion\\DataModelBase::validate'],
-            'PhanTypeMagicVoidWithReturn' => ['\\Nene\\Xion\\DataModelBase::__set'],
-            'PhanTypeMismatchArgumentInternal' => ['\\Nene\\Xion\\DataModelBase::validate'],
-            'PhanTypeMismatchArgumentNullableInternal' => ['\\Nene\\Xion\\DataModelBase::setNow'],
-            'PhanTypeMismatchForeach' => ['\\Nene\\Xion\\DataModelBase::validate']
-        ],
-        'class/xion/PdoConnection.php' => [
-            'PhanUndeclaredConstantOfClass' => ['\\Nene\\Xion\\PdoConnection::__construct']
-        ],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/class/db/Todo.php
+++ b/class/db/Todo.php
@@ -44,7 +44,7 @@ class Todo extends DataModelBase
      *
      * @var array
      */
-    protected static $validation = [
+    protected static array $validation = [
         'user_id'      => ['required' => true],
         'title'        => ['required' => true, 'maxlength' => 255],
         'is_completed' => ['required' => true, 'bool' => true],

--- a/class/db/User.php
+++ b/class/db/User.php
@@ -45,7 +45,7 @@ class User extends DataModelBase
      *
      * @var array
      */
-    protected static $validation = [
+    protected static array $validation = [
         'created_at' => ['required' => true],
         'updated_at' => ['required' => true],
         'user_id'    => ['required' => true, 'maxlength' => 64],

--- a/class/xion/DataModelBase.php
+++ b/class/xion/DataModelBase.php
@@ -57,6 +57,19 @@ abstract class DataModelBase
     protected static array $schema = [];
 
     /**
+     * Validation rules.
+     *
+     * Subclasses declare this as a protected static property with their
+     * field-level rules. The base class declares the property with an empty
+     * default so Phan can infer the array shape (resolves the Phan baseline
+     * entries for DataModelBase::validate — PhanTypeArraySuspicious,
+     * PhanTypeMismatchArgumentInternal, PhanTypeMismatchForeach).
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    protected static array $validation = [];
+
+    /**
      * Logger
      *
      * @var Logger
@@ -193,12 +206,16 @@ abstract class DataModelBase
      * Setter.
      * The value is set in the parameter according to the type set in the schema.
      *
+     * PHP ignores the return value of __set (it is a void magic method).
+     * Do not add a return statement — use {@see set()} or {@see setParam()}
+     * if you need the result.
+     *
      * @param string $prop Parameter key.
      * @param mixed  $val  Parameter value.
      *
-     * @return mixed
+     * @return void
      */
-    public function __set(string $prop, mixed $val)
+    public function __set(string $prop, mixed $val): void
     {
         if (!isset(static::$schema[$prop])) {
             throw new \InvalidArgumentException('SET ' . $prop . ' IS DISABLE.');
@@ -208,19 +225,24 @@ abstract class DataModelBase
         $type = gettype($val);
         if ($type === $schema) {
             $this->data[$prop] = $val;
-            return true;
+            return;
         }
 
+        // PHP ignores the return value of __set; assignments are the side-effect.
         switch ($schema) {
             case self::BOOLEAN:
-                return $this->data[$prop] = (bool) $val;
+                $this->data[$prop] = (bool) $val;
+                break;
             case self::INTEGER:
-                return $this->data[$prop] = (int) $val;
+                $this->data[$prop] = (int) $val;
+                break;
             case self::DOUBLE:
-                return $this->data[$prop] = (float) $val;
+                $this->data[$prop] = (float) $val;
+                break;
             case self::STRING:
             default:
-                return $this->data[$prop] = (string) $val;
+                $this->data[$prop] = (string) $val;
+                break;
         }
     }
 
@@ -272,13 +294,13 @@ abstract class DataModelBase
     public function validate(string $prop = '', string $value = ''): mixed
     {
         if ($prop == '') {
-            foreach ($this->validation as $key => $val) {
+            foreach (static::$validation as $key => $val) {
                 if (!$this->doValid($this->$key, $val)) {
                     return ($key);
                 }
             }
-        } elseif (in_array($prop, $this->validation, true)) {
-            if (!$this->doValid($value, $this->validation[$prop])) {
+        } elseif (array_key_exists($prop, static::$validation)) {
+            if (!$this->doValid($value, static::$validation[$prop])) {
                 return (false);
             }
         }
@@ -360,7 +382,8 @@ abstract class DataModelBase
      */
     public function setNow(): void
     {
-        if (strlen($this->created_at) <= 1) {
+        // Cast to string: __get returns mixed; strlen requires string.
+        if (strlen((string)$this->created_at) <= 1) {
             $this->created_at = date('YmdHi');
         }
         $this->updated_at = date('YmdHi');

--- a/class/xion/PdoConnection.php
+++ b/class/xion/PdoConnection.php
@@ -64,6 +64,10 @@ class PdoConnection
                         DB_PASS
                     );
                     $this->connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                    // @phan-suppress-next-line PhanUndeclaredConstantOfClass
+                    // PDO::MYSQL_ATTR_USE_BUFFERED_QUERY is a MySQL-driver constant.
+                    // It is available at runtime when the MySQL PDO driver is loaded,
+                    // but Phan cannot resolve driver-specific constants statically.
                     $this->connection->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
                     break;
                 case 'SQLite3':


### PR DESCRIPTION
## Summary

Closes all 6 pre-existing Phan suppressions in `.phan/baseline.php`. The baseline is now empty — future Phan runs start from a clean slate. Resolves the `static-analysis-baseline cleanup` field trial candidate.

## Code

### `class/xion/DataModelBase.php` (5 issues)

**Root cause**: `$this->validation` was accessed without a declaration in the base class, and `__set` had return statements in a void magic method.

- **Added** `protected static array $validation = []` (mirrors the existing `$schema` pattern → fixes PhanTypeArraySuspicious, PhanTypeMismatchForeach, PhanTypeMismatchArgumentInternal)
- **Changed** `$this->validation` → `static::$validation` in `validate()` (fixes PhanAccessPropertyStaticAsNonStatic)
- **Changed** `in_array($prop, ...)` → `array_key_exists($prop, ...)` in `validate()` (also fixes type mismatch; $prop is a key, not a value)
- **Changed** `strlen($this->created_at)` → `strlen((string)$this->created_at)` in `setNow()` (fixes PhanTypeMismatchArgumentNullableInternal)
- **Removed** `return` from `__set` switch cases + changed PHPDoc to `@return void` + added `void` return type (fixes PhanTypeMagicVoidWithReturn)

### `class/db/User.php` + `class/db/Todo.php`

- Added `array` type to `protected static array $validation` (required when parent declares a typed static property)

### `class/xion/PdoConnection.php` (1 issue)

- Added `@phan-suppress-next-line PhanUndeclaredConstantOfClass` + explanatory comment for `PDO::MYSQL_ATTR_USE_BUFFERED_QUERY` (MySQL-driver constant, correct at runtime, not resolvable statically)

### `.phan/baseline.php`

- Regenerated in app container (predis installed) → **0 suppressions**

## Test plan

- [x] `composer test` — 178 tests, 352 assertions, all pass
- [x] `composer analyze` — Phan clean, baseline empty
- [x] `composer format:check` — CS Fixer clean

Closes #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)