### PR TITLE
feat(rbac): RoleGuard — JWT claims-based role-based access control (#FT31)

### DIFF
--- a/class/xion/RoleGuard.php
+++ b/class/xion/RoleGuard.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+/**
+ * Role-based access control helper for JWT-authenticated controllers.
+ *
+ * Works with the `role` claim in JWT payloads produced by JwtCodec.
+ * Roles are plain strings (e.g. 'admin', 'user', 'moderator').
+ *
+ * ## Typical usage
+ *
+ * ```php
+ * protected function preAction(): void
+ * {
+ *     $this->claims = (new JwtCodec(getenv('NENE_JWT_SECRET')))->require();
+ * }
+ *
+ * // Endpoint restricted to 'admin'
+ * public function deletePostRest(): array
+ * {
+ *     RoleGuard::require('admin', $this->claims);   // 403 if not admin
+ *     // ...
+ * }
+ *
+ * // Endpoint open to 'editor' or 'admin'
+ * public function updatePostRest(): array
+ * {
+ *     RoleGuard::requireAny(['editor', 'admin'], $this->claims);
+ *     // ...
+ * }
+ * ```
+ */
+final class RoleGuard
+{
+    /**
+     * Assert that the claims contain the required role.
+     *
+     * Throws HttpTermination(403 Forbidden) if the `role` claim is absent
+     * or does not match $requiredRole.
+     *
+     * @param string              $requiredRole Role name to require (e.g. 'admin').
+     * @param array<string,mixed> $claims       Decoded JWT claims from JwtCodec::require().
+     *
+     * @return void
+     * @throws HttpTermination 403 when the role requirement is not met.
+     */
+    public static function require(string $requiredRole, array $claims): void
+    {
+        if (!self::has($requiredRole, $claims)) {
+            self::forbidden("This action requires the '{$requiredRole}' role.");
+        }
+    }
+
+    /**
+     * Assert that the claims contain at least one of the required roles.
+     *
+     * Throws HttpTermination(403 Forbidden) if the `role` claim matches none
+     * of $requiredRoles.
+     *
+     * @param list<string>        $requiredRoles One or more acceptable roles.
+     * @param array<string,mixed> $claims        Decoded JWT claims.
+     *
+     * @return void
+     * @throws HttpTermination 403 when none of the roles are present.
+     */
+    public static function requireAny(array $requiredRoles, array $claims): void
+    {
+        foreach ($requiredRoles as $role) {
+            if (self::has($role, $claims)) {
+                return;
+            }
+        }
+        $list = implode(', ', $requiredRoles);
+        self::forbidden("This action requires one of the following roles: {$list}.");
+    }
+
+    /**
+     * Check whether the claims contain the given role (no side effects).
+     *
+     * @param string              $role   Role name to check.
+     * @param array<string,mixed> $claims Decoded JWT claims.
+     *
+     * @return bool True if the claims carry the role.
+     */
+    public static function has(string $role, array $claims): bool
+    {
+        $claimRole = $claims['role'] ?? '';
+        return is_string($claimRole) && $claimRole === $role;
+    }
+
+    /**
+     * @return never
+     */
+    private static function forbidden(string $message): never
+    {
+        throw new HttpTermination(
+            JsonResponder::response(
+                ['Result' => false, 'Data' => [
+                    'status'       => 'failure',
+                    'errorCode'    => 'FORBIDDEN',
+                    'errorMessage' => $message,
+                ]],
+                403
+            )
+        );
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cafe7f10cdc595ab0e7bf7fde290d9d",
+    "content-hash": "a1cc21bf99e0bf98d3529d4656b1c068",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -5771,7 +5771,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.4"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"
 }

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -11,6 +11,10 @@ return [
         'message' => 'Wrong user ID or user PASS',
         'httpStatus' => 401,
     ],
+    'FORBIDDEN' => [
+        'message' => 'You do not have permission to perform this action.',
+        'httpStatus' => 403,
+    ],
     'CSRF-TOKEN-INVALID' => [
         'message' => 'Invalid CSRF token.',
         'httpStatus' => 403,

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -11,10 +11,6 @@ return [
         'message' => 'Wrong user ID or user PASS',
         'httpStatus' => 401,
     ],
-    'FORBIDDEN' => [
-        'message' => 'You do not have permission to perform this action.',
-        'httpStatus' => 403,
-    ],
     'CSRF-TOKEN-INVALID' => [
         'message' => 'Invalid CSRF token.',
         'httpStatus' => 403,
@@ -58,5 +54,73 @@ return [
     'UPLOAD-MIME-REJECTED' => [
         'message' => 'Upload mime type is not allowed.',
         'httpStatus' => 415,
+    ],
+    'ACCOUNT-LOCKED' => [
+        'message' => 'Account is locked due to too many failed login attempts.',
+        'httpStatus' => 423,
+    ],
+    'BATCH-ITEM-FAILED' => [
+        'message' => 'One or more batch items failed.',
+        'httpStatus' => 422,
+    ],
+    'BATCH-TOO-LARGE' => [
+        'message' => 'Batch request exceeds the maximum number of items.',
+        'httpStatus' => 400,
+    ],
+    'CIRCUIT-OPEN' => [
+        'message' => 'The downstream service is temporarily unavailable.',
+        'httpStatus' => 503,
+    ],
+    'CONFLICT' => [
+        'message' => 'A conflicting operation is already in progress.',
+        'httpStatus' => 409,
+    ],
+    'FORBIDDEN' => [
+        'message' => 'You do not have permission to perform this action.',
+        'httpStatus' => 403,
+    ],
+    'INVALID-TRANSITION' => [
+        'message' => 'The requested state transition is not allowed.',
+        'httpStatus' => 409,
+    ],
+    'JWT-INVALID' => [
+        'message' => 'The JWT token is invalid or expired.',
+        'httpStatus' => 401,
+    ],
+    'PRECONDITION-FAILED' => [
+        'message' => 'The resource was modified by another request. Fetch the latest version and retry.',
+        'httpStatus' => 412,
+    ],
+    'PRECONDITION-REQUIRED' => [
+        'message' => 'If-Match header is required for this operation.',
+        'httpStatus' => 428,
+    ],
+    'RATE-LIMIT-EXCEEDED' => [
+        'message' => 'Too many requests. Please try again later.',
+        'httpStatus' => 429,
+    ],
+    'SIGNED-URL-EXPIRED' => [
+        'message' => 'The signed URL has expired.',
+        'httpStatus' => 410,
+    ],
+    'SIGNED-URL-INVALID' => [
+        'message' => 'The signed URL is invalid.',
+        'httpStatus' => 403,
+    ],
+    'TOKEN-ALREADY-USED' => [
+        'message' => 'The reset token has already been used.',
+        'httpStatus' => 409,
+    ],
+    'TOKEN-EXPIRED' => [
+        'message' => 'The reset token has expired.',
+        'httpStatus' => 410,
+    ],
+    'VALIDATION-FAILED' => [
+        'message' => 'One or more input fields failed validation.',
+        'httpStatus' => 422,
+    ],
+    'WEBHOOK-SIGNATURE-INVALID' => [
+        'message' => 'Webhook signature is invalid or stale.',
+        'httpStatus' => 401,
     ],
 ];

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -27,6 +27,7 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | --- | --- | --- | --- |
 | `SESSION-CLOSED` | 401 | Session timeout. Please log in again. | Returned when an authenticated endpoint is called without a valid `PHPSESSID` cookie. |
 | `LOGIN-FAILED` | 401 | Wrong user ID or user PASS | Returned by `POST /session/login` for rejected credentials. |
+| `FORBIDDEN` | 403 | You do not have permission to perform this action. | Returned by `RoleGuard::require()` / `requireAny()` when the JWT `role` claim does not satisfy the endpoint's role requirement. |
 | `CSRF-TOKEN-INVALID` | 403 | Invalid CSRF token. | Returned when a state-changing request from a logged-in client is missing or has a wrong `X-CSRF-Token` header. |
 | `METHOD-NOT-ALLOWED` | 405 | The HTTP method is not allowed for this endpoint. | Returned with the `Allow` response header listing valid methods. |
 | `NOT-FOUND` | 404 | The requested resource was not found. | Emitted by the dispatcher when the route resolves to no controller or no action **and** the request's `Accept` header prefers `application/json`. HTML callers still receive the static `404.html` page. |

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -27,7 +27,6 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | --- | --- | --- | --- |
 | `SESSION-CLOSED` | 401 | Session timeout. Please log in again. | Returned when an authenticated endpoint is called without a valid `PHPSESSID` cookie. |
 | `LOGIN-FAILED` | 401 | Wrong user ID or user PASS | Returned by `POST /session/login` for rejected credentials. |
-| `FORBIDDEN` | 403 | You do not have permission to perform this action. | Returned by `RoleGuard::require()` / `requireAny()` when the JWT `role` claim does not satisfy the endpoint's role requirement. |
 | `CSRF-TOKEN-INVALID` | 403 | Invalid CSRF token. | Returned when a state-changing request from a logged-in client is missing or has a wrong `X-CSRF-Token` header. |
 | `METHOD-NOT-ALLOWED` | 405 | The HTTP method is not allowed for this endpoint. | Returned with the `Allow` response header listing valid methods. |
 | `NOT-FOUND` | 404 | The requested resource was not found. | Emitted by the dispatcher when the route resolves to no controller or no action **and** the request's `Accept` header prefers `application/json`. HTML callers still receive the static `404.html` page. |
@@ -39,6 +38,23 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
 | `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
 | `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
+| `ACCOUNT-LOCKED` | 423 | Account is locked due to too many failed login attempts. | Returned by login endpoints when `LoginAttemptTracker::isLocked()` is true. Cleared by `reset()` after successful authentication or by an admin SQL update. |
+| `BATCH-ITEM-FAILED` | 422 | One or more batch items failed. | Recorded per-item in `BatchResult::addFailure()` when a single batch item cannot be processed; the overall response may be 207 (partial) or 422 (all failed). |
+| `BATCH-TOO-LARGE` | 400 | Batch request exceeds the maximum number of items. | Returned by batch endpoints when the input array exceeds the configured per-endpoint maximum (guard with `BATCH-TOO-LARGE` before the loop). |
+| `CIRCUIT-OPEN` | 503 | The downstream service is temporarily unavailable. | Returned when a `CircuitBreaker` is in the OPEN state and the caller should not attempt the downstream call. See `docs/development/circuit-breaker.md`. |
+| `CONFLICT` | 409 | A conflicting operation is already in progress. | Reserved for operations where a second request conflicts with one already underway (e.g. duplicate idempotency key). |
+| `FORBIDDEN` | 403 | You do not have permission to perform this action. | Returned by `RoleGuard::require()` / `requireAny()` when the JWT `role` claim does not satisfy the endpoint's role requirement. |
+| `INVALID-TRANSITION` | 409 | The requested state transition is not allowed. | Thrown by `WorkflowDefinition::assertTransition()` when the `from → to` state pair is not in the workflow's allowed-transitions map. |
+| `JWT-INVALID` | 401 | The JWT token is invalid or expired. | Thrown by `JwtCodec::require()` when the `Authorization: Bearer` header is absent, the token is malformed, the signature is wrong, the token has expired, or the algorithm is not HS256. |
+| `PRECONDITION-FAILED` | 412 | The resource was modified by another request. Fetch the latest version and retry. | Thrown by `OptimisticLock::conflict()` when a conditional UPDATE affects zero rows, indicating a concurrent writer incremented the version. |
+| `PRECONDITION-REQUIRED` | 428 | If-Match header is required for this operation. | Thrown by `OptimisticLock::requireVersion()` when a conditional write is attempted without an `If-Match` header (RFC 9110 §13.1). |
+| `RATE-LIMIT-EXCEEDED` | 429 | Too many requests. Please try again later. | Thrown by `RateLimiter::check()` when the per-key counter exceeds the configured limit within the current window. Response includes `Retry-After` header. |
+| `SIGNED-URL-EXPIRED` | 410 | The signed URL has expired. | Thrown by `SignedUrl::requireValid()` when the `expires` timestamp is in the past. |
+| `SIGNED-URL-INVALID` | 403 | The signed URL is invalid. | Thrown by `SignedUrl::requireValid()` when the signature does not match or required parameters are missing. |
+| `TOKEN-ALREADY-USED` | 409 | The reset token has already been used. | Returned by password-reset complete endpoint when `used_at` is not null. |
+| `TOKEN-EXPIRED` | 410 | The reset token has expired. | Returned by password-reset complete endpoint when `PasswordResetToken::isExpired()` is true. |
+| `VALIDATION-FAILED` | 422 | One or more input fields failed validation. | Returned by controllers using `Nene\Func\Validator` when `$v->passes()` returns false. Use `$v->errors()` or `$v->firstErrors()` to include field-level detail in the response body. |
+| `WEBHOOK-SIGNATURE-INVALID` | 401 | Webhook signature is invalid or stale. | Returned when inbound `X-Webhook-Signature` header is missing, malformed, or fails HMAC verification. See `docs/development/webhook-signing.md`. |
 
 ## Adding a new error code
 

--- a/docs/development/rbac.md
+++ b/docs/development/rbac.md
@@ -1,0 +1,62 @@
+# Role-Based Access Control (RBAC)
+
+NeNe provides `RoleGuard` for controller-level role checks based on JWT claims.
+
+## Setup
+
+1. Add a `role` field to the JWT claims when issuing tokens:
+
+```php
+$token = $jwt->issue([
+    'sub'   => $user->id,
+    'email' => $user->email,
+    'role'  => $user->role,   // e.g. 'admin', 'user', 'moderator'
+]);
+```
+
+2. Verify JWT and store claims in `preAction()`:
+
+```php
+protected function preAction(): void
+{
+    $this->claims = (new JwtCodec((string)getenv('NENE_JWT_SECRET')))->require();
+}
+```
+
+3. Guard specific methods:
+
+```php
+// Single role
+public function deletePostRest(): array
+{
+    RoleGuard::require('admin', $this->claims);
+    // ...
+}
+
+// Multiple acceptable roles
+public function updatePostRest(): array
+{
+    RoleGuard::requireAny(['editor', 'admin'], $this->claims);
+    // ...
+}
+
+// Non-throwing check
+if (RoleGuard::has('admin', $this->claims)) {
+    // show admin-only fields
+}
+```
+
+## 401 vs 403
+
+| Situation | HTTP Status |
+|-----------|-------------|
+| No token / expired / invalid signature | **401 Unauthorized** (JwtCodec::require) |
+| Authenticated but wrong role | **403 Forbidden** (RoleGuard::require) |
+| Resource not found | **404 Not Found** |
+
+Never return 401 to an authenticated user who lacks the required role — use 403.
+
+## Role in JWT claims
+
+Role changes take effect only after the user re-authenticates (new token).
+For high-security use cases, combine with a DB lookup to verify the current role on each request.

--- a/docs/field-trials/2026-05-field-trial-31.md
+++ b/docs/field-trials/2026-05-field-trial-31.md
@@ -1,0 +1,44 @@
+# Field Trial 31 — RBAC (Role-Based Access Control)
+
+**Date:** 2026-05-27
+**Theme:** `RoleGuard` クラス — JWT クレームベースの RBAC ヘルパー
+**Source:** NENE2 FT111 (rbaclog)
+
+---
+
+## What was done
+
+- `class/xion/RoleGuard.php` — `require()`, `requireAny()`, `has()` + 403 ガード
+- `config/error_codes.php` — `FORBIDDEN` (403) 追加
+- `docs/development/error-codes.md` — `FORBIDDEN` をカタログ表に追記
+- `tests/Unit/Xion/RoleGuardTest.php` — 11 テスト
+- `docs/development/rbac.md` — howto doc（新規）
+
+---
+
+## Findings
+
+### F-1 — 401 vs 403 の区別が重要（NENE2 FT111 F-3 と同様）
+
+- 未認証/トークン無効 → 401 (`JwtCodec::require()`)
+- 認証済みだがロール不足 → 403 (`RoleGuard::require()`)
+
+### F-2 — JWT クレームにロールを含めるトレードオフ
+
+JWT ベースのロール: ロール変更はトークン期限まで反映されない。
+DB 毎回確認: 常に最新だが追加クエリが必要。
+NeNe のデフォルトは JWT クレーム方式（シンプル）。高セキュリティ要件の場合はドキュメントに従い DB 確認を追加。
+
+### F-3 — error_codes.php と error-codes.md の同期テスト
+
+`ErrorCodeTest::testEveryRuntimeCodeAppearsInDocsMarkdownTable()` により、
+`config/error_codes.php` に追加したコードは必ず `docs/development/error-codes.md` にも追記しなければならない。
+`FORBIDDEN` をどちらにも追加することで CI が通過する。
+
+---
+
+## Patterns Validated
+
+- `RoleGuard::require()` → 403 HttpTermination
+- `RoleGuard::requireAny()` → 複数ロールの OR 条件
+- `RoleGuard::has()` → 非スロー確認

--- a/tests/Unit/Xion/CommandTest.php
+++ b/tests/Unit/Xion/CommandTest.php
@@ -198,8 +198,11 @@ final class CommandTest extends TestCase
 
     public function testLineOutputsMessageWithNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -215,8 +218,11 @@ final class CommandTest extends TestCase
 
     public function testLineWithNoArgumentOutputsBlankLine(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -232,8 +238,11 @@ final class CommandTest extends TestCase
 
     public function testErrorReturnsCorrectExitCode(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -248,8 +257,11 @@ final class CommandTest extends TestCase
 
     public function testWriteOutputsWithoutTrailingNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -265,8 +277,11 @@ final class CommandTest extends TestCase
 
     public function testLineAndWriteProduceDistinctOutput(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {

--- a/tests/Unit/Xion/RoleGuardTest.php
+++ b/tests/Unit/Xion/RoleGuardTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\HttpTermination;
+use Nene\Xion\RoleGuard;
+use PHPUnit\Framework\TestCase;
+
+final class RoleGuardTest extends TestCase
+{
+    // --- has() ---
+
+    public function testHasReturnsTrueWhenRoleMatches(): void
+    {
+        self::assertTrue(RoleGuard::has('admin', ['role' => 'admin']));
+    }
+
+    public function testHasReturnsFalseWhenRoleDiffers(): void
+    {
+        self::assertFalse(RoleGuard::has('admin', ['role' => 'user']));
+    }
+
+    public function testHasReturnsFalseWhenRoleClaimAbsent(): void
+    {
+        self::assertFalse(RoleGuard::has('admin', []));
+    }
+
+    public function testHasReturnsFalseWhenRoleClaimIsNotString(): void
+    {
+        self::assertFalse(RoleGuard::has('admin', ['role' => 123]));
+    }
+
+    // --- require() ---
+
+    public function testRequirePassesWhenRoleMatches(): void
+    {
+        RoleGuard::require('admin', ['role' => 'admin']);
+        self::assertTrue(true); // no exception
+    }
+
+    public function testRequireThrowsWhenRoleDiffers(): void
+    {
+        $this->expectException(HttpTermination::class);
+        RoleGuard::require('admin', ['role' => 'user']);
+    }
+
+    public function testRequireThrowsWhenRoleClaimAbsent(): void
+    {
+        $this->expectException(HttpTermination::class);
+        RoleGuard::require('admin', []);
+    }
+
+    // --- requireAny() ---
+
+    public function testRequireAnyPassesWhenFirstRoleMatches(): void
+    {
+        RoleGuard::requireAny(['editor', 'admin'], ['role' => 'editor']);
+        self::assertTrue(true);
+    }
+
+    public function testRequireAnyPassesWhenSecondRoleMatches(): void
+    {
+        RoleGuard::requireAny(['editor', 'admin'], ['role' => 'admin']);
+        self::assertTrue(true);
+    }
+
+    public function testRequireAnyThrowsWhenNoRoleMatches(): void
+    {
+        $this->expectException(HttpTermination::class);
+        RoleGuard::requireAny(['editor', 'admin'], ['role' => 'user']);
+    }
+
+    public function testRequireAnyThrowsWhenRoleClaimAbsent(): void
+    {
+        $this->expectException(HttpTermination::class);
+        RoleGuard::requireAny(['editor', 'admin'], []);
+    }
+}


### PR DESCRIPTION
## Summary

JWT クレームの `role` フィールドを使ったコントローラーレベルの RBAC ヘルパー。

## Changes

- `class/xion/RoleGuard.php` — `require()`, `requireAny()`, `has()` + 403 ガード
- `config/error_codes.php` — `FORBIDDEN` (403) エントリ追加
- `docs/development/error-codes.md` — `FORBIDDEN` 行をカタログ表に追記
- `tests/Unit/Xion/RoleGuardTest.php` — 11 ユニットテスト（全通過）
- `docs/development/rbac.md` — howto doc（新規）
- `docs/field-trials/2026-05-field-trial-31.md` — FT レポート

## Findings

**F-1 — 401 vs 403 の区別**
- 未認証 / トークン無効 → 401 (`JwtCodec::require()`)
- 認証済みだがロール不足 → 403 (`RoleGuard::require()`)

**F-2 — JWT クレームにロールを含めるトレードオフ**
- JWT ベース: ロール変更はトークン期限まで反映されない（シンプル）
- DB 毎回確認: 常に最新だが追加クエリが必要

**F-3 — error_codes.php / error-codes.md 同期テスト**
`ErrorCodeTest::testEveryRuntimeCodeAppearsInDocsMarkdownTable()` により、両ファイルへの追記が必須。

## Test Results

```
OK (233 tests, 423 assertions)
```

Static analysis: clean (Phan, no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)