### PR TITLE
feat(rate-limiting): RateLimiter + RateLimiterStorageInterface + RedisRateLimiterStorage (#FT28)

### DIFF
--- a/class/func/RateLimiter.php
+++ b/class/func/RateLimiter.php
@@ -35,7 +35,9 @@ use Nene\Xion\JsonResponder;
  */
 final class RateLimiter
 {
-    public function __construct(private readonly RateLimiterStorageInterface $storage) {}
+    public function __construct(private readonly RateLimiterStorageInterface $storage)
+    {
+    }
 
     /**
      * Check the rate limit for a key.

--- a/class/func/RateLimiter.php
+++ b/class/func/RateLimiter.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Func;
+
+use Nene\Xion\HttpTermination;
+use Nene\Xion\JsonResponder;
+
+/**
+ * Fixed-window rate limiter.
+ *
+ * Uses a storage backend (typically Redis) to count requests per key
+ * within a sliding window. Designed to be called from `preAction()`
+ * or at the start of a REST method.
+ *
+ * ## Typical usage
+ *
+ * ```php
+ * protected function preAction(): void
+ * {
+ *     $redis   = \Nene\Xion\RedisConnection::getInstance();
+ *     $storage = new RedisRateLimiterStorage($redis);
+ *     $limiter = new RateLimiter($storage);
+ *     $limiter->check(
+ *         key: 'login:ip:' . ($_SERVER['REMOTE_ADDR'] ?? 'unknown'),
+ *         limit: 10,
+ *         windowSeconds: 60
+ *     );
+ * }
+ * ```
+ *
+ * `check()` throws `HttpTermination(429)` with `Retry-After` header if exceeded.
+ * On success it sets the `X-RateLimit-*` response headers.
+ */
+final class RateLimiter
+{
+    public function __construct(private readonly RateLimiterStorageInterface $storage) {}
+
+    /**
+     * Check the rate limit for a key.
+     *
+     * Sets `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
+     * headers on every request.
+     *
+     * Throws `HttpTermination(429)` with `Retry-After: N` when exceeded.
+     *
+     * @param string $key           Unique bucket key.
+     * @param int    $limit         Maximum requests allowed in the window.
+     * @param int    $windowSeconds Window duration in seconds.
+     *
+     * @return void
+     */
+    public function check(string $key, int $limit, int $windowSeconds): void
+    {
+        $count     = $this->storage->increment($key, $windowSeconds);
+        $remaining = max(0, $limit - $count);
+        $ttl       = $this->storage->ttl($key);
+
+        header('X-RateLimit-Limit: ' . $limit);
+        header('X-RateLimit-Remaining: ' . $remaining);
+        header('X-RateLimit-Reset: ' . $ttl);
+
+        if ($count > $limit) {
+            header('Retry-After: ' . $ttl);
+            throw new HttpTermination(
+                JsonResponder::response(
+                    ['Result' => false, 'Data' => [
+                        'status'       => 'failure',
+                        'errorCode'    => 'RATE-LIMIT-EXCEEDED',
+                        'errorMessage' => 'Too many requests. Please retry after ' . $ttl . ' seconds.',
+                    ]],
+                    429
+                )
+            );
+        }
+    }
+
+    /**
+     * Peek at the current count for a key without incrementing.
+     *
+     * @param string $key   Bucket key.
+     * @param int    $limit Maximum allowed.
+     *
+     * @return int Remaining requests (0 if already exceeded).
+     */
+    public function remaining(string $key, int $limit): int
+    {
+        return max(0, $limit - $this->storage->count($key));
+    }
+}

--- a/class/func/RateLimiterStorageInterface.php
+++ b/class/func/RateLimiterStorageInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Func;
+
+/**
+ * Storage backend for RateLimiter.
+ */
+interface RateLimiterStorageInterface
+{
+    /**
+     * Atomically increment the counter for the given key within a time window.
+     *
+     * If the key does not exist, create it with value 1 and set its TTL.
+     * If it already exists, increment and return the new value.
+     *
+     * @param string $key           Bucket key (e.g. "login:ip:1.2.3.4").
+     * @param int    $windowSeconds Window duration in seconds.
+     *
+     * @return int New counter value after increment.
+     */
+    public function increment(string $key, int $windowSeconds): int;
+
+    /**
+     * Return remaining TTL of the key in seconds, or 0 if key does not exist.
+     */
+    public function ttl(string $key): int;
+
+    /**
+     * Get the current counter value without incrementing, or 0 if absent.
+     */
+    public function count(string $key): int;
+}

--- a/class/func/RedisRateLimiterStorage.php
+++ b/class/func/RedisRateLimiterStorage.php
@@ -14,7 +14,9 @@ use Predis\Client;
  */
 final class RedisRateLimiterStorage implements RateLimiterStorageInterface
 {
-    public function __construct(private readonly Client $redis) {}
+    public function __construct(private readonly Client $redis)
+    {
+    }
 
     public function increment(string $key, int $windowSeconds): int
     {

--- a/class/func/RedisRateLimiterStorage.php
+++ b/class/func/RedisRateLimiterStorage.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Func;
+
+use Predis\Client;
+
+/**
+ * Redis-backed rate limiter storage using INCR + EXPIRE.
+ *
+ * IMPORTANT: PHP-FPM workers share this state via Redis. Do NOT use
+ * ArrayRateLimiterStorage in production.
+ */
+final class RedisRateLimiterStorage implements RateLimiterStorageInterface
+{
+    public function __construct(private readonly Client $redis) {}
+
+    public function increment(string $key, int $windowSeconds): int
+    {
+        $count = (int)$this->redis->incr($key);
+        if ($count === 1) {
+            $this->redis->expire($key, $windowSeconds);
+        }
+        return $count;
+    }
+
+    public function ttl(string $key): int
+    {
+        return max(0, (int)$this->redis->ttl($key));
+    }
+
+    public function count(string $key): int
+    {
+        return (int)($this->redis->get($key) ?? 0);
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cafe7f10cdc595ab0e7bf7fde290d9d",
+    "content-hash": "a1cc21bf99e0bf98d3529d4656b1c068",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -5771,7 +5771,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.4"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"
 }

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -55,8 +55,72 @@ return [
         'message' => 'Upload mime type is not allowed.',
         'httpStatus' => 415,
     ],
+    'ACCOUNT-LOCKED' => [
+        'message' => 'Account is locked due to too many failed login attempts.',
+        'httpStatus' => 423,
+    ],
+    'BATCH-ITEM-FAILED' => [
+        'message' => 'One or more batch items failed.',
+        'httpStatus' => 422,
+    ],
+    'BATCH-TOO-LARGE' => [
+        'message' => 'Batch request exceeds the maximum number of items.',
+        'httpStatus' => 400,
+    ],
+    'CIRCUIT-OPEN' => [
+        'message' => 'The downstream service is temporarily unavailable.',
+        'httpStatus' => 503,
+    ],
+    'CONFLICT' => [
+        'message' => 'A conflicting operation is already in progress.',
+        'httpStatus' => 409,
+    ],
+    'FORBIDDEN' => [
+        'message' => 'You do not have permission to perform this action.',
+        'httpStatus' => 403,
+    ],
+    'INVALID-TRANSITION' => [
+        'message' => 'The requested state transition is not allowed.',
+        'httpStatus' => 409,
+    ],
+    'JWT-INVALID' => [
+        'message' => 'The JWT token is invalid or expired.',
+        'httpStatus' => 401,
+    ],
+    'PRECONDITION-FAILED' => [
+        'message' => 'The resource was modified by another request. Fetch the latest version and retry.',
+        'httpStatus' => 412,
+    ],
+    'PRECONDITION-REQUIRED' => [
+        'message' => 'If-Match header is required for this operation.',
+        'httpStatus' => 428,
+    ],
     'RATE-LIMIT-EXCEEDED' => [
         'message' => 'Too many requests. Please try again later.',
         'httpStatus' => 429,
+    ],
+    'SIGNED-URL-EXPIRED' => [
+        'message' => 'The signed URL has expired.',
+        'httpStatus' => 410,
+    ],
+    'SIGNED-URL-INVALID' => [
+        'message' => 'The signed URL is invalid.',
+        'httpStatus' => 403,
+    ],
+    'TOKEN-ALREADY-USED' => [
+        'message' => 'The reset token has already been used.',
+        'httpStatus' => 409,
+    ],
+    'TOKEN-EXPIRED' => [
+        'message' => 'The reset token has expired.',
+        'httpStatus' => 410,
+    ],
+    'VALIDATION-FAILED' => [
+        'message' => 'One or more input fields failed validation.',
+        'httpStatus' => 422,
+    ],
+    'WEBHOOK-SIGNATURE-INVALID' => [
+        'message' => 'Webhook signature is invalid or stale.',
+        'httpStatus' => 401,
     ],
 ];

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -55,4 +55,8 @@ return [
         'message' => 'Upload mime type is not allowed.',
         'httpStatus' => 415,
     ],
+    'RATE-LIMIT-EXCEEDED' => [
+        'message' => 'Too many requests. Please try again later.',
+        'httpStatus' => 429,
+    ],
 ];

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -38,7 +38,23 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
 | `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
 | `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
+| `ACCOUNT-LOCKED` | 423 | Account is locked due to too many failed login attempts. | Returned by login endpoints when `LoginAttemptTracker::isLocked()` is true. Cleared by `reset()` after successful authentication or by an admin SQL update. |
+| `BATCH-ITEM-FAILED` | 422 | One or more batch items failed. | Recorded per-item in `BatchResult::addFailure()` when a single batch item cannot be processed; the overall response may be 207 (partial) or 422 (all failed). |
+| `BATCH-TOO-LARGE` | 400 | Batch request exceeds the maximum number of items. | Returned by batch endpoints when the input array exceeds the configured per-endpoint maximum (guard with `BATCH-TOO-LARGE` before the loop). |
+| `CIRCUIT-OPEN` | 503 | The downstream service is temporarily unavailable. | Returned when a `CircuitBreaker` is in the OPEN state and the caller should not attempt the downstream call. See `docs/development/circuit-breaker.md`. |
+| `CONFLICT` | 409 | A conflicting operation is already in progress. | Reserved for operations where a second request conflicts with one already underway (e.g. duplicate idempotency key). |
+| `FORBIDDEN` | 403 | You do not have permission to perform this action. | Returned by `RoleGuard::require()` / `requireAny()` when the JWT `role` claim does not satisfy the endpoint's role requirement. |
+| `INVALID-TRANSITION` | 409 | The requested state transition is not allowed. | Thrown by `WorkflowDefinition::assertTransition()` when the `from → to` state pair is not in the workflow's allowed-transitions map. |
+| `JWT-INVALID` | 401 | The JWT token is invalid or expired. | Thrown by `JwtCodec::require()` when the `Authorization: Bearer` header is absent, the token is malformed, the signature is wrong, the token has expired, or the algorithm is not HS256. |
+| `PRECONDITION-FAILED` | 412 | The resource was modified by another request. Fetch the latest version and retry. | Thrown by `OptimisticLock::conflict()` when a conditional UPDATE affects zero rows, indicating a concurrent writer incremented the version. |
+| `PRECONDITION-REQUIRED` | 428 | If-Match header is required for this operation. | Thrown by `OptimisticLock::requireVersion()` when a conditional write is attempted without an `If-Match` header (RFC 9110 §13.1). |
 | `RATE-LIMIT-EXCEEDED` | 429 | Too many requests. Please try again later. | Thrown by `RateLimiter::check()` when the per-key counter exceeds the configured limit within the current window. Response includes `Retry-After` header. |
+| `SIGNED-URL-EXPIRED` | 410 | The signed URL has expired. | Thrown by `SignedUrl::requireValid()` when the `expires` timestamp is in the past. |
+| `SIGNED-URL-INVALID` | 403 | The signed URL is invalid. | Thrown by `SignedUrl::requireValid()` when the signature does not match or required parameters are missing. |
+| `TOKEN-ALREADY-USED` | 409 | The reset token has already been used. | Returned by password-reset complete endpoint when `used_at` is not null. |
+| `TOKEN-EXPIRED` | 410 | The reset token has expired. | Returned by password-reset complete endpoint when `PasswordResetToken::isExpired()` is true. |
+| `VALIDATION-FAILED` | 422 | One or more input fields failed validation. | Returned by controllers using `Nene\Func\Validator` when `$v->passes()` returns false. Use `$v->errors()` or `$v->firstErrors()` to include field-level detail in the response body. |
+| `WEBHOOK-SIGNATURE-INVALID` | 401 | Webhook signature is invalid or stale. | Returned when inbound `X-Webhook-Signature` header is missing, malformed, or fails HMAC verification. See `docs/development/webhook-signing.md`. |
 
 ## Adding a new error code
 

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -38,6 +38,7 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
 | `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
 | `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
+| `RATE-LIMIT-EXCEEDED` | 429 | Too many requests. Please try again later. | Thrown by `RateLimiter::check()` when the per-key counter exceeds the configured limit within the current window. Response includes `Retry-After` header. |
 
 ## Adding a new error code
 

--- a/docs/development/rate-limiting.md
+++ b/docs/development/rate-limiting.md
@@ -1,6 +1,38 @@
 # Rate Limiting
 
-How to add request rate limiting to NeNe endpoints using Redis (already available via `predis/predis`). NeNe does not ship a built-in rate-limiting middleware — this guide shows how to add it.
+How to add request rate limiting to NeNe endpoints using the built-in `RateLimiter` class (backed by Redis via `predis/predis`).
+
+## Framework class: `RateLimiter`
+
+`Nene\Func\RateLimiter` and `Nene\Func\RedisRateLimiterStorage` are built-in.
+Add `predis/predis` to your project if not already present (it ships with NeNe).
+
+### Typical usage
+
+```php
+use Nene\Func\RateLimiter;
+use Nene\Func\RedisRateLimiterStorage;
+use Nene\Xion\RedisConnection;
+
+protected function preAction(): void
+{
+    $storage = new RedisRateLimiterStorage(RedisConnection::getInstance());
+    $limiter = new RateLimiter($storage);
+    $limiter->check(
+        key: 'login:ip:' . ($_SERVER['REMOTE_ADDR'] ?? 'unknown'),
+        limit: 10,
+        windowSeconds: 60
+    );
+}
+```
+
+`check()` throws `HttpTermination(429)` with a `Retry-After` header when the limit is exceeded. On every request it also sets `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers. No further action is needed in the controller — the framework catches `HttpTermination` and emits the response automatically.
+
+To inspect the remaining quota without consuming a request, use `remaining()`:
+
+```php
+$left = $limiter->remaining('login:ip:' . $ip, 10);
+```
 
 ## When to add rate limiting
 
@@ -12,83 +44,38 @@ How to add request rate limiting to NeNe endpoints using Redis (already availabl
 | API endpoints (general) | Abuse / scraping | Optional — depends on traffic |
 | Internal admin endpoints | Lower risk | Low priority |
 
-## The sliding window counter pattern
+## The fixed-window counter pattern
 
-The simplest Redis-based approach uses a per-key counter with a TTL:
+`RateLimiter` uses a fixed-window counter backed by Redis:
 
 1. `INCR key` — atomically increment the counter and get the new value.
-2. If the returned value is 1 (first request), set the key TTL with `EXPIRE key <window_seconds>`.
-3. If the counter exceeds the limit, return 429.
+2. If the returned value is 1 (first request in the window), set the key TTL with `EXPIRE key <window_seconds>`.
+3. If the counter exceeds the limit, throw `HttpTermination(429)` with `Retry-After`.
 
-```php
-// class/func/RateLimiter.php
-
-namespace Nene\Func;
-
-use Predis\Client;
-
-final class RateLimiter
-{
-    private Client $redis;
-
-    public function __construct(Client $redis)
-    {
-        $this->redis = $redis;
-    }
-
-    /**
-     * Check if the given key is within the allowed rate.
-     *
-     * @param string $key      Unique identifier (e.g. "login:ip:1.2.3.4")
-     * @param int    $limit    Max requests allowed within the window
-     * @param int    $window   Window duration in seconds
-     * @return bool  true = allowed, false = rate limit exceeded
-     */
-    public function allow(string $key, int $limit, int $window): bool
-    {
-        $count = (int)$this->redis->incr($key);
-        if ($count === 1) {
-            $this->redis->expire($key, $window);
-        }
-        return $count <= $limit;
-    }
-
-    /** Remaining requests in the current window */
-    public function remaining(string $key, int $limit): int
-    {
-        $count = (int)($this->redis->get($key) ?? 0);
-        return max(0, $limit - $count);
-    }
-
-    /** Seconds until the current window resets */
-    public function ttl(string $key): int
-    {
-        return max(0, (int)$this->redis->ttl($key));
-    }
-}
-```
+`RedisRateLimiterStorage` handles steps 1–2. `RateLimiter::check()` handles step 3.
 
 ## Usage in a controller
 
+Call `check()` from `preAction()` (applies to all methods in the controller) or from a specific REST method:
+
 ```php
 use Nene\Func\RateLimiter;
+use Nene\Func\RedisRateLimiterStorage;
 use Nene\Xion\RedisConnection;
 
-// POST /session/login
+// POST /session/login — 10 attempts per 15 minutes per IP
 public function indexPostRest(): array
 {
     $ip      = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
-    $limiter = new RateLimiter(RedisConnection::getInstance());
-    $key     = 'rate:login:ip:' . $ip;
-
-    // 10 attempts per 15 minutes per IP
-    if (!$limiter->allow($key, limit: 10, window: 900)) {
-        return $this->API_RESPONSE->failure('RATE-LIMIT-EXCEEDED');
-    }
+    $storage = new RedisRateLimiterStorage(RedisConnection::getInstance());
+    $limiter = new RateLimiter($storage);
+    $limiter->check('rate:login:ip:' . $ip, limit: 10, windowSeconds: 900);
 
     // ... verify credentials ...
 }
 ```
+
+If the limit is exceeded, `check()` terminates the request with a 429 JSON response before reaching your credential logic.
 
 ## Rate limit key strategies
 
@@ -112,33 +99,27 @@ Namespace keys with `rate:` to distinguish from session and feature-flag keys in
 
 ## Response headers
 
-Include `Retry-After` and rate limit headers in 429 responses to help clients back off correctly:
+`RateLimiter::check()` sets these headers on every request (not just 429):
 
-```php
-if (!$limiter->allow($key, 10, 900)) {
-    $retryAfter = $limiter->ttl($key);
-    header('Retry-After: ' . $retryAfter);
-    header('X-RateLimit-Limit: 10');
-    header('X-RateLimit-Remaining: 0');
-    header('X-RateLimit-Reset: ' . (time() + $retryAfter));
-    return $this->API_RESPONSE->failure('RATE-LIMIT-EXCEEDED');
-}
-```
+| Header | Value |
+|---|---|
+| `X-RateLimit-Limit` | The configured `$limit` |
+| `X-RateLimit-Remaining` | Remaining requests in the current window (0 if exceeded) |
+| `X-RateLimit-Reset` | Seconds until the window resets |
+
+On a 429 response, `Retry-After` is also set to the same TTL value so clients can back off correctly. No manual header management is required — `check()` handles all of this before throwing.
 
 ## Error code
 
-```php
-// config/error_codes.php
-'RATE-LIMIT-EXCEEDED' => ['message' => 'Too many requests. Please try again later.', 'httpStatus' => 429],
-```
+`RATE-LIMIT-EXCEEDED` (HTTP 429) is already registered in `config/error_codes.php`. No action needed — `RateLimiter::check()` uses it automatically.
 
 ## RedisConnection
 
 NeNe already has `class/xion/RedisConnection.php` (singleton Predis client). Check the connection uses the same Redis instance as session storage. The rate limiter keys live alongside session keys — use distinct prefixes to avoid collisions.
 
 ```php
-$redis = \Nene\Xion\RedisConnection::getInstance();
-$limiter = new RateLimiter($redis);
+$storage = new \Nene\Func\RedisRateLimiterStorage(\Nene\Xion\RedisConnection::getInstance());
+$limiter = new \Nene\Func\RateLimiter($storage);
 ```
 
 ## Limitations of the simple INCR pattern

--- a/docs/field-trials/2026-05-field-trial-28.md
+++ b/docs/field-trials/2026-05-field-trial-28.md
@@ -1,0 +1,43 @@
+# Field Trial 28 — Rate Limiting 実装
+
+**Date:** 2026-05-27
+**Theme:** `RateLimiter` + `RateLimiterStorageInterface` + `RedisRateLimiterStorage` 実装
+**Source:** NENE2 FT46 (ratelimitlog), FT73 (quotalog), FT107 (throttlelog)
+
+---
+
+## What was done
+
+- `class/func/RateLimiterStorageInterface.php` — storage 抽象インターフェース
+- `class/func/RedisRateLimiterStorage.php` — Predis 実装（INCR + EXPIRE）
+- `class/func/RateLimiter.php` — 固定ウィンドウレートリミッター
+  - `check()`: 超過時 HttpTermination(429) + Retry-After ヘッダー
+  - `remaining()`: 残りリクエスト数
+- `config/error_codes.php` — `RATE-LIMIT-EXCEEDED` (429) 追加
+- `docs/development/error-codes.md` — `RATE-LIMIT-EXCEEDED` カタログ行追加（ErrorCodeTest の contract test を通すため）
+- `tests/Unit/Func/RateLimiterTest.php` — 11 テスト（インメモリストレージ使用）
+- `docs/development/rate-limiting.md` — 実際の API に合わせて全面更新
+
+---
+
+## Findings
+
+### F-1 — storage interface でテスタビリティを確保（設計）
+
+NENE2 FT107 の `InMemoryRateLimitStorage` と同様に、`RateLimiterStorageInterface` を抽出してテストを Redis 依存にしない。テストファイル内に `ArrayRateLimiterStorage` を `final class` として定義することで、production autoload に漏れ込まない。
+
+### F-2 — X-RateLimit-* ヘッダーは標準的なクライアント期待値（best practice）
+
+`X-RateLimit-Limit` / `X-RateLimit-Remaining` / `X-RateLimit-Reset` を毎回設定することで、クライアントが 429 になる前に上限を把握できる。`check()` が毎回これらを設定するため、呼び出し側での手動ヘッダー管理は不要。
+
+### F-3 — リバースプロキシ背後では REMOTE_ADDR が信頼できない（note）
+
+本番では `X-Forwarded-For` や `X-Real-IP` を使うが、プロキシが制御下にある場合のみ信頼する。`docs/development/rate-limiting.md` の key strategies セクションにすでに `$ip` 変数として抽象化されており、呼び出し側で適切な IP 取得ロジックを差し込める設計になっている。
+
+### F-4 — `headers_list()` は CLI SAPI では空を返す（テスト上の制約）
+
+`@runInSeparateProcess` は CLI SAPI での `header()` 呼び出し結果を `headers_list()` に反映しない。ヘッダー設定の網羅テストは不可能なため、「check() が例外なく完了し、storage の count が期待値になること」でヘッダーパスのコードが実行されたことを間接的に確認する設計に変更した。
+
+### F-5 — `ErrorCodeTest` の contract test が error_codes.php と error-codes.md の同期を強制
+
+新しいエラーコードを `config/error_codes.php` に追加するだけでは不十分で、`docs/development/error-codes.md` のカタログテーブルへの追加も必須であることが判明した（`tests/Unit/Xion/ErrorCodeTest::testEveryRuntimeCodeAppearsInDocsMarkdownTable` が失敗）。エラーコード追加時の手順として明示化しておく。

--- a/tests/Unit/Func/RateLimiterTest.php
+++ b/tests/Unit/Func/RateLimiterTest.php
@@ -164,7 +164,6 @@ final class RateLimiterTest extends TestCase
             ->onlyMethods(['__call'])
             ->getMock();
 
-        /** @var list<array{method: string, args: list<mixed>}> $callLog */
         $callLog = [];
         $redis->method('__call')
             ->willReturnCallback(function (string $method, array $args) use (&$callLog) {
@@ -182,8 +181,11 @@ final class RateLimiterTest extends TestCase
         $result  = $storage->increment('rate:key', 60);
 
         self::assertSame(1, $result);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
         self::assertSame('incr', $callLog[0]['method']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
         self::assertSame('expire', $callLog[1]['method']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
         self::assertSame(['rate:key', 60], $callLog[1]['args']);
     }
 

--- a/tests/Unit/Func/RateLimiterTest.php
+++ b/tests/Unit/Func/RateLimiterTest.php
@@ -164,6 +164,7 @@ final class RateLimiterTest extends TestCase
             ->onlyMethods(['__call'])
             ->getMock();
 
+        /** @var list<array{method: string, args: list<mixed>}> $callLog */
         $callLog = [];
         $redis->method('__call')
             ->willReturnCallback(function (string $method, array $args) use (&$callLog) {

--- a/tests/Unit/Func/RateLimiterTest.php
+++ b/tests/Unit/Func/RateLimiterTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Func;
+
+use Nene\Func\RateLimiter;
+use Nene\Func\RateLimiterStorageInterface;
+use Nene\Func\RedisRateLimiterStorage;
+use Nene\Xion\HttpTermination;
+use PHPUnit\Framework\TestCase;
+use Predis\Client;
+
+/**
+ * In-memory storage for testing. Lives here so it doesn't leak into production autoload.
+ */
+final class ArrayRateLimiterStorage implements RateLimiterStorageInterface
+{
+    /** @var array<string,int> */
+    private array $counts = [];
+    /** @var array<string,int> */
+    private array $ttls   = [];
+
+    public function increment(string $key, int $windowSeconds): int
+    {
+        $this->counts[$key] = ($this->counts[$key] ?? 0) + 1;
+        $this->ttls[$key]   = $windowSeconds;
+        return $this->counts[$key];
+    }
+
+    public function ttl(string $key): int
+    {
+        return $this->ttls[$key] ?? 0;
+    }
+
+    public function count(string $key): int
+    {
+        return $this->counts[$key] ?? 0;
+    }
+}
+
+final class RateLimiterTest extends TestCase
+{
+    // -------------------------------------------------------------------
+    // RateLimiter::check() — within limit
+    // -------------------------------------------------------------------
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCheckWithinLimitDoesNotThrow(): void
+    {
+        $storage = new ArrayRateLimiterStorage();
+        $limiter = new RateLimiter($storage);
+
+        // Should not throw when count (1) <= limit (5)
+        $limiter->check('test:key', 5, 60);
+
+        // If we reach here the check passed
+        self::assertTrue(true);
+    }
+
+    /**
+     * headers_list() returns an empty array under the CLI SAPI, so we cannot
+     * assert exact header values here. Instead we verify that check() completes
+     * without throwing (header emission is covered by the code path being
+     * exercised) and that the storage received the correct increment call.
+     */
+    public function testCheckSetsRateLimitHeadersWithoutThrowing(): void
+    {
+        $storage = new ArrayRateLimiterStorage();
+        $limiter = new RateLimiter($storage);
+
+        $limiter->check('test:key', 5, 60);
+
+        // count should be 1 after one check
+        self::assertSame(1, $storage->count('test:key'));
+    }
+
+    // -------------------------------------------------------------------
+    // RateLimiter::check() — exceeds limit
+    // -------------------------------------------------------------------
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCheckExceedingLimitThrowsHttpTermination(): void
+    {
+        $storage = new ArrayRateLimiterStorage();
+        $limiter = new RateLimiter($storage);
+
+        // Burn through all 3 allowed requests
+        $limiter->check('busy:key', 3, 60);
+        $limiter->check('busy:key', 3, 60);
+        $limiter->check('busy:key', 3, 60);
+
+        // 4th request must throw
+        $this->expectException(HttpTermination::class);
+        $limiter->check('busy:key', 3, 60);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCheckExceedingLimitThrowsWith429Response(): void
+    {
+        $storage = new ArrayRateLimiterStorage();
+        $limiter = new RateLimiter($storage);
+
+        $limiter->check('busy:key', 1, 60);
+
+        try {
+            $limiter->check('busy:key', 1, 60);
+            self::fail('Expected HttpTermination was not thrown.');
+        } catch (HttpTermination $e) {
+            self::assertSame(429, $e->response()->statusCode());
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // RateLimiter::remaining()
+    // -------------------------------------------------------------------
+
+    public function testRemainingReturnsLimitMinusCount(): void
+    {
+        $storage = new ArrayRateLimiterStorage();
+        // Simulate 3 prior hits
+        $storage->increment('key', 60);
+        $storage->increment('key', 60);
+        $storage->increment('key', 60);
+
+        $limiter = new RateLimiter($storage);
+        self::assertSame(7, $limiter->remaining('key', 10));
+    }
+
+    public function testRemainingReturnsZeroWhenCountExceedsLimit(): void
+    {
+        $storage = new ArrayRateLimiterStorage();
+        // Simulate 15 hits against a limit of 10
+        for ($i = 0; $i < 15; $i++) {
+            $storage->increment('key', 60);
+        }
+
+        $limiter = new RateLimiter($storage);
+        self::assertSame(0, $limiter->remaining('key', 10));
+    }
+
+    public function testRemainingReturnsFullLimitWhenNoRequests(): void
+    {
+        $storage = new ArrayRateLimiterStorage();
+        $limiter = new RateLimiter($storage);
+
+        self::assertSame(10, $limiter->remaining('new:key', 10));
+    }
+
+    // -------------------------------------------------------------------
+    // RedisRateLimiterStorage — unit tests with Predis mock
+    // -------------------------------------------------------------------
+
+    public function testRedisStorageIncrementFirstRequestSetsExpiry(): void
+    {
+        $redis = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__call'])
+            ->getMock();
+
+        $callLog = [];
+        $redis->method('__call')
+            ->willReturnCallback(function (string $method, array $args) use (&$callLog) {
+                $callLog[] = ['method' => $method, 'args' => $args];
+                return match ($method) {
+                    'incr'   => 1,
+                    'expire' => true,
+                    'ttl'    => 60,
+                    'get'    => null,
+                    default  => null,
+                };
+            });
+
+        $storage = new RedisRateLimiterStorage($redis);
+        $result  = $storage->increment('rate:key', 60);
+
+        self::assertSame(1, $result);
+        self::assertSame('incr',   $callLog[0]['method']);
+        self::assertSame('expire', $callLog[1]['method']);
+        self::assertSame(['rate:key', 60], $callLog[1]['args']);
+    }
+
+    public function testRedisStorageIncrementSubsequentRequestSkipsExpiry(): void
+    {
+        $redis = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__call'])
+            ->getMock();
+
+        $callLog = [];
+        $redis->method('__call')
+            ->willReturnCallback(function (string $method, array $args) use (&$callLog) {
+                $callLog[] = ['method' => $method, 'args' => $args];
+                return match ($method) {
+                    'incr'   => 2,
+                    'expire' => true,
+                    default  => null,
+                };
+            });
+
+        $storage = new RedisRateLimiterStorage($redis);
+        $result  = $storage->increment('rate:key', 60);
+
+        self::assertSame(2, $result);
+
+        $methods = array_column($callLog, 'method');
+        self::assertContains('incr',     $methods);
+        self::assertNotContains('expire', $methods);
+    }
+
+    public function testRedisStorageTtlReturnsNonNegative(): void
+    {
+        $redis = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__call'])
+            ->getMock();
+
+        $redis->method('__call')
+            ->willReturnCallback(fn (string $method) => match ($method) {
+                'ttl'  => -1,
+                default => null,
+            });
+
+        $storage = new RedisRateLimiterStorage($redis);
+        self::assertSame(0, $storage->ttl('missing:key'));
+    }
+
+    public function testRedisStorageCountReturnsZeroForMissingKey(): void
+    {
+        $redis = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__call'])
+            ->getMock();
+
+        $redis->method('__call')
+            ->willReturn(null);
+
+        $storage = new RedisRateLimiterStorage($redis);
+        self::assertSame(0, $storage->count('absent:key'));
+    }
+}

--- a/tests/Unit/Func/RateLimiterTest.php
+++ b/tests/Unit/Func/RateLimiterTest.php
@@ -181,7 +181,7 @@ final class RateLimiterTest extends TestCase
         $result  = $storage->increment('rate:key', 60);
 
         self::assertSame(1, $result);
-        self::assertSame('incr',   $callLog[0]['method']);
+        self::assertSame('incr', $callLog[0]['method']);
         self::assertSame('expire', $callLog[1]['method']);
         self::assertSame(['rate:key', 60], $callLog[1]['args']);
     }
@@ -210,7 +210,7 @@ final class RateLimiterTest extends TestCase
         self::assertSame(2, $result);
 
         $methods = array_column($callLog, 'method');
-        self::assertContains('incr',     $methods);
+        self::assertContains('incr', $methods);
         self::assertNotContains('expire', $methods);
     }
 

--- a/tests/Unit/Xion/CommandTest.php
+++ b/tests/Unit/Xion/CommandTest.php
@@ -198,8 +198,11 @@ final class CommandTest extends TestCase
 
     public function testLineOutputsMessageWithNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -215,8 +218,11 @@ final class CommandTest extends TestCase
 
     public function testLineWithNoArgumentOutputsBlankLine(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -232,8 +238,11 @@ final class CommandTest extends TestCase
 
     public function testErrorReturnsCorrectExitCode(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -248,8 +257,11 @@ final class CommandTest extends TestCase
 
     public function testWriteOutputsWithoutTrailingNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -265,8 +277,11 @@ final class CommandTest extends TestCase
 
     public function testLineAndWriteProduceDistinctOutput(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {


### PR DESCRIPTION
## Summary

FT28: Implement the built-in `RateLimiter` class that was documented in `docs/development/rate-limiting.md` (FT23) but not yet shipped.

## Changes

| File | Change |
|---|---|
| `class/func/RateLimiterStorageInterface.php` | New — storage abstraction interface |
| `class/func/RedisRateLimiterStorage.php` | New — Predis INCR+EXPIRE backend |
| `class/func/RateLimiter.php` | New — fixed-window rate limiter |
| `config/error_codes.php` | Add `RATE-LIMIT-EXCEEDED` (429) |
| `docs/development/error-codes.md` | Add catalog row for `RATE-LIMIT-EXCEEDED` |
| `docs/development/rate-limiting.md` | Update to reflect actual `check()` API |
| `tests/Unit/Func/RateLimiterTest.php` | New — 11 tests (ArrayRateLimiterStorage + Predis mock) |
| `docs/field-trials/2026-05-field-trial-28.md` | FT28 report |

## API

```php
// preAction() or REST method
$storage = new RedisRateLimiterStorage(RedisConnection::getInstance());
$limiter = new RateLimiter($storage);
$limiter->check('rate:login:ip:' . $ip, limit: 10, windowSeconds: 900);
// → throws HttpTermination(429) with Retry-After when exceeded
// → sets X-RateLimit-Limit / X-RateLimit-Remaining / X-RateLimit-Reset on every request
$left = $limiter->remaining('rate:login:ip:' . $ip, 10);
```

## Tests

233 unit tests, all passing. Static analysis (Phan) clean.

## Key findings

- **F-1** Storage interface keeps tests Redis-free (`ArrayRateLimiterStorage` defined inside the test file)
- **F-4** `headers_list()` returns empty under CLI SAPI — header tests verify the storage side-effect instead
- **F-5** `ErrorCodeTest` contract test enforces that every `config/error_codes.php` entry also appears in `docs/development/error-codes.md` — caught missing catalog row

🤖 Generated with [Claude Code](https://claude.com/claude-code)