### PR TITLE
fix(installer): derive table list dynamically from SchemaDefinition (#449)

### DIFF
--- a/class/xion/DatabaseInstaller.php
+++ b/class/xion/DatabaseInstaller.php
@@ -29,7 +29,7 @@ final class DatabaseInstaller
         return [
             'databaseType' => DB_TYPE,
             'databaseName' => DB_TYPE === 'MySQL' ? DB_NAME : DB_FILE,
-            'tables' => ['users', 'todos'],
+            'tables' => array_keys(SchemaDefinition::tables()),
             'sampleUser' => 'admin',
         ];
     }
@@ -59,8 +59,9 @@ final class DatabaseInstaller
         }
 
         try {
-            self::assertTableExists($pdo, 'users');
-            self::assertTableExists($pdo, 'todos');
+            foreach (array_keys(SchemaDefinition::tables()) as $table) {
+                self::assertTableExists($pdo, $table);
+            }
             $result['schema'] = true;
             $result['healthStatus'] = 'ok';
         } catch (\Throwable $throwable) {
@@ -198,10 +199,6 @@ SQL);
      */
     private static function assertTableExists(PDO $pdo, string $table): void
     {
-        if (!in_array($table, ['users', 'todos'], true)) {
-            throw new \InvalidArgumentException('Unexpected table check: ' . $table);
-        }
-
         $pdo->query('SELECT COUNT(*) FROM ' . $table);
     }
 

--- a/cli/setupDatabase.php
+++ b/cli/setupDatabase.php
@@ -48,7 +48,7 @@ echo 'Welcome NeNe-PHP database setup!' . PHP_EOL . PHP_EOL;
 echo 'Environment file: ' . ($loadedEnv === [] ? 'not loaded' : $envPath) . PHP_EOL;
 echo 'Database type: ' . DB_TYPE . PHP_EOL;
 echo 'Database target: ' . (DB_TYPE === 'MySQL' ? DB_HOST . ':' . DB_PORT . '/' . DB_NAME : DB_DIR . DB_FILE) . PHP_EOL;
-echo 'This command creates users/todos tables and inserts the sample admin data when missing.' . PHP_EOL . PHP_EOL;
+echo 'This command creates schema tables and inserts the sample admin data when missing.' . PHP_EOL . PHP_EOL;
 
 if (!isset($options['yes'])) {
     echo 'Do you want to continue? (Y/N)' . PHP_EOL;


### PR DESCRIPTION
Closes #449.

## Changes

- `DatabaseInstaller::install()`: `'tables' => array_keys(SchemaDefinition::tables())` instead of hardcoded `['users','todos']`
- `DatabaseInstaller::health()`: iterates `SchemaDefinition::tables()` keys instead of hardcoded pair
- `DatabaseInstaller::assertTableExists()`: removed unnecessary allowlist guard (table names only come from SchemaDefinition internal code)
- `cli/setupDatabase.php`: description updated from 'creates users/todos tables' to 'creates schema tables'

## Verification

Adding a new table to `SchemaDefinition` now causes `composer setup` to output the new table name in the Tables list and `health()` to verify it too.

All 198 unit tests pass. Phan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)