### PR TITLE
docs(field-trial): FT21 DataMapperBase test補強 report (#443)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-21.md
+++ b/docs/field-trials/2026-05-field-trial-21.md
@@ -1,0 +1,60 @@
+# Field Trial 21 — DataMapperBase unit tests
+
+**Date**: 2026-05-27
+**Issue**: #443 (deferred from #407)
+**PR**: #444 (feat — tests only, no production code change)
+**Branch**: `feat/443-datamapperbase-tests`
+
+## Objective
+
+Close the coverage gap on `DataMapperBase` that was explicitly deferred during the #407 PR review. The deferred work was: unit tests for `execute()`, `decorate()`, `assoc()`, `KEY_SID` inheritance rules, `getTableColumn()`, and `getSearchARRAY()` — all of which require PDO test doubles or constant-dependent parsing logic.
+
+## Findings
+
+### F-1 — Mock PDO/PDOStatement works cleanly
+
+PHPUnit's `createMock(PDO::class)` and `createMock(PDOStatement::class)` cover all DB-interaction paths in `DataMapperBase` without a real database or container. The same factory pattern used in `DataModelBaseTest` (`::withDb()` bypass of `__construct`) works here identically.
+
+No special PDO configuration was needed. `execute()` and `executeQuery()` both follow a try/catch(PDOException) pattern that converts to `HttpTermination`, which is testable via `$this->expectException(HttpTermination::class)`.
+
+### F-2 — Guarded `define()` is the right constant strategy for test files
+
+Test files that depend on runtime constants (`APP_DEBUG`, `DB_COLUMN_NAME_CREATED`, `DB_COLUMN_NAME_UPDATED`, `DB_COLUMN_TIMESTAMP`, `DB_NUM_PREFIX`) must guard each `define()` call:
+
+```php
+if (!defined('APP_DEBUG')) {
+    define('APP_DEBUG', false);
+}
+```
+
+PHPUnit runs all tests in one process; without guards the second test file that defines the same constant causes a fatal error. This pattern was already established in earlier test files in the suite.
+
+### F-3 — `getSearchARRAY()` handles all delimiter variants correctly
+
+The method correctly normalises full-width comma (`、`), full-width space (`　`), ASCII comma, and ASCII space — including multi-space collapse and leading/trailing trim. 8 test cases (single space, comma, full-width comma, full-width space, multi-space collapse, trim, single keyword, mixed delimiters) all pass as expected.
+
+### F-4 — `getTableColumn()` KEY_SID exclusion is unconditional
+
+Regardless of the `$is_exclude_date` flag, the column matching `KEY_SID` is always excluded. The date-column exclusion (`created_at` / `updated_at`) is controlled by the flag + `DB_COLUMN_TIMESTAMP` constant. Fixture schema (`test_id`, `title`, `created_at`, `updated_at`) + full exclusion leaves exactly `{title}` — confirmed by `assertCount(1, $columns)`.
+
+### F-5 — No Phan issues introduced
+
+The new test file added no Phan findings. Phan baseline remains empty (0 suppressions) after this trial.
+
+## What changed
+
+| File | Change |
+|---|---|
+| `tests/Unit/Xion/DataMapperBaseTest.php` | **New** — 20 unit tests + 3 fixture classes |
+
+No production code changed. This trial is pure test coverage.
+
+## Test count delta
+
+Before: 178 tests. After: **198 tests, 378 assertions**.
+
+## Related
+
+- `class/xion/DataMapperBase.php` — the class under test
+- `docs/field-trials/candidates.md` — candidate entry struck through
+- Issue #407 (original deferral note)

--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -71,10 +71,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 #### ~~static-analysis-baseline cleanup~~ → **complete** (2026-05-27, PR #440)
 
-#### DataMapperBase test补強 (#407 deferred chunk)
-**Why**: FT-407 deferred the PDO-dependent unit test work. Coverage on `DataMapperBase::execute()` / `decorate()` / KEY_SID rules is thin.
-**Trigger**: Whenever before a planned `DataMapperBase` refactor.
-**Size**: medium (needs PDO test double design).
+#### ~~DataMapperBase test補強 (#407 deferred chunk)~~ → **FT21 complete** (2026-05-27)
 
 ---
 
@@ -82,6 +79,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT21 — DataMapperBase test補強** (2026-05-27): 20 unit tests for `execute()` / `executeQuery()` / `decorate()` / `assoc()` / `KEY_SID` / `getTableColumn()` / `getSearchARRAY()`. Mock PDO/PDOStatement; no real DB. PR #444.
 - **ADR-0012 — PHP version policy** (2026-05-27): \`"php": ">=8.4"\` declared; upgrade cadence documented. PR #442.
 - **static-analysis-baseline cleanup** (2026-05-27): all 6 Phan baseline entries resolved. PR #440. Baseline now empty.
 - **ADR-0011 — Smarty selection** (2026-05-27): retrospective ADR. PR #438. Records why Smarty over Twig/Blade + revisit triggers.


### PR DESCRIPTION
## Summary

Closes the docs side of #443.

- Adds `docs/field-trials/2026-05-field-trial-21.md` — FT21 trial report (5 findings)
- Updates `docs/field-trials/candidates.md` — strikes through the DataMapperBase test補強 candidate; adds to archive trail

No production or test code changes (feat side already merged as #444).

🤖 Generated with [Claude Code](https://claude.com/claude-code)