### PR TITLE
feat(schema): add nullable column option to SchemaCompiler (#448)

### DIFF
--- a/class/xion/SchemaCompiler.php
+++ b/class/xion/SchemaCompiler.php
@@ -157,15 +157,17 @@ SQL;
      */
     public static function mysqlColumn(string $name, array $column): string
     {
-        $type = (string)($column['type'] ?? '');
+        $type     = (string)($column['type'] ?? '');
+        $nullable = (bool)($column['nullable'] ?? false);
+        $nn       = $nullable ? '' : ' NOT NULL';
         return match (true) {
             $type === 'pk-bigint'       => $name . ' BIGINT UNSIGNED NOT NULL AUTO_INCREMENT',
-            $type === 'bigint'          => $name . ' BIGINT UNSIGNED NOT NULL',
-            $type === 'text'            => $name . ' TEXT NOT NULL',
+            $type === 'bigint'          => $name . ' BIGINT UNSIGNED' . $nn,
+            $type === 'text'            => $name . ' TEXT' . $nn,
             $type === 'bool'            => $name . ' TINYINT(1) NOT NULL DEFAULT ' . (int)($column['default'] ?? 0),
             $type === 'datetime-now'    => $name . ' DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP',
             $type === 'datetime-touch'  => $name . ' DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
-            str_starts_with($type, 'varchar:') => $name . ' VARCHAR(' . (int)substr($type, strlen('varchar:')) . ') NOT NULL',
+            str_starts_with($type, 'varchar:') => $name . ' VARCHAR(' . (int)substr($type, strlen('varchar:')) . ')' . $nn,
             default => throw new InvalidArgumentException('Unknown column type for ' . $name . ': ' . $type),
         };
     }
@@ -175,15 +177,17 @@ SQL;
      */
     public static function sqliteColumn(string $name, array $column): string
     {
-        $type = (string)($column['type'] ?? '');
+        $type     = (string)($column['type'] ?? '');
+        $nullable = (bool)($column['nullable'] ?? false);
+        $nn       = $nullable ? '' : ' NOT NULL';
         return match (true) {
             $type === 'pk-bigint'       => $name . ' INTEGER PRIMARY KEY AUTOINCREMENT',
-            $type === 'bigint'          => $name . ' INTEGER NOT NULL',
-            $type === 'text'            => $name . ' TEXT NOT NULL',
+            $type === 'bigint'          => $name . ' INTEGER' . $nn,
+            $type === 'text'            => $name . ' TEXT' . $nn,
             $type === 'bool'            => $name . ' INTEGER NOT NULL DEFAULT ' . (int)($column['default'] ?? 0),
             $type === 'datetime-now'    => $name . ' TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP',
             $type === 'datetime-touch'  => $name . ' TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP',
-            str_starts_with($type, 'varchar:') => $name . ' TEXT NOT NULL',
+            str_starts_with($type, 'varchar:') => $name . ' TEXT' . $nn,
             default => throw new InvalidArgumentException('Unknown column type for ' . $name . ': ' . $type),
         };
     }

--- a/class/xion/SchemaDefinition.php
+++ b/class/xion/SchemaDefinition.php
@@ -26,6 +26,16 @@ namespace Nene\Xion;
  *                            ON UPDATE CURRENT_TIMESTAMP (MySQL);
  *                            SQLite simulates via a trigger.
  *
+ * Column options (added alongside `type`):
+ *
+ * - `nullable: true`      → omit NOT NULL from the generated DDL; the column
+ *                            accepts NULL values. Applies to `bigint`, `text`,
+ *                            and `varchar:*`. Not applicable to `pk-bigint`,
+ *                            `bool`, or `datetime-*` columns, which are always
+ *                            NOT NULL.
+ * - `default: <scalar>`   → column default value (currently only used for
+ *                            `bool` columns; e.g. `'default' => 0`).
+ *
  * See ADR-0005 for the consolidation rationale.
  */
 final class SchemaDefinition

--- a/docs/tutorials/building-a-service.md
+++ b/docs/tutorials/building-a-service.md
@@ -645,7 +645,14 @@ Name your own mapper methods to avoid collisions. For soft-delete (setting `is_d
 
 ### Column nullability
 
-`SchemaDefinition` / `SchemaCompiler` does not yet have a nullable column variant — every column compiles to `NOT NULL`. For truly optional data, use an empty string as the sentinel (`''`) and bind with `PDO::PARAM_STR` in the mapper. Do not try to insert `NULL` into a column defined via `SchemaDefinition`.
+To allow a column to store `NULL`, add `'nullable' => true` to its definition in `SchemaDefinition::tables()`:
+
+```php
+'note' => ['type' => 'text', 'nullable' => true],
+'parent_id' => ['type' => 'bigint', 'nullable' => true],
+```
+
+Without `nullable`, every column compiles to `NOT NULL`. The `nullable` option applies to `text`, `varchar:*`, and `bigint` columns. `pk-bigint`, `bool`, and `datetime-*` columns are always `NOT NULL` and ignore the option.
 
 ## Add Authentication Requirements
 

--- a/tests/Unit/Xion/SchemaCompilerTest.php
+++ b/tests/Unit/Xion/SchemaCompilerTest.php
@@ -83,6 +83,64 @@ final class SchemaCompilerTest extends TestCase
         }
     }
 
+    // ------------------------------------------------------------------
+    // nullable column option (#448)
+    // ------------------------------------------------------------------
+
+    public function testMysqlNullableTextOmitsNotNull(): void
+    {
+        $ddl = SchemaCompiler::mysqlColumn('note', ['type' => 'text', 'nullable' => true]);
+        self::assertSame('note TEXT', $ddl);
+        self::assertStringNotContainsString('NOT NULL', $ddl);
+    }
+
+    public function testMysqlNullableVarcharOmitsNotNull(): void
+    {
+        $ddl = SchemaCompiler::mysqlColumn('slug', ['type' => 'varchar:128', 'nullable' => true]);
+        self::assertSame('slug VARCHAR(128)', $ddl);
+        self::assertStringNotContainsString('NOT NULL', $ddl);
+    }
+
+    public function testMysqlNullableBigintOmitsNotNull(): void
+    {
+        $ddl = SchemaCompiler::mysqlColumn('parent_id', ['type' => 'bigint', 'nullable' => true]);
+        self::assertSame('parent_id BIGINT UNSIGNED', $ddl);
+        self::assertStringNotContainsString('NOT NULL', $ddl);
+    }
+
+    public function testMysqlNonNullableTextRetainsNotNull(): void
+    {
+        $ddl = SchemaCompiler::mysqlColumn('body', ['type' => 'text']);
+        self::assertSame('body TEXT NOT NULL', $ddl);
+    }
+
+    public function testSqliteNullableTextOmitsNotNull(): void
+    {
+        $ddl = SchemaCompiler::sqliteColumn('note', ['type' => 'text', 'nullable' => true]);
+        self::assertSame('note TEXT', $ddl);
+        self::assertStringNotContainsString('NOT NULL', $ddl);
+    }
+
+    public function testSqliteNullableVarcharOmitsNotNull(): void
+    {
+        $ddl = SchemaCompiler::sqliteColumn('slug', ['type' => 'varchar:128', 'nullable' => true]);
+        self::assertSame('slug TEXT', $ddl);
+        self::assertStringNotContainsString('NOT NULL', $ddl);
+    }
+
+    public function testSqliteNullableBigintOmitsNotNull(): void
+    {
+        $ddl = SchemaCompiler::sqliteColumn('parent_id', ['type' => 'bigint', 'nullable' => true]);
+        self::assertSame('parent_id INTEGER', $ddl);
+        self::assertStringNotContainsString('NOT NULL', $ddl);
+    }
+
+    public function testSqliteNonNullableTextRetainsNotNull(): void
+    {
+        $ddl = SchemaCompiler::sqliteColumn('body', ['type' => 'text']);
+        self::assertSame('body TEXT NOT NULL', $ddl);
+    }
+
     /**
      * Drift gate for ADR-0005: the committed `docker/mysql/init/001_schema.sql`
      * DDL section must equal the compiler's MySQL output. The hand-written


### PR DESCRIPTION
Closes #448.

## What

Adds `'nullable' => true` as a column definition option in `SchemaDefinition`. When present, `NOT NULL` is omitted from the generated DDL for `bigint`, `text`, and `varchar:*` columns.

```php
// SchemaDefinition.php — now valid
'note'      => ['type' => 'text',    'nullable' => true],
'parent_id' => ['type' => 'bigint',  'nullable' => true],
'alias'     => ['type' => 'varchar:128', 'nullable' => true],
```

`pk-bigint`, `bool`, and `datetime-*` columns are always `NOT NULL` and ignore the option.

## Changes

| File | Change |
|---|---|
| `class/xion/SchemaCompiler.php` | `mysqlColumn()` + `sqliteColumn()` honour `$column['nullable']` |
| `class/xion/SchemaDefinition.php` | Docblock updated with `nullable` + `default` option docs |
| `tests/Unit/Xion/SchemaCompilerTest.php` | 8 new tests (4 MySQL + 4 SQLite) |
| `docs/tutorials/building-a-service.md` | Nullable note updated with the actual syntax |

## Tests

```
206 tests, 392 assertions — OK
```

Phan clean. CS Fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)