### PR TITLE
feat(audit): AuditLogger — append-only audit trail helper (#FT33)

### DIFF
--- a/class/xion/AuditLogger.php
+++ b/class/xion/AuditLogger.php
@@ -99,11 +99,11 @@ final class AuditLogger
                 ' (actor_id, action, resource_type, resource_id, payload)' .
                 ' VALUES (:actor_id, :action, :resource_type, :resource_id, :payload)'
             );
-            $stmt->bindValue(':actor_id',      $actorId,                                                          PDO::PARAM_INT);
-            $stmt->bindValue(':action',        $action,                                                           PDO::PARAM_STR);
-            $stmt->bindValue(':resource_type', $resourceType,                                                     PDO::PARAM_STR);
-            $stmt->bindValue(':resource_id',   $resourceId,                                                       PDO::PARAM_INT);
-            $stmt->bindValue(':payload',       json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR), PDO::PARAM_STR);
+            $stmt->bindValue(':actor_id', $actorId, PDO::PARAM_INT);
+            $stmt->bindValue(':action', $action, PDO::PARAM_STR);
+            $stmt->bindValue(':resource_type', $resourceType, PDO::PARAM_STR);
+            $stmt->bindValue(':resource_id', $resourceId, PDO::PARAM_INT);
+            $stmt->bindValue(':payload', json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR), PDO::PARAM_STR);
             $stmt->execute();
         } catch (\PDOException $e) {
             // Audit failures must not break the primary operation.

--- a/class/xion/AuditLogger.php
+++ b/class/xion/AuditLogger.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use Monolog\Logger;
+use PDO;
+
+/**
+ * Append-only audit log writer.
+ *
+ * Records actor / action / resource mutations to an `audit_log` table.
+ * The table is intentionally write-only via this class; only SELECT via
+ * SQL or a dedicated read mapper is supported. Never add UPDATE/DELETE
+ * routes for audit records — immutability is the point.
+ *
+ * ## Schema (add to SchemaDefinition or SQL migration)
+ *
+ * ```sql
+ * CREATE TABLE audit_log (
+ *     id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+ *     actor_id      BIGINT       NOT NULL,
+ *     action        VARCHAR(64)  NOT NULL,   -- 'created' | 'updated' | 'deleted' | custom
+ *     resource_type VARCHAR(64)  NOT NULL,   -- e.g. 'task', 'user', 'order'
+ *     resource_id   BIGINT       NOT NULL,
+ *     payload       TEXT         NOT NULL,   -- JSON: snapshot / before+after / notes
+ *     created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ *
+ * ## Typical usage
+ *
+ * ```php
+ * $audit = new AuditLogger();
+ *
+ * // Create
+ * $task = $this->taskMapper->create($title, $body, $actorId);
+ * $audit->record($actorId, 'created', 'task', $task->id, ['title' => $title]);
+ *
+ * // Update (before/after)
+ * $before = $this->taskMapper->find($id);
+ * $after  = $this->taskMapper->update($id, $newData);
+ * $audit->record($actorId, 'updated', 'task', $id, [
+ *     'before' => ['title' => $before->title],
+ *     'after'  => ['title' => $after->title],
+ * ]);
+ *
+ * // Delete
+ * $task = $this->taskMapper->find($id);
+ * $this->taskMapper->delete($task);
+ * $audit->record($actorId, 'deleted', 'task', $id, ['title' => $task->title]);
+ * ```
+ */
+final class AuditLogger
+{
+    private const TABLE = 'audit_log';
+
+    private PDO $db;
+
+    private Logger $logger;
+
+    /**
+     * @param string      $table  Override the default table name (for testing or multi-tenant use).
+     * @param PDO|null    $db     Database connection. Defaults to PdoConnection::getInstance().
+     * @param Logger|null $logger Logger instance. Defaults to Log::getInstance().
+     */
+    public function __construct(
+        private readonly string $table = self::TABLE,
+        ?PDO $db = null,
+        ?Logger $logger = null,
+    ) {
+        $this->db     = $db     ?? PdoConnection::getInstance();
+        $this->logger = $logger ?? Log::getInstance();
+    }
+
+    /**
+     * Append an audit record.
+     *
+     * @param int                 $actorId      ID of the user performing the action.
+     * @param string              $action       Action name: 'created', 'updated', 'deleted', or custom.
+     * @param string              $resourceType Resource type name (e.g. 'task', 'order').
+     * @param int                 $resourceId   Resource primary key.
+     * @param array<string,mixed> $payload      Arbitrary context (snapshot, before/after, notes).
+     *                                          Do NOT include passwords or other secrets.
+     *
+     * @return void
+     */
+    public function record(
+        int $actorId,
+        string $action,
+        string $resourceType,
+        int $resourceId,
+        array $payload = [],
+    ): void {
+        try {
+            $stmt = $this->db->prepare(
+                'INSERT INTO ' . $this->table .
+                ' (actor_id, action, resource_type, resource_id, payload)' .
+                ' VALUES (:actor_id, :action, :resource_type, :resource_id, :payload)'
+            );
+            $stmt->bindValue(':actor_id',      $actorId,                                                          PDO::PARAM_INT);
+            $stmt->bindValue(':action',        $action,                                                           PDO::PARAM_STR);
+            $stmt->bindValue(':resource_type', $resourceType,                                                     PDO::PARAM_STR);
+            $stmt->bindValue(':resource_id',   $resourceId,                                                       PDO::PARAM_INT);
+            $stmt->bindValue(':payload',       json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR), PDO::PARAM_STR);
+            $stmt->execute();
+        } catch (\PDOException $e) {
+            // Audit failures must not break the primary operation.
+            // Log the error and continue.
+            $this->logger->error('AuditLogger: failed to record audit entry.', [
+                'exception'     => $e->getMessage(),
+                'actor_id'      => $actorId,
+                'action'        => $action,
+                'resource_type' => $resourceType,
+                'resource_id'   => $resourceId,
+            ]);
+        }
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cafe7f10cdc595ab0e7bf7fde290d9d",
+    "content-hash": "a1cc21bf99e0bf98d3529d4656b1c068",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -5771,7 +5771,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.4"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"
 }

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -55,4 +55,72 @@ return [
         'message' => 'Upload mime type is not allowed.',
         'httpStatus' => 415,
     ],
+    'ACCOUNT-LOCKED' => [
+        'message' => 'Account is locked due to too many failed login attempts.',
+        'httpStatus' => 423,
+    ],
+    'BATCH-ITEM-FAILED' => [
+        'message' => 'One or more batch items failed.',
+        'httpStatus' => 422,
+    ],
+    'BATCH-TOO-LARGE' => [
+        'message' => 'Batch request exceeds the maximum number of items.',
+        'httpStatus' => 400,
+    ],
+    'CIRCUIT-OPEN' => [
+        'message' => 'The downstream service is temporarily unavailable.',
+        'httpStatus' => 503,
+    ],
+    'CONFLICT' => [
+        'message' => 'A conflicting operation is already in progress.',
+        'httpStatus' => 409,
+    ],
+    'FORBIDDEN' => [
+        'message' => 'You do not have permission to perform this action.',
+        'httpStatus' => 403,
+    ],
+    'INVALID-TRANSITION' => [
+        'message' => 'The requested state transition is not allowed.',
+        'httpStatus' => 409,
+    ],
+    'JWT-INVALID' => [
+        'message' => 'The JWT token is invalid or expired.',
+        'httpStatus' => 401,
+    ],
+    'PRECONDITION-FAILED' => [
+        'message' => 'The resource was modified by another request. Fetch the latest version and retry.',
+        'httpStatus' => 412,
+    ],
+    'PRECONDITION-REQUIRED' => [
+        'message' => 'If-Match header is required for this operation.',
+        'httpStatus' => 428,
+    ],
+    'RATE-LIMIT-EXCEEDED' => [
+        'message' => 'Too many requests. Please try again later.',
+        'httpStatus' => 429,
+    ],
+    'SIGNED-URL-EXPIRED' => [
+        'message' => 'The signed URL has expired.',
+        'httpStatus' => 410,
+    ],
+    'SIGNED-URL-INVALID' => [
+        'message' => 'The signed URL is invalid.',
+        'httpStatus' => 403,
+    ],
+    'TOKEN-ALREADY-USED' => [
+        'message' => 'The reset token has already been used.',
+        'httpStatus' => 409,
+    ],
+    'TOKEN-EXPIRED' => [
+        'message' => 'The reset token has expired.',
+        'httpStatus' => 410,
+    ],
+    'VALIDATION-FAILED' => [
+        'message' => 'One or more input fields failed validation.',
+        'httpStatus' => 422,
+    ],
+    'WEBHOOK-SIGNATURE-INVALID' => [
+        'message' => 'Webhook signature is invalid or stale.',
+        'httpStatus' => 401,
+    ],
 ];

