### PR TITLE
docs(field-trial): FT22 ai-agent-journey — tutorial fixes (F-1 delete() + F-5 error-codes)

### DIFF
--- a/docs/field-trials/2026-05-field-trial-22.md
+++ b/docs/field-trials/2026-05-field-trial-22.md
@@ -1,0 +1,99 @@
+# Field Trial 22 — ai-agent-journey
+
+**Date**: 2026-05-27
+**Issue**: N/A (meta-trial, no feature issue)
+**PRs**: #451 (fixes + report)
+**Branch**: `feat/447-ft22-doc-fixes`
+
+## Objective
+
+Phase 6 thesis self-verification: bootstrap a fresh NeNe clone with a clean AI agent (a `general-purpose` subagent with no prior NeNe knowledge), give it the docs and the task of building a small REST service end-to-end, and record what was still confusing.
+
+**Service built**: `bookmarks` — four public REST endpoints (`GET /bookmark/index`, `POST /bookmark/index`, `GET /bookmark/item/id_{id}`, `DELETE /bookmark/item/id_{id}`).
+
+**Clone**: `../NeNe-FT/ft22-ai-agent-journey` (fresh clone at `40fffd5`, same commit as main at time of trial).
+
+## Outcome
+
+The agent successfully built and tested the bookmarks service. All tests pass:
+
+- Unit: **198 tests, 381 assertions** (0 failures)
+- HTTP: **48 tests, 362 assertions, 6 skipped** (skips are expected: bearer-auth and error-exposure env vars not set)
+
+The service is fully functional. The agent's code was clean and idiomatic NeNe.
+
+## Findings
+
+### F-1 — `DataMapperBase::delete()` name collision (CRITICAL doc gap) → Issue #446
+
+**What happened**: The agent tried to implement a soft-delete mapper method named `delete(int $id)`. `DataMapperBase` already declares `public function delete(mixed $data): void`. PHP 8.4 treats the incompatible signature override as a fatal error.
+
+**Why it matters**: A newcomer following the NeNe pattern for soft-delete (the `is_deleted = 1` idiom) would naturally reach for `delete()` as the method name. The tutorial examples use `is_deleted` but do not show how to implement the deletion half — and make no mention that `insert()`, `update()`, `delete()`, `find()`, `findALL()`, `countById()`, `countAll()` are all reserved by the base class.
+
+**Fix**: Added a "Reserved method names in DataMapperBase" warning section to `docs/tutorials/building-a-service.md` (this PR). Canonical alternative: `softDelete(int $id): bool`.
+
+### F-2 — `SchemaDefinition` has no nullable column type (undocumented limitation) → Issue #448
+
+**What happened**: The task asked for an optional `note` column (nullable text). `SchemaCompiler` compiles all columns as `NOT NULL`. The agent had to read `SchemaCompiler.php` source to discover the limitation and use empty string as the sentinel instead.
+
+**Why it matters**: The tutorial, `SchemaDefinition.php` docblock, and `schema-migrations.md` are all silent on this. Newcomers attempting to model optional data will be confused when `INSERT` fails on `NULL`.
+
+**Fix (partial)**: Added a "Column nullability" note to the tutorial (this PR). Long-term: add a `nullable` modifier to `SchemaCompiler` (Issue #448 deferred).
+
+### F-3 / F-6 — `composer setup` output shows hardcoded table list → Issue #449
+
+**What happened**: `DatabaseInstaller::install()` always outputs `Tables: users, todos` regardless of what `SchemaDefinition` actually defines. After adding the `bookmarks` table and running `composer setup`, the output still said `Tables: users, todos`, making it look like the setup missed the new table.
+
+**Why it matters**: The agent had to run `SHOW TABLES` in MySQL directly to confirm the table existed. A human newcomer would likely spend time debugging something that actually worked.
+
+**Fix**: Filed as Issue #449 (make table list dynamic). Not fixed in this PR — requires a code change to `DatabaseInstaller`.
+
+### F-4 — No per-entity CRUD HTTP test example → Issue #450
+
+**What happened**: The tutorial directs developers to "look at an existing HTTP test file". The only existing file is `tests/Http/HttpSmokeTest.php` — a general smoke test covering many endpoints, not a per-entity create/read/delete test. The `HttpRuntimeTestCase` base class has Todo-specific helpers (`createTodo`, `deleteTodosWithTitlePrefix`) that are not generalizable.
+
+**Why it matters**: The recommended test structure — create unique data per test, clean up on teardown, test each endpoint in isolation — is not illustrated anywhere. The agent pieced it together from the base class and smoke test, but a human newcomer would struggle.
+
+**Fix**: Filed as Issue #450 (add TodoTest.php or a canonical CRUD test example to the tutorial). Not fixed in this PR — requires a TodoTest.php to be authored.
+
+### F-5 — Tutorial doesn't mention `docs/development/error-codes.md` must be updated → Issue #447
+
+**What happened**: The 'Add Error Codes' section shows editing `config/error_codes.php`. A unit test (`ErrorCodeTest::testEveryRuntimeCodeAppearsInDocsMarkdownTable`) enforces that `docs/development/error-codes.md` stays in sync. The tutorial says nothing about this. The agent discovered the requirement only when unit tests failed.
+
+**Fix**: Added a callout block to the tutorial (this PR). Immediate.
+
+## What worked well
+
+- **Routing convention** (`{action}GetRest`, `{action}PostRest`, `{action}DeleteRest`) is clearly documented and correct. No surprises.
+- **`SESSION_CHECK = false` in `preAction()`** for public endpoints — clear, one-liner, worked as described.
+- **Schema compilation pipeline** (`SchemaDefinition` → `composer schema:generate` → `001_schema.sql`) — worked correctly once the agent understood the flow. The `SchemaDefinition.php` docblock is helpful.
+- **`TransactionManager`** — clear pattern in the tutorial, worked first try.
+- **`normalizeRow()` guidance** — the explicit rationale ("PDO returns everything as strings") is excellent. Agent applied it correctly.
+- **`$this->REQUEST_JSON` / `$this->request->getParam()`** — clear from tutorial + TodoController reference.
+- **Error code catalog structure** (`message` + `httpStatus`) — straightforward.
+- **OpenAPI YAML format** — easy to copy-paste from existing paths.
+- **`composer test` / `composer test:http`** — scripts work exactly as documented.
+
+## Files changed in this PR
+
+| File | Change |
+|---|---|
+| `docs/tutorials/building-a-service.md` | Added reserved-method-names warning + column nullability note (F-1, F-2) + error-codes.md callout (F-5) |
+| `docs/field-trials/2026-05-field-trial-22.md` | This report |
+| `docs/field-trials/candidates.md` | Strike through ai-agent-journey candidate; add to archive trail |
+
+## Deferred findings (filed as issues)
+
+| Issue | Finding |
+|---|---|
+| #446 | F-1 `delete()` collision — **fixed in tutorial** (this PR) |
+| #447 | F-5 error-codes.md sync — **fixed in tutorial** (this PR) |
+| #448 | F-2 nullable column limitation — deferred (implementation needed) |
+| #449 | F-3/F-6 hardcoded installer table list — deferred (code change needed) |
+| #450 | F-4 no per-entity CRUD test example — deferred (TodoTest.php needed) |
+
+## Related
+
+- `docs/field-trials/candidates.md` — ai-agent-journey candidate
+- Phase 6 thesis: `docs/milestones/`
+- FT22 clone: `../NeNe-FT/ft22-ai-agent-journey`

--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -57,10 +57,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ### Meta / evaluation (Phase 6 系譜)
 
-#### ai-agent-journey
-**Why**: Phase 6 thesis self-verification. Bootstrap a fresh clone with a clean AI agent and have it build a small service end-to-end using only the docs. Surface what's still confusing.
-**Trigger**: After a significant docs investment (now, after FT13-17 + journal added, would be a reasonable time).
-**Size**: long (4-8 hours), unique findings.
+#### ~~ai-agent-journey~~ → **FT22 complete** (2026-05-27)
 
 #### docs-journey-newcomer
 **Why**: Similar to ai-agent-journey but human-centered. Trial with a developer who has never seen NeNe.
@@ -79,6 +76,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT22 — ai-agent-journey** (2026-05-27): clean subagent built `bookmarks` REST service end-to-end using only docs. 5 doc gaps found (F-1/F-5 fixed immediately, F-2/F-3/F-4 deferred as Issues #446-#450). PR #451.
 - **FT21 — DataMapperBase test補強** (2026-05-27): 20 unit tests for `execute()` / `executeQuery()` / `decorate()` / `assoc()` / `KEY_SID` / `getTableColumn()` / `getSearchARRAY()`. Mock PDO/PDOStatement; no real DB. PR #444.
 - **ADR-0012 — PHP version policy** (2026-05-27): \`"php": ">=8.4"\` declared; upgrade cadence documented. PR #442.
 - **static-analysis-baseline cleanup** (2026-05-27): all 6 Phan baseline entries resolved. PR #440. Baseline now empty.

--- a/docs/tutorials/building-a-service.md
+++ b/docs/tutorials/building-a-service.md
@@ -522,6 +522,8 @@ return [
 
 The public JSON envelope wraps that data under `Data`.
 
+> **Also update `docs/development/error-codes.md`.** A unit test (`ErrorCodeTest::testEveryRuntimeCodeAppearsInDocsMarkdownTable`) verifies that every entry in `config/error_codes.php` appears in the markdown catalog table. Adding to the PHP file without updating the markdown causes unit tests to fail. Add a row for each new code in the table in `docs/development/error-codes.md`.
+
 ## Add Database Code
 
 Use a data model for schema metadata and validation, and a mapper for SQL.
@@ -634,6 +636,16 @@ When you add a new table, keep MySQL and SQLite setup aligned:
 docker/mysql/init/001_schema.sql
 cli/initSQLite.php
 ```
+
+### Reserved method names in DataMapperBase
+
+`DataMapperBase` already declares `insert()`, `update()`, `delete()`, `find()`, `findALL()`, `countById()`, `countAll()` as public methods. Overriding any of these with an incompatible signature causes a PHP fatal error.
+
+Name your own mapper methods to avoid collisions. For soft-delete (setting `is_deleted = 1`) the conventional choice is `softDelete(int $id): bool`.
+
+### Column nullability
+
+`SchemaDefinition` / `SchemaCompiler` does not yet have a nullable column variant — every column compiles to `NOT NULL`. For truly optional data, use an empty string as the sentinel (`''`) and bind with `PDO::PARAM_STR` in the mapper. Do not try to insert `NULL` into a column defined via `SchemaDefinition`.
 
 ## Add Authentication Requirements
 


### PR DESCRIPTION
## Summary

FT22 ai-agent-journey: a clean AI subagent built a `bookmarks` REST service on a fresh NeNe clone using only the docs. 5 documentation gaps were found. This PR addresses the two immediately fixable ones.

### Findings summary

| # | Severity | Status |
|---|---|---|
| F-1 | Critical — `DataMapperBase::delete()` name collision fatal error if tutorial followed verbatim | Fixed here |
| F-2 | Medium — nullable column limitation not documented | Issue #448 (deferred) |
| F-3/F-6 | Medium — `composer setup` reports hardcoded table list | Issue #449 (deferred) |
| F-4 | Medium — no per-entity CRUD HTTP test example | Issue #450 (deferred) |
| F-5 | Medium — tutorial doesn't mention `docs/development/error-codes.md` sync requirement | Fixed here |

### Changes in `docs/tutorials/building-a-service.md`

- Added "Reserved method names in DataMapperBase" section: `insert()`, `update()`, `delete()`, `find()`, `findALL()`, `countById()`, `countAll()` are reserved; soft-delete should use `softDelete()`
- Added "Column nullability" note: `SchemaCompiler` has no nullable variant; use empty string sentinel
- Added callout to "Add Error Codes" section: also update `docs/development/error-codes.md` (enforced by `ErrorCodeTest`)

### Other changes

- `docs/field-trials/2026-05-field-trial-22.md` — trial report
- `docs/field-trials/candidates.md` — strike-through + archive trail

### Issues filed

- #446 — delete() name collision (tutorial corrected here)
- #447 — error-codes.md sync (tutorial corrected here)
- #448 — nullable column limitation (deferred)
- #449 — hardcoded installer table list (deferred, code change needed)
- #450 — no CRUD HTTP test example (deferred, TodoTest.php needed)

### Agent journey result

The agent successfully built all 4 endpoints. Tests: 198 unit + 48 HTTP (6 expected skips). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
