### PR TITLE
feat(docs): port NENE2 FT80-99 patterns — security + design howtos (#455)

### DIFF
--- a/class/xion/JsonResponder.php
+++ b/class/xion/JsonResponder.php
@@ -158,7 +158,7 @@ class JsonResponder
      */
     private static function encode(array $response): string
     {
-        return json_encode($response, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?: '{}';
+        return json_encode($response, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE) ?: '{}';
     }
 
     /**

--- a/docs/development/agent-bearer-auth.md
+++ b/docs/development/agent-bearer-auth.md
@@ -102,12 +102,60 @@ A future trial may pick this up when:
 - Token rotation needs an overlap window (old + new valid simultaneously).
 - Per-route or per-scope authorization is needed beyond "is this the admin?".
 
+## JWT-based Bearer auth (custom implementation)
+
+NeNe's built-in Bearer auth uses a pre-shared static token (`NENE_AGENT_BEARER_TOKEN`) validated with `hash_equals`. If you build a custom JWT-based auth system (e.g., for user-facing API tokens), these edge cases must be handled:
+
+### Security edge cases (FT94 findings from NENE2)
+
+| Scenario | Required behaviour |
+|---|---|
+| Missing `Authorization` header | 401 + `WWW-Authenticate: Bearer` response header |
+| Non-Bearer scheme (`Basic ...`) | 401 |
+| `Authorization: Bearer` with no token | 401 |
+| Expired token (`exp` claim in the past) | 401 — always validate `exp` |
+| Not-yet-valid token (`nbf` in the future) | 401 — validate `nbf` if you issue it |
+| Signature with wrong secret | 401 — `hash_equals` (constant-time) |
+| Tampered payload (header.different_payload.original_sig) | 401 — signature mismatch |
+| `alg: none` attack (unsigned token) | 401 — reject any algorithm other than your declared one (e.g. HS256) |
+| Correct token, but accessing another user's resource | 404 — see IDOR prevention |
+
+**Always declare and enforce the algorithm.** A JWT library that does not explicitly verify `alg === 'HS256'` (or your chosen algorithm) may accept `alg: none` tokens — unsigned tokens that bypass signature verification entirely. Specify the expected algorithm in the verifier constructor, not from the token header.
+
+**Always set `exp` on issued tokens.** A token without `exp` is valid forever. If `exp` is missing and your verifier does not reject it, a stolen token can never be revoked.
+
+**Use `hash_equals` for all secret comparisons.** String comparison with `===` has timing side-channels. `hash_equals` takes constant time regardless of where the strings diverge.
+
+```php
+// Correct constant-time comparison
+if (!hash_equals($expectedToken, $incomingToken)) {
+    throw new \RuntimeException('Invalid token');
+}
+```
+
+### IDOR via JWT claims
+
+When the JWT `sub` (subject) claim identifies the user, all database queries for owned resources must use the claim value as the owner filter — not the id from the URL:
+
+```php
+// WRONG — user in URL can mismatch the authenticated user
+$userId = (int)$this->request->getParam('userId');
+$entries = $mapper->findByUserId($userId);
+
+// RIGHT — always use the identity from the token
+$userId = (int)($jwtClaims['sub'] ?? 0);
+$entries = $mapper->findByUserId($userId);
+```
+
+This is the same ownership-in-SQL pattern as `docs/development/idor-prevention.md`.
+
 ## Related
 
 - `docs/adr/0008-optional-bearer-for-agent-routes.md` — design rationale.
 - `docs/api/openapi.yaml` — `bearerAuth` security scheme + TODO operations.
 - `docs/api/reference-client.md` — non-browser caller flows (Bearer pattern).
 - `docs/development/production-deployment.md` — env matrix, including `NENE_AGENT_BEARER_TOKEN` and `NENE_AGENT_BEARER_USER`.
+- `docs/development/idor-prevention.md` — ownership isolation patterns.
 - `docs/field-trials/2026-05-field-trial-16.md` — the trial that built this.
 - `class/xion/BearerAuth.php` — implementation.
 - nene-mcp project (`https://github.com/hideyukiMORI/nene-mcp`) — the sister MCP server that originated this requirement.

--- a/docs/development/booking-systems.md
+++ b/docs/development/booking-systems.md
@@ -1,0 +1,156 @@
+# Booking and Reservation Systems (Double-Booking Prevention)
+
+Reservation systems face two concurrent-write problems: **double-booking** (two users claim the same slot) and **capacity overflow** (more bookings than available seats). Both require database-level enforcement — application-level checks alone are not safe under concurrency.
+
+## The TOCTOU problem
+
+The typical "check then insert" flow:
+
+```
+T1: SELECT count(*) → 4 (under capacity 5)
+T2: SELECT count(*) → 4 (under capacity 5)
+T1: INSERT booking row    ← now 5 (at capacity)
+T2: INSERT booking row    ← now 6 (over capacity! TOCTOU)
+```
+
+Both T1 and T2 pass the check, and both insert. The application must serialize the check+insert using a UNIQUE constraint, a SELECT FOR UPDATE, or a single-statement conditional INSERT.
+
+## Pattern A — UNIQUE constraint (exclusive slots)
+
+For resources with one slot per time unit (hotel room nights, doctor appointments, parking spaces), a UNIQUE constraint on `(resource_id, date)` is the simplest guard:
+
+```php
+// SchemaDefinition
+
+'bookings' => [
+    'columns' => [
+        'id'          => ['type' => 'pk-bigint'],
+        'created_at'  => ['type' => 'datetime-now'],
+        'resource_id' => ['type' => 'bigint'],
+        'user_id'     => ['type' => 'bigint'],
+        'booked_date' => ['type' => 'varchar:10'],   // YYYY-MM-DD
+    ],
+    'unique' => [
+        'bookings_resource_date_unique' => ['resource_id', 'booked_date'],
+    ],
+],
+```
+
+The controller attempts the INSERT and catches the constraint violation:
+
+```php
+public function indexPostRest(): array
+{
+    $resourceId = (int)($this->REQUEST_JSON['resource_id'] ?? 0);
+    $date       = trim((string)($this->REQUEST_JSON['date'] ?? ''));
+    $userId     = $this->getLoginUserId();
+
+    // Validate date format
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+        return $this->API_RESPONSE->failure('BOOKING-DATE-INVALID');
+    }
+
+    try {
+        $booking = (new Database\BookingMapper())->create($resourceId, $userId, $date);
+        return $this->API_RESPONSE->success(['booking' => $this->normalizeRow($booking)]);
+    } catch (\PDOException $e) {
+        if (str_contains($e->getCode(), '23')) { // SQLSTATE 23xxx = constraint violation
+            return $this->API_RESPONSE->failure('BOOKING-ALREADY-EXISTS'); // 409
+        }
+        throw $e;
+    }
+}
+```
+
+## Pattern B — capacity check with serialized INSERT
+
+For resources with limited capacity (events, classes, tours), a COUNT-based check must be serialized. MySQL's `SELECT ... FOR UPDATE` locks the relevant rows:
+
+```php
+public function create(int $resourceId, int $userId, string $date, int $capacity): ?array
+{
+    $transaction = new \Nene\Xion\TransactionManager();
+    return $transaction->run(function () use ($resourceId, $userId, $date, $capacity): ?array {
+        // Lock: prevents concurrent SELECTs from seeing stale count during this transaction
+        $countStmt = $this->DB->prepare('
+            SELECT COUNT(*) AS booked
+            FROM ' . static::TARGET_TABLE . '
+            WHERE resource_id = :rid AND booked_date = :date
+            FOR UPDATE
+        ');
+        $countStmt->bindValue(':rid',  $resourceId, PDO::PARAM_INT);
+        $countStmt->bindValue(':date', $date,       PDO::PARAM_STR);
+        $row    = $this->execute($countStmt)->fetch(PDO::FETCH_ASSOC);
+        $booked = (int)($row['booked'] ?? 0);
+
+        if ($booked >= $capacity) {
+            return null; // caller maps to 409
+        }
+
+        $insertStmt = $this->DB->prepare('
+            INSERT INTO ' . static::TARGET_TABLE . ' (resource_id, user_id, booked_date)
+            VALUES (:rid, :uid, :date)
+        ');
+        $insertStmt->bindValue(':rid',  $resourceId, PDO::PARAM_INT);
+        $insertStmt->bindValue(':uid',  $userId,     PDO::PARAM_INT);
+        $insertStmt->bindValue(':date', $date,       PDO::PARAM_STR);
+        $this->execute($insertStmt);
+
+        return $this->findRowById((int)$this->DB->lastInsertId());
+    });
+}
+```
+
+> `FOR UPDATE` is MySQL only. For SQLite, use `BEGIN EXCLUSIVE` (PDO: `$this->DB->exec('BEGIN EXCLUSIVE')`) or rely on the UNIQUE constraint approach.
+
+## Pattern C — conditional INSERT (MySQL)
+
+A single SQL statement that inserts only if capacity is not exceeded:
+
+```sql
+INSERT INTO bookings (resource_id, user_id, booked_date)
+SELECT :rid, :uid, :date
+WHERE (
+    SELECT COUNT(*) FROM bookings
+    WHERE resource_id = :rid AND booked_date = :date
+) < :capacity
+```
+
+Check `rowCount() === 1` after execution. If 0, capacity was already reached.
+
+## Error codes
+
+```php
+// config/error_codes.php
+'BOOKING-DATE-INVALID'    => ['message' => 'Booking date is not a valid date.',      'httpStatus' => 400],
+'BOOKING-ALREADY-EXISTS'  => ['message' => 'This slot is already booked.',            'httpStatus' => 409],
+'BOOKING-CAPACITY-FULL'   => ['message' => 'This slot is fully booked.',              'httpStatus' => 409],
+```
+
+## Distinguishing "already booked" from "capacity full"
+
+In Pattern A (UNIQUE constraint), both "already booked by me" and "booked by someone else" result in a constraint violation — you get a 409 for both and cannot easily distinguish them without an extra query.
+
+In Pattern B (COUNT check), you know exactly why the insert failed (capacity hit). If you also need "I already booked this" detection, add a UNIQUE on `(resource_id, user_id, booked_date)` for per-user exclusivity.
+
+## Testing
+
+Always test the race condition path:
+
+```php
+// Simulate concurrent bookings: create two identical requests
+$firstResponse  = $this->client->json('POST', '/booking/index', ['resource_id' => 1, 'date' => '2026-07-01']);
+$secondResponse = $this->client->json('POST', '/booking/index', ['resource_id' => 1, 'date' => '2026-07-01']);
+
+self::assertSame(200, $firstResponse->statusCode());
+self::assertSame(409, $secondResponse->statusCode());
+self::assertSame('BOOKING-ALREADY-EXISTS', $secondResponse->json()['Data']['errorCode']);
+```
+
+In real concurrency tests, use goroutines/threads or parallel curl. In sequential tests, verify the second attempt is rejected.
+
+## Related
+
+- `docs/development/ledger-systems.md` — idempotency key pattern for duplicate-request prevention
+- `docs/development/idor-prevention.md` — ownership isolation
+- `docs/tutorials/building-a-service.md` — TransactionManager pattern

--- a/docs/development/cors-and-csrf.md
+++ b/docs/development/cors-and-csrf.md
@@ -1,0 +1,62 @@
+# CORS and CSRF — They Are Not the Same
+
+A common misconception: "I have CORS configured, so I'm protected from CSRF." This is wrong. CORS and CSRF protect against different threat models.
+
+## CORS — controls what browsers read
+
+CORS (Cross-Origin Resource Sharing) governs whether a **browser** is allowed to read a response from a different origin. It is enforced by the browser, not the server.
+
+If an attacker makes a request from `evil.example.com`:
+- Without a permissive CORS header, the browser refuses to give the attacker's JavaScript access to the response body.
+- **But the request still arrives at your server and may execute.** CORS does not prevent the request — it only blocks the attacker from reading the result.
+
+A curl script or any non-browser client can set any `Origin` header it likes — CORS does not stop non-browser callers at all.
+
+## CSRF — cross-site state-changing requests
+
+CSRF (Cross-Site Request Forgery) exploits the fact that browsers automatically send cookies (including your session cookie) with every request to a domain. An attacker's page can trick a logged-in user's browser into making a state-changing request to your site — with the user's real session attached.
+
+**CORS does not prevent CSRF** because the CSRF request is sent by the user's browser (with real credentials), not by the attacker's server. The browser's own same-origin restriction prevents the attacker from reading the response, but the server has already executed the action.
+
+## NeNe's protection model
+
+NeNe uses a **CSRF token in `X-CSRF-Token`** (not a cookie) for state-changing REST requests. An attacker's page cannot read the CSRF token (same-origin policy prevents cross-origin JavaScript from reading the token), so forged requests fail validation.
+
+| Caller type | CSRF risk | Protection |
+|---|---|---|
+| Browser (session cookie) | Yes | `X-CSRF-Token` header required for POST/PUT/PATCH/DELETE |
+| Bearer-authenticated agent | No | Bearer token is not a cookie; browsers cannot forge it |
+| curl / API client | No | No real user session to exploit |
+
+### Why JSON APIs with Bearer are CSRF-immune
+
+When authentication uses `Authorization: Bearer <token>` instead of a session cookie:
+- There is no cookie for the browser to auto-send.
+- An attacker's page cannot forge an `Authorization` header (browsers' same-origin restriction prevents cross-origin reads, and setting custom headers triggers CORS preflight which the server controls).
+- CSRF attacks require implicit credential transport — Bearer tokens are explicit.
+
+This is why NeNe's `CsrfProtectionPolicy::requiresToken()` returns `false` for bearer-authenticated requests.
+
+### When CORS matters
+
+Configure CORS restrictively when:
+- Your API is accessed by browser-based clients from a known origin.
+- You want to prevent untrusted origins from reading API responses (even non-session API responses).
+
+NeNe does not ship a CORS middleware — add a `header('Access-Control-Allow-Origin: ...')` in `htdocs/index.php` or in a `preAction()` hook if your deployment needs cross-origin access.
+
+## Summary
+
+| Concern | Mechanism | Who enforces |
+|---|---|---|
+| Prevent cross-origin JS from reading response | CORS (`Access-Control-Allow-Origin`) | Browser |
+| Prevent cross-site state-changing requests by authenticated user | CSRF token | Server |
+| Prevent state-changing requests without explicit credential | Bearer token + `Authorization` header | Server |
+
+**Do not rely on CORS as a CSRF defense.** Use NeNe's `X-CSRF-Token` for browser sessions, or Bearer auth for stateless clients.
+
+## Related
+
+- `docs/development/agent-bearer-auth.md` — Bearer auth and JWT edge cases
+- `docs/development/security-headers.md` — response security headers
+- `class/xion/CsrfProtectionPolicy.php` — CSRF token enforcement

--- a/docs/development/feature-flags.md
+++ b/docs/development/feature-flags.md
@@ -1,0 +1,165 @@
+# Feature Flags
+
+Feature flags (feature toggles) let you deploy code dark, enable features for specific users, or roll back instantly without a deploy. The pattern shown here uses a database for persistence with a two-level priority model: global defaults overridden by per-user settings.
+
+## Schema
+
+```php
+// class/xion/SchemaDefinition.php
+
+'feature_flags' => [
+    'columns' => [
+        'id'         => ['type' => 'pk-bigint'],
+        'created_at' => ['type' => 'datetime-now'],
+        'updated_at' => ['type' => 'datetime-touch'],
+        'flag_name'  => ['type' => 'varchar:128'],
+        'is_enabled' => ['type' => 'bool', 'default' => 0],
+    ],
+    'unique' => [
+        'feature_flags_name_unique' => ['flag_name'],
+    ],
+],
+'feature_flag_overrides' => [
+    'columns' => [
+        'id'         => ['type' => 'pk-bigint'],
+        'created_at' => ['type' => 'datetime-now'],
+        'updated_at' => ['type' => 'datetime-touch'],
+        'flag_name'  => ['type' => 'varchar:128'],
+        'user_id'    => ['type' => 'bigint'],
+        'is_enabled' => ['type' => 'bool', 'default' => 0],
+    ],
+    'unique' => [
+        'feature_flag_overrides_flag_user_unique' => ['flag_name', 'user_id'],
+    ],
+],
+```
+
+## Evaluation logic
+
+```
+is_enabled(flag, user) =
+  1. Per-user override exists? → use override value
+  2. Global default exists?    → use global value
+  3. Neither?                  → false (off by default)
+```
+
+## FeatureFlagService
+
+```php
+// class/func/FeatureFlagService.php
+
+final class FeatureFlagService
+{
+    public function isEnabled(string $flagName, int $userId): bool
+    {
+        // Check per-user override first
+        $stmt = \Nene\Xion\PdoConnection::getInstance()->prepare('
+            SELECT is_enabled FROM feature_flag_overrides
+            WHERE flag_name = :flag AND user_id = :uid
+            LIMIT 1
+        ');
+        $stmt->bindValue(':flag', $flagName, \PDO::PARAM_STR);
+        $stmt->bindValue(':uid',  $userId,   \PDO::PARAM_INT);
+        $stmt->execute();
+        $override = $stmt->fetch(\PDO::FETCH_ASSOC);
+        if (is_array($override)) {
+            return (bool)$override['is_enabled'];
+        }
+
+        // Fall back to global default
+        $stmt2 = \Nene\Xion\PdoConnection::getInstance()->prepare('
+            SELECT is_enabled FROM feature_flags
+            WHERE flag_name = :flag
+            LIMIT 1
+        ');
+        $stmt2->bindValue(':flag', $flagName, \PDO::PARAM_STR);
+        $stmt2->execute();
+        $global = $stmt2->fetch(\PDO::FETCH_ASSOC);
+        if (is_array($global)) {
+            return (bool)$global['is_enabled'];
+        }
+
+        return false; // not found → off by default
+    }
+}
+```
+
+## Controller usage
+
+```php
+public function someFeatureGetRest(): array
+{
+    $userId = $this->getLoginUserId();
+
+    if (!(new \Nene\Func\FeatureFlagService())->isEnabled('new-dashboard', $userId)) {
+        return $this->API_RESPONSE->failure('FEATURE-NOT-AVAILABLE'); // 403 or 404
+    }
+
+    // Feature is enabled for this user — proceed
+    return $this->API_RESPONSE->success(['dashboard' => $this->loadDashboard($userId)]);
+}
+```
+
+## Management endpoints
+
+Expose flag management only to admins:
+
+```php
+// POST /admin/featureflag/index  — set global default
+// PUT  /admin/featureflag/override/id_{id}  — set per-user override
+// DELETE /admin/featureflag/override/id_{id} — remove override (fall back to global)
+```
+
+## Upsert pattern for overrides
+
+Setting a per-user override is an upsert: insert if not exists, update if it does:
+
+```php
+public function upsertOverride(string $flagName, int $userId, bool $isEnabled): void
+{
+    // MySQL: INSERT ... ON DUPLICATE KEY UPDATE
+    $stmt = $this->DB->prepare('
+        INSERT INTO feature_flag_overrides (flag_name, user_id, is_enabled)
+        VALUES (:flag, :uid, :enabled)
+        ON DUPLICATE KEY UPDATE is_enabled = :enabled
+    ');
+    $stmt->bindValue(':flag',    $flagName,          PDO::PARAM_STR);
+    $stmt->bindValue(':uid',     $userId,            PDO::PARAM_INT);
+    $stmt->bindValue(':enabled', $isEnabled ? 1 : 0, PDO::PARAM_INT);
+    $this->execute($stmt);
+}
+```
+
+For SQLite: use `INSERT OR REPLACE INTO ...` or the try-INSERT-catch-UPDATE pattern.
+
+## Caching considerations
+
+For high-traffic applications, evaluating flags per-request with two DB queries is expensive. Cache the evaluation result in Redis (NeNe already has `predis/predis`):
+
+```php
+$cacheKey = "feature:{$flagName}:user:{$userId}";
+$cached   = $redis->get($cacheKey);
+if ($cached !== null) {
+    return (bool)(int)$cached;
+}
+$result = $this->evaluateFromDb($flagName, $userId);
+$redis->setex($cacheKey, 60, $result ? '1' : '0'); // 60-second TTL
+return $result;
+```
+
+Invalidate on flag or override change.
+
+## When to use feature flags
+
+| Use case | Appropriate? |
+|---|---|
+| Gradual rollout to % of users | ✅ (add percentage-based evaluation) |
+| A/B testing | ✅ (two flag variants, assign on first evaluation) |
+| Kill switch for a broken feature | ✅ |
+| Config values (strings, numbers) | ❌ Use environment variables or a config table |
+| Permanent feature gating (paid tiers) | ❌ Use user tier / subscription, not flags |
+
+## Related
+
+- `docs/development/session-storage.md` — Redis usage in NeNe
+- `docs/development/ledger-systems.md` — upsert pattern with idempotency

--- a/docs/development/idor-prevention.md
+++ b/docs/development/idor-prevention.md
@@ -1,0 +1,195 @@
+# IDOR Prevention (Object-Level Authorization)
+
+IDOR (Insecure Direct Object Reference) is the vulnerability class where a user can access, modify, or delete another user's resource by guessing or iterating an id. It is OWASP API Security Top 10 #1 (Broken Object Level Authorization).
+
+NeNe provides no automatic ownership guard — every controller that serves owned resources must enforce it explicitly. This guide shows the canonical pattern.
+
+## The core rule
+
+**Every query that returns an owned resource must scope by both `id` AND `owner_id`.**
+
+Never fetch by id alone and check ownership after:
+
+```php
+// WRONG — information leakage: tells attacker "this id exists"
+$note = $mapper->findRowById($id);
+if ($note === null)             { return $this->API_RESPONSE->failure('NOTE-NOT-FOUND'); }
+if ($note['user_id'] !== $uid) { return $this->API_RESPONSE->failure('NOTE-FORBIDDEN'); }
+
+// RIGHT — returns null for both "not found" and "wrong owner"
+$note = $mapper->findRowByIdAndUserId($id, $uid);
+if ($note === null) { return $this->API_RESPONSE->failure('NOTE-NOT-FOUND'); }
+```
+
+The correct pattern enforces ownership at the SQL layer. Both "does not exist" and "belongs to someone else" return the same 404 — no information leakage.
+
+## Mapper pattern
+
+```php
+// class/db/NoteMapper.php
+
+public function findRowByIdAndUserId(int $id, int $userId): ?array
+{
+    $stmt = $this->DB->prepare('
+        SELECT id, title, body, created_at, updated_at
+        FROM ' . static::TARGET_TABLE . '
+        WHERE id = :id
+          AND user_id = :user_id
+          AND is_deleted = 0
+        LIMIT 1
+    ');
+    $stmt->bindValue(':id',      $id,     PDO::PARAM_INT);
+    $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+    $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+    return is_array($row) ? $row : null;
+}
+
+public function updateByIdAndUserId(int $id, int $userId, string $title, string $body): ?array
+{
+    $stmt = $this->DB->prepare('
+        UPDATE ' . static::TARGET_TABLE . '
+        SET title = :title, body = :body
+        WHERE id = :id AND user_id = :user_id AND is_deleted = 0
+    ');
+    $stmt->bindValue(':title',   $title,  PDO::PARAM_STR);
+    $stmt->bindValue(':body',    $body,   PDO::PARAM_STR);
+    $stmt->bindValue(':id',      $id,     PDO::PARAM_INT);
+    $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+    $this->execute($stmt);
+    return $stmt->rowCount() > 0 ? $this->findRowByIdAndUserId($id, $userId) : null;
+}
+
+public function softDeleteByIdAndUserId(int $id, int $userId): bool
+{
+    $stmt = $this->DB->prepare('
+        UPDATE ' . static::TARGET_TABLE . '
+        SET is_deleted = 1
+        WHERE id = :id AND user_id = :user_id AND is_deleted = 0
+    ');
+    $stmt->bindValue(':id',      $id,     PDO::PARAM_INT);
+    $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+    $this->execute($stmt);
+    return $stmt->rowCount() > 0;
+}
+
+public function findRowsByUserId(int $userId): array
+{
+    $stmt = $this->DB->prepare('
+        SELECT id, title, body, created_at, updated_at
+        FROM ' . static::TARGET_TABLE . '
+        WHERE user_id = :user_id AND is_deleted = 0
+        ORDER BY id DESC
+    ');
+    $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+    return $this->execute($stmt)->fetchAll(PDO::FETCH_ASSOC);
+}
+```
+
+## Controller pattern
+
+```php
+// class/controller/NoteController.php
+
+public function itemGetRest(): array
+{
+    $uid = $this->getLoginUserId();
+    $id  = $this->getNoteId();
+    if ($id === null) {
+        return $this->API_RESPONSE->failure('NOTE-ID-REQUIRED');
+    }
+
+    $note = (new Database\NoteMapper())->findRowByIdAndUserId($id, $uid);
+    if ($note === null) {
+        return $this->API_RESPONSE->failure('NOTE-NOT-FOUND'); // 404 — intentionally same for not-found AND wrong-owner
+    }
+
+    return $this->API_RESPONSE->success(['note' => $this->normalizeRow($note)]);
+}
+
+public function itemDeleteRest(): array
+{
+    $uid = $this->getLoginUserId();
+    $id  = $this->getNoteId();
+    if ($id === null) {
+        return $this->API_RESPONSE->failure('NOTE-ID-REQUIRED');
+    }
+
+    if (!(new Database\NoteMapper())->softDeleteByIdAndUserId($id, $uid)) {
+        return $this->API_RESPONSE->failure('NOTE-NOT-FOUND');
+    }
+
+    return $this->API_RESPONSE->success(['id' => $id]);
+}
+```
+
+## 404 vs 403 — the correct choice
+
+Return **404**, not 403, when the resource exists but belongs to another user.
+
+- **403**: confirms the resource exists and the current user lacks permission — tells an attacker which ids are valid.
+- **404**: indistinguishable from "id never existed" — no information leakage.
+
+This is the RFC 9110 §15.5.4 intent: `403 Forbidden` is appropriate when the identity is known and the server chooses not to reveal further detail is impossible. For ownership isolation, `404` is the universally accepted standard (GitHub, Stripe, Google APIs all do this).
+
+## Schema considerations
+
+Add an indexed `user_id` column to every owned table:
+
+```php
+// class/xion/SchemaDefinition.php
+
+'notes' => [
+    'columns' => [
+        'id'         => ['type' => 'pk-bigint'],
+        'created_at' => ['type' => 'datetime-now'],
+        'updated_at' => ['type' => 'datetime-touch'],
+        'user_id'    => ['type' => 'bigint'],        // foreign key to users.id
+        'title'      => ['type' => 'varchar:255'],
+        'body'       => ['type' => 'text'],
+        'is_deleted' => ['type' => 'bool', 'default' => 0],
+    ],
+    'indexes' => [
+        'notes_user_id_index' => ['user_id'],        // index ownership queries
+    ],
+    'foreign_keys' => [
+        'notes_user_id_foreign' => [
+            'columns'    => ['user_id'],
+            'references' => ['users', ['id']],
+            'on_delete'  => 'CASCADE',
+        ],
+    ],
+],
+```
+
+## Testing
+
+Every owned-resource endpoint needs at least these three test cases:
+
+1. **Happy path** — authenticated owner can access their resource.
+2. **Other user's resource** — returns 404, not 403.
+3. **Non-existent id** — returns 404 (same response, same status).
+
+If the happy-path and the cross-user test return the same 404 and are indistinguishable, the ownership is correctly implemented.
+
+```php
+public function testGetNoteReturns404ForAnotherUsersNote(): void
+{
+    // Log in as user A, create a note
+    $clientA = $this->newClient();
+    $this->loginAs($clientA, 'user-a', 'pass-a');
+    $note = $this->createNote($clientA, 'Private note');
+
+    // Log in as user B, try to fetch user A's note
+    $clientB = $this->newClient();
+    $this->loginAs($clientB, 'user-b', 'pass-b');
+    $response = $clientB->request('GET', '/note/item/id_' . $note['id']);
+
+    self::assertSame(404, $response->statusCode());
+}
+```
+
+## Related
+
+- `docs/development/agent-bearer-auth.md` — authentication and JWT edge cases
+- `docs/tutorials/building-a-service.md` — controller and mapper patterns
+- OWASP API Security Top 10 2023 — [API1:2023 Broken Object Level Authorization](https://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/)

--- a/docs/development/invitation-tokens.md
+++ b/docs/development/invitation-tokens.md
@@ -1,0 +1,199 @@
+# Invitation Token Systems
+
+How to implement one-time invitation codes: generate, claim (with expiry), and revoke. Pair with **`docs/development/ledger-systems.md`** for the idempotency key pattern.
+
+## Schema
+
+```php
+// class/xion/SchemaDefinition.php
+
+'invitations' => [
+    'columns' => [
+        'id'          => ['type' => 'pk-bigint'],
+        'created_at'  => ['type' => 'datetime-now'],
+        'updated_at'  => ['type' => 'datetime-touch'],
+        'code'        => ['type' => 'varchar:64'],           // random token
+        'issuer_id'   => ['type' => 'bigint'],
+        'status'      => ['type' => 'varchar:16'],           // pending | claimed | revoked
+        'claimed_by'  => ['type' => 'bigint', 'nullable' => true],
+        'claimed_at'  => ['type' => 'varchar:19', 'nullable' => true],
+        'expires_at'  => ['type' => 'varchar:19', 'nullable' => true], // NULL = never expires
+    ],
+    'unique' => [
+        'invitations_code_unique' => ['code'],
+    ],
+],
+```
+
+Valid `status` values: `pending` → `claimed` or `revoked`. Only `pending` codes can be claimed or revoked.
+
+## Code generation
+
+```php
+// Generate a cryptographically random 32-hex code
+$code = bin2hex(random_bytes(16)); // 32 characters, negligible collision probability
+```
+
+Do not use `uniqid()`, `md5(time())`, or sequential integers — these are predictable.
+
+## Mapper
+
+```php
+// class/db/InvitationMapper.php
+
+class InvitationMapper extends \Nene\Xion\DataMapperBase
+{
+    const TARGET_TABLE = 'invitations';
+    const KEY_SID      = 'id';
+
+    public function create(int $issuerId, ?string $expiresAt): array
+    {
+        $code = bin2hex(random_bytes(16));
+        $stmt = $this->DB->prepare('
+            INSERT INTO ' . static::TARGET_TABLE . '
+                (code, issuer_id, status, expires_at)
+            VALUES (:code, :issuer, :status, :expires)
+        ');
+        $stmt->bindValue(':code',    $code,      PDO::PARAM_STR);
+        $stmt->bindValue(':issuer',  $issuerId,  PDO::PARAM_INT);
+        $stmt->bindValue(':status',  'pending',  PDO::PARAM_STR);
+        $stmt->bindValue(':expires', $expiresAt, $expiresAt === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $this->execute($stmt);
+        return $this->findRowById((int)$this->DB->lastInsertId());
+    }
+
+    public function findByCode(string $code): ?array
+    {
+        $stmt = $this->DB->prepare('
+            SELECT * FROM ' . static::TARGET_TABLE . ' WHERE code = :code LIMIT 1
+        ');
+        $stmt->bindValue(':code', $code, PDO::PARAM_STR);
+        $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+        return is_array($row) ? $row : null;
+    }
+
+    /** @return 'ok'|'not_found'|'already_used'|'expired' */
+    public function claim(string $code, int $claimedBy): string
+    {
+        $row = $this->findByCode($code);
+        if ($row === null) {
+            return 'not_found';
+        }
+        if ($row['status'] !== 'pending') {
+            return 'already_used';
+        }
+        if ($row['expires_at'] !== null && $row['expires_at'] < (new \DateTime())->format('Y-m-d H:i:s')) {
+            return 'expired';
+        }
+
+        $stmt = $this->DB->prepare('
+            UPDATE ' . static::TARGET_TABLE . '
+            SET status = :status, claimed_by = :uid, claimed_at = :now
+            WHERE code = :code AND status = :pending
+        ');
+        $stmt->bindValue(':status',  'claimed',                                    PDO::PARAM_STR);
+        $stmt->bindValue(':uid',     $claimedBy,                                   PDO::PARAM_INT);
+        $stmt->bindValue(':now',     (new \DateTime())->format('Y-m-d H:i:s'),     PDO::PARAM_STR);
+        $stmt->bindValue(':code',    $code,                                        PDO::PARAM_STR);
+        $stmt->bindValue(':pending', 'pending',                                    PDO::PARAM_STR);
+        $this->execute($stmt);
+
+        return 'ok';
+    }
+
+    /** @return 'ok'|'not_found'|'not_pending' */
+    public function revoke(string $code, int $issuerId): string
+    {
+        $row = $this->findByCode($code);
+        if ($row === null || (int)$row['issuer_id'] !== $issuerId) {
+            return 'not_found'; // issuer mismatch → 404 (not 403, avoid info leak)
+        }
+        if ($row['status'] !== 'pending') {
+            return 'not_pending';
+        }
+
+        $stmt = $this->DB->prepare('
+            UPDATE ' . static::TARGET_TABLE . '
+            SET status = :status
+            WHERE code = :code AND issuer_id = :issuer AND status = :pending
+        ');
+        $stmt->bindValue(':status',  'revoked',  PDO::PARAM_STR);
+        $stmt->bindValue(':code',    $code,      PDO::PARAM_STR);
+        $stmt->bindValue(':issuer',  $issuerId,  PDO::PARAM_INT);
+        $stmt->bindValue(':pending', 'pending',  PDO::PARAM_STR);
+        $this->execute($stmt);
+
+        return 'ok';
+    }
+}
+```
+
+## Controller: claim endpoint
+
+```php
+// POST /invitation/claim/code_{code}
+public function claimPostRest(string $code): array
+{
+    $claimedBy = $this->getLoginUserId();
+
+    $result = (new Database\InvitationMapper())->claim($code, $claimedBy);
+
+    return match ($result) {
+        'ok'         => $this->API_RESPONSE->success([]),
+        'not_found'  => $this->API_RESPONSE->failure('INVITATION-NOT-FOUND'),
+        'already_used' => $this->API_RESPONSE->failure('INVITATION-ALREADY-USED'),
+        'expired'    => $this->API_RESPONSE->failure('INVITATION-EXPIRED'),
+    };
+}
+```
+
+## Controller: revoke endpoint (issuer only)
+
+```php
+// DELETE /invitation/revoke/code_{code}
+public function revokeDeleteRest(string $code): array
+{
+    $issuerId = $this->getLoginUserId();
+
+    $result = (new Database\InvitationMapper())->revoke($code, $issuerId);
+
+    return match ($result) {
+        'ok'          => $this->API_RESPONSE->success([]),
+        'not_found'   => $this->API_RESPONSE->failure('INVITATION-NOT-FOUND'),
+        'not_pending' => $this->API_RESPONSE->failure('INVITATION-NOT-PENDING'),
+    };
+}
+```
+
+## Error codes
+
+```php
+// config/error_codes.php
+'INVITATION-NOT-FOUND'    => ['message' => 'Invitation code not found.',               'httpStatus' => 404],
+'INVITATION-ALREADY-USED' => ['message' => 'This invitation has already been used.',   'httpStatus' => 409],
+'INVITATION-EXPIRED'      => ['message' => 'This invitation has expired.',             'httpStatus' => 409],
+'INVITATION-NOT-PENDING'  => ['message' => 'This invitation is no longer pending.',    'httpStatus' => 409],
+```
+
+## Security notes
+
+- **Return 404, not 403, when an issuer tries to revoke someone else's code.** Returning 403 confirms the code exists and belongs to a different issuer — an information leak.
+- **The `WHERE code = :code AND status = :pending` guard in the UPDATE** prevents a race condition where two simultaneous claims could both succeed (each checks status before the other updates it). Both cannot match after the first UPDATE — the second UPDATE affects 0 rows.
+- **Never expose the `claimed_by` user ID in responses to non-issuers.** Claiming proves the code is valid; who claimed it is the issuer's business only.
+- **Set a short expiry for registration invitations.** 24–72 hours is typical. A null `expires_at` is appropriate only for special cases (admin-issued permanent access, beta testers).
+
+## Expiry format
+
+Store `expires_at` as `YYYY-MM-DD HH:MM:SS` UTC string. String comparison with `<` works correctly for lexicographic ISO datetime ordering:
+
+```php
+if ($row['expires_at'] !== null && $row['expires_at'] < (new \DateTime('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s')) {
+    return 'expired';
+}
+```
+
+## Related
+
+- `docs/development/ledger-systems.md` — idempotency key pattern (UNIQUE constraint prevents double-claim)
+- `docs/development/idor-prevention.md` — ownership isolation (issuer can only revoke their own codes)
+- `docs/development/state-machines.md` — status transition patterns

--- a/docs/development/json-only-api.md
+++ b/docs/development/json-only-api.md
@@ -1,0 +1,94 @@
+# JSON-Only API Behavior
+
+NeNe is a JSON-first framework. This page documents the concrete behavior of NeNe's HTTP layer regarding content negotiation, request bodies, and response types — so developers know what to expect without guessing.
+
+## Response: always JSON (no content negotiation)
+
+NeNe does not implement `Accept` header content negotiation. All responses are always:
+
+```
+Content-Type: application/json; charset=utf-8
+```
+
+Regardless of what `Accept` the client sends:
+
+| Client `Accept` header | Response `Content-Type` |
+|---|---|
+| (none) | `application/json; charset=utf-8` |
+| `application/json` | `application/json; charset=utf-8` |
+| `*/*` | `application/json; charset=utf-8` |
+| `text/html` | `application/json; charset=utf-8` |
+| `application/xml` | `application/json; charset=utf-8` |
+
+NeNe does **not** return `406 Not Acceptable` — even if the client's `Accept` list has no overlap with `application/json`. This is a deliberate design choice for simplicity: NeNe serves JSON and only JSON.
+
+## Request body: JSON required for POST/PUT/PATCH
+
+NeNe reads request bodies using `JsonResponder`, which calls `json_decode()` on the raw request body. It does **not** check the inbound `Content-Type` header — it tries to parse as JSON unconditionally.
+
+| Request scenario | Result |
+|---|---|
+| `Content-Type: application/json` + valid JSON body | ✅ 200 / parsed correctly |
+| No `Content-Type` header + valid JSON body | ✅ parsed correctly (liberal input) |
+| `Content-Type: application/x-www-form-urlencoded` + form body | ❌ 400 (JSON parse failure) |
+| `Content-Type: application/json` + empty body | ⚠️ depends — `null` from `json_decode('')` |
+| Empty body, no content-type | ⚠️ `json_decode('')` returns `null` |
+
+**Practical rules for API clients:**
+- Always send `Content-Type: application/json` (habit/documentation value — NeNe does not enforce it, but clients should).
+- Send a valid JSON object `{}` for requests with no fields (not an empty body, and not `[]`).
+
+## `json_encode([])` pitfall for tests
+
+In PHP, `json_encode([])` produces `"[]"` (a JSON array), not `"{}"` (a JSON object). NeNe's controller code typically reads `$this->REQUEST_JSON['field']` expecting an object; receiving an array causes unexpected behavior.
+
+**In tests, never use an empty PHP array as a "no body" substitute:**
+
+```php
+// WRONG — sends JSON array "[]", not empty object
+$response = $this->client->json('POST', '/booking/index', []);
+
+// RIGHT — send an empty JSON object
+$response = $this->client->json('POST', '/booking/index', new \stdClass());
+// Or: send an object with unrelated fields if the endpoint requires something
+$response = $this->client->json('POST', '/booking/index', ['_dummy' => true]);
+```
+
+When testing "missing required field" validation, send a JSON object that omits the required field — not an empty body:
+
+```php
+// Testing that missing 'name' → 422
+$response = $this->client->json('POST', '/item/index', ['description' => 'test']); // no 'name' key
+```
+
+## Non-ASCII characters in responses
+
+NeNe's `JsonResponder::encode()` uses `JSON_UNESCAPED_UNICODE`, so Japanese, Chinese, emoji, and other non-ASCII characters appear as-is in JSON responses:
+
+```json
+{ "name": "田中 太郎", "emoji": "🎉" }
+```
+
+Not as escaped sequences:
+
+```json
+{ "name": "田中 太郎", "emoji": "🎉" }
+```
+
+> **Exception:** `View::encodeScriptJson()` — used for JSON embedded in HTML `<script>` tags — intentionally keeps `JSON_HEX_TAG` and similar flags and does **not** apply `JSON_UNESCAPED_UNICODE`. HTML context requires XSS-safe escaping.
+
+## 405 Method Not Allowed
+
+When a route path exists but the HTTP method is not registered, NeNe returns 405. When neither path nor method matches, it returns 404.
+
+```
+GET /todo/index     → 200 (route exists, correct method)
+DELETE /todo/index  → 405 (route exists, wrong method)
+GET /nonexistent    → 404 (no route matches)
+```
+
+## Related
+
+- `docs/development/cors-and-csrf.md` — CORS headers and CSRF protection
+- `docs/development/security-headers.md` — response security headers
+- `docs/development/unicode-validation.md` — `mb_strlen` and character encoding

--- a/docs/development/ledger-systems.md
+++ b/docs/development/ledger-systems.md
@@ -1,0 +1,196 @@
+# Append-Only Ledger Systems
+
+An append-only ledger stores every financial or point transaction as an immutable row. The current balance is always computed with `SUM()` rather than stored in a column. This design prevents silent balance corrections, guarantees a complete audit trail, and makes concurrency bugs visible.
+
+Use this pattern for: reward credits, wallet balances, loyalty points, virtual currency, account journals.
+
+## Core principles
+
+1. **Never UPDATE or DELETE ledger rows.** Every change is a new row.
+2. **Balance is computed on read.** `SELECT COALESCE(SUM(amount * direction), 0) FROM ledger WHERE user_id = ?`
+3. **Direction encodes sign.** `direction = 1` for credits (earn), `direction = -1` for debits (spend).
+4. **Idempotency key prevents duplicates.** Client-supplied unique key on writes; duplicate submission replays the original response.
+
+## Schema
+
+```php
+// class/xion/SchemaDefinition.php
+
+'credit_transactions' => [
+    'columns' => [
+        'id'              => ['type' => 'pk-bigint'],
+        'created_at'      => ['type' => 'datetime-now'],
+        'user_id'         => ['type' => 'bigint'],
+        'type'            => ['type' => 'varchar:16'],   // 'earn' | 'spend' | 'adjust'
+        'amount'          => ['type' => 'bigint'],        // always positive
+        'direction'       => ['type' => 'bigint'],        // 1 or -1
+        'description'     => ['type' => 'varchar:255'],
+        'idempotency_key' => ['type' => 'varchar:128', 'nullable' => true],
+    ],
+    'indexes' => [
+        'credit_transactions_user_id_index' => ['user_id'],
+    ],
+    'unique' => [
+        'credit_transactions_idempotency_key_unique' => ['idempotency_key'],
+    ],
+    'foreign_keys' => [
+        'credit_transactions_user_id_foreign' => [
+            'columns'    => ['user_id'],
+            'references' => ['users', ['id']],
+            'on_delete'  => 'CASCADE',
+        ],
+    ],
+],
+```
+
+MySQL CHECK constraints (not available in SchemaDefinition) can enforce `direction IN (1, -1)` and `amount > 0` — add these to the raw SQL migration if needed.
+
+## Mapper
+
+```php
+// class/db/CreditTransactionMapper.php
+
+public function getBalance(int $userId): int
+{
+    $stmt = $this->DB->prepare('
+        SELECT COALESCE(SUM(amount * direction), 0) AS bal
+        FROM ' . static::TARGET_TABLE . '
+        WHERE user_id = :user_id
+    ');
+    $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+    $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+    return (int)($row['bal'] ?? 0);
+}
+
+/**
+ * @return array<string,mixed> Inserted transaction row.
+ * @throws \RuntimeException on duplicate idempotency_key (catch PDOException with SQLSTATE 23000).
+ */
+public function earn(int $userId, int $amount, string $description, ?string $idempotencyKey = null): array
+{
+    $stmt = $this->DB->prepare('
+        INSERT INTO ' . static::TARGET_TABLE . ' (user_id, type, amount, direction, description, idempotency_key)
+        VALUES (:user_id, :type, :amount, 1, :description, :idempotency_key)
+    ');
+    $stmt->bindValue(':user_id',         $userId,          PDO::PARAM_INT);
+    $stmt->bindValue(':type',            'earn',           PDO::PARAM_STR);
+    $stmt->bindValue(':amount',          $amount,          PDO::PARAM_INT);
+    $stmt->bindValue(':description',     $description,     PDO::PARAM_STR);
+    $stmt->bindValue(':idempotency_key', $idempotencyKey,  PDO::PARAM_STR);
+    $this->execute($stmt);
+    return $this->findRowById((int)$this->DB->lastInsertId());
+}
+
+/**
+ * @return array<string,mixed>|null Transaction row, or null if insufficient balance.
+ */
+public function spend(int $userId, int $amount, string $description, ?string $idempotencyKey = null): ?array
+{
+    if ($this->getBalance($userId) < $amount) {
+        return null; // insufficient balance
+    }
+    $stmt = $this->DB->prepare('
+        INSERT INTO ' . static::TARGET_TABLE . ' (user_id, type, amount, direction, description, idempotency_key)
+        VALUES (:user_id, :type, :amount, -1, :description, :idempotency_key)
+    ');
+    $stmt->bindValue(':user_id',         $userId,         PDO::PARAM_INT);
+    $stmt->bindValue(':type',            'spend',         PDO::PARAM_STR);
+    $stmt->bindValue(':amount',          $amount,         PDO::PARAM_INT);
+    $stmt->bindValue(':description',     $description,    PDO::PARAM_STR);
+    $stmt->bindValue(':idempotency_key', $idempotencyKey, PDO::PARAM_STR);
+    $this->execute($stmt);
+    return $this->findRowById((int)$this->DB->lastInsertId());
+}
+
+public function findByIdempotencyKey(string $key): ?array
+{
+    $stmt = $this->DB->prepare('
+        SELECT * FROM ' . static::TARGET_TABLE . ' WHERE idempotency_key = :key LIMIT 1
+    ');
+    $stmt->bindValue(':key', $key, PDO::PARAM_STR);
+    $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+    return is_array($row) ? $row : null;
+}
+```
+
+## Controller — idempotent earn
+
+```php
+public function earnPostRest(): array
+{
+    $userId          = $this->getLoginUserId();
+    $amount          = (int)($this->REQUEST_JSON['amount']          ?? 0);
+    $description     = trim((string)($this->REQUEST_JSON['description']     ?? ''));
+    $idempotencyKey  = trim((string)($this->REQUEST_JSON['idempotency_key'] ?? '')) ?: null;
+
+    if ($amount <= 0) {
+        return $this->API_RESPONSE->failure('CREDIT-AMOUNT-INVALID');
+    }
+
+    $mapper = new Database\CreditTransactionMapper();
+
+    // Idempotency: replay existing transaction on duplicate key
+    if ($idempotencyKey !== null) {
+        $existing = $mapper->findByIdempotencyKey($idempotencyKey);
+        if ($existing !== null) {
+            return $this->API_RESPONSE->success(['transaction' => $this->normalizeRow($existing)]);
+        }
+    }
+
+    try {
+        $transaction = $mapper->earn($userId, $amount, $description, $idempotencyKey);
+    } catch (\PDOException $e) {
+        // UNIQUE constraint on idempotency_key — race condition between check and insert
+        if ($idempotencyKey !== null && str_contains($e->getMessage(), '23000')) {
+            $existing = $mapper->findByIdempotencyKey($idempotencyKey);
+            if ($existing !== null) {
+                return $this->API_RESPONSE->success(['transaction' => $this->normalizeRow($existing)]);
+            }
+        }
+        throw $e;
+    }
+
+    return $this->API_RESPONSE->success(['transaction' => $this->normalizeRow($transaction)]);
+}
+```
+
+## Balance concurrency
+
+The `getBalance()` + `spend()` sequence has a TOCTOU window: two concurrent spends can both pass the balance check and both insert. For strict balance enforcement, use a database transaction:
+
+```php
+$transaction->run(function () use ($mapper, $userId, $amount, $description): array {
+    $balance = $mapper->getBalanceForUpdate($userId); // SELECT ... FOR UPDATE (MySQL only)
+    if ($balance < $amount) {
+        throw new \DomainException('CREDIT-INSUFFICIENT');
+    }
+    return $mapper->spend($userId, $amount, $description);
+});
+```
+
+For SQLite or low-volume scenarios, the optimistic approach (check then insert, accept rare inconsistency in tests) is simpler. Use `FOR UPDATE` only when strict serialization is required.
+
+## Query patterns
+
+```sql
+-- Balance
+SELECT COALESCE(SUM(amount * direction), 0) AS balance
+FROM credit_transactions
+WHERE user_id = ?;
+
+-- History (most recent first)
+SELECT id, type, amount, direction, description, created_at
+FROM credit_transactions
+WHERE user_id = ?
+ORDER BY id DESC;
+
+-- Filtered by type
+SELECT * FROM credit_transactions
+WHERE user_id = ? AND type = 'spend'
+ORDER BY id DESC;
+```
+
+## Related
+
+- `docs/development/idor-prevention.md` — ownership isolation pattern
+- `docs/tutorials/building-a-service.md` — mapper and transaction patterns

--- a/docs/development/many-to-many.md
+++ b/docs/development/many-to-many.md
@@ -1,0 +1,194 @@
+# Many-to-Many Relationships
+
+How to model M:N relationships in NeNe using a join table: add/remove membership, filter by membership, and avoid row duplication on multi-group JOIN queries.
+
+The examples use a contact–group scenario (contacts belong to multiple groups per owner), but the pattern applies to any M:N: posts–tags, users–roles, products–categories.
+
+## Schema
+
+```php
+// class/xion/SchemaDefinition.php
+
+'contacts' => [
+    'columns' => [
+        'id'         => ['type' => 'pk-bigint'],
+        'created_at' => ['type' => 'datetime-now'],
+        'updated_at' => ['type' => 'datetime-touch'],
+        'owner_id'   => ['type' => 'bigint'],
+        'name'       => ['type' => 'varchar:255'],
+        'email'      => ['type' => 'varchar:255'],
+        'phone'      => ['type' => 'varchar:64'],
+        'notes'      => ['type' => 'text'],
+    ],
+    'indexes' => [
+        'contacts_owner_id_index' => ['owner_id'],
+    ],
+],
+'contact_groups' => [
+    'columns' => [
+        'id'         => ['type' => 'pk-bigint'],
+        'created_at' => ['type' => 'datetime-now'],
+        'owner_id'   => ['type' => 'bigint'],
+        'name'       => ['type' => 'varchar:128'],
+    ],
+    'unique' => [
+        'contact_groups_owner_name_unique' => ['owner_id', 'name'],
+    ],
+],
+'contact_group_members' => [
+    'columns' => [
+        'contact_id' => ['type' => 'bigint'],
+        'group_id'   => ['type' => 'bigint'],
+    ],
+    'unique' => [
+        'contact_group_members_pk' => ['contact_id', 'group_id'],
+    ],
+],
+```
+
+> `contact_group_members` has no `id` or `created_at` — the composite primary key is the pair `(contact_id, group_id)`. Add `created_at` only if you need membership timestamps (e.g., "added to group on ...").
+
+## Mapper: add to group (idempotent)
+
+Use `INSERT OR IGNORE` (SQLite) or `INSERT IGNORE` (MySQL) so adding a contact to a group it's already in is a no-op:
+
+```php
+// SQLite
+public function addToGroup(int $contactId, int $groupId): void
+{
+    $stmt = $this->DB->prepare('
+        INSERT OR IGNORE INTO contact_group_members (contact_id, group_id)
+        VALUES (:cid, :gid)
+    ');
+    $stmt->bindValue(':cid', $contactId, PDO::PARAM_INT);
+    $stmt->bindValue(':gid', $groupId,   PDO::PARAM_INT);
+    $this->execute($stmt);
+}
+
+// MySQL equivalent
+// INSERT IGNORE INTO contact_group_members (contact_id, group_id) VALUES (?, ?)
+```
+
+## Mapper: remove from group
+
+```php
+public function removeFromGroup(int $contactId, int $groupId): bool
+{
+    $stmt = $this->DB->prepare('
+        DELETE FROM contact_group_members WHERE contact_id = :cid AND group_id = :gid
+    ');
+    $stmt->bindValue(':cid', $contactId, PDO::PARAM_INT);
+    $stmt->bindValue(':gid', $groupId,   PDO::PARAM_INT);
+    $this->execute($stmt);
+    return $stmt->rowCount() > 0;
+}
+```
+
+## Mapper: load contact with its groups
+
+Load the contact row first, then load its groups in a second query. This avoids JOIN duplication (a contact in 3 groups returns 3 rows with JOINs):
+
+```php
+public function findWithGroups(int $contactId, int $ownerId): ?array
+{
+    // Ownership check built into the WHERE clause (IDOR prevention)
+    $stmt = $this->DB->prepare('
+        SELECT * FROM contacts WHERE id = :id AND owner_id = :owner LIMIT 1
+    ');
+    $stmt->bindValue(':id',    $contactId, PDO::PARAM_INT);
+    $stmt->bindValue(':owner', $ownerId,   PDO::PARAM_INT);
+    $contact = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+    if (!is_array($contact)) {
+        return null;
+    }
+
+    $gStmt = $this->DB->prepare('
+        SELECT cg.id, cg.name
+        FROM contact_groups cg
+        JOIN contact_group_members m ON m.group_id = cg.id
+        WHERE m.contact_id = :cid
+        ORDER BY cg.name ASC
+    ');
+    $gStmt->bindValue(':cid', $contactId, PDO::PARAM_INT);
+    $contact['groups'] = $this->execute($gStmt)->fetchAll(PDO::FETCH_ASSOC);
+
+    return $contact;
+}
+```
+
+## Mapper: filter contacts by group membership
+
+Use an `EXISTS` subquery instead of a JOIN. A JOIN with a join table returns one row per membership — if a contact is in 3 groups and you filter by one group, a JOIN still returns 1 row (correct), but if you filter by multiple groups simultaneously the JOIN requires `HAVING COUNT(DISTINCT group_id) = N` to avoid false positives. EXISTS is semantically cleaner:
+
+```php
+public function findByGroup(int $ownerId, int $groupId): array
+{
+    $stmt = $this->DB->prepare('
+        SELECT c.*
+        FROM contacts c
+        WHERE c.owner_id = :owner
+          AND EXISTS (
+              SELECT 1 FROM contact_group_members m
+              WHERE m.contact_id = c.id AND m.group_id = :gid
+          )
+        ORDER BY c.name ASC
+    ');
+    $stmt->bindValue(':owner', $ownerId, PDO::PARAM_INT);
+    $stmt->bindValue(':gid',   $groupId, PDO::PARAM_INT);
+    return $this->execute($stmt)->fetchAll(PDO::FETCH_ASSOC) ?: [];
+}
+```
+
+## Mapper: delete contact with cascade
+
+When deleting a contact, remove its memberships first (or use `ON DELETE CASCADE` if your schema supports it):
+
+```php
+public function deleteWithMemberships(int $contactId, int $ownerId): bool
+{
+    $transaction = new \Nene\Xion\TransactionManager();
+    return $transaction->run(function () use ($contactId, $ownerId): bool {
+        // Confirm ownership before deleting
+        $row = $this->findByIdAndOwner($contactId, $ownerId);
+        if ($row === null) {
+            return false; // caller returns 404
+        }
+
+        // Remove memberships
+        $del1 = $this->DB->prepare('DELETE FROM contact_group_members WHERE contact_id = :cid');
+        $del1->bindValue(':cid', $contactId, PDO::PARAM_INT);
+        $this->execute($del1);
+
+        // Remove contact
+        $del2 = $this->DB->prepare('DELETE FROM contacts WHERE id = :id AND owner_id = :owner');
+        $del2->bindValue(':id',    $contactId, PDO::PARAM_INT);
+        $del2->bindValue(':owner', $ownerId,   PDO::PARAM_INT);
+        $this->execute($del2);
+
+        return true;
+    });
+}
+```
+
+## SQLite LIKE case-sensitivity caution
+
+SQLite's `LIKE` is case-insensitive for ASCII by default. Searching for `q=Bob` matches both `Bob Smith` (name) and `bob@example.com` (email). This can cause unexpected cross-row matches in tests.
+
+MySQL's `LIKE` is also case-insensitive by default on `utf8mb4_general_ci`. Use `LOWER(column) LIKE LOWER(:q)` for explicit case-insensitive behavior, or use the collation that matches your needs.
+
+In tests: ensure each row has distinct enough test data that a search for one row's term does not accidentally match another.
+
+## Error codes
+
+```php
+// config/error_codes.php
+'CONTACT-NOT-FOUND'        => ['message' => 'Contact not found.',       'httpStatus' => 404],
+'CONTACT-GROUP-NOT-FOUND'  => ['message' => 'Group not found.',         'httpStatus' => 404],
+'CONTACT-ALREADY-IN-GROUP' => ['message' => 'Already in this group.',   'httpStatus' => 409],
+```
+
+## Related
+
+- `docs/development/idor-prevention.md` — ownership isolation in SQL (owner_id WHERE clause)
+- `docs/development/sql-injection.md` — LIKE wildcard escaping for search
+- `docs/tutorials/building-a-service.md` — TransactionManager pattern

--- a/docs/development/optimistic-locking.md
+++ b/docs/development/optimistic-locking.md
@@ -1,0 +1,164 @@
+# Optimistic Locking (ETag / If-Match)
+
+When two users edit the same resource concurrently, the second write silently overwrites the first. This is the **lost-update problem**. Optimistic locking prevents it using HTTP conditional write semantics (ETag + If-Match).
+
+NeNe has no built-in `If-Match` helper. This guide shows how to implement it in a mapper and controller.
+
+## How it works
+
+1. **GET** returns the resource with an `ETag` header: `ETag: "v3"` (based on a `version` column).
+2. **PUT/DELETE** client sends `If-Match: "v3"`.
+3. Server checks: if the stored version matches, apply the write and increment `version`. If not, return `412 Precondition Failed`.
+4. If `If-Match` is absent, return `428 Precondition Required`.
+
+The client retries on 412 by fetching the latest version first.
+
+## Schema
+
+Add a `version` column to any resource that needs optimistic locking:
+
+```php
+// class/xion/SchemaDefinition.php
+'documents' => [
+    'columns' => [
+        'id'         => ['type' => 'pk-bigint'],
+        'created_at' => ['type' => 'datetime-now'],
+        'updated_at' => ['type' => 'datetime-touch'],
+        'title'      => ['type' => 'varchar:255'],
+        'body'       => ['type' => 'text'],
+        'version'    => ['type' => 'bigint'],         // optimistic lock counter
+    ],
+],
+```
+
+Seed the `version` to `1` on insert. Increment on every successful update.
+
+## Mapper
+
+```php
+public function create(string $title, string $body): array
+{
+    $stmt = $this->DB->prepare('
+        INSERT INTO ' . static::TARGET_TABLE . ' (title, body, version)
+        VALUES (:title, :body, 1)
+    ');
+    $stmt->bindValue(':title', $title, PDO::PARAM_STR);
+    $stmt->bindValue(':body',  $body,  PDO::PARAM_STR);
+    $this->execute($stmt);
+    return $this->findRowById((int)$this->DB->lastInsertId());
+}
+
+/**
+ * Conditional update — only applies when stored version matches.
+ *
+ * @return array<string,mixed>|null Updated row, or null if version mismatch / not found.
+ */
+public function updateIfVersion(int $id, string $title, string $body, int $expectedVersion): ?array
+{
+    $stmt = $this->DB->prepare('
+        UPDATE ' . static::TARGET_TABLE . '
+        SET title = :title, body = :body, version = version + 1
+        WHERE id = :id AND version = :version
+    ');
+    $stmt->bindValue(':title',   $title,           PDO::PARAM_STR);
+    $stmt->bindValue(':body',    $body,             PDO::PARAM_STR);
+    $stmt->bindValue(':id',      $id,               PDO::PARAM_INT);
+    $stmt->bindValue(':version', $expectedVersion,  PDO::PARAM_INT);
+    $this->execute($stmt);
+    return $stmt->rowCount() > 0 ? $this->findRowById($id) : null;
+}
+```
+
+When `rowCount() === 0`, it means either the document does not exist or the version has advanced — the response is 412 either way.
+
+## Controller
+
+```php
+public function itemGetRest(): array
+{
+    $id  = $this->getDocumentId();
+    $doc = (new Database\DocumentMapper())->findRowById($id);
+    if ($doc === null) {
+        return $this->API_RESPONSE->failure('DOCUMENT-NOT-FOUND');
+    }
+
+    // Emit ETag so the client knows the current version
+    header('ETag: "v' . (int)$doc['version'] . '"');
+
+    return $this->API_RESPONSE->success(['document' => $this->normalizeRow($doc)]);
+}
+
+public function itemPutRest(): array
+{
+    $id  = $this->getDocumentId();
+    if ($id === null) {
+        return $this->API_RESPONSE->failure('DOCUMENT-ID-REQUIRED');
+    }
+
+    // 428 Precondition Required — If-Match header is mandatory for conditional writes
+    $ifMatch = $_SERVER['HTTP_IF_MATCH'] ?? '';
+    if ($ifMatch === '') {
+        return $this->API_RESPONSE->failure('PRECONDITION-REQUIRED');
+    }
+
+    // Parse ETag: "v3" → 3
+    if (!preg_match('/^"v(\d+)"$/', $ifMatch, $m) && $ifMatch !== '*') {
+        return $this->API_RESPONSE->failure('PRECONDITION-INVALID');
+    }
+
+    $title = trim((string)($this->REQUEST_JSON['title'] ?? ''));
+    $body  = trim((string)($this->REQUEST_JSON['body']  ?? ''));
+
+    $mapper = new Database\DocumentMapper();
+
+    if ($ifMatch === '*') {
+        // Wildcard — "match if resource exists"; fetch current version
+        $current = $mapper->findRowById($id);
+        if ($current === null) {
+            return $this->API_RESPONSE->failure('DOCUMENT-NOT-FOUND');
+        }
+        $expectedVersion = (int)$current['version'];
+    } else {
+        $expectedVersion = (int)$m[1];
+    }
+
+    $updated = $mapper->updateIfVersion($id, $title, $body, $expectedVersion);
+
+    if ($updated === null) {
+        // Could be not-found OR stale version — return 412 (cannot distinguish without extra query)
+        return $this->API_RESPONSE->failure('PRECONDITION-FAILED');
+    }
+
+    header('ETag: "v' . (int)$updated['version'] . '"');
+    return $this->API_RESPONSE->success(['document' => $this->normalizeRow($updated)]);
+}
+```
+
+## Error codes
+
+```php
+// config/error_codes.php
+'PRECONDITION-REQUIRED'  => ['message' => 'If-Match header is required.',              'httpStatus' => 428],
+'PRECONDITION-INVALID'   => ['message' => 'If-Match header value is not a valid ETag.', 'httpStatus' => 400],
+'PRECONDITION-FAILED'    => ['message' => 'Resource has been modified since last read.', 'httpStatus' => 412],
+```
+
+## Caveats
+
+- Optimistic locking is appropriate for low-to-medium concurrency scenarios. Under very high write contention, clients spend most time retrying — consider pessimistic locking (SELECT ... FOR UPDATE) in those cases.
+- If you cannot distinguish "not found" from "version mismatch" (because the update affected 0 rows for both reasons), returning 412 for both is acceptable. A subsequent GET will reveal whether the document exists.
+- `$_SERVER['HTTP_IF_MATCH']` works in NeNe's Apache-based Docker setup. In other environments, confirm the header is forwarded (some load balancers strip unknown headers).
+
+## When to use it
+
+Use optimistic locking when:
+- Multiple users can edit the same resource (documents, shared notes, configs).
+- Writes are infrequent relative to reads.
+- A lost-update causes user-visible data loss.
+
+Skip it for single-owner resources (the owner is the only writer — no concurrency risk).
+
+## Related
+
+- `docs/development/idor-prevention.md` — object-level authorization
+- `docs/tutorials/building-a-service.md` — controller and mapper patterns

--- a/docs/development/rate-limiting.md
+++ b/docs/development/rate-limiting.md
@@ -1,0 +1,180 @@
+# Rate Limiting
+
+How to add request rate limiting to NeNe endpoints using Redis (already available via `predis/predis`). NeNe does not ship a built-in rate-limiting middleware — this guide shows how to add it.
+
+## When to add rate limiting
+
+| Endpoint type | Risk without limiting | Recommendation |
+|---|---|---|
+| Login / `POST /session/login` | Brute-force password attacks | Yes — always |
+| Invitation claim / registration | Enumeration of invite codes | Yes |
+| Password reset request | Email flooding / enumeration | Yes |
+| API endpoints (general) | Abuse / scraping | Optional — depends on traffic |
+| Internal admin endpoints | Lower risk | Low priority |
+
+## The sliding window counter pattern
+
+The simplest Redis-based approach uses a per-key counter with a TTL:
+
+1. `INCR key` — atomically increment the counter and get the new value.
+2. If the returned value is 1 (first request), set the key TTL with `EXPIRE key <window_seconds>`.
+3. If the counter exceeds the limit, return 429.
+
+```php
+// class/func/RateLimiter.php
+
+namespace Nene\Func;
+
+use Predis\Client;
+
+final class RateLimiter
+{
+    private Client $redis;
+
+    public function __construct(Client $redis)
+    {
+        $this->redis = $redis;
+    }
+
+    /**
+     * Check if the given key is within the allowed rate.
+     *
+     * @param string $key      Unique identifier (e.g. "login:ip:1.2.3.4")
+     * @param int    $limit    Max requests allowed within the window
+     * @param int    $window   Window duration in seconds
+     * @return bool  true = allowed, false = rate limit exceeded
+     */
+    public function allow(string $key, int $limit, int $window): bool
+    {
+        $count = (int)$this->redis->incr($key);
+        if ($count === 1) {
+            $this->redis->expire($key, $window);
+        }
+        return $count <= $limit;
+    }
+
+    /** Remaining requests in the current window */
+    public function remaining(string $key, int $limit): int
+    {
+        $count = (int)($this->redis->get($key) ?? 0);
+        return max(0, $limit - $count);
+    }
+
+    /** Seconds until the current window resets */
+    public function ttl(string $key): int
+    {
+        return max(0, (int)$this->redis->ttl($key));
+    }
+}
+```
+
+## Usage in a controller
+
+```php
+use Nene\Func\RateLimiter;
+use Nene\Xion\RedisConnection;
+
+// POST /session/login
+public function indexPostRest(): array
+{
+    $ip      = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+    $limiter = new RateLimiter(RedisConnection::getInstance());
+    $key     = 'rate:login:ip:' . $ip;
+
+    // 10 attempts per 15 minutes per IP
+    if (!$limiter->allow($key, limit: 10, window: 900)) {
+        return $this->API_RESPONSE->failure('RATE-LIMIT-EXCEEDED');
+    }
+
+    // ... verify credentials ...
+}
+```
+
+## Rate limit key strategies
+
+Choose the key based on what you want to throttle:
+
+```php
+// Per IP address (unauthenticated endpoints — login, registration)
+$key = 'rate:login:ip:' . ($ip);
+
+// Per user ID (authenticated endpoints — password reset, email send)
+$key = 'rate:password-reset:user:' . $userId;
+
+// Per API key (third-party integrations)
+$key = 'rate:api:key:' . hash('sha256', $apiKey);
+
+// Global endpoint cap (emergency brake)
+$key = 'rate:global:endpoint:' . $endpointName;
+```
+
+Namespace keys with `rate:` to distinguish from session and feature-flag keys in the same Redis instance.
+
+## Response headers
+
+Include `Retry-After` and rate limit headers in 429 responses to help clients back off correctly:
+
+```php
+if (!$limiter->allow($key, 10, 900)) {
+    $retryAfter = $limiter->ttl($key);
+    header('Retry-After: ' . $retryAfter);
+    header('X-RateLimit-Limit: 10');
+    header('X-RateLimit-Remaining: 0');
+    header('X-RateLimit-Reset: ' . (time() + $retryAfter));
+    return $this->API_RESPONSE->failure('RATE-LIMIT-EXCEEDED');
+}
+```
+
+## Error code
+
+```php
+// config/error_codes.php
+'RATE-LIMIT-EXCEEDED' => ['message' => 'Too many requests. Please try again later.', 'httpStatus' => 429],
+```
+
+## RedisConnection
+
+NeNe already has `class/xion/RedisConnection.php` (singleton Predis client). Check the connection uses the same Redis instance as session storage. The rate limiter keys live alongside session keys — use distinct prefixes to avoid collisions.
+
+```php
+$redis = \Nene\Xion\RedisConnection::getInstance();
+$limiter = new RateLimiter($redis);
+```
+
+## Limitations of the simple INCR pattern
+
+| Limitation | Mitigation |
+|---|---|
+| Race on INCR + EXPIRE (two calls, not atomic) | Use a Lua script or Redis `SET key 0 EX <window> NX` for atomic initialization |
+| Fixed-window resets allow bursts at boundary | Use a sliding-window log (ZADD / ZREMRANGEBYSCORE) for strict rate control |
+| No distributed coordination across multiple PHP workers | Redis handles this natively — all workers share the same counter |
+
+For most NeNe use cases (protecting login and registration endpoints on a single server), the simple INCR pattern is sufficient.
+
+## Lua script for atomic initialization
+
+If the race between `INCR` and `EXPIRE` is a concern, use a Lua script that sets both atomically:
+
+```lua
+-- rate_limit.lua
+local key   = KEYS[1]
+local limit = tonumber(ARGV[1])
+local ttl   = tonumber(ARGV[2])
+
+local count = redis.call('INCR', key)
+if count == 1 then
+    redis.call('EXPIRE', key, ttl)
+end
+return count
+```
+
+```php
+$count = $this->redis->eval($luaScript, 1, $key, $limit, $window);
+return (int)$count <= $limit;
+```
+
+## Related
+
+- `docs/development/feature-flags.md` — Redis caching pattern
+- `docs/development/session-storage.md` — Redis session storage
+- `docs/development/agent-bearer-auth.md` — Bearer token authentication (stateless; rate-limit by bearer key, not session)

--- a/docs/development/ratings.md
+++ b/docs/development/ratings.md
@@ -1,0 +1,217 @@
+# Ratings and Aggregations
+
+How to implement a star-rating system with upsert semantics: one rating per (item, rater) pair, live aggregated summary (average, count, distribution), and per-rater CRUD.
+
+## The upsert pattern
+
+Ratings are naturally "create or update" — a user may re-rate an item any number of times, and each re-rate replaces the previous score. The cleanest way to implement this is:
+
+1. Attempt `INSERT`.
+2. On UNIQUE constraint violation, `UPDATE` instead.
+
+This is more reliable than a SELECT-then-branch because it avoids a TOCTOU race where two concurrent requests could both pass the SELECT check and both INSERT.
+
+## Schema
+
+```php
+// class/xion/SchemaDefinition.php
+
+'ratings' => [
+    'columns' => [
+        'id'         => ['type' => 'pk-bigint'],
+        'created_at' => ['type' => 'datetime-now'],
+        'updated_at' => ['type' => 'datetime-touch'],
+        'item_id'    => ['type' => 'bigint'],
+        'rater_id'   => ['type' => 'bigint'],
+        'score'      => ['type' => 'bigint'],           // 1–5 (validate in application)
+        'review'     => ['type' => 'text'],
+    ],
+    'unique' => [
+        'ratings_item_rater_unique' => ['item_id', 'rater_id'],
+    ],
+    'indexes' => [
+        'ratings_item_id_index' => ['item_id'],
+    ],
+],
+```
+
+> **CHECK constraint:** MySQL supports `CHECK(score BETWEEN 1 AND 5)` in CREATE TABLE. Validate in application code first (return 422) — the DB constraint is a safety net.
+
+## Mapper: upsert
+
+```php
+// class/db/RatingMapper.php
+
+class RatingMapper extends \Nene\Xion\DataMapperBase
+{
+    const TARGET_TABLE = 'ratings';
+    const KEY_SID      = 'id';
+
+    public function upsert(int $itemId, int $raterId, int $score, string $review): array
+    {
+        try {
+            $stmt = $this->DB->prepare('
+                INSERT INTO ' . static::TARGET_TABLE . ' (item_id, rater_id, score, review)
+                VALUES (:item, :rater, :score, :review)
+            ');
+            $stmt->bindValue(':item',   $itemId,  PDO::PARAM_INT);
+            $stmt->bindValue(':rater',  $raterId, PDO::PARAM_INT);
+            $stmt->bindValue(':score',  $score,   PDO::PARAM_INT);
+            $stmt->bindValue(':review', $review,  PDO::PARAM_STR);
+            $this->execute($stmt);
+            return $this->findRowById((int)$this->DB->lastInsertId());
+        } catch (\PDOException $e) {
+            if (str_starts_with((string)$e->getCode(), '23')) { // UNIQUE violation
+                $upd = $this->DB->prepare('
+                    UPDATE ' . static::TARGET_TABLE . '
+                    SET score = :score, review = :review
+                    WHERE item_id = :item AND rater_id = :rater
+                ');
+                $upd->bindValue(':score',  $score,   PDO::PARAM_INT);
+                $upd->bindValue(':review', $review,  PDO::PARAM_STR);
+                $upd->bindValue(':item',   $itemId,  PDO::PARAM_INT);
+                $upd->bindValue(':rater',  $raterId, PDO::PARAM_INT);
+                $this->execute($upd);
+
+                // Return the updated row
+                $find = $this->DB->prepare('
+                    SELECT * FROM ' . static::TARGET_TABLE . '
+                    WHERE item_id = :item AND rater_id = :rater LIMIT 1
+                ');
+                $find->bindValue(':item',  $itemId,  PDO::PARAM_INT);
+                $find->bindValue(':rater', $raterId, PDO::PARAM_INT);
+                return $this->execute($find)->fetch(PDO::FETCH_ASSOC);
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * @return array{average: float|null, count: int, distribution: array<int, int>}
+     */
+    public function summary(int $itemId): array
+    {
+        $stmt = $this->DB->prepare('
+            SELECT AVG(score) AS avg_score, COUNT(*) AS cnt
+            FROM ' . static::TARGET_TABLE . '
+            WHERE item_id = :item
+        ');
+        $stmt->bindValue(':item', $itemId, PDO::PARAM_INT);
+        $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+
+        $count   = (int)($row['cnt'] ?? 0);
+        $average = $count > 0 ? round((float)$row['avg_score'], 2) : null;
+
+        // Score distribution (1–5)
+        $dist = array_fill(1, 5, 0);
+        if ($count > 0) {
+            $dStmt = $this->DB->prepare('
+                SELECT score, COUNT(*) AS n
+                FROM ' . static::TARGET_TABLE . '
+                WHERE item_id = :item
+                GROUP BY score
+            ');
+            $dStmt->bindValue(':item', $itemId, PDO::PARAM_INT);
+            foreach ($this->execute($dStmt)->fetchAll(PDO::FETCH_ASSOC) as $d) {
+                $dist[(int)$d['score']] = (int)$d['n'];
+            }
+        }
+
+        return [
+            'average'      => $average,
+            'count'        => $count,
+            'distribution' => $dist,
+        ];
+    }
+
+    public function findByRater(int $itemId, int $raterId): ?array
+    {
+        $stmt = $this->DB->prepare('
+            SELECT * FROM ' . static::TARGET_TABLE . '
+            WHERE item_id = :item AND rater_id = :rater LIMIT 1
+        ');
+        $stmt->bindValue(':item',  $itemId,  PDO::PARAM_INT);
+        $stmt->bindValue(':rater', $raterId, PDO::PARAM_INT);
+        $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+        return is_array($row) ? $row : null;
+    }
+
+    public function deleteByRater(int $itemId, int $raterId): bool
+    {
+        $stmt = $this->DB->prepare('
+            DELETE FROM ' . static::TARGET_TABLE . '
+            WHERE item_id = :item AND rater_id = :rater
+        ');
+        $stmt->bindValue(':item',  $itemId,  PDO::PARAM_INT);
+        $stmt->bindValue(':rater', $raterId, PDO::PARAM_INT);
+        $this->execute($stmt);
+        return $stmt->rowCount() > 0;
+    }
+}
+```
+
+## Controller: upsert endpoint
+
+```php
+// PUT /rating/item/id_{itemId}/rater/id_{raterId}
+public function upsertPutRest(int $itemId, int $raterId): array
+{
+    $score  = (int)($this->REQUEST_JSON['score']  ?? 0);
+    $review = trim((string)($this->REQUEST_JSON['review'] ?? ''));
+
+    if ($score < 1 || $score > 5) {
+        return $this->API_RESPONSE->failure('RATING-SCORE-INVALID');
+    }
+
+    $rating = (new Database\RatingMapper())->upsert($itemId, $raterId, $score, $review);
+    return $this->API_RESPONSE->success(['rating' => $this->normalizeRow($rating)]);
+}
+
+// GET /rating/item/id_{itemId}/summary
+public function summaryGetRest(int $itemId): array
+{
+    $summary = (new Database\RatingMapper())->summary($itemId);
+    return $this->API_RESPONSE->success($summary);
+}
+```
+
+## Response: summary
+
+```json
+{
+    "status": "success",
+    "Data": {
+        "average": 4.25,
+        "count": 8,
+        "distribution": { "1": 0, "2": 1, "3": 0, "4": 3, "5": 4 }
+    }
+}
+```
+
+`average` is `null` when no ratings exist (returns `null` instead of 0 to distinguish "no data" from "zero average").
+
+## Error codes
+
+```php
+// config/error_codes.php
+'RATING-SCORE-INVALID' => ['message' => 'Score must be between 1 and 5.', 'httpStatus' => 422],
+'RATING-NOT-FOUND'     => ['message' => 'Rating not found.',              'httpStatus' => 404],
+```
+
+## MySQL upsert alternative
+
+MySQL supports `ON DUPLICATE KEY UPDATE` which avoids the try-catch pattern:
+
+```sql
+INSERT INTO ratings (item_id, rater_id, score, review)
+VALUES (?, ?, ?, ?)
+ON DUPLICATE KEY UPDATE score = VALUES(score), review = VALUES(review)
+```
+
+The try-catch approach works for both MySQL and SQLite and is preferred when targeting multiple databases.
+
+## Related
+
+- `docs/development/booking-systems.md` — UNIQUE constraint as the primary guard
+- `docs/development/ledger-systems.md` — idempotency key pattern
+- `docs/development/reactions.md` — toggle pattern (add/remove, same UNIQUE-constraint base)

--- a/docs/development/reactions.md
+++ b/docs/development/reactions.md
@@ -1,0 +1,212 @@
+# Reactions (Toggle Pattern)
+
+How to implement emoji / like reactions on arbitrary targets: toggle semantics (first PUT adds, second PUT removes), grouped counts, and per-user current state.
+
+## Design
+
+- **Toggle semantics:** a single PUT endpoint adds the reaction if absent, removes it if present. Different reaction types from the same user on the same target are independent.
+- **Polymorphic target:** store `target_type` + `target_id` to react on heterogeneous entities (posts, comments, replies) with a single table.
+- **UNIQUE constraint as toggle key:** `(target_id, target_type, reaction_type, user_id)` prevents double reactions and is the key used to detect existing reactions.
+
+## Schema
+
+```php
+// class/xion/SchemaDefinition.php
+
+'reactions' => [
+    'columns' => [
+        'id'            => ['type' => 'pk-bigint'],
+        'created_at'    => ['type' => 'datetime-now'],
+        'target_id'     => ['type' => 'bigint'],
+        'target_type'   => ['type' => 'varchar:64'],    // 'post', 'comment', etc.
+        'reaction_type' => ['type' => 'varchar:32'],    // 'like', 'heart', 'laugh', etc.
+        'user_id'       => ['type' => 'bigint'],
+    ],
+    'unique' => [
+        'reactions_target_user_type_unique' => ['target_id', 'target_type', 'reaction_type', 'user_id'],
+    ],
+    'indexes' => [
+        'reactions_target_index' => ['target_id', 'target_type'],
+    ],
+],
+```
+
+## Mapper: toggle
+
+```php
+// class/db/ReactionMapper.php
+
+class ReactionMapper extends \Nene\Xion\DataMapperBase
+{
+    const TARGET_TABLE = 'reactions';
+    const KEY_SID      = 'id';
+
+    /** @return 'added'|'removed' */
+    public function toggle(int $targetId, string $targetType, string $reactionType, int $userId): string
+    {
+        // Check if reaction exists
+        $check = $this->DB->prepare('
+            SELECT id FROM ' . static::TARGET_TABLE . '
+            WHERE target_id = :tid AND target_type = :ttype AND reaction_type = :rtype AND user_id = :uid
+            LIMIT 1
+        ');
+        $check->bindValue(':tid',   $targetId,     PDO::PARAM_INT);
+        $check->bindValue(':ttype', $targetType,   PDO::PARAM_STR);
+        $check->bindValue(':rtype', $reactionType, PDO::PARAM_STR);
+        $check->bindValue(':uid',   $userId,       PDO::PARAM_INT);
+        $existing = $this->execute($check)->fetch(PDO::FETCH_ASSOC);
+
+        if (is_array($existing)) {
+            // Remove existing reaction
+            $del = $this->DB->prepare('DELETE FROM ' . static::TARGET_TABLE . ' WHERE id = :id');
+            $del->bindValue(':id', $existing['id'], PDO::PARAM_INT);
+            $this->execute($del);
+            return 'removed';
+        }
+
+        // Add reaction
+        $ins = $this->DB->prepare('
+            INSERT INTO ' . static::TARGET_TABLE . ' (target_id, target_type, reaction_type, user_id)
+            VALUES (:tid, :ttype, :rtype, :uid)
+        ');
+        $ins->bindValue(':tid',   $targetId,     PDO::PARAM_INT);
+        $ins->bindValue(':ttype', $targetType,   PDO::PARAM_STR);
+        $ins->bindValue(':rtype', $reactionType, PDO::PARAM_STR);
+        $ins->bindValue(':uid',   $userId,       PDO::PARAM_INT);
+        $this->execute($ins);
+        return 'added';
+    }
+
+    /**
+     * @param int|null $forUserId  If provided, include user's reactions in the result.
+     * @return array{total: int, by_type: array<string, int>, user_reactions: list<string>}
+     */
+    public function summary(int $targetId, string $targetType, ?int $forUserId = null): array
+    {
+        // Count by reaction type
+        $stmt = $this->DB->prepare('
+            SELECT reaction_type, COUNT(*) AS cnt
+            FROM ' . static::TARGET_TABLE . '
+            WHERE target_id = :tid AND target_type = :ttype
+            GROUP BY reaction_type
+        ');
+        $stmt->bindValue(':tid',   $targetId,   PDO::PARAM_INT);
+        $stmt->bindValue(':ttype', $targetType, PDO::PARAM_STR);
+        $rows = $this->execute($stmt)->fetchAll(PDO::FETCH_ASSOC);
+
+        $byType = [];
+        $total  = 0;
+        foreach ($rows as $row) {
+            $byType[$row['reaction_type']] = (int)$row['cnt'];
+            $total += (int)$row['cnt'];
+        }
+
+        // Per-user reactions (optional)
+        $userReactions = [];
+        if ($forUserId !== null) {
+            $uStmt = $this->DB->prepare('
+                SELECT reaction_type FROM ' . static::TARGET_TABLE . '
+                WHERE target_id = :tid AND target_type = :ttype AND user_id = :uid
+            ');
+            $uStmt->bindValue(':tid',   $targetId,   PDO::PARAM_INT);
+            $uStmt->bindValue(':ttype', $targetType, PDO::PARAM_STR);
+            $uStmt->bindValue(':uid',   $forUserId,  PDO::PARAM_INT);
+            $userReactions = array_column(
+                $this->execute($uStmt)->fetchAll(PDO::FETCH_ASSOC),
+                'reaction_type'
+            );
+        }
+
+        return [
+            'total'          => $total,
+            'by_type'        => $byType,
+            'user_reactions' => $userReactions,
+        ];
+    }
+
+    /** Explicit remove (no toggle — returns false if not found) */
+    public function remove(int $targetId, string $targetType, string $reactionType, int $userId): bool
+    {
+        $stmt = $this->DB->prepare('
+            DELETE FROM ' . static::TARGET_TABLE . '
+            WHERE target_id = :tid AND target_type = :ttype AND reaction_type = :rtype AND user_id = :uid
+        ');
+        $stmt->bindValue(':tid',   $targetId,     PDO::PARAM_INT);
+        $stmt->bindValue(':ttype', $targetType,   PDO::PARAM_STR);
+        $stmt->bindValue(':rtype', $reactionType, PDO::PARAM_STR);
+        $stmt->bindValue(':uid',   $userId,       PDO::PARAM_INT);
+        $this->execute($stmt);
+        return $stmt->rowCount() > 0;
+    }
+}
+```
+
+## Controller
+
+```php
+// PUT /reaction/toggle/type_{targetType}/id_{targetId}/reaction_{reactionType}
+public function togglePutRest(string $targetType, int $targetId, string $reactionType): array
+{
+    $userId = $this->getLoginUserId();
+
+    // Allowlist reaction types
+    $allowedTypes = ['like', 'heart', 'laugh', 'sad', 'wow'];
+    if (!in_array($reactionType, $allowedTypes, true)) {
+        return $this->API_RESPONSE->failure('REACTION-TYPE-INVALID');
+    }
+
+    $result = (new Database\ReactionMapper())->toggle($targetId, $targetType, $reactionType, $userId);
+
+    // Optional: return different HTTP status to let callers distinguish add vs remove
+    // 'added' → 201, 'removed' → 200
+    $summary = (new Database\ReactionMapper())->summary($targetId, $targetType, $userId);
+    return $this->API_RESPONSE->success(['action' => $result, 'summary' => $summary]);
+}
+
+// GET /reaction/summary/type_{targetType}/id_{targetId}
+public function summaryGetRest(string $targetType, int $targetId): array
+{
+    $userId  = AUTH_SESSION->isLoggedIn() ? $this->getLoginUserId() : null;
+    $summary = (new Database\ReactionMapper())->summary($targetId, $targetType, $userId);
+    return $this->API_RESPONSE->success($summary);
+}
+```
+
+## Response shape
+
+```json
+{
+    "status": "success",
+    "Data": {
+        "total": 5,
+        "by_type": { "like": 3, "heart": 2 },
+        "user_reactions": ["like"]
+    }
+}
+```
+
+`user_reactions` is `[]` when no `forUserId` is provided (unauthenticated summary).
+
+## Error codes
+
+```php
+// config/error_codes.php
+'REACTION-TYPE-INVALID'  => ['message' => 'Invalid reaction type.',  'httpStatus' => 400],
+'REACTION-NOT-FOUND'     => ['message' => 'Reaction not found.',     'httpStatus' => 404],
+```
+
+## API design note: toggle status codes
+
+The toggle endpoint can return different HTTP status codes to help callers distinguish outcome without parsing the body:
+
+| Outcome | HTTP status | Rationale |
+|---|---|---|
+| Reaction added | 201 Created | A new resource was created |
+| Reaction removed | 200 OK | The resource was deleted |
+
+This deviates from pure REST (PUT is normally idempotent and returns the same status), but is pragmatic for toggle APIs. An alternative is always returning 200 with `"action": "added"|"removed"` in the body.
+
+## Related
+
+- `docs/development/idor-prevention.md` — ownership isolation if reactions are per-owner
+- `docs/development/ledger-systems.md` — idempotency key UNIQUE constraint pattern

--- a/docs/development/session-tracking.md
+++ b/docs/development/session-tracking.md
@@ -1,0 +1,215 @@
+# Session Tracking (Multi-Device Management)
+
+How to track user sessions — tokens, heartbeats, and revocation — on top of NeNe's existing cookie-based auth. Useful for "active devices" UIs, multi-device logouts, and security audit logs.
+
+This is an application-layer session table, not a replacement for `$_SESSION`. NeNe's PHP session cookie handles auth; this table tracks metadata about that session (IP, user agent, last seen) and supports bulk revocation.
+
+## Schema
+
+```php
+// class/xion/SchemaDefinition.php
+
+'user_sessions' => [
+    'columns' => [
+        'id'           => ['type' => 'pk-bigint'],
+        'created_at'   => ['type' => 'datetime-now'],
+        'updated_at'   => ['type' => 'datetime-touch'],
+        'token'        => ['type' => 'varchar:128'],         // random session token
+        'user_id'      => ['type' => 'bigint'],
+        'ip'           => ['type' => 'varchar:45'],          // IPv4 or IPv6
+        'user_agent'   => ['type' => 'text'],
+        'last_seen_at' => ['type' => 'varchar:19'],          // UTC YYYY-MM-DD HH:MM:SS
+        'revoked_at'   => ['type' => 'varchar:19', 'nullable' => true],  // NULL = active
+    ],
+    'unique' => [
+        'user_sessions_token_unique' => ['token'],
+    ],
+    'indexes' => [
+        'user_sessions_user_id_index' => ['user_id'],
+    ],
+],
+```
+
+`revoked_at IS NULL` means the session is active. `revoked_at IS NOT NULL` means revoked. Never delete rows — keep history for audit purposes.
+
+## Token generation
+
+```php
+// 64-char hex string: 32 bytes of entropy, negligible collision probability
+$token = bin2hex(random_bytes(32));
+```
+
+Alternatively use a UUID if your stack already has a UUID library.
+
+## Mapper
+
+```php
+// class/db/UserSessionMapper.php
+
+class UserSessionMapper extends \Nene\Xion\DataMapperBase
+{
+    const TARGET_TABLE = 'user_sessions';
+    const KEY_SID      = 'id';
+
+    public function create(int $userId, string $ip, string $userAgent): array
+    {
+        $token = bin2hex(random_bytes(32));
+        $now   = (new \DateTime())->format('Y-m-d H:i:s');
+
+        $stmt = $this->DB->prepare('
+            INSERT INTO ' . static::TARGET_TABLE . ' (token, user_id, ip, user_agent, last_seen_at)
+            VALUES (:token, :uid, :ip, :ua, :now)
+        ');
+        $stmt->bindValue(':token', $token,     PDO::PARAM_STR);
+        $stmt->bindValue(':uid',   $userId,    PDO::PARAM_INT);
+        $stmt->bindValue(':ip',    $ip,        PDO::PARAM_STR);
+        $stmt->bindValue(':ua',    $userAgent, PDO::PARAM_STR);
+        $stmt->bindValue(':now',   $now,       PDO::PARAM_STR);
+        $this->execute($stmt);
+
+        return $this->findRowById((int)$this->DB->lastInsertId());
+    }
+
+    public function findByToken(string $token): ?array
+    {
+        $stmt = $this->DB->prepare('
+            SELECT * FROM ' . static::TARGET_TABLE . ' WHERE token = :token LIMIT 1
+        ');
+        $stmt->bindValue(':token', $token, PDO::PARAM_STR);
+        $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+        return is_array($row) ? $row : null;
+    }
+
+    /** Update last_seen_at without fetching the full row */
+    public function heartbeat(string $token): bool
+    {
+        $stmt = $this->DB->prepare('
+            UPDATE ' . static::TARGET_TABLE . '
+            SET last_seen_at = :now
+            WHERE token = :token AND revoked_at IS NULL
+        ');
+        $stmt->bindValue(':now',   (new \DateTime())->format('Y-m-d H:i:s'), PDO::PARAM_STR);
+        $stmt->bindValue(':token', $token, PDO::PARAM_STR);
+        $this->execute($stmt);
+        return $stmt->rowCount() > 0; // false → token not found or already revoked
+    }
+
+    /** Revoke a single session; returns false if token not found or already revoked */
+    public function revoke(string $token): bool
+    {
+        $stmt = $this->DB->prepare('
+            UPDATE ' . static::TARGET_TABLE . '
+            SET revoked_at = :now
+            WHERE token = :token AND revoked_at IS NULL
+        ');
+        $stmt->bindValue(':now',   (new \DateTime())->format('Y-m-d H:i:s'), PDO::PARAM_STR);
+        $stmt->bindValue(':token', $token, PDO::PARAM_STR);
+        $this->execute($stmt);
+        return $stmt->rowCount() > 0;
+    }
+
+    /** Revoke all active sessions for a user; returns count of revoked rows */
+    public function revokeAll(int $userId): int
+    {
+        $stmt = $this->DB->prepare('
+            UPDATE ' . static::TARGET_TABLE . '
+            SET revoked_at = :now
+            WHERE user_id = :uid AND revoked_at IS NULL
+        ');
+        $stmt->bindValue(':now', (new \DateTime())->format('Y-m-d H:i:s'), PDO::PARAM_STR);
+        $stmt->bindValue(':uid', $userId, PDO::PARAM_INT);
+        $this->execute($stmt);
+        return $stmt->rowCount();
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findByUser(int $userId, bool $activeOnly = false): array
+    {
+        $sql = 'SELECT * FROM ' . static::TARGET_TABLE . ' WHERE user_id = :uid';
+        if ($activeOnly) {
+            $sql .= ' AND revoked_at IS NULL';
+        }
+        $sql .= ' ORDER BY created_at DESC';
+
+        $stmt = $this->DB->prepare($sql);
+        $stmt->bindValue(':uid', $userId, PDO::PARAM_INT);
+        return $this->execute($stmt)->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+}
+```
+
+## Controller: create session on login
+
+Call this inside your login controller after verifying credentials:
+
+```php
+public function loginPostRest(): array
+{
+    // ... verify credentials, set AUTH_SESSION ...
+
+    // Record the session in the tracking table
+    $ip        = $_SERVER['REMOTE_ADDR'] ?? '';
+    $userAgent = $_SERVER['HTTP_USER_AGENT'] ?? '';
+    $session   = (new Database\UserSessionMapper())->create($this->getLoginUserId(), $ip, $userAgent);
+
+    return $this->API_RESPONSE->success(['session_token' => $session['token']]);
+}
+```
+
+## Controller: heartbeat
+
+Clients should call this endpoint periodically to update `last_seen_at` (e.g., every 5 minutes):
+
+```php
+// POST /usersession/heartbeat/token_{token}
+public function heartbeatPostRest(string $token): array
+{
+    $ok = (new Database\UserSessionMapper())->heartbeat($token);
+    return $ok
+        ? $this->API_RESPONSE->success([])
+        : $this->API_RESPONSE->failure('SESSION-NOT-FOUND');
+}
+```
+
+## Controller: revoke all (logout everywhere)
+
+```php
+// DELETE /usersession/all
+public function allDeleteRest(): array
+{
+    $count = (new Database\UserSessionMapper())->revokeAll($this->getLoginUserId());
+    return $this->API_RESPONSE->success(['revoked' => $count]);
+}
+```
+
+## The `rowCount()` trick for bulk operations
+
+`PDOStatement::rowCount()` returns the number of rows affected by the last UPDATE, DELETE, or INSERT. For bulk revocation, use this directly — no extra COUNT query needed:
+
+```php
+$stmt->execute();
+$revokedCount = $stmt->rowCount(); // how many sessions were revoked
+```
+
+## Error codes
+
+```php
+// config/error_codes.php
+'SESSION-NOT-FOUND' => ['message' => 'Session not found or already revoked.', 'httpStatus' => 404],
+```
+
+## Query parameter boolean coercion
+
+If filtering by `?active=true` (string), check the exact string value:
+
+```php
+$activeOnly = ($this->REQUEST->getParam('active', '') === 'true');
+```
+
+`"1"`, `"yes"`, `"on"` do **not** match `=== 'true'`. Document the expected value explicitly in your API docs. There is no built-in query-parameter boolean coercion in NeNe.
+
+## Related
+
+- `docs/development/agent-bearer-auth.md` — Bearer token auth (stateless; no session table needed)
+- `docs/development/idor-prevention.md` — ownership isolation (user can only see/revoke their own sessions)
+- `docs/development/temporal-data.md` — date-range queries

--- a/docs/development/sql-injection.md
+++ b/docs/development/sql-injection.md
@@ -1,0 +1,156 @@
+# SQL Injection Defense
+
+NeNe's database layer uses PDO prepared statements for all value binding. This makes the most common injection vectors impossible by construction. However, one area requires extra care: **`ORDER BY` clauses cannot be parameterized**.
+
+## What is safe by default
+
+PDO prepared statements are the only supported way to bind user-supplied values:
+
+```php
+$stmt = $this->DB->prepare('
+    SELECT * FROM articles WHERE user_id = :user_id AND title LIKE :q
+');
+$stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+$stmt->bindValue(':q',       '%' . $q . '%', PDO::PARAM_STR);
+```
+
+The driver treats bound values as data, not SQL structure. Classic injection payloads (`' OR '1'='1`, `'; DROP TABLE --`) are stored or searched for as literal strings.
+
+This applies to: `WHERE`, `HAVING`, `INSERT` values, `UPDATE` values, `LIMIT`/`OFFSET` (when bound as int).
+
+## LIKE injection
+
+LIKE wildcards in the bound value itself (`%`, `_`) are NOT escaped by PDO — they are passed through as SQL wildcards. A value of `%` matches every row.
+
+If user-supplied `%` and `_` should be treated as literals, escape them before binding:
+
+```php
+$raw   = (string)($this->REQUEST_JSON['q'] ?? '');
+$safe  = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $raw);
+$stmt->bindValue(':q', '%' . $safe . '%', PDO::PARAM_STR);
+```
+
+For most search boxes, `%` matching everything is merely incorrect, not a security issue. Decide whether to escape based on the consequence.
+
+## ORDER BY — the mandatory whitelist
+
+**SQL column names and sort directions cannot be parameterized.** This query does not work:
+
+```php
+// BROKEN — PDO binds :sort as a quoted string value, not a column name
+$stmt = $this->DB->prepare('SELECT * FROM articles ORDER BY :sort ASC');
+$stmt->bindValue(':sort', 'title');
+// Result: ORDER BY 'title' ASC — no ordering, or error, depending on the driver
+```
+
+If you interpolate user input directly into `ORDER BY`, you create a SQL injection vector:
+
+```php
+// DANGEROUS — do not do this
+$sort = $this->REQUEST_JSON['sort'] ?? 'id';
+$stmt = $this->DB->prepare("SELECT * FROM articles ORDER BY {$sort} DESC");
+```
+
+An attacker can inject: `(SELECT SLEEP(5))`, `CASE WHEN 1=1 THEN title ELSE id END`, etc.
+
+### Whitelist pattern
+
+Validate the sort column against a strict allowlist before interpolation:
+
+```php
+class ArticleMapper extends DataMapperBase
+{
+    /** @var array<string, string> Allowed sort columns (input => SQL column). */
+    private const SORT_COLUMNS = [
+        'id'         => 'id',
+        'title'      => 'title',
+        'created_at' => 'created_at',
+    ];
+
+    /** @var array<string, string> Allowed sort directions. */
+    private const SORT_DIRS = [
+        'asc'  => 'ASC',
+        'desc' => 'DESC',
+    ];
+
+    public function findPublishedRows(string $sortInput = 'id', string $dirInput = 'asc'): array
+    {
+        $col = self::SORT_COLUMNS[$sortInput] ?? 'id';          // unknown → safe default
+        $dir = self::SORT_DIRS[strtolower($dirInput)] ?? 'ASC'; // unknown → safe default
+
+        $stmt = $this->DB->prepare('
+            SELECT id, title, created_at
+            FROM ' . static::TARGET_TABLE . '
+            WHERE is_deleted = 0
+            ORDER BY ' . $col . ' ' . $dir . '
+        ');
+
+        return $this->execute($stmt)->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+```
+
+The controller reads `sort` and `order` from query params, validates format, and passes them to the mapper:
+
+```php
+public function indexGetRest(): array
+{
+    $sort  = (string)($this->REQUEST_JSON['sort']  ?? 'id');
+    $order = (string)($this->REQUEST_JSON['order'] ?? 'asc');
+
+    $mapper = new Database\ArticleMapper();
+    return $this->API_RESPONSE->success([
+        'articles' => $mapper->findPublishedRows($sort, $order),
+    ]);
+}
+```
+
+Unknown sort values fall back to the default silently, or you can return `SORT-FIELD-INVALID`:
+
+```php
+if (!array_key_exists($sort, ArticleMapper::SORT_COLUMNS)) {
+    return $this->API_RESPONSE->failure('SORT-FIELD-INVALID');
+}
+```
+
+### Sort direction injection is easy to neutralize
+
+Even without a whitelist, direction injection is neutralized by normalization:
+
+```php
+// Any direction string that is not 'desc' becomes 'ASC' — injection impossible
+$dir = strtolower($dirInput) === 'desc' ? 'DESC' : 'ASC';
+```
+
+Use this pattern for direction; use the whitelist pattern for column names.
+
+## Path parameter coercion
+
+URL path parameters (the `id` in `/article/item/id_42`) must always be cast to integers before use in SQL:
+
+```php
+$id = $this->request->getParam('id');
+if ($id === null || !ctype_digit((string)$id)) {
+    return $this->API_RESPONSE->failure('ARTICLE-ID-REQUIRED');
+}
+// Now safe to interpolate as integer
+$stmt->bindValue(':id', (int)$id, PDO::PARAM_INT);
+```
+
+`ctype_digit()` rejects strings that `(int)` would silently truncate to 0 (e.g., `42abc` → `42`).
+
+## Summary
+
+| Source | Safe | How |
+|---|---|---|
+| `WHERE` value | ✅ | PDO bind |
+| `INSERT` value | ✅ | PDO bind |
+| `LIKE` pattern | ⚠️ | PDO bind; wildcards pass through — escape `%` / `_` if needed |
+| `ORDER BY` column | ❌ | Must whitelist |
+| `ORDER BY` direction | ✅ with care | Normalize: only `'ASC'` or `'DESC'` |
+| Path `id` param | ✅ with care | `ctype_digit()` + `(int)` cast |
+
+## Related
+
+- `docs/development/idor-prevention.md` — object-level authorization
+- `docs/tutorials/building-a-service.md` — mapper patterns

--- a/docs/development/state-machines.md
+++ b/docs/development/state-machines.md
@@ -1,0 +1,199 @@
+# State Machine Workflows
+
+A state machine formalizes multi-step business processes: order approval, content moderation, support tickets, delivery tracking. Instead of ad-hoc `status` column updates, a state machine enforces valid transitions, records history, and exposes "what's allowed next" to clients.
+
+## Core design
+
+- **`WorkflowDefinition`** — static class with the allowed-transitions map. Not DB-driven; one class per workflow type.
+- **`instances` table** — stores current state, arbitrary JSON context, and workflow name.
+- **`transitions` table** — append-only history; never update or delete.
+- **`allowed_next`** — derived at serialization time from the definition; clients always know what they can do.
+
+## Schema
+
+```php
+// class/xion/SchemaDefinition.php
+
+'workflow_instances' => [
+    'columns' => [
+        'id'            => ['type' => 'pk-bigint'],
+        'created_at'    => ['type' => 'datetime-now'],
+        'updated_at'    => ['type' => 'datetime-touch'],
+        'workflow'      => ['type' => 'varchar:64'],
+        'current_state' => ['type' => 'varchar:64'],
+        'context'       => ['type' => 'text'],          // arbitrary JSON blob
+    ],
+],
+'workflow_transitions' => [
+    'columns' => [
+        'id'          => ['type' => 'pk-bigint'],
+        'created_at'  => ['type' => 'datetime-now'],
+        'instance_id' => ['type' => 'bigint'],
+        'from_state'  => ['type' => 'varchar:64'],
+        'to_state'    => ['type' => 'varchar:64'],
+        'actor'       => ['type' => 'varchar:255'],
+        'note'        => ['type' => 'text', 'nullable' => true],
+    ],
+    'indexes' => [
+        'workflow_transitions_instance_id_index' => ['instance_id'],
+    ],
+    'foreign_keys' => [
+        'workflow_transitions_instance_id_foreign' => [
+            'columns'    => ['instance_id'],
+            'references' => ['workflow_instances', ['id']],
+            'on_delete'  => 'CASCADE',
+        ],
+    ],
+],
+```
+
+## WorkflowDefinition
+
+```php
+// class/func/WorkflowDefinition.php
+
+final class WorkflowDefinition
+{
+    /** @var array<string, array<string, list<string>>> Workflow name → from-state → allowed to-states */
+    private const DEFINITIONS = [
+        'order' => [
+            'draft'     => ['submitted'],
+            'submitted' => ['approved', 'rejected'],
+            'approved'  => ['fulfilled', 'cancelled'],
+            'rejected'  => [],       // terminal
+            'fulfilled' => [],       // terminal
+            'cancelled' => [],       // terminal
+        ],
+    ];
+
+    public static function isValidWorkflow(string $workflow): bool
+    {
+        return isset(self::DEFINITIONS[$workflow]);
+    }
+
+    public static function initialState(string $workflow): string
+    {
+        return array_key_first(self::DEFINITIONS[$workflow]) ?? 'draft';
+    }
+
+    /**
+     * @return list<string> Valid next states from the current state.
+     */
+    public static function allowedNext(string $workflow, string $currentState): array
+    {
+        return self::DEFINITIONS[$workflow][$currentState] ?? [];
+    }
+
+    public static function isValidTransition(string $workflow, string $from, string $to): bool
+    {
+        return in_array($to, self::allowedNext($workflow, $from), true);
+    }
+}
+```
+
+## Mapper
+
+```php
+// class/db/WorkflowInstanceMapper.php
+
+public function create(string $workflow, array $context = []): array
+{
+    $initialState = WorkflowDefinition::initialState($workflow);
+    $stmt = $this->DB->prepare('
+        INSERT INTO ' . static::TARGET_TABLE . ' (workflow, current_state, context)
+        VALUES (:workflow, :state, :context)
+    ');
+    $stmt->bindValue(':workflow', $workflow,                           PDO::PARAM_STR);
+    $stmt->bindValue(':state',    $initialState,                      PDO::PARAM_STR);
+    $stmt->bindValue(':context',  json_encode($context, JSON_THROW_ON_ERROR), PDO::PARAM_STR);
+    $this->execute($stmt);
+    return $this->findRowById((int)$this->DB->lastInsertId());
+}
+
+/**
+ * Apply a transition — returns updated instance or null if invalid.
+ */
+public function transition(
+    int $id,
+    string $toState,
+    string $actor,
+    ?string $note,
+    WorkflowTransitionMapper $historyMapper
+): ?array {
+    $instance = $this->findRowById($id);
+    if ($instance === null) {
+        return null;
+    }
+    $workflow = (string)$instance['workflow'];
+    $from     = (string)$instance['current_state'];
+
+    if (!WorkflowDefinition::isValidTransition($workflow, $from, $toState)) {
+        return null; // caller maps to 409 Conflict
+    }
+
+    $transaction = new \Nene\Xion\TransactionManager();
+    return $transaction->run(function () use ($id, $from, $toState, $actor, $note, $historyMapper): array {
+        $stmt = $this->DB->prepare('
+            UPDATE ' . static::TARGET_TABLE . ' SET current_state = :state WHERE id = :id
+        ');
+        $stmt->bindValue(':state', $toState, PDO::PARAM_STR);
+        $stmt->bindValue(':id',    $id,      PDO::PARAM_INT);
+        $this->execute($stmt);
+
+        $historyMapper->record($id, $from, $toState, $actor, $note);
+
+        return $this->findRowById($id);
+    });
+}
+```
+
+## Controller response with `allowed_next`
+
+```php
+private function normalizeInstance(array $row): array
+{
+    $workflow     = (string)$row['workflow'];
+    $currentState = (string)$row['current_state'];
+    return [
+        'id'            => (int)$row['id'],
+        'workflow'      => $workflow,
+        'current_state' => $currentState,
+        'allowed_next'  => WorkflowDefinition::allowedNext($workflow, $currentState),
+        'context'       => json_decode((string)$row['context'], true) ?? [],
+        'created_at'    => (string)$row['created_at'],
+        'updated_at'    => (string)$row['updated_at'],
+    ];
+}
+
+public function transitionPostRest(): array
+{
+    $id      = $this->getInstanceId();
+    $toState = trim((string)($this->REQUEST_JSON['to_state'] ?? ''));
+    $actor   = trim((string)($this->REQUEST_JSON['actor']    ?? ''));
+    $note    = trim((string)($this->REQUEST_JSON['note']     ?? '')) ?: null;
+
+    $instance = (new Database\WorkflowInstanceMapper())
+        ->transition($id, $toState, $actor, $note, new Database\WorkflowTransitionMapper());
+
+    if ($instance === null) {
+        return $this->API_RESPONSE->failure('WORKFLOW-TRANSITION-INVALID'); // 409
+    }
+
+    return $this->API_RESPONSE->success(['instance' => $this->normalizeInstance($instance)]);
+}
+```
+
+## Key design decisions
+
+| Decision | Recommendation |
+|---|---|
+| Workflow definition | Static class — not DB-driven. Changing a workflow is a code deploy, not a DB edit. |
+| Terminal states | Empty `allowed_next` — the general invalid-transition guard handles them automatically. |
+| Invalid transition response | `409 Conflict` — the resource exists and the request is understood but cannot be applied. |
+| History table | Append-only. Actor and note on each row support auditing. |
+| `context` field | Arbitrary JSON blob stored as TEXT. Decoded on hydration. Avoid over-normalizing domain data into the generic workflow table. |
+
+## Related
+
+- `docs/development/ledger-systems.md` — append-only history pattern
+- `docs/tutorials/building-a-service.md` — TransactionManager, mapper patterns

--- a/docs/development/temporal-data.md
+++ b/docs/development/temporal-data.md
@@ -1,0 +1,150 @@
+# Temporal Data (Date-Effective Records)
+
+Temporal data tracks how a value changes over time: product prices, tax rates, user tier benefits, permission policies. Instead of overwriting a single row, each change inserts a new row with an effective date range.
+
+## The pattern
+
+Each temporal record has `effective_from` and `effective_to` columns. The active record is the one where `NOW()` falls within the range. When a new record is created, the previous open-ended record is closed.
+
+```
+id  effective_from      effective_to        price
+1   2026-01-01          2026-03-31          980
+2   2026-04-01          2026-05-31          1200
+3   2026-06-01          NULL                1100   ← current
+```
+
+`NULL` in `effective_to` means "open-ended" (no planned end date yet).
+
+## Schema
+
+```php
+// class/xion/SchemaDefinition.php
+
+'price_tiers' => [
+    'columns' => [
+        'id'             => ['type' => 'pk-bigint'],
+        'created_at'     => ['type' => 'datetime-now'],
+        'product_id'     => ['type' => 'bigint'],
+        'price'          => ['type' => 'bigint'],             // price in cents / lowest unit
+        'effective_from' => ['type' => 'varchar:10'],         // YYYY-MM-DD
+        'effective_to'   => ['type' => 'varchar:10', 'nullable' => true], // NULL = open-ended
+    ],
+    'indexes' => [
+        'price_tiers_product_id_index' => ['product_id'],
+    ],
+],
+```
+
+Store dates as `VARCHAR(10)` in `YYYY-MM-DD` ISO format rather than `DATETIME` for date-only precision. MySQL and SQLite compare ISO date strings lexicographically correctly.
+
+## Mapper — current record lookup
+
+```php
+// Current price for a product (as of today)
+public function findCurrentByProductId(int $productId): ?array
+{
+    $today = (new \DateTime())->format('Y-m-d');
+    $stmt  = $this->DB->prepare('
+        SELECT id, product_id, price, effective_from, effective_to
+        FROM ' . static::TARGET_TABLE . '
+        WHERE product_id = :product_id
+          AND effective_from <= :today
+          AND (effective_to IS NULL OR effective_to >= :today)
+        LIMIT 1
+    ');
+    $stmt->bindValue(':product_id', $productId, PDO::PARAM_INT);
+    $stmt->bindValue(':today',      $today,     PDO::PARAM_STR);
+    $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+    return is_array($row) ? $row : null;
+}
+
+// Price at a specific date (historical query)
+public function findByProductIdAtDate(int $productId, string $date): ?array
+{
+    $stmt = $this->DB->prepare('
+        SELECT id, product_id, price, effective_from, effective_to
+        FROM ' . static::TARGET_TABLE . '
+        WHERE product_id = :product_id
+          AND effective_from <= :date
+          AND (effective_to IS NULL OR effective_to >= :date)
+        LIMIT 1
+    ');
+    $stmt->bindValue(':product_id', $productId, PDO::PARAM_INT);
+    $stmt->bindValue(':date',       $date,      PDO::PARAM_STR);
+    $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+    return is_array($row) ? $row : null;
+}
+```
+
+## Mapper — insert new tier (auto-close previous)
+
+```php
+public function createTier(int $productId, int $price, string $effectiveFrom): array
+{
+    $transaction = new \Nene\Xion\TransactionManager();
+    return $transaction->run(function () use ($productId, $price, $effectiveFrom): array {
+        // Close the current open-ended tier one day before the new one starts
+        $prevEnd = (new \DateTime($effectiveFrom))
+            ->modify('-1 day')
+            ->format('Y-m-d');
+        $closeStmt = $this->DB->prepare('
+            UPDATE ' . static::TARGET_TABLE . '
+            SET effective_to = :prev_end
+            WHERE product_id = :product_id
+              AND effective_to IS NULL
+        ');
+        $closeStmt->bindValue(':prev_end',   $prevEnd,   PDO::PARAM_STR);
+        $closeStmt->bindValue(':product_id', $productId, PDO::PARAM_INT);
+        $this->execute($closeStmt);
+
+        // Insert the new tier
+        $insertStmt = $this->DB->prepare('
+            INSERT INTO ' . static::TARGET_TABLE . ' (product_id, price, effective_from)
+            VALUES (:product_id, :price, :effective_from)
+        ');
+        $insertStmt->bindValue(':product_id',    $productId,    PDO::PARAM_INT);
+        $insertStmt->bindValue(':price',         $price,        PDO::PARAM_INT);
+        $insertStmt->bindValue(':effective_from', $effectiveFrom, PDO::PARAM_STR);
+        $this->execute($insertStmt);
+
+        return $this->findRowById((int)$this->DB->lastInsertId());
+    });
+}
+```
+
+## Design decisions
+
+| Decision | Recommendation |
+|---|---|
+| Date format | `YYYY-MM-DD` string (VARCHAR 10). Lexicographic comparison works correctly for ISO dates. |
+| Open-ended sentinel | `NULL` in `effective_to`. Do not use a magic far-future date (`9999-12-31`) — NULL is unambiguous and queries are cleaner. |
+| Half-open vs closed interval | Use a **closed interval** (`effective_from <= date AND effective_to >= date`). This avoids gaps on day boundaries. |
+| Auto-close previous | Do it in a transaction with the insert of the new tier. Never leave overlapping open-ended records. |
+| Historical query | Always query with a specific date parameter — never use `NOW()` in historical lookups. |
+
+## Validation
+
+When accepting `effective_from` from client input, validate the date format:
+
+```php
+$from = trim((string)($this->REQUEST_JSON['effective_from'] ?? ''));
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $from) || !strtotime($from)) {
+    return $this->API_RESPONSE->failure('PRICE-DATE-INVALID');
+}
+// Also check: new tier must start after the current active tier's effective_from
+```
+
+## History listing
+
+```sql
+SELECT id, price, effective_from, effective_to
+FROM price_tiers
+WHERE product_id = ?
+ORDER BY effective_from DESC
+```
+
+## Related
+
+- `docs/development/ledger-systems.md` — append-only immutable records
+- `docs/development/state-machines.md` — lifecycle patterns
+- `docs/tutorials/building-a-service.md` — TransactionManager pattern

--- a/docs/development/timezone-handling.md
+++ b/docs/development/timezone-handling.md
@@ -1,0 +1,189 @@
+# Timezone Handling
+
+How to accept, validate, store, and render timezone-aware datetimes in NeNe APIs. Pair with **`docs/development/temporal-data.md`** for date-range storage patterns.
+
+## The core rule: store UTC, display local
+
+All datetimes stored in the database must be in UTC. Conversion to the user's local time happens at read time, not write time. This avoids ambiguity during DST transitions and makes sorting and comparison straightforward.
+
+```
+Client input:  "2026-11-01T01:30:00"  +  "America/New_York"
+                        ↓
+      Convert to UTC before storing
+                        ↓
+DB row:         "2026-11-01 05:30:00"   (UTC)
+```
+
+## IANA timezone validation
+
+**Do not rely on PHP's `DateTimeZone` constructor alone.** It silently accepts timezone abbreviations (`"EST"`, `"PST"`) that are not canonical IANA identifiers. The constructor does not throw an exception for them:
+
+```php
+new DateTimeZone('EST');    // succeeds — no exception
+new DateTimeZone('Foobar'); // throws: Unknown or bad timezone
+```
+
+But `"EST"` is not an IANA identifier — it is a legacy abbreviation. DST-unaware, fragile, and not in `DateTimeZone::listIdentifiers()`.
+
+**Always validate with membership check:**
+
+```php
+function isValidIanaTimezone(string $tz): bool
+{
+    return in_array($tz, \DateTimeZone::listIdentifiers(), true);
+}
+
+// Usage
+$tz = trim((string)($this->REQUEST_JSON['timezone'] ?? ''));
+if (!isValidIanaTimezone($tz)) {
+    return $this->API_RESPONSE->failure('EVENT-TIMEZONE-INVALID');
+}
+```
+
+## Local → UTC conversion
+
+```php
+function localToUtc(string $localDatetime, string $ianaTimezone): string
+{
+    $dt = new \DateTimeImmutable($localDatetime, new \DateTimeZone($ianaTimezone));
+    $dt = $dt->setTimezone(new \DateTimeZone('UTC'));
+    return $dt->format('Y-m-d H:i:s');
+}
+
+// Example
+echo localToUtc('2026-07-15 10:00:00', 'America/New_York');
+// → "2026-07-15 14:00:00"  (New York is UTC-4 in July, EDT)
+```
+
+## UTC → local display
+
+```php
+function utcToLocal(string $utcDatetime, string $ianaTimezone): string
+{
+    $dt = new \DateTimeImmutable($utcDatetime, new \DateTimeZone('UTC'));
+    $dt = $dt->setTimezone(new \DateTimeZone($ianaTimezone));
+    return $dt->format('Y-m-d H:i:s');
+}
+```
+
+## Schema
+
+Store `started_at_utc` as a `DATETIME`-equivalent string (`YYYY-MM-DD HH:MM:SS`). Also store the original timezone name so it can be re-expressed later:
+
+```php
+// class/xion/SchemaDefinition.php
+
+'events' => [
+    'columns' => [
+        'id'           => ['type' => 'pk-bigint'],
+        'created_at'   => ['type' => 'datetime-now'],
+        'updated_at'   => ['type' => 'datetime-touch'],
+        'title'        => ['type' => 'varchar:255'],
+        'timezone'     => ['type' => 'varchar:64'],     // IANA name, e.g. "Asia/Tokyo"
+        'started_at'   => ['type' => 'varchar:19'],     // UTC, "YYYY-MM-DD HH:MM:SS"
+    ],
+    'indexes' => [
+        'events_started_at_index' => ['started_at'],
+    ],
+],
+```
+
+## Controller: create endpoint
+
+```php
+public function indexPostRest(): array
+{
+    $title    = trim((string)($this->REQUEST_JSON['title']    ?? ''));
+    $tz       = trim((string)($this->REQUEST_JSON['timezone'] ?? ''));
+    $localDt  = trim((string)($this->REQUEST_JSON['start']    ?? ''));
+
+    if ($title === '') {
+        return $this->API_RESPONSE->failure('EVENT-TITLE-REQUIRED');
+    }
+    if (!isValidIanaTimezone($tz)) {
+        return $this->API_RESPONSE->failure('EVENT-TIMEZONE-INVALID');
+    }
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $localDt)) {
+        return $this->API_RESPONSE->failure('EVENT-START-INVALID');
+    }
+
+    $utcDt = localToUtc($localDt, $tz);
+    $event = (new Database\EventMapper())->create($title, $tz, $utcDt);
+
+    return $this->API_RESPONSE->success(['event' => $this->normalizeRow($event)]);
+}
+```
+
+## Controller: list with optional timezone conversion
+
+Accept an optional `?timezone=` query parameter to convert stored UTC times to a local view:
+
+```php
+public function indexGetRest(): array
+{
+    $outputTz = $this->REQUEST->getParam('timezone', '');
+    if ($outputTz !== '' && !isValidIanaTimezone($outputTz)) {
+        return $this->API_RESPONSE->failure('EVENT-TIMEZONE-INVALID');
+    }
+
+    $events = (new Database\EventMapper())->findAll();
+
+    if ($outputTz !== '') {
+        foreach ($events as &$event) {
+            $event['started_at_local'] = utcToLocal($event['started_at'], $outputTz);
+            $event['display_timezone'] = $outputTz;
+        }
+        unset($event);
+    }
+
+    return $this->API_RESPONSE->success(['events' => $events]);
+}
+```
+
+## DST edge cases
+
+### Ambiguous times (clock falls back)
+
+When a clock falls back (e.g., `America/New_York` in November), the local time `01:30 AM` occurs twice:
+- First occurrence: EDT (UTC-4) → 05:30 UTC
+- Second occurrence: EST (UTC-5) → 06:30 UTC
+
+PHP's `DateTimeImmutable` resolves ambiguous times to the **first occurrence** (the pre-transition offset). If your application requires disambiguation (e.g., flight scheduling), collect the UTC offset explicitly from the client instead of relying on timezone name + local time alone.
+
+### Non-existent times (clock springs forward)
+
+When a clock springs forward (e.g., `2026-03-08 02:30:00 America/New_York`), the local time does not exist — the clock jumps from 02:00 to 03:00. PHP silently adjusts to the nearest valid time. For user-facing input, validate that the resulting UTC → local round-trip equals the original input:
+
+```php
+$reconstructed = utcToLocal(localToUtc($localDt, $tz), $tz);
+if ($reconstructed !== $localDt) {
+    return $this->API_RESPONSE->failure('EVENT-START-NONEXISTENT'); // DST gap
+}
+```
+
+## Error codes
+
+```php
+// config/error_codes.php
+'EVENT-TITLE-REQUIRED'      => ['message' => 'Event title is required.',                     'httpStatus' => 400],
+'EVENT-TIMEZONE-INVALID'    => ['message' => 'Timezone must be a valid IANA timezone name.',  'httpStatus' => 400],
+'EVENT-START-INVALID'       => ['message' => 'Event start must be YYYY-MM-DDTHH:MM:SS.',     'httpStatus' => 400],
+'EVENT-START-NONEXISTENT'   => ['message' => 'That local time does not exist (DST gap).',    'httpStatus' => 422],
+```
+
+## Summary
+
+| Concern | Recommended approach |
+|---|---|
+| Store datetime | UTC in `VARCHAR(19)` (`YYYY-MM-DD HH:MM:SS`) |
+| Store timezone | IANA name in `VARCHAR(64)` alongside the UTC datetime |
+| Validate input timezone | `in_array($tz, DateTimeZone::listIdentifiers(), true)` |
+| Convert local → UTC | `DateTimeImmutable($local, new DateTimeZone($tz))->setTimezone(UTC)` |
+| Display in local time | `setTimezone(new DateTimeZone($outputTz))->format(...)` |
+| DST ambiguous time | Document that PHP picks first occurrence; ask for explicit UTC offset for precision |
+| DST gap (spring-forward) | Round-trip check: `utcToLocal(localToUtc(t, tz), tz) === t` |
+
+## Related
+
+- `docs/development/temporal-data.md` — date-range (effective_from/effective_to) patterns
+- `docs/development/booking-systems.md` — datetime-based slot booking

--- a/docs/development/unicode-validation.md
+++ b/docs/development/unicode-validation.md
@@ -1,0 +1,105 @@
+# Unicode and Encoding Validation
+
+NeNe applications often handle multilingual input — Japanese, Arabic, emoji, and other non-ASCII text. This guide covers the common pitfalls.
+
+## JSON responses: non-ASCII is NOT escaped
+
+`JsonResponder` includes `JSON_UNESCAPED_UNICODE` so Japanese and emoji are returned as-is:
+
+```json
+{"title": "ホーム"}       // ✅ readable
+{"title": "ホーム"}  // ❌ old behavior
+```
+
+> **Note for `<script>` context:** `View::encodeScriptJson()` intentionally does NOT use `JSON_UNESCAPED_UNICODE` because it outputs JSON inside an HTML `<script>` tag where unescaped line terminators (U+2028, U+2029) could break the script block. Use `json_encode` with the `JSON_HEX_*` flags for that context.
+
+## String length: use `mb_strlen`, not `strlen`
+
+`strlen` counts **bytes**, not characters. For multibyte text the byte count is wrong:
+
+```php
+strlen('あ')             // 3 (UTF-8 bytes)
+mb_strlen('あ', 'UTF-8') // 1 (character)
+
+strlen('Hello 👋')       // 10 (6 + 4 bytes for the emoji)
+mb_strlen('Hello 👋', 'UTF-8') // 7 (characters)
+```
+
+Always validate length with `mb_strlen`:
+
+```php
+$title = trim((string)($this->REQUEST_JSON['title'] ?? ''));
+if (mb_strlen($title, 'UTF-8') > 255) {
+    return $this->API_RESPONSE->failure('TITLE-TOO-LONG');
+}
+```
+
+### Grapheme clusters and emoji sequences
+
+`mb_strlen` counts Unicode codepoints, not grapheme clusters (rendered glyphs). A family emoji `👨‍👩‍👧` is one visible glyph but 5 codepoints (joined by U+200D Zero Width Joiner). `mb_strlen` returns 5, not 1.
+
+For a "50 characters as displayed" limit, use `grapheme_strlen()` from the `intl` extension:
+
+```php
+if (grapheme_strlen($title) > 50) {
+    return $this->API_RESPONSE->failure('TITLE-TOO-LONG');
+}
+```
+
+For most practical applications `mb_strlen` is sufficient — users understand that multi-codepoint emoji "use more characters." Only use `grapheme_strlen` when the user-visible count must be exact.
+
+## Null bytes
+
+SQLite (and MySQL) TEXT columns accept null bytes. A value like `"Alice\x00Bob"` is stored and retrieved without error. PHP itself is null-byte safe in modern versions, but some library functions (file path operations, certain C extensions) treat `\x00` as a string terminator.
+
+Reject null bytes explicitly for any user-supplied string:
+
+```php
+$value = (string)($this->REQUEST_JSON['name'] ?? '');
+if (str_contains($value, "\x00")) {
+    return $this->API_RESPONSE->failure('INVALID-INPUT');
+}
+```
+
+Alternatively, strip null bytes silently if your use case treats them as noise:
+
+```php
+$value = str_replace("\x00", '', $value);
+```
+
+## LIKE search with non-ASCII
+
+LIKE pattern matching is case-insensitive for ASCII but case-sensitive for non-ASCII in most MySQL collations. For Japanese, MySQL's `utf8mb4_unicode_ci` collation handles case folding for Latin characters; Hiragana/Katakana are treated as distinct.
+
+For a multilingual search box, test with the actual target collation (`utf8mb4_unicode_ci` is the NeNe default).
+
+## Common validation snippet
+
+A reusable pattern for validated string inputs:
+
+```php
+/**
+ * Validate and clean a user-supplied UTF-8 string.
+ *
+ * @return string|null Cleaned string, or null if validation fails.
+ */
+private function validateString(mixed $raw, int $maxChars): ?string
+{
+    if (!is_string($raw)) {
+        return null;
+    }
+    $value = trim($raw);
+    if ($value === '' || str_contains($value, "\x00")) {
+        return null;
+    }
+    if (mb_strlen($value, 'UTF-8') > $maxChars) {
+        return null;
+    }
+    return $value;
+}
+```
+
+## Related
+
+- `docs/development/sql-injection.md` — SQL injection defense including LIKE wildcard escaping
+- `docs/tutorials/building-a-service.md` — controller and mapper patterns

--- a/docs/development/waitlist-queue.md
+++ b/docs/development/waitlist-queue.md
@@ -1,0 +1,206 @@
+# Waitlist / FIFO Queue
+
+How to implement a FIFO waitlist where users join named queues and are served in order. Position is derived (never stored), and the history is preserved via soft-status.
+
+## The position-derivation pattern
+
+**Do not store a position number.** Stored positions become stale the moment any entry ahead of the target is served or leaves. Instead, compute position on demand:
+
+```sql
+SELECT COUNT(*) AS position
+FROM waitlist_entries
+WHERE queue = :queue
+  AND status = 'waiting'
+  AND joined_at <= :target_joined_at
+```
+
+This returns the user's 1-based ordinal position. The result is always accurate without any update cascade.
+
+## Schema
+
+```php
+// class/xion/SchemaDefinition.php
+
+'waitlist_entries' => [
+    'columns' => [
+        'id'        => ['type' => 'pk-bigint'],
+        'created_at'=> ['type' => 'datetime-now'],
+        'updated_at'=> ['type' => 'datetime-touch'],
+        'queue'     => ['type' => 'varchar:128'],      // named queue identifier
+        'user_id'   => ['type' => 'bigint'],
+        'status'    => ['type' => 'varchar:16'],        // waiting | served | left
+        'note'      => ['type' => 'text'],
+        'joined_at' => ['type' => 'varchar:19'],        // UTC, YYYY-MM-DD HH:MM:SS
+    ],
+    'unique' => [
+        // One entry per (queue, user_id) across all statuses
+        'waitlist_queue_user_unique' => ['queue', 'user_id'],
+    ],
+    'indexes' => [
+        'waitlist_queue_status_index' => ['queue', 'status'],
+    ],
+],
+```
+
+## Mapper
+
+```php
+// class/db/WaitlistMapper.php
+
+class WaitlistMapper extends \Nene\Xion\DataMapperBase
+{
+    const TARGET_TABLE = 'waitlist_entries';
+    const KEY_SID      = 'id';
+
+    /** @return array|null null = already in queue (409) */
+    public function join(string $queue, int $userId, string $note = ''): ?array
+    {
+        $joinedAt = (new \DateTime())->format('Y-m-d H:i:s');
+        $stmt = $this->DB->prepare('
+            INSERT INTO ' . static::TARGET_TABLE . ' (queue, user_id, status, note, joined_at)
+            VALUES (:queue, :uid, :status, :note, :joined)
+        ');
+        $stmt->bindValue(':queue',  $queue,    PDO::PARAM_STR);
+        $stmt->bindValue(':uid',    $userId,   PDO::PARAM_INT);
+        $stmt->bindValue(':status', 'waiting', PDO::PARAM_STR);
+        $stmt->bindValue(':note',   $note,     PDO::PARAM_STR);
+        $stmt->bindValue(':joined', $joinedAt, PDO::PARAM_STR);
+        try {
+            $this->execute($stmt);
+        } catch (\PDOException $e) {
+            if (str_starts_with((string)$e->getCode(), '23')) { // constraint violation
+                return null; // caller maps to 409
+            }
+            throw $e;
+        }
+
+        $id  = (int)$this->DB->lastInsertId();
+        $row = $this->findRowById($id);
+        $row['position'] = $this->computePosition($queue, $joinedAt);
+        return $row;
+    }
+
+    /** @return list<array<string, mixed>> entries in FIFO order with sequential position */
+    public function listWaiting(string $queue): array
+    {
+        $stmt = $this->DB->prepare('
+            SELECT * FROM ' . static::TARGET_TABLE . '
+            WHERE queue = :queue AND status = :status
+            ORDER BY joined_at ASC
+        ');
+        $stmt->bindValue(':queue',  $queue,    PDO::PARAM_STR);
+        $stmt->bindValue(':status', 'waiting', PDO::PARAM_STR);
+        $rows = $this->execute($stmt)->fetchAll(PDO::FETCH_ASSOC);
+        // Assign sequential positions in PHP — no N+1 queries
+        foreach ($rows as $i => &$row) {
+            $row['position'] = $i + 1;
+        }
+        unset($row);
+        return $rows;
+    }
+
+    public function getPosition(string $queue, int $userId): ?array
+    {
+        $stmt = $this->DB->prepare('
+            SELECT * FROM ' . static::TARGET_TABLE . '
+            WHERE queue = :queue AND user_id = :uid AND status = :status
+            LIMIT 1
+        ');
+        $stmt->bindValue(':queue',  $queue,    PDO::PARAM_STR);
+        $stmt->bindValue(':uid',    $userId,   PDO::PARAM_INT);
+        $stmt->bindValue(':status', 'waiting', PDO::PARAM_STR);
+        $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+        if (!is_array($row)) {
+            return null;
+        }
+        $row['position'] = $this->computePosition($queue, $row['joined_at']);
+        return $row;
+    }
+
+    /** Serve the first waiting entry; returns the served row or null if queue is empty */
+    public function advance(string $queue): ?array
+    {
+        $transaction = new \Nene\Xion\TransactionManager();
+        return $transaction->run(function () use ($queue): ?array {
+            $stmt = $this->DB->prepare('
+                SELECT * FROM ' . static::TARGET_TABLE . '
+                WHERE queue = :queue AND status = :status
+                ORDER BY joined_at ASC
+                LIMIT 1
+                FOR UPDATE
+            ');
+            $stmt->bindValue(':queue',  $queue,    PDO::PARAM_STR);
+            $stmt->bindValue(':status', 'waiting', PDO::PARAM_STR);
+            $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+            if (!is_array($row)) {
+                return null; // empty queue
+            }
+
+            $upd = $this->DB->prepare('
+                UPDATE ' . static::TARGET_TABLE . ' SET status = :served WHERE id = :id
+            ');
+            $upd->bindValue(':served', 'served', PDO::PARAM_STR);
+            $upd->bindValue(':id',     $row['id'], PDO::PARAM_INT);
+            $this->execute($upd);
+
+            return $this->findRowById((int)$row['id']);
+        });
+    }
+
+    public function leave(string $queue, int $userId): bool
+    {
+        $stmt = $this->DB->prepare('
+            UPDATE ' . static::TARGET_TABLE . '
+            SET status = :left
+            WHERE queue = :queue AND user_id = :uid AND status = :waiting
+        ');
+        $stmt->bindValue(':left',    'left',    PDO::PARAM_STR);
+        $stmt->bindValue(':queue',   $queue,    PDO::PARAM_STR);
+        $stmt->bindValue(':uid',     $userId,   PDO::PARAM_INT);
+        $stmt->bindValue(':waiting', 'waiting', PDO::PARAM_STR);
+        $affected = $this->execute($stmt)->rowCount();
+        return $affected > 0;
+    }
+
+    private function computePosition(string $queue, string $joinedAt): int
+    {
+        $stmt = $this->DB->prepare('
+            SELECT COUNT(*) AS pos FROM ' . static::TARGET_TABLE . '
+            WHERE queue = :queue AND status = :status AND joined_at <= :joined
+        ');
+        $stmt->bindValue(':queue',  $queue,    PDO::PARAM_STR);
+        $stmt->bindValue(':status', 'waiting', PDO::PARAM_STR);
+        $stmt->bindValue(':joined', $joinedAt, PDO::PARAM_STR);
+        $row = $this->execute($stmt)->fetch(PDO::FETCH_ASSOC);
+        return (int)($row['pos'] ?? 1);
+    }
+}
+```
+
+> **SQLite note:** `FOR UPDATE` is MySQL only. For SQLite, use `BEGIN EXCLUSIVE` (`$this->DB->exec('BEGIN EXCLUSIVE')`) or rely on SQLite's file-level locking.
+
+## Error codes
+
+```php
+// config/error_codes.php
+'WAITLIST-ALREADY-JOINED' => ['message' => 'You are already in this queue.', 'httpStatus' => 409],
+'WAITLIST-NOT-IN-QUEUE'   => ['message' => 'You are not in this queue.',     'httpStatus' => 404],
+'WAITLIST-EMPTY'          => ['message' => 'The queue is empty.',             'httpStatus' => 404],
+```
+
+## Design decisions
+
+| Decision | Recommendation |
+|---|---|
+| Position storage | Derived via COUNT — never stored. Avoids stale data on concurrent exits. |
+| Soft-status model | Rows are never deleted. `status IN ('waiting', 'served', 'left')` preserves history. |
+| Re-join after leaving | Not supported with soft-status + UNIQUE constraint. Remove the UNIQUE or add application-layer logic if re-join is required. |
+| Position in list response | Assign sequentially in PHP after ORDER BY `joined_at ASC` — avoids N+1. |
+| Concurrent advance | `FOR UPDATE` (MySQL) or `BEGIN EXCLUSIVE` (SQLite) prevents two `advance` calls serving the same entry. |
+| Empty queue | `advance` returns `null` → 404, not 409. There is nothing wrong with the request; the queue is just empty. |
+
+## Related
+
+- `docs/development/booking-systems.md` — capacity check with SELECT FOR UPDATE
+- `docs/development/state-machines.md` — status transition patterns
+- `docs/development/ledger-systems.md` — idempotency key / UNIQUE constraint patterns

--- a/docs/field-trials/2026-05-field-trial-23.md
+++ b/docs/field-trials/2026-05-field-trial-23.md
@@ -1,0 +1,101 @@
+# Field Trial 23 — NENE2 Pattern Survey
+
+**Date:** 2026-05-27
+**Theme:** Survey NENE2 FT80–99 findings and port all applicable patterns into NeNe documentation and code
+**Source:** `/home/xi/docker/NENE2/docs/field-trials/` (FT80–FT99)
+**PR:** #455
+
+---
+
+## What was done
+
+A systematic review of 20 NENE2 field trials (FT80–FT99) was conducted to extract patterns applicable to NeNe. NENE2 is a separate PHP framework that runs similar field trials; its findings on security, data modeling, and API design patterns translate directly.
+
+From the review, 23 candidate ideas were identified. All were incorporated into NeNe in this trial:
+
+**Code fix (1):**
+- `class/xion/JsonResponder.php` — added `JSON_UNESCAPED_UNICODE` so Japanese, emoji, and other non-ASCII characters appear as-is in API responses instead of `\uXXXX` escape sequences. (Source: NENE2 general pattern)
+
+**New documentation (19 files in `docs/development/`):**
+
+| File | Pattern | Source FT |
+|---|---|---|
+| `idor-prevention.md` | SQL-level ownership enforcement; 404 not 403 | FT94 |
+| `sql-injection.md` | Parameterized queries; LIKE escaping; ORDER BY allowlist | FT94 |
+| `unicode-validation.md` | `mb_strlen` vs `strlen`; null-byte; `grapheme_strlen` | FT94 |
+| `optimistic-locking.md` | ETag/If-Match; version column; 412/428 | FT93 |
+| `ledger-systems.md` | Append-only; COALESCE SUM; idempotency key | FT83 |
+| `state-machines.md` | WorkflowDefinition; transitions table; allowed_next | FT87 |
+| `temporal-data.md` | effective_from/effective_to; NULL open-ended; auto-close | FT80 |
+| `booking-systems.md` | UNIQUE constraint; SELECT FOR UPDATE; conditional INSERT | FT79 |
+| `feature-flags.md` | Global default + per-user override; Redis caching | FT98 |
+| `cors-and-csrf.md` | CORS ≠ CSRF; Bearer is CSRF-immune | FT92 |
+| `timezone-handling.md` | Store UTC; IANA `listIdentifiers()` validation; DST handling | FT95 |
+| `invitation-tokens.md` | Random code generation; pending/claimed/revoked; expiry | FT85 |
+| `waitlist-queue.md` | FIFO; derived position via COUNT; soft-status | FT84 |
+| `many-to-many.md` | Join table; EXISTS filter; idempotent add; cascade delete | FT88 |
+| `reactions.md` | Toggle semantics; polymorphic target_type; UNIQUE as key | FT89 |
+| `ratings.md` | Upsert try-INSERT/catch; aggregated summary; distribution | FT82 |
+| `session-tracking.md` | Token-based session table; heartbeat; revokeAll; rowCount | FT86 |
+| `rate-limiting.md` | Redis INCR+EXPIRE; key strategies; Retry-After; Lua atomic | gap (not in NENE2) |
+| `json-only-api.md` | Accept header behavior; json_encode([]) pitfall; non-ASCII | FT96 |
+
+**Enhanced documentation (1 file):**
+- `docs/development/agent-bearer-auth.md` — added "JWT-based Bearer auth" section with edge cases table: `alg:none` attack, `exp` validation, `hash_equals`, IDOR via `sub` claim (source: FT94)
+
+---
+
+## Findings
+
+### F-1 — `JSON_UNESCAPED_UNICODE` was missing from JsonResponder (medium)
+
+**Symptom:** API responses containing Japanese text or emoji returned `\uXXXX` escape sequences instead of the actual characters.
+
+```json
+// Before
+{ "name": "田中太郎" }
+
+// After
+{ "name": "田中太郎" }
+```
+
+**Fix:** Added `JSON_UNESCAPED_UNICODE` to `JsonResponder::encode()`.
+
+**Note:** `View::encodeScriptJson()` was intentionally not changed — script-context JSON embedding requires XSS-safe escaping and should keep `JSON_HEX_TAG`.
+
+### F-2 — IANA timezone validation needs `listIdentifiers()` membership check (medium, documented)
+
+PHP's `DateTimeZone` constructor silently accepts non-IANA abbreviations like `"EST"`. `new DateTimeZone('EST')` succeeds without exception, but `"EST"` is not in `DateTimeZone::listIdentifiers()`. Validation that only uses `try/catch` passes invalid abbreviations.
+
+**Fix documented in `timezone-handling.md`:** Always validate with `in_array($tz, DateTimeZone::listIdentifiers(), true)`.
+
+### F-3 — `json_encode([])` produces `[]` not `{}` — pitfall in tests (low, documented)
+
+PHP's `json_encode([])` returns a JSON array `[]`, not an empty object `{}`. Sending `[]` as a request body to NeNe controllers that read `$this->REQUEST_JSON['field']` causes unexpected behavior or 400 errors.
+
+**Fix documented in `json-only-api.md`:** Send `new \stdClass()` or an object with unrelated fields when testing "no body" scenarios.
+
+### F-4 — Rate limiting is a documented gap (low, new doc)
+
+No rate-limiting middleware exists in NeNe (or NENE2). The pattern was documented from first principles in `rate-limiting.md` using Redis INCR+EXPIRE, matching NeNe's existing Redis dependency.
+
+---
+
+## Results
+
+| Artifact | Count |
+|---|---|
+| PHP files modified | 1 |
+| Documentation files created | 19 |
+| Documentation files enhanced | 1 |
+| Source FTs surveyed | 20 (FT80–FT99) |
+| Candidate ideas extracted | 23 |
+| Ideas incorporated | 23 (100%) |
+
+---
+
+## Related
+
+- Source: `/home/xi/docker/NENE2/docs/field-trials/` (FT80–FT99)
+- PR: #455
+- Preceding trial: FT22 (ai-agent-journey) → found doc gaps → many of these docs address those gaps

--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -76,6 +76,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT23 — NENE2 pattern survey** (2026-05-27): systematic review of NENE2 FT80–99; 1 code fix (`JSON_UNESCAPED_UNICODE`), 19 new docs, 1 enhanced doc. PR #455.
 - **FT22 — ai-agent-journey** (2026-05-27): clean subagent built `bookmarks` REST service end-to-end using only docs. 5 doc gaps found (F-1/F-5 fixed immediately, F-2/F-3/F-4 deferred as Issues #446-#450). PR #451.
 - **FT21 — DataMapperBase test補強** (2026-05-27): 20 unit tests for `execute()` / `executeQuery()` / `decorate()` / `assoc()` / `KEY_SID` / `getTableColumn()` / `getSearchARRAY()`. Mock PDO/PDOStatement; no real DB. PR #444.
 - **ADR-0012 — PHP version policy** (2026-05-27): \`"php": ">=8.4"\` declared; upgrade cadence documented. PR #442.


### PR DESCRIPTION
## Summary

Systematic survey of NENE2 FT80–99 (20 field trials). All 23 applicable patterns incorporated into NeNe.

### Code fix

- **`class/xion/JsonResponder.php`** — add `JSON_UNESCAPED_UNICODE` so Japanese, emoji, and other non-ASCII characters appear as-is in API responses instead of `\uXXXX` sequences. `View::encodeScriptJson()` intentionally unchanged (XSS-safe escaping required in `<script>` context).

### New documentation (19 files)

| File | Pattern |
|---|---|
| `idor-prevention.md` | SQL-level ownership; 404 not 403 |
| `sql-injection.md` | Parameterized queries; LIKE escaping; ORDER BY allowlist |
| `unicode-validation.md` | `mb_strlen`; null-byte; `grapheme_strlen` |
| `optimistic-locking.md` | ETag/If-Match; version column; 412/428 |
| `ledger-systems.md` | Append-only; COALESCE SUM; idempotency key |
| `state-machines.md` | WorkflowDefinition; transitions table; allowed_next |
| `temporal-data.md` | effective_from/effective_to; NULL open-ended; auto-close |
| `booking-systems.md` | UNIQUE constraint; SELECT FOR UPDATE; conditional INSERT |
| `feature-flags.md` | Global + per-user override; Redis caching |
| `cors-and-csrf.md` | CORS ≠ CSRF; Bearer is CSRF-immune |
| `timezone-handling.md` | Store UTC; IANA listIdentifiers(); DST edge cases |
| `invitation-tokens.md` | Random code; pending/claimed/revoked; expiry |
| `waitlist-queue.md` | FIFO; derived position via COUNT; soft-status |
| `many-to-many.md` | Join table; EXISTS filter; cascade delete |
| `reactions.md` | Toggle; polymorphic target_type; UNIQUE as key |
| `ratings.md` | Upsert try-INSERT/catch; summary with distribution |
| `session-tracking.md` | Token table; heartbeat; revokeAll; rowCount |
| `rate-limiting.md` | Redis INCR+EXPIRE; key strategies; Retry-After |
| `json-only-api.md` | Accept header behavior; json_encode([]) pitfall |

### Enhanced documentation (1 file)

- **`agent-bearer-auth.md`** — added "JWT-based Bearer auth" section: `alg:none` attack, `exp` required, `hash_equals`, IDOR via `sub` claim.

### Field trial report

- `docs/field-trials/2026-05-field-trial-23.md` — FT23 report

### Key findings

- **F-1 (code fix):** `JSON_UNESCAPED_UNICODE` was missing — Japanese/emoji was `\uXXXX` in all API responses
- **F-2 (documented):** PHP's `DateTimeZone` constructor silently accepts non-IANA abbreviations like `"EST"` — need `listIdentifiers()` membership check
- **F-3 (documented):** `json_encode([])` → `[]` not `{}` — pitfall when sending "no body" in tests
- **F-4 (new doc):** Rate limiting is a documented gap; added Redis INCR+EXPIRE pattern

## Checklist

- [x] Tests pass (`make test`)
- [x] PHP syntax check (`php -l class/xion/JsonResponder.php`)
- [x] Field trial report written (`docs/field-trials/2026-05-field-trial-23.md`)
- [x] Candidates backlog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