--- a/docs/development/audit-log.md
+++ b/docs/development/audit-log.md
@@ -1,0 +1,78 @@
+# Audit Log (Audit Trail)
+
+How to record every state-changing operation in NeNe using `AuditLogger`.
+
+## Framework class: `AuditLogger`
+
+`Nene\Xion\AuditLogger` writes append-only records to an `audit_log` table.
+
+```php
+$audit = new AuditLogger();
+$audit->record($actorId, 'created', 'task', $task->id, ['title' => $task->title]);
+```
+
+## Schema
+
+Add to `class/xion/SchemaDefinition.php`:
+
+```php
+'audit_log' => [
+    'columns' => [
+        'id'            => ['type' => 'pk-bigint'],
+        'created_at'    => ['type' => 'datetime-now'],
+        'actor_id'      => ['type' => 'bigint'],
+        'action'        => ['type' => 'varchar:64'],   // created | updated | deleted | custom
+        'resource_type' => ['type' => 'varchar:64'],   // e.g. 'task', 'user'
+        'resource_id'   => ['type' => 'bigint'],
+        'payload'       => ['type' => 'text'],         // JSON snapshot / before+after
+    ],
+    'indexes' => [
+        'audit_log_actor_id_index'            => ['actor_id'],
+        'audit_log_resource_type_id_index'    => ['resource_type', 'resource_id'],
+    ],
+],
+```
+
+## Usage patterns
+
+### Create
+
+```php
+$task = $this->taskMapper->create($title, $body, $actorId);
+$audit->record($actorId, 'created', 'task', $task->id, [
+    'title' => $task->title,
+    'body'  => $task->body,
+]);
+```
+
+### Update (before/after)
+
+```php
+$before = $this->taskMapper->find($id);
+$after  = $this->taskMapper->update($id, $newTitle, $newBody);
+$audit->record($actorId, 'updated', 'task', $id, [
+    'before' => ['title' => $before->title, 'body' => $before->body],
+    'after'  => ['title' => $after->title,  'body' => $after->body],
+]);
+```
+
+### Delete
+
+```php
+$task = $this->taskMapper->find($id);
+$this->taskMapper->delete($task);
+$audit->record($actorId, 'deleted', 'task', $task->id, [
+    'title' => $task->title,
+]);
+```
+
+## Immutability
+
+Never expose write endpoints (`POST /audit`, `DELETE /audit/{id}`) for audit records.
+`AuditLogger` only inserts — no `update()` or `delete()` methods by design.
+
+## Security notes
+
+- **Do not log secrets**: never include passwords, tokens, or API keys in payload.
+- **Actor from JWT claims**: always use `$claims['sub']` as `$actorId`, never a user-supplied value.
+- **Audit failures must not break primary operations**: `AuditLogger::record()` catches `PDOException` internally and logs the error via Monolog — the main operation continues.

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -38,6 +38,23 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
 | `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
 | `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
+| `ACCOUNT-LOCKED` | 423 | Account is locked due to too many failed login attempts. | Returned by login endpoints when `LoginAttemptTracker::isLocked()` is true. Cleared by `reset()` after successful authentication or by an admin SQL update. |
+| `BATCH-ITEM-FAILED` | 422 | One or more batch items failed. | Recorded per-item in `BatchResult::addFailure()` when a single batch item cannot be processed; the overall response may be 207 (partial) or 422 (all failed). |
+| `BATCH-TOO-LARGE` | 400 | Batch request exceeds the maximum number of items. | Returned by batch endpoints when the input array exceeds the configured per-endpoint maximum (guard with `BATCH-TOO-LARGE` before the loop). |
+| `CIRCUIT-OPEN` | 503 | The downstream service is temporarily unavailable. | Returned when a `CircuitBreaker` is in the OPEN state and the caller should not attempt the downstream call. See `docs/development/circuit-breaker.md`. |
+| `CONFLICT` | 409 | A conflicting operation is already in progress. | Reserved for operations where a second request conflicts with one already underway (e.g. duplicate idempotency key). |
+| `FORBIDDEN` | 403 | You do not have permission to perform this action. | Returned by `RoleGuard::require()` / `requireAny()` when the JWT `role` claim does not satisfy the endpoint's role requirement. |
+| `INVALID-TRANSITION` | 409 | The requested state transition is not allowed. | Thrown by `WorkflowDefinition::assertTransition()` when the `from → to` state pair is not in the workflow's allowed-transitions map. |
+| `JWT-INVALID` | 401 | The JWT token is invalid or expired. | Thrown by `JwtCodec::require()` when the `Authorization: Bearer` header is absent, the token is malformed, the signature is wrong, the token has expired, or the algorithm is not HS256. |
+| `PRECONDITION-FAILED` | 412 | The resource was modified by another request. Fetch the latest version and retry. | Thrown by `OptimisticLock::conflict()` when a conditional UPDATE affects zero rows, indicating a concurrent writer incremented the version. |
+| `PRECONDITION-REQUIRED` | 428 | If-Match header is required for this operation. | Thrown by `OptimisticLock::requireVersion()` when a conditional write is attempted without an `If-Match` header (RFC 9110 §13.1). |
+| `RATE-LIMIT-EXCEEDED` | 429 | Too many requests. Please try again later. | Thrown by `RateLimiter::check()` when the per-key counter exceeds the configured limit within the current window. Response includes `Retry-After` header. |
+| `SIGNED-URL-EXPIRED` | 410 | The signed URL has expired. | Thrown by `SignedUrl::requireValid()` when the `expires` timestamp is in the past. |
+| `SIGNED-URL-INVALID` | 403 | The signed URL is invalid. | Thrown by `SignedUrl::requireValid()` when the signature does not match or required parameters are missing. |
+| `TOKEN-ALREADY-USED` | 409 | The reset token has already been used. | Returned by password-reset complete endpoint when `used_at` is not null. |
+| `TOKEN-EXPIRED` | 410 | The reset token has expired. | Returned by password-reset complete endpoint when `PasswordResetToken::isExpired()` is true. |
+| `VALIDATION-FAILED` | 422 | One or more input fields failed validation. | Returned by controllers using `Nene\Func\Validator` when `$v->passes()` returns false. Use `$v->errors()` or `$v->firstErrors()` to include field-level detail in the response body. |
+| `WEBHOOK-SIGNATURE-INVALID` | 401 | Webhook signature is invalid or stale. | Returned when inbound `X-Webhook-Signature` header is missing, malformed, or fails HMAC verification. See `docs/development/webhook-signing.md`. |
 
 ## Adding a new error code
 

--- a/docs/field-trials/2026-05-field-trial-33.md
+++ b/docs/field-trials/2026-05-field-trial-33.md
@@ -1,0 +1,44 @@
+# Field Trial 33 — 監査ログ（Audit Trail）
+
+**Date:** 2026-05-27
+**Theme:** `AuditLogger` — append-only 監査ログヘルパー
+**Source:** NENE2 FT59 (auditlog), FT74 (auditlog), FT114
+
+---
+
+## What was done
+
+- `class/xion/AuditLogger.php` — `record()` メソッドのみの write-only ヘルパー
+- `tests/Unit/Xion/AuditLoggerTest.php` — 9 テスト、23 アサーション
+- `docs/development/audit-log.md` — howto doc
+
+---
+
+## Findings
+
+### F-1 — 監査失敗が主操作を止めてはいけない（設計方針）
+
+`record()` が `PDOException` をキャッチして Monolog にエラーを記録する。
+`prepare()` と `execute()` の両方を単一の try/catch で囲み、監査ログの書き込み失敗でユーザーの操作が中断されることを防ぐ。
+
+### F-2 — 監査レコードは immutable（設計方針）
+
+`AuditLogger` は `record()` のみ。UPDATE/DELETE API は意図的に持たない。
+
+### F-3 — ペイロードに機密情報を含めない（セキュリティ）
+
+パスワードハッシュ、トークン、API キーは payload に含めない。howto doc に明記。
+
+### F-4 — Logger 注入によるテスト容易性
+
+`Log::getInstance()` はランタイム定数（`ACCESS_LOG_PATH` 等）を必要とするため、テスト環境での直接呼び出しが困難だった。コンストラクタに `?Logger $logger = null` を追加し、デフォルトで `Log::getInstance()` を使いつつテストでは no-handler の `Logger('test')` を注入するパターンで解決した。
+
+---
+
+## Patterns Validated
+
+- `INSERT INTO audit_log (actor_id, action, ...) VALUES (:actor_id, ...)` パターン
+- `JSON_UNESCAPED_UNICODE` による日本語 payload の安全エンコード
+- `PDOException` キャッチで主操作を保護（prepare / execute 両方を単一 try/catch）
+- before/after スナップショットパターン（howto doc で文書化）
+- コンストラクタ注入によるテスト容易性（PDO + Logger）

--- a/tests/Unit/Xion/AuditLoggerTest.php
+++ b/tests/Unit/Xion/AuditLoggerTest.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Monolog\Logger;
+use Nene\Xion\AuditLogger;
+use PDO;
+use PDOStatement;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for AuditLogger (FT33 — audit trail).
+ *
+ * Strategy: AuditLogger accepts PDO and Logger via constructor injection.
+ * A mock PDO and a no-handler Logger are passed directly, so no real
+ * database or container is needed.
+ *
+ * Coverage:
+ *  - record() executes INSERT with correct bound parameters
+ *  - record() JSON-encodes the payload
+ *  - record() JSON-encodes Japanese characters with JSON_UNESCAPED_UNICODE
+ *  - record() does not propagate PDOException from execute() (catches internally)
+ *  - record() does not propagate PDOException from prepare() (catches internally)
+ *  - default table name is 'audit_log'
+ *  - custom table name is used in SQL
+ */
+final class AuditLoggerTest extends TestCase
+{
+    /** @var PDO&MockObject */
+    private PDO $mockPdo;
+
+    /** @var PDOStatement&MockObject */
+    private PDOStatement $mockStmt;
+
+    private Logger $nullLogger;
+
+    private AuditLogger $logger;
+
+    protected function setUp(): void
+    {
+        $this->mockPdo    = $this->createMock(PDO::class);
+        $this->mockStmt   = $this->createMock(PDOStatement::class);
+        // No-handler logger: error() calls do not fail, nothing is written.
+        $this->nullLogger = new Logger('test');
+        $this->logger     = new AuditLogger('audit_log', $this->mockPdo, $this->nullLogger);
+    }
+
+    // ------------------------------------------------------------------ //
+    // record() — INSERT execution
+    // ------------------------------------------------------------------ //
+
+    public function testRecordExecutesInsert(): void
+    {
+        $this->mockPdo
+            ->expects($this->once())
+            ->method('prepare')
+            ->willReturn($this->mockStmt);
+
+        $this->mockStmt->expects($this->once())->method('execute');
+
+        $this->logger->record(1, 'created', 'task', 42, ['title' => 'hello']);
+    }
+
+    public function testRecordSqlContainsExpectedTokens(): void
+    {
+        $capturedSql = '';
+
+        $this->mockPdo
+            ->method('prepare')
+            ->willReturnCallback(function (string $sql) use (&$capturedSql): PDOStatement {
+                $capturedSql = $sql;
+                return $this->mockStmt;
+            });
+
+        $this->mockStmt->method('execute');
+
+        $this->logger->record(7, 'updated', 'order', 99, []);
+
+        $this->assertStringContainsString('INSERT INTO', $capturedSql);
+        $this->assertStringContainsString('audit_log', $capturedSql);
+        $this->assertStringContainsString(':actor_id', $capturedSql);
+        $this->assertStringContainsString(':action', $capturedSql);
+        $this->assertStringContainsString(':resource_type', $capturedSql);
+        $this->assertStringContainsString(':resource_id', $capturedSql);
+        $this->assertStringContainsString(':payload', $capturedSql);
+    }
+
+    public function testRecordBindsCorrectParameters(): void
+    {
+        $this->mockPdo->method('prepare')->willReturn($this->mockStmt);
+
+        $capture = new BindingCapture();
+
+        $this->mockStmt
+            ->method('bindValue')
+            ->willReturnCallback(function (string $param, mixed $value, int $type) use ($capture): bool {
+                $capture->add($param, $value, $type);
+                return true;
+            });
+
+        $this->mockStmt->method('execute');
+
+        $this->logger->record(5, 'deleted', 'user', 123, []);
+
+        $this->assertSame(5, $capture->value(':actor_id'));
+        $this->assertSame(PDO::PARAM_INT, $capture->type(':actor_id'));
+
+        $this->assertSame('deleted', $capture->value(':action'));
+        $this->assertSame(PDO::PARAM_STR, $capture->type(':action'));
+
+        $this->assertSame('user', $capture->value(':resource_type'));
+        $this->assertSame(PDO::PARAM_STR, $capture->type(':resource_type'));
+
+        $this->assertSame(123, $capture->value(':resource_id'));
+        $this->assertSame(PDO::PARAM_INT, $capture->type(':resource_id'));
+    }
+
+    // ------------------------------------------------------------------ //
+    // record() — JSON payload encoding
+    // ------------------------------------------------------------------ //
+
+    public function testRecordEncodesPayloadAsJson(): void
+    {
+        $this->mockPdo->method('prepare')->willReturn($this->mockStmt);
+
+        $capturedPayload = '';
+
+        $this->mockStmt
+            ->method('bindValue')
+            ->willReturnCallback(function (string $param, mixed $value) use (&$capturedPayload): bool {
+                if ($param === ':payload') {
+                    $capturedPayload = (string)$value;
+                }
+                return true;
+            });
+
+        $this->mockStmt->method('execute');
+
+        $this->logger->record(1, 'created', 'task', 10, ['title' => 'buy milk', 'done' => false]);
+
+        $decoded = json_decode($capturedPayload, true);
+        $this->assertSame(['title' => 'buy milk', 'done' => false], $decoded);
+    }
+
+    public function testRecordEncodesJapanesePayloadWithoutEscaping(): void
+    {
+        $this->mockPdo->method('prepare')->willReturn($this->mockStmt);
+
+        $capturedPayload = '';
+
+        $this->mockStmt
+            ->method('bindValue')
+            ->willReturnCallback(function (string $param, mixed $value) use (&$capturedPayload): bool {
+                if ($param === ':payload') {
+                    $capturedPayload = (string)$value;
+                }
+                return true;
+            });
+
+        $this->mockStmt->method('execute');
+
+        $this->logger->record(1, 'created', 'task', 1, ['title' => '日本語タイトル']);
+
+        // JSON_UNESCAPED_UNICODE keeps multibyte chars as-is (not \uXXXX).
+        $this->assertStringContainsString('日本語タイトル', $capturedPayload);
+    }
+
+    public function testRecordEncodesEmptyPayloadAsEmptyJsonArray(): void
+    {
+        $this->mockPdo->method('prepare')->willReturn($this->mockStmt);
+
+        $capturedPayload = '';
+
+        $this->mockStmt
+            ->method('bindValue')
+            ->willReturnCallback(function (string $param, mixed $value) use (&$capturedPayload): bool {
+                if ($param === ':payload') {
+                    $capturedPayload = (string)$value;
+                }
+                return true;
+            });
+
+        $this->mockStmt->method('execute');
+
+        $this->logger->record(1, 'created', 'task', 1, []);
+
+        $this->assertSame('[]', $capturedPayload);
+    }
+
+    // ------------------------------------------------------------------ //
+    // record() — PDOException swallowed
+    // ------------------------------------------------------------------ //
+
+    public function testRecordDoesNotPropagateExecutePdoException(): void
+    {
+        $this->mockPdo->method('prepare')->willReturn($this->mockStmt);
+
+        $this->mockStmt->method('bindValue')->willReturn(true);
+        $this->mockStmt
+            ->method('execute')
+            ->willThrowException(new \PDOException('Disk full'));
+
+        // record() must catch the exception internally — no exception surfaces here.
+        $this->logger->record(1, 'created', 'task', 1, []);
+
+        // Reaching this assertion confirms the exception was swallowed.
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRecordDoesNotPropagatePrepareException(): void
+    {
+        $this->mockPdo
+            ->method('prepare')
+            ->willThrowException(new \PDOException('Connection lost'));
+
+        // prepare() throws PDOException; record() catches it internally.
+        $this->logger->record(2, 'deleted', 'order', 7, []);
+
+        $this->addToAssertionCount(1);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Custom table name
+    // ------------------------------------------------------------------ //
+
+    public function testCustomTableNameAppearsInSql(): void
+    {
+        $customLogger = new AuditLogger('tenant_audit_log', $this->mockPdo, $this->nullLogger);
+
+        $capturedSql = '';
+
+        $this->mockPdo
+            ->method('prepare')
+            ->willReturnCallback(function (string $sql) use (&$capturedSql): PDOStatement {
+                $capturedSql = $sql;
+                return $this->mockStmt;
+            });
+
+        $this->mockStmt->method('execute');
+
+        $customLogger->record(1, 'created', 'task', 1, []);
+
+        $this->assertStringContainsString('tenant_audit_log', $capturedSql);
+    }
+}
+
+// ======================================================================
+// Test helpers
+// ======================================================================
+
+/**
+ * Captures bindValue() calls so Phan can type-check the assertions
+ * without encountering array-offset issues from closures with &$bindings.
+ */
+final class BindingCapture
+{
+    /** @var array<string, array{value: mixed, type: int}> */
+    private array $data = [];
+
+    public function add(string $param, mixed $value, int $type): void
+    {
+        $this->data[$param] = ['value' => $value, 'type' => $type];
+    }
+
+    public function value(string $param): mixed
+    {
+        return $this->data[$param]['value'];
+    }
+
+    public function type(string $param): int
+    {
+        return $this->data[$param]['type'];
+    }
+}

--- a/tests/Unit/Xion/CommandTest.php
+++ b/tests/Unit/Xion/CommandTest.php
@@ -198,8 +198,11 @@ final class CommandTest extends TestCase
 
     public function testLineOutputsMessageWithNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -215,8 +218,11 @@ final class CommandTest extends TestCase
 
     public function testLineWithNoArgumentOutputsBlankLine(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -232,8 +238,11 @@ final class CommandTest extends TestCase
 
     public function testErrorReturnsCorrectExitCode(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -248,8 +257,11 @@ final class CommandTest extends TestCase
 
     public function testWriteOutputsWithoutTrailingNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -265,8 +277,11 @@ final class CommandTest extends TestCase
 
     public function testLineAndWriteProduceDistinctOutput(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {


### PR DESCRIPTION
## Summary

Add `Nene\Xion\AuditLogger`, a lightweight append-only audit log helper based on NENE2 FT114 patterns. Records who did what to which resource in an `audit_log` table. The class is intentionally write-only — no update/delete methods — to preserve immutability.

## Code

- `class/xion/AuditLogger.php` — final `record()`-only helper; PDO + Logger injected via constructor (defaults to framework singletons).
- `tests/Unit/Xion/AuditLoggerTest.php` — 9 tests, 23 assertions: INSERT SQL, parameter bindings, JSON payload encoding, `JSON_UNESCAPED_UNICODE` for Japanese, PDOException swallowing (both `prepare()` and `execute()`), custom table name.
- `docs/development/audit-log.md` — create/update/delete usage patterns, schema snippet, immutability + security notes.
- `docs/field-trials/2026-05-field-trial-33.md` — FT33 report.

## Test plan

- [x] `composer test` — 231 tests, 435 assertions, OK
- [ ] `composer test:http`
- [x] `composer analyze` — clean (no new issues)
- [ ] `composer format:check`
- [ ] live verify: n/a — helper class only; integration left to app layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)