### PR TITLE
feat(jwt): JwtCodec — HS256 JWT issue/verify without external library (#FT30)

### DIFF
--- a/class/xion/JwtCodec.php
+++ b/class/xion/JwtCodec.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+/**
+ * JWT HS256 issuer and verifier.
+ *
+ * Issues and verifies compact JSON Web Tokens signed with HMAC-SHA256.
+ * Implements only the HS256 algorithm to prevent algorithm-confusion attacks
+ * (alg:none, RS256 with symmetric secret, etc.).
+ *
+ * ## Typical usage
+ *
+ * ```php
+ * $jwt = new JwtCodec((string)getenv('NENE_JWT_SECRET'));
+ *
+ * // Issue (e.g. on login)
+ * $token = $jwt->issue(['sub' => $userId, 'email' => $user->email]);
+ *
+ * // Verify (e.g. in preAction)
+ * $claims = $jwt->require();   // reads Authorization: Bearer header; 401 on invalid/expired
+ *
+ * // Or: decode without throwing
+ * $claims = $jwt->decode($token);  // null on invalid
+ * ```
+ *
+ * Trial source: FT30 (`docs/field-trials/2026-05-field-trial-30.md`).
+ */
+final readonly class JwtCodec
+{
+    /**
+     * @param string $secret     HMAC secret key. Must be at least 32 bytes for HS256.
+     * @param int    $defaultTtl Default token lifetime in seconds. Default: 3600 (1 hour).
+     */
+    public function __construct(
+        private string $secret,
+        private int $defaultTtl = 3600,
+    ) {}
+
+    /**
+     * Issue a new JWT with the given claims.
+     *
+     * `iat` and `exp` are set automatically if not provided in $claims.
+     * All other standard claims (sub, email, etc.) are passed through as-is.
+     *
+     * @param array<string,mixed> $claims  Payload claims.
+     * @param int|null            $ttl     Override lifetime in seconds; null uses defaultTtl.
+     *
+     * @return string Compact JWT string (header.payload.signature).
+     */
+    public function issue(array $claims, ?int $ttl = null): string
+    {
+        $now = time();
+        $claims['iat'] = $claims['iat'] ?? $now;
+        $claims['exp'] = $claims['exp'] ?? ($now + ($ttl ?? $this->defaultTtl));
+
+        $headerJson  = json_encode(['alg' => 'HS256', 'typ' => 'JWT'], JSON_THROW_ON_ERROR);
+        $payloadJson = json_encode($claims, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+
+        $header  = $this->base64url((string)$headerJson);
+        $payload = $this->base64url((string)$payloadJson);
+        $sig     = $this->sign($header . '.' . $payload);
+
+        return $header . '.' . $payload . '.' . $sig;
+    }
+
+    /**
+     * Decode and verify a JWT string.
+     *
+     * Returns the decoded claims array on success.
+     * Returns null if the token is missing, malformed, has a wrong signature,
+     * expired, or uses a non-HS256 algorithm.
+     *
+     * @param string $token Compact JWT string.
+     *
+     * @return array<string,mixed>|null Decoded claims, or null on any failure.
+     */
+    public function decode(string $token): ?array
+    {
+        $parts = explode('.', $token);
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        [$headerB64, $payloadB64, $sigB64] = $parts;
+
+        // Verify signature using constant-time comparison
+        $expectedSig = $this->sign($headerB64 . '.' . $payloadB64);
+        if (!hash_equals($expectedSig, $sigB64)) {
+            return null;
+        }
+
+        // Decode header and verify algorithm
+        $headerDecoded = $this->base64urlDecode($headerB64);
+        if ($headerDecoded === '') {
+            return null;
+        }
+        $header = $this->jsonDecode($headerDecoded);
+        if ($header === null || ($header['alg'] ?? '') !== 'HS256') {
+            return null;
+        }
+
+        // Decode payload
+        $payloadDecoded = $this->base64urlDecode($payloadB64);
+        if ($payloadDecoded === '') {
+            return null;
+        }
+        $claims = $this->jsonDecode($payloadDecoded);
+        if ($claims === null) {
+            return null;
+        }
+
+        // Validate exp (required — always reject tokens without exp)
+        if (!isset($claims['exp']) || !is_int($claims['exp'])) {
+            return null;
+        }
+        if (time() >= $claims['exp']) {
+            return null;    // expired
+        }
+
+        // Validate nbf if present
+        if (isset($claims['nbf']) && is_int($claims['nbf']) && time() < $claims['nbf']) {
+            return null;    // not yet valid
+        }
+
+        return $claims;
+    }
+
+    /**
+     * Read the Authorization: Bearer header from the current request and verify the JWT.
+     *
+     * Throws HttpTermination(401) if the header is absent, malformed, or invalid.
+     * Returns the decoded claims on success.
+     *
+     * @return array<string,mixed> Decoded JWT claims.
+     */
+    public function require(): array
+    {
+        $header = $this->readBearerHeader();
+        if ($header === null) {
+            $this->unauthorized('Authorization: Bearer header is required.');
+        }
+
+        $claims = $this->decode($header);
+        if ($claims === null) {
+            $this->unauthorized('Token is invalid or expired.');
+        }
+
+        return $claims;
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    /**
+     * @return never
+     */
+    private function unauthorized(string $message): never
+    {
+        header('WWW-Authenticate: Bearer');
+        throw new HttpTermination(
+            JsonResponder::response(
+                ['Result' => false, 'Data' => [
+                    'status'       => 'failure',
+                    'errorCode'    => 'JWT-INVALID',
+                    'errorMessage' => $message,
+                ]],
+                401
+            )
+        );
+    }
+
+    private function sign(string $data): string
+    {
+        return $this->base64url(
+            (string)hash_hmac('sha256', $data, $this->secret, binary: true)
+        );
+    }
+
+    private function base64url(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    private function base64urlDecode(string $data): string
+    {
+        $decoded = base64_decode(strtr($data, '-_', '+/'), strict: true);
+        return $decoded === false ? '' : $decoded;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function jsonDecode(string $json): ?array
+    {
+        if ($json === '') {
+            return null;
+        }
+        try {
+            $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+            return is_array($decoded) ? $decoded : null;
+        } catch (\JsonException) {
+            return null;
+        }
+    }
+
+    private function readBearerHeader(): ?string
+    {
+        // Try Apache headers
+        if (function_exists('apache_request_headers')) {
+            $headers = apache_request_headers();
+            foreach ($headers as $name => $value) {
+                if (strtolower($name) === 'authorization') {
+                    return $this->extractBearerToken($value);
+                }
+            }
+        }
+
+        // Try getallheaders() (some PHP SAPI configs)
+        if (function_exists('getallheaders')) {
+            $headers = getallheaders();
+            foreach ($headers as $name => $value) {
+                if (strtolower($name) === 'authorization') {
+                    return $this->extractBearerToken($value);
+                }
+            }
+        }
+
+        // Fallback to $_SERVER
+        $raw = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+        return $this->extractBearerToken($raw);
+    }
+
+    private function extractBearerToken(string $header): ?string
+    {
+        if (!str_starts_with($header, 'Bearer ')) {
+            return null;
+        }
+        $token = trim(substr($header, 7));
+        return $token !== '' ? $token : null;
+    }
+}

--- a/class/xion/JwtCodec.php
+++ b/class/xion/JwtCodec.php
@@ -50,7 +50,8 @@ final readonly class JwtCodec
     public function __construct(
         private string $secret,
         private int $defaultTtl = 3600,
-    ) {}
+    ) {
+    }
 
     /**
      * Issue a new JWT with the given claims.

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cafe7f10cdc595ab0e7bf7fde290d9d",
+    "content-hash": "a1cc21bf99e0bf98d3529d4656b1c068",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -5771,7 +5771,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.4"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"
 }

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -55,8 +55,72 @@ return [
         'message' => 'Upload mime type is not allowed.',
         'httpStatus' => 415,
     ],
+    'ACCOUNT-LOCKED' => [
+        'message' => 'Account is locked due to too many failed login attempts.',
+        'httpStatus' => 423,
+    ],
+    'BATCH-ITEM-FAILED' => [
+        'message' => 'One or more batch items failed.',
+        'httpStatus' => 422,
+    ],
+    'BATCH-TOO-LARGE' => [
+        'message' => 'Batch request exceeds the maximum number of items.',
+        'httpStatus' => 400,
+    ],
+    'CIRCUIT-OPEN' => [
+        'message' => 'The downstream service is temporarily unavailable.',
+        'httpStatus' => 503,
+    ],
+    'CONFLICT' => [
+        'message' => 'A conflicting operation is already in progress.',
+        'httpStatus' => 409,
+    ],
+    'FORBIDDEN' => [
+        'message' => 'You do not have permission to perform this action.',
+        'httpStatus' => 403,
+    ],
+    'INVALID-TRANSITION' => [
+        'message' => 'The requested state transition is not allowed.',
+        'httpStatus' => 409,
+    ],
     'JWT-INVALID' => [
         'message' => 'The JWT token is invalid or expired.',
+        'httpStatus' => 401,
+    ],
+    'PRECONDITION-FAILED' => [
+        'message' => 'The resource was modified by another request. Fetch the latest version and retry.',
+        'httpStatus' => 412,
+    ],
+    'PRECONDITION-REQUIRED' => [
+        'message' => 'If-Match header is required for this operation.',
+        'httpStatus' => 428,
+    ],
+    'RATE-LIMIT-EXCEEDED' => [
+        'message' => 'Too many requests. Please try again later.',
+        'httpStatus' => 429,
+    ],
+    'SIGNED-URL-EXPIRED' => [
+        'message' => 'The signed URL has expired.',
+        'httpStatus' => 410,
+    ],
+    'SIGNED-URL-INVALID' => [
+        'message' => 'The signed URL is invalid.',
+        'httpStatus' => 403,
+    ],
+    'TOKEN-ALREADY-USED' => [
+        'message' => 'The reset token has already been used.',
+        'httpStatus' => 409,
+    ],
+    'TOKEN-EXPIRED' => [
+        'message' => 'The reset token has expired.',
+        'httpStatus' => 410,
+    ],
+    'VALIDATION-FAILED' => [
+        'message' => 'One or more input fields failed validation.',
+        'httpStatus' => 422,
+    ],
+    'WEBHOOK-SIGNATURE-INVALID' => [
+        'message' => 'Webhook signature is invalid or stale.',
         'httpStatus' => 401,
     ],
 ];

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -55,4 +55,8 @@ return [
         'message' => 'Upload mime type is not allowed.',
         'httpStatus' => 415,
     ],
+    'JWT-INVALID' => [
+        'message' => 'The JWT token is invalid or expired.',
+        'httpStatus' => 401,
+    ],
 ];

--- a/docs/development/agent-bearer-auth.md
+++ b/docs/development/agent-bearer-auth.md
@@ -102,9 +102,27 @@ A future trial may pick this up when:
 - Token rotation needs an overlap window (old + new valid simultaneously).
 - Per-route or per-scope authorization is needed beyond "is this the admin?".
 
-## JWT-based Bearer auth (custom implementation)
+## JWT-based Bearer auth: `JwtCodec`
 
-NeNe's built-in Bearer auth uses a pre-shared static token (`NENE_AGENT_BEARER_TOKEN`) validated with `hash_equals`. If you build a custom JWT-based auth system (e.g., for user-facing API tokens), these edge cases must be handled:
+`Nene\Xion\JwtCodec` ships with NeNe. Set `NENE_JWT_SECRET` in `.env` and use:
+
+```php
+$jwt = new JwtCodec((string)getenv('NENE_JWT_SECRET'));
+
+// Issue (e.g. in login action)
+$token = $jwt->issue(['sub' => $userId, 'email' => $user->email]);
+
+// Verify in preAction (throws 401 on invalid/expired)
+protected function preAction(): void
+{
+    $this->JWT_CLAIMS = (new JwtCodec((string)getenv('NENE_JWT_SECRET')))->require();
+}
+
+// Access claims in REST method
+$userId = (int)($this->JWT_CLAIMS['sub'] ?? 0);
+```
+
+`issue()` automatically sets `iat` and `exp`. Tokens without `exp` are always rejected.
 
 ### Security edge cases (FT94 findings from NENE2)
 

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -38,6 +38,7 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
 | `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
 | `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
+| `JWT-INVALID` | 401 | The JWT token is invalid or expired. | Thrown by `JwtCodec::require()` when the `Authorization: Bearer` header is absent, the token is malformed, the signature is wrong, the token has expired, or the algorithm is not HS256. |
 
 ## Adding a new error code
 

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -38,7 +38,23 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
 | `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
 | `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
+| `ACCOUNT-LOCKED` | 423 | Account is locked due to too many failed login attempts. | Returned by login endpoints when `LoginAttemptTracker::isLocked()` is true. Cleared by `reset()` after successful authentication or by an admin SQL update. |
+| `BATCH-ITEM-FAILED` | 422 | One or more batch items failed. | Recorded per-item in `BatchResult::addFailure()` when a single batch item cannot be processed; the overall response may be 207 (partial) or 422 (all failed). |
+| `BATCH-TOO-LARGE` | 400 | Batch request exceeds the maximum number of items. | Returned by batch endpoints when the input array exceeds the configured per-endpoint maximum (guard with `BATCH-TOO-LARGE` before the loop). |
+| `CIRCUIT-OPEN` | 503 | The downstream service is temporarily unavailable. | Returned when a `CircuitBreaker` is in the OPEN state and the caller should not attempt the downstream call. See `docs/development/circuit-breaker.md`. |
+| `CONFLICT` | 409 | A conflicting operation is already in progress. | Reserved for operations where a second request conflicts with one already underway (e.g. duplicate idempotency key). |
+| `FORBIDDEN` | 403 | You do not have permission to perform this action. | Returned by `RoleGuard::require()` / `requireAny()` when the JWT `role` claim does not satisfy the endpoint's role requirement. |
+| `INVALID-TRANSITION` | 409 | The requested state transition is not allowed. | Thrown by `WorkflowDefinition::assertTransition()` when the `from → to` state pair is not in the workflow's allowed-transitions map. |
 | `JWT-INVALID` | 401 | The JWT token is invalid or expired. | Thrown by `JwtCodec::require()` when the `Authorization: Bearer` header is absent, the token is malformed, the signature is wrong, the token has expired, or the algorithm is not HS256. |
+| `PRECONDITION-FAILED` | 412 | The resource was modified by another request. Fetch the latest version and retry. | Thrown by `OptimisticLock::conflict()` when a conditional UPDATE affects zero rows, indicating a concurrent writer incremented the version. |
+| `PRECONDITION-REQUIRED` | 428 | If-Match header is required for this operation. | Thrown by `OptimisticLock::requireVersion()` when a conditional write is attempted without an `If-Match` header (RFC 9110 §13.1). |
+| `RATE-LIMIT-EXCEEDED` | 429 | Too many requests. Please try again later. | Thrown by `RateLimiter::check()` when the per-key counter exceeds the configured limit within the current window. Response includes `Retry-After` header. |
+| `SIGNED-URL-EXPIRED` | 410 | The signed URL has expired. | Thrown by `SignedUrl::requireValid()` when the `expires` timestamp is in the past. |
+| `SIGNED-URL-INVALID` | 403 | The signed URL is invalid. | Thrown by `SignedUrl::requireValid()` when the signature does not match or required parameters are missing. |
+| `TOKEN-ALREADY-USED` | 409 | The reset token has already been used. | Returned by password-reset complete endpoint when `used_at` is not null. |
+| `TOKEN-EXPIRED` | 410 | The reset token has expired. | Returned by password-reset complete endpoint when `PasswordResetToken::isExpired()` is true. |
+| `VALIDATION-FAILED` | 422 | One or more input fields failed validation. | Returned by controllers using `Nene\Func\Validator` when `$v->passes()` returns false. Use `$v->errors()` or `$v->firstErrors()` to include field-level detail in the response body. |
+| `WEBHOOK-SIGNATURE-INVALID` | 401 | Webhook signature is invalid or stale. | Returned when inbound `X-Webhook-Signature` header is missing, malformed, or fails HMAC verification. See `docs/development/webhook-signing.md`. |
 
 ## Adding a new error code
 

--- a/docs/field-trials/2026-05-field-trial-30.md
+++ b/docs/field-trials/2026-05-field-trial-30.md
@@ -1,0 +1,46 @@
+# Field Trial 30 — JWT 認証実装
+
+**Date:** 2026-05-27
+**Theme:** `JwtCodec` — 外部ライブラリなし HS256 JWT 発行・検証
+**Source:** NENE2 FT110 (jwtlog), FT113 (JWT refresh token rotation)
+
+---
+
+## What was done
+
+- `class/xion/JwtCodec.php`
+  - `issue(array $claims, ?int $ttl): string`
+  - `decode(string $token): ?array` — 失敗時 null（throw なし）
+  - `require(): array` — Authorization: Bearer ヘッダー読み取り + 検証、失敗時 HttpTermination(401)
+  - alg:none 防御、exp 必須、nbf 検証、hash_equals 署名比較
+- `config/error_codes.php` — `JWT-INVALID` (401) 追加
+- `docs/development/error-codes.md` — `JWT-INVALID` カタログ行追加
+- `tests/Unit/Xion/JwtCodecTest.php` — 12 テスト
+- `docs/development/agent-bearer-auth.md` — JwtCodec セクション追加
+
+---
+
+## Findings
+
+### F-1 — `exp` 必須にすることで無期限トークンを防ぐ（設計）
+
+`decode()` で `exp` がない/`int` でないトークンは null を返す。
+NENE2 FT110 F-4 と同様、`exp` なしトークンは永久に有効になるリスクがある。
+
+### F-2 — 外部ライブラリ不要（NeNe 設計原則確認）
+
+HS256 = HMAC-SHA256 + base64url。PHP 標準関数だけで実装でき、依存を増やさない。
+
+### F-3 — `error-codes.md` 同期テストが新規エラーコード追加を捕捉
+
+`ErrorCodeTest::testEveryRuntimeCodeAppearsInDocsMarkdownTable()` が `config/error_codes.php` と `docs/development/error-codes.md` の乖離を CI で検出する。`JWT-INVALID` 追加時に両ファイルの更新が必要であることを確認した。
+
+---
+
+## Patterns Validated
+
+- `hash_equals()` による定数時間署名比較（タイミング攻撃防止）
+- alg フィールド検証（`HS256` のみ受け入れ）
+- `exp` + `nbf` のタイムスタンプ検証
+- `issue()` の `iat`/`exp` 自動付与
+- `base64_decode(..., strict: true)` で不正な base64 を早期リジェクト

--- a/tests/Unit/Xion/CommandTest.php
+++ b/tests/Unit/Xion/CommandTest.php
@@ -198,8 +198,11 @@ final class CommandTest extends TestCase
 
     public function testLineOutputsMessageWithNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -215,8 +218,11 @@ final class CommandTest extends TestCase
 
     public function testLineWithNoArgumentOutputsBlankLine(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -232,8 +238,11 @@ final class CommandTest extends TestCase
 
     public function testErrorReturnsCorrectExitCode(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -248,8 +257,11 @@ final class CommandTest extends TestCase
 
     public function testWriteOutputsWithoutTrailingNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -265,8 +277,11 @@ final class CommandTest extends TestCase
 
     public function testLineAndWriteProduceDistinctOutput(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {

--- a/tests/Unit/Xion/JwtCodecTest.php
+++ b/tests/Unit/Xion/JwtCodecTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\JwtCodec;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for JwtCodec.
+ *
+ * `require()` reads Authorization headers via superglobals / SAPI functions
+ * and is therefore not tested here. All security-relevant logic is exercised
+ * through `issue()` and `decode()`.
+ */
+final class JwtCodecTest extends TestCase
+{
+    private JwtCodec $jwt;
+
+    protected function setUp(): void
+    {
+        $this->jwt = new JwtCodec('super-secret-key-that-is-at-least-32-bytes-long');
+    }
+
+    public function testIssueReturnsThreePartToken(): void
+    {
+        $token = $this->jwt->issue(['sub' => '42']);
+        $parts = explode('.', $token);
+        self::assertCount(3, $parts, 'JWT must have exactly three dot-separated parts');
+    }
+
+    public function testDecodeValidatesOwnToken(): void
+    {
+        $token = $this->jwt->issue(['sub' => '42', 'email' => 'user@example.com']);
+        $claims = $this->jwt->decode($token);
+        self::assertNotNull($claims, 'decode() must accept a freshly issued token');
+    }
+
+    public function testDecodeReturnsCorrectClaims(): void
+    {
+        $token  = $this->jwt->issue(['sub' => '99', 'email' => 'alice@example.com']);
+        $claims = $this->jwt->decode($token);
+        self::assertIsArray($claims);
+        assert($claims !== null);   // narrow type for static analysis
+        self::assertSame('99', $claims['sub']);
+        self::assertSame('alice@example.com', $claims['email']);
+        self::assertArrayHasKey('iat', $claims);
+        self::assertArrayHasKey('exp', $claims);
+        self::assertIsInt($claims['iat']);
+        self::assertIsInt($claims['exp']);
+    }
+
+    public function testDecodeReturnsNullForExpiredToken(): void
+    {
+        // Issue a token that is already expired (exp in the past)
+        $token  = $this->jwt->issue(['sub' => '1'], ttl: -1);
+        $claims = $this->jwt->decode($token);
+        self::assertNull($claims, 'decode() must reject an expired token');
+    }
+
+    public function testDecodeReturnsNullForWrongSignature(): void
+    {
+        $token = $this->jwt->issue(['sub' => '1']);
+        // Tamper: flip one character in the signature (last part)
+        $parts         = explode('.', $token);
+        $parts[2]      = $parts[2][0] === 'A' ? 'B' . substr($parts[2], 1) : 'A' . substr($parts[2], 1);
+        $tamperedToken = implode('.', $parts);
+
+        self::assertNull($this->jwt->decode($tamperedToken), 'decode() must reject wrong signature');
+    }
+
+    public function testDecodeReturnsNullForAlgNoneToken(): void
+    {
+        // Build a manually crafted alg:none token
+        $encodeB64url = static function (string $data): string {
+            return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+        };
+        $header  = $encodeB64url((string)json_encode(['alg' => 'none', 'typ' => 'JWT']));
+        $payload = $encodeB64url((string)json_encode(['sub' => '1', 'exp' => time() + 3600, 'iat' => time()]));
+        $token   = $header . '.' . $payload . '.';
+
+        self::assertNull($this->jwt->decode($token), 'decode() must reject alg:none tokens');
+    }
+
+    public function testDecodeReturnsNullForMissingExp(): void
+    {
+        // Craft a token without exp by building it manually using the same secret
+        // We issue normally then strip exp from the payload to simulate the case
+        $secret = 'super-secret-key-that-is-at-least-32-bytes-long';
+        $encodeB64url = static function (string $data): string {
+            return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+        };
+        $header  = $encodeB64url((string)json_encode(['alg' => 'HS256', 'typ' => 'JWT']));
+        $payload = $encodeB64url((string)json_encode(['sub' => '1', 'iat' => time()]));
+        $sig     = rtrim(strtr(base64_encode(
+            (string)hash_hmac('sha256', $header . '.' . $payload, $secret, binary: true)
+        ), '+/', '-_'), '=');
+        $token   = $header . '.' . $payload . '.' . $sig;
+
+        self::assertNull($this->jwt->decode($token), 'decode() must reject tokens without exp');
+    }
+
+    public function testDecodeReturnsNullForFutureNbf(): void
+    {
+        $token = $this->jwt->issue(['sub' => '1', 'nbf' => time() + 3600]);
+        self::assertNull($this->jwt->decode($token), 'decode() must reject token whose nbf is in the future');
+    }
+
+    public function testDecodeReturnsNullForEmptyString(): void
+    {
+        self::assertNull($this->jwt->decode(''), 'decode() must return null for empty string');
+    }
+
+    public function testDecodeReturnsNullForInvalidBase64(): void
+    {
+        self::assertNull($this->jwt->decode('!!!.!!!.!!!'), 'decode() must return null for invalid base64');
+    }
+
+    public function testIssueWithExplicitExpHonorsIt(): void
+    {
+        $explicitExp = time() + 7200;
+        $token       = $this->jwt->issue(['sub' => '1', 'exp' => $explicitExp]);
+        $claims      = $this->jwt->decode($token);
+        self::assertIsArray($claims);
+        assert($claims !== null);   // narrow type for static analysis
+        self::assertSame($explicitExp, $claims['exp'], 'issue() must honour a caller-provided exp');
+    }
+
+    public function testDecodeReturnsNullWithDifferentSecret(): void
+    {
+        $other  = new JwtCodec('completely-different-secret-key-that-is-32-bytes');
+        $token  = $this->jwt->issue(['sub' => '1']);
+        $claims = $other->decode($token);
+        self::assertNull($claims, 'decode() must reject tokens signed with a different secret');
+    }
+}


### PR DESCRIPTION
## Summary

FT30 implementation: adds `Nene\Xion\JwtCodec`, a pure-PHP HS256 JWT issuer and verifier with no external library dependency. Issues and verifies compact JWTs signed with HMAC-SHA256. Traces to NENE2 FT110 (jwtlog) and FT113 (JWT refresh token rotation).

## Code

- `class/xion/JwtCodec.php` — `issue()`, `decode()`, `require()`; alg:none defence, `exp` required, `nbf` validation, `hash_equals` sig compare
- `config/error_codes.php` — `JWT-INVALID` (401) entry
- `docs/development/error-codes.md` — `JWT-INVALID` catalog row (satisfies ErrorCodeTest sync check)
- `tests/Unit/Xion/JwtCodecTest.php` — 12 unit tests
- `docs/development/agent-bearer-auth.md` — JwtCodec usage section replaces placeholder
- `docs/field-trials/2026-05-field-trial-30.md` — FT report

## Test plan

- [x] `composer test` — 234/234 green
- [ ] `composer test:http`
- [x] `composer analyze` — exit 0
- [ ] `composer format:check`
- [ ] live verify: `curl -H "Authorization: Bearer $TOKEN" http://nene.local/...`

Closes #FT30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)