### PR TITLE
feat(state-machine): WorkflowDefinition — code-driven transition map (#FT29)

### DIFF
--- a/class/func/WorkflowDefinition.php
+++ b/class/func/WorkflowDefinition.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Func;
+
+/**
+ * Static workflow definitions for state-machine workflows.
+ *
+ * Stores the allowed-transitions map for each named workflow.
+ * Definitions are code-level (not DB-driven) to keep the state machine
+ * auditable and type-safe.
+ *
+ * ## Adding a new workflow
+ *
+ * Add an entry to DEFINITIONS:
+ *   'my-workflow' => [
+ *       'pending'  => ['active', 'cancelled'],
+ *       'active'   => ['completed', 'cancelled'],
+ *       'completed'=> [],   // terminal
+ *       'cancelled'=> [],   // terminal
+ *   ]
+ *
+ * The first key in the map is the initial state.
+ */
+final class WorkflowDefinition
+{
+    /**
+     * Workflow name → (from-state → list<to-state>).
+     * All states that appear as values must also appear as keys.
+     * Terminal states map to an empty list.
+     *
+     * @var array<string, array<string, list<string>>>
+     */
+    private const DEFINITIONS = [
+        'order' => [
+            'draft'     => ['submitted'],
+            'submitted' => ['approved', 'rejected', 'cancelled'],
+            'approved'  => ['fulfilled', 'cancelled'],
+            'rejected'  => [],
+            'fulfilled' => [],
+            'cancelled' => [],
+        ],
+        'content' => [
+            'draft'     => ['submitted'],
+            'submitted' => ['approved', 'rejected'],
+            'approved'  => [],
+            'rejected'  => ['draft'],   // can revise and resubmit
+        ],
+    ];
+
+    /**
+     * Check whether the given workflow name is registered.
+     */
+    public static function isValidWorkflow(string $workflow): bool
+    {
+        return isset(self::DEFINITIONS[$workflow]);
+    }
+
+    /**
+     * Return the initial state of a workflow (first key in the map).
+     *
+     * @throws \InvalidArgumentException If the workflow is unknown.
+     */
+    public static function initialState(string $workflow): string
+    {
+        if (!self::isValidWorkflow($workflow)) {
+            throw new \InvalidArgumentException("Unknown workflow: {$workflow}");
+        }
+        $first = array_key_first(self::DEFINITIONS[$workflow]);
+        assert($first !== null);
+        return $first;
+    }
+
+    /**
+     * Return the list of valid next states from the current state.
+     *
+     * @return list<string>
+     * @throws \InvalidArgumentException If the workflow or state is unknown.
+     */
+    public static function allowedNext(string $workflow, string $fromState): array
+    {
+        if (!self::isValidWorkflow($workflow)) {
+            throw new \InvalidArgumentException("Unknown workflow: {$workflow}");
+        }
+        if (!array_key_exists($fromState, self::DEFINITIONS[$workflow])) {
+            throw new \InvalidArgumentException("Unknown state '{$fromState}' in workflow '{$workflow}'");
+        }
+        return self::DEFINITIONS[$workflow][$fromState];
+    }
+
+    /**
+     * Check whether a transition is valid.
+     */
+    public static function canTransition(string $workflow, string $fromState, string $toState): bool
+    {
+        try {
+            return in_array($toState, self::allowedNext($workflow, $fromState), strict: true);
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+    }
+
+    /**
+     * Assert that a transition is valid; throw HttpTermination(409) if not.
+     *
+     * @throws \Nene\Xion\HttpTermination 409 Conflict when the transition is not allowed.
+     */
+    public static function assertTransition(string $workflow, string $fromState, string $toState): void
+    {
+        if (!self::canTransition($workflow, $fromState, $toState)) {
+            throw new \Nene\Xion\HttpTermination(
+                \Nene\Xion\JsonResponder::response(
+                    ['Result' => false, 'Data' => [
+                        'status'       => 'failure',
+                        'errorCode'    => 'INVALID-TRANSITION',
+                        'errorMessage' => "Transition from '{$fromState}' to '{$toState}' is not allowed.",
+                    ]],
+                    409
+                )
+            );
+        }
+    }
+
+    /**
+     * Return all defined states for a workflow.
+     *
+     * @return list<string>
+     * @throws \InvalidArgumentException If the workflow is unknown.
+     */
+    public static function allStates(string $workflow): array
+    {
+        if (!self::isValidWorkflow($workflow)) {
+            throw new \InvalidArgumentException("Unknown workflow: {$workflow}");
+        }
+        return array_keys(self::DEFINITIONS[$workflow]);
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cafe7f10cdc595ab0e7bf7fde290d9d",
+    "content-hash": "a1cc21bf99e0bf98d3529d4656b1c068",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -5771,7 +5771,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.4"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"
 }

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -55,8 +55,72 @@ return [
         'message' => 'Upload mime type is not allowed.',
         'httpStatus' => 415,
     ],
+    'ACCOUNT-LOCKED' => [
+        'message' => 'Account is locked due to too many failed login attempts.',
+        'httpStatus' => 423,
+    ],
+    'BATCH-ITEM-FAILED' => [
+        'message' => 'One or more batch items failed.',
+        'httpStatus' => 422,
+    ],
+    'BATCH-TOO-LARGE' => [
+        'message' => 'Batch request exceeds the maximum number of items.',
+        'httpStatus' => 400,
+    ],
+    'CIRCUIT-OPEN' => [
+        'message' => 'The downstream service is temporarily unavailable.',
+        'httpStatus' => 503,
+    ],
+    'CONFLICT' => [
+        'message' => 'A conflicting operation is already in progress.',
+        'httpStatus' => 409,
+    ],
+    'FORBIDDEN' => [
+        'message' => 'You do not have permission to perform this action.',
+        'httpStatus' => 403,
+    ],
     'INVALID-TRANSITION' => [
         'message' => 'The requested state transition is not allowed.',
         'httpStatus' => 409,
+    ],
+    'JWT-INVALID' => [
+        'message' => 'The JWT token is invalid or expired.',
+        'httpStatus' => 401,
+    ],
+    'PRECONDITION-FAILED' => [
+        'message' => 'The resource was modified by another request. Fetch the latest version and retry.',
+        'httpStatus' => 412,
+    ],
+    'PRECONDITION-REQUIRED' => [
+        'message' => 'If-Match header is required for this operation.',
+        'httpStatus' => 428,
+    ],
+    'RATE-LIMIT-EXCEEDED' => [
+        'message' => 'Too many requests. Please try again later.',
+        'httpStatus' => 429,
+    ],
+    'SIGNED-URL-EXPIRED' => [
+        'message' => 'The signed URL has expired.',
+        'httpStatus' => 410,
+    ],
+    'SIGNED-URL-INVALID' => [
+        'message' => 'The signed URL is invalid.',
+        'httpStatus' => 403,
+    ],
+    'TOKEN-ALREADY-USED' => [
+        'message' => 'The reset token has already been used.',
+        'httpStatus' => 409,
+    ],
+    'TOKEN-EXPIRED' => [
+        'message' => 'The reset token has expired.',
+        'httpStatus' => 410,
+    ],
+    'VALIDATION-FAILED' => [
+        'message' => 'One or more input fields failed validation.',
+        'httpStatus' => 422,
+    ],
+    'WEBHOOK-SIGNATURE-INVALID' => [
+        'message' => 'Webhook signature is invalid or stale.',
+        'httpStatus' => 401,
     ],
 ];

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -55,4 +55,8 @@ return [
         'message' => 'Upload mime type is not allowed.',
         'httpStatus' => 415,
     ],
+    'INVALID-TRANSITION' => [
+        'message' => 'The requested state transition is not allowed.',
+        'httpStatus' => 409,
+    ],
 ];

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -38,6 +38,7 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
 | `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
 | `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
+| `INVALID-TRANSITION` | 409 | The requested state transition is not allowed. | Thrown by `WorkflowDefinition::assertTransition()` when the `from → to` state pair is not in the workflow's allowed-transitions map. |
 
 ## Adding a new error code
 

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -38,7 +38,23 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
 | `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
 | `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
+| `ACCOUNT-LOCKED` | 423 | Account is locked due to too many failed login attempts. | Returned by login endpoints when `LoginAttemptTracker::isLocked()` is true. Cleared by `reset()` after successful authentication or by an admin SQL update. |
+| `BATCH-ITEM-FAILED` | 422 | One or more batch items failed. | Recorded per-item in `BatchResult::addFailure()` when a single batch item cannot be processed; the overall response may be 207 (partial) or 422 (all failed). |
+| `BATCH-TOO-LARGE` | 400 | Batch request exceeds the maximum number of items. | Returned by batch endpoints when the input array exceeds the configured per-endpoint maximum (guard with `BATCH-TOO-LARGE` before the loop). |
+| `CIRCUIT-OPEN` | 503 | The downstream service is temporarily unavailable. | Returned when a `CircuitBreaker` is in the OPEN state and the caller should not attempt the downstream call. See `docs/development/circuit-breaker.md`. |
+| `CONFLICT` | 409 | A conflicting operation is already in progress. | Reserved for operations where a second request conflicts with one already underway (e.g. duplicate idempotency key). |
+| `FORBIDDEN` | 403 | You do not have permission to perform this action. | Returned by `RoleGuard::require()` / `requireAny()` when the JWT `role` claim does not satisfy the endpoint's role requirement. |
 | `INVALID-TRANSITION` | 409 | The requested state transition is not allowed. | Thrown by `WorkflowDefinition::assertTransition()` when the `from → to` state pair is not in the workflow's allowed-transitions map. |
+| `JWT-INVALID` | 401 | The JWT token is invalid or expired. | Thrown by `JwtCodec::require()` when the `Authorization: Bearer` header is absent, the token is malformed, the signature is wrong, the token has expired, or the algorithm is not HS256. |
+| `PRECONDITION-FAILED` | 412 | The resource was modified by another request. Fetch the latest version and retry. | Thrown by `OptimisticLock::conflict()` when a conditional UPDATE affects zero rows, indicating a concurrent writer incremented the version. |
+| `PRECONDITION-REQUIRED` | 428 | If-Match header is required for this operation. | Thrown by `OptimisticLock::requireVersion()` when a conditional write is attempted without an `If-Match` header (RFC 9110 §13.1). |
+| `RATE-LIMIT-EXCEEDED` | 429 | Too many requests. Please try again later. | Thrown by `RateLimiter::check()` when the per-key counter exceeds the configured limit within the current window. Response includes `Retry-After` header. |
+| `SIGNED-URL-EXPIRED` | 410 | The signed URL has expired. | Thrown by `SignedUrl::requireValid()` when the `expires` timestamp is in the past. |
+| `SIGNED-URL-INVALID` | 403 | The signed URL is invalid. | Thrown by `SignedUrl::requireValid()` when the signature does not match or required parameters are missing. |
+| `TOKEN-ALREADY-USED` | 409 | The reset token has already been used. | Returned by password-reset complete endpoint when `used_at` is not null. |
+| `TOKEN-EXPIRED` | 410 | The reset token has expired. | Returned by password-reset complete endpoint when `PasswordResetToken::isExpired()` is true. |
+| `VALIDATION-FAILED` | 422 | One or more input fields failed validation. | Returned by controllers using `Nene\Func\Validator` when `$v->passes()` returns false. Use `$v->errors()` or `$v->firstErrors()` to include field-level detail in the response body. |
+| `WEBHOOK-SIGNATURE-INVALID` | 401 | Webhook signature is invalid or stale. | Returned when inbound `X-Webhook-Signature` header is missing, malformed, or fails HMAC verification. See `docs/development/webhook-signing.md`. |
 
 ## Adding a new error code
 

--- a/docs/development/state-machines.md
+++ b/docs/development/state-machines.md
@@ -47,7 +47,40 @@ A state machine formalizes multi-step business processes: order approval, conten
 ],
 ```
 
-## WorkflowDefinition
+## Framework class: `WorkflowDefinition`
+
+`Nene\Func\WorkflowDefinition` ships with NeNe. Add custom workflows by editing
+`DEFINITIONS` in that class.
+
+| Method | Description |
+|--------|-------------|
+| `WorkflowDefinition::isValidWorkflow(string)` | Whether the workflow is registered |
+| `WorkflowDefinition::initialState(string)` | First state of a workflow |
+| `WorkflowDefinition::allowedNext(string, string)` | Valid next states from current state |
+| `WorkflowDefinition::canTransition(string, string, string)` | Check transition validity (bool) |
+| `WorkflowDefinition::assertTransition(string, string, string)` | Assert valid; throws 409 if not |
+| `WorkflowDefinition::allStates(string)` | All states in a workflow |
+
+### Controller pattern
+
+```php
+// POST /orders/{id}/transition
+public function transitionPostRest(): array
+{
+    $order    = $this->orderMapper->find($this->getOrderId());
+    $toState  = (string)($this->body['status'] ?? '');
+
+    WorkflowDefinition::assertTransition('order', $order->status, $toState);   // 409 on invalid
+
+    $this->orderMapper->updateStatus($order->id, $toState);
+    return $this->API_RESPONSE->success([
+        'status'       => $toState,
+        'allowed_next' => WorkflowDefinition::allowedNext('order', $toState),
+    ]);
+}
+```
+
+## WorkflowDefinition (skeleton)
 
 ```php
 // class/func/WorkflowDefinition.php

--- a/docs/field-trials/2026-05-field-trial-29.md
+++ b/docs/field-trials/2026-05-field-trial-29.md
@@ -1,0 +1,61 @@
+# Field Trial 29 — State Machine 実装
+
+**Date:** 2026-05-27
+**Theme:** `WorkflowDefinition` クラス実装 — コードドリブンな遷移マップと 409 ガード
+
+---
+
+## What was done
+
+- `class/func/WorkflowDefinition.php`
+  - `isValidWorkflow()`, `initialState()`, `allowedNext()`, `canTransition()`, `assertTransition()`, `allStates()`
+  - 組み込みワークフロー: `order`, `content`
+- `config/error_codes.php` — `INVALID-TRANSITION` (409) 追加
+- `docs/development/error-codes.md` — `INVALID-TRANSITION` をカタログテーブルに追加
+- `tests/Unit/Func/WorkflowDefinitionTest.php` — 16 テスト
+- `docs/development/state-machines.md` — フレームワークヘルパーセクション追加
+
+---
+
+## Findings
+
+### F-1 — PHP enum vs static map の選択（設計）
+
+NENE2 は PHP backed enum を使う。NeNe の既存 doc は static map を使う。
+両者の差: enum は型安全だが各ワークフローに enum クラスが必要; static map は1ファイルで管理できる。
+NeNe では複数ワークフローを1ファイルで管理できる static map を選択。アプリ開発者が enum を好む場合は enum も使える（排他ではない）。
+
+### F-2 — terminal state の `assertTransition` が 409（設計確認）
+
+terminal state からの遷移は `allowedNext() = []` のため、いかなる `toState` も 409 になる。正しい動作。
+
+### F-3 — error-codes.md の同期テスト（検知）
+
+`config/error_codes.php` に追加したコードが `docs/development/error-codes.md` のテーブルに未記載だと `ErrorCodeTest::testEveryRuntimeCodeAppearsInDocsMarkdownTable` が失敗する。エラーコード追加時は必ずドキュメントも更新する。
+
+---
+
+## Patterns Validated
+
+- `match` 代わりの連想配列で遷移マップを表現
+- terminal state = 空リスト
+- `assertTransition()` が `HttpTermination(409)` を throw するため、controller は if 文不要
+- `allowed_next` をレスポンスに含めることでクライアントが次のアクションを知れる
+
+---
+
+## Results
+
+| Check | Result |
+|---|---|
+| PHPUnit (unit) — WorkflowDefinitionTest | 16 tests, 16 assertions — OK |
+| PHPUnit (unit) — full suite | 254 tests — OK |
+| Phan | 0 errors (exit 0) |
+
+---
+
+## Related
+
+- `class/func/WorkflowDefinition.php` — 実装
+- `docs/development/state-machines.md` — 設計ドキュメント
+- `config/error_codes.php` — `INVALID-TRANSITION` エントリ

--- a/tests/Unit/Func/WorkflowDefinitionTest.php
+++ b/tests/Unit/Func/WorkflowDefinitionTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Func;
+
+use InvalidArgumentException;
+use Nene\Func\WorkflowDefinition;
+use Nene\Xion\HttpTermination;
+use PHPUnit\Framework\TestCase;
+
+final class WorkflowDefinitionTest extends TestCase
+{
+    // ── isValidWorkflow ───────────────────────────────────────────────────
+
+    public function testIsValidWorkflowReturnsTrueForKnownWorkflow(): void
+    {
+        self::assertTrue(WorkflowDefinition::isValidWorkflow('order'));
+    }
+
+    public function testIsValidWorkflowReturnsFalseForUnknownWorkflow(): void
+    {
+        self::assertFalse(WorkflowDefinition::isValidWorkflow('unknown'));
+    }
+
+    // ── initialState ─────────────────────────────────────────────────────
+
+    public function testInitialStateReturnsFirstStateForOrder(): void
+    {
+        self::assertSame('draft', WorkflowDefinition::initialState('order'));
+    }
+
+    public function testInitialStateThrowsForUnknownWorkflow(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        WorkflowDefinition::initialState('unknown');
+    }
+
+    // ── allowedNext ───────────────────────────────────────────────────────
+
+    public function testAllowedNextReturnsTransitionsFromDraft(): void
+    {
+        self::assertSame(['submitted'], WorkflowDefinition::allowedNext('order', 'draft'));
+    }
+
+    public function testAllowedNextReturnsEmptyArrayForTerminalState(): void
+    {
+        self::assertSame([], WorkflowDefinition::allowedNext('order', 'fulfilled'));
+    }
+
+    public function testAllowedNextThrowsForUnknownState(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        WorkflowDefinition::allowedNext('order', 'unknown-state');
+    }
+
+    // ── canTransition ─────────────────────────────────────────────────────
+
+    public function testCanTransitionReturnsTrueForValidTransition(): void
+    {
+        self::assertTrue(WorkflowDefinition::canTransition('order', 'draft', 'submitted'));
+    }
+
+    public function testCanTransitionReturnsFalseForInvalidTransition(): void
+    {
+        self::assertFalse(WorkflowDefinition::canTransition('order', 'draft', 'approved'));
+    }
+
+    public function testCanTransitionReturnsFalseFromTerminalState(): void
+    {
+        self::assertFalse(WorkflowDefinition::canTransition('order', 'fulfilled', 'anything'));
+    }
+
+    public function testCanTransitionReturnsFalseForUnknownWorkflow(): void
+    {
+        self::assertFalse(WorkflowDefinition::canTransition('unknown-workflow', 'draft', 'submitted'));
+    }
+
+    // ── assertTransition ──────────────────────────────────────────────────
+
+    public function testAssertTransitionSucceedsForValidTransition(): void
+    {
+        // Must not throw
+        WorkflowDefinition::assertTransition('order', 'draft', 'submitted');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAssertTransitionThrowsHttpTerminationForInvalidTransition(): void
+    {
+        $this->expectException(HttpTermination::class);
+        WorkflowDefinition::assertTransition('order', 'draft', 'approved');
+    }
+
+    public function testAssertTransitionResponseHas409StatusCode(): void
+    {
+        try {
+            WorkflowDefinition::assertTransition('order', 'draft', 'approved');
+            self::fail('Expected HttpTermination was not thrown.');
+        } catch (HttpTermination $e) {
+            self::assertSame(409, $e->response()->statusCode());
+        }
+    }
+
+    // ── allStates ─────────────────────────────────────────────────────────
+
+    public function testAllStatesReturnsCompleteListForOrder(): void
+    {
+        self::assertSame(
+            ['draft', 'submitted', 'approved', 'rejected', 'fulfilled', 'cancelled'],
+            WorkflowDefinition::allStates('order')
+        );
+    }
+
+    public function testAllStatesThrowsForUnknownWorkflow(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        WorkflowDefinition::allStates('unknown');
+    }
+}

--- a/tests/Unit/Xion/CommandTest.php
+++ b/tests/Unit/Xion/CommandTest.php
@@ -198,8 +198,11 @@ final class CommandTest extends TestCase
 
     public function testLineOutputsMessageWithNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -215,8 +218,11 @@ final class CommandTest extends TestCase
 
     public function testLineWithNoArgumentOutputsBlankLine(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -232,8 +238,11 @@ final class CommandTest extends TestCase
 
     public function testErrorReturnsCorrectExitCode(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -248,8 +257,11 @@ final class CommandTest extends TestCase
 
     public function testWriteOutputsWithoutTrailingNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -265,8 +277,11 @@ final class CommandTest extends TestCase
 
     public function testLineAndWriteProduceDistinctOutput(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {


### PR DESCRIPTION
## Summary

Implements `Nene\Func\WorkflowDefinition` — a static, code-driven state-machine helper that enforces valid transitions and throws `HttpTermination(409)` on invalid ones.

## Changes

- **`class/func/WorkflowDefinition.php`** — new class with 6 static methods:
  - `isValidWorkflow(string)` — whether the workflow is registered
  - `initialState(string)` — first state of a workflow
  - `allowedNext(string, string)` — valid next states from current state
  - `canTransition(string, string, string)` — check transition validity (bool)
  - `assertTransition(string, string, string)` — assert valid; throws 409 if not
  - `allStates(string)` — all states in a workflow
  - Built-in workflows: `order`, `content`
- **`config/error_codes.php`** — `INVALID-TRANSITION` (409) entry added
- **`docs/development/error-codes.md`** — catalog table updated
- **`docs/development/state-machines.md`** — framework-class reference table + controller pattern added
- **`tests/Unit/Func/WorkflowDefinitionTest.php`** — 16 tests covering all methods and edge cases
- **`docs/field-trials/2026-05-field-trial-29.md`** — FT report

## Test results

| Check | Result |
|---|---|
| PHPUnit (unit) — WorkflowDefinitionTest | 16 tests, 16 assertions — OK |
| PHPUnit (unit) — full suite | all tests — OK |
| Phan | 0 errors |

## Design notes

- Static map (not PHP enum) keeps all workflows in one file — simpler for multi-workflow apps
- Terminal states map to `[]`; `assertTransition()` automatically rejects any exit from them with 409
- `assertTransition()` throws `HttpTermination`, so controllers need no if-statement around it

🤖 Generated with [Claude Code](https://claude.com/claude-code)