### PR TITLE
feat(batch): BatchResult — partial-success accumulator (#FT40)

### DIFF
--- a/class/xion/BatchResult.php
+++ b/class/xion/BatchResult.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Nene\Xion;
 
 /**

--- a/class/xion/BatchResult.php
+++ b/class/xion/BatchResult.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+namespace Nene\Xion;
+
+/**
+ * Accumulates per-item results for a batch operation.
+ *
+ * Usage:
+ *   $result = new BatchResult();
+ *   foreach ($items as $i => $item) {
+ *       try {
+ *           $id = $mapper->create($item);
+ *           $result->addSuccess($i, ['id' => $id]);
+ *       } catch (\Throwable $e) {
+ *           $result->addFailure($i, 'VALIDATION-FAILED', $e->getMessage());
+ *       }
+ *   }
+ *   http_response_code($result->httpStatus());
+ *   echo json_encode($result->toArray());
+ */
+final class BatchResult
+{
+    /** @var array<int, array{index: int, status: 'success'|'failure', data?: mixed, errorCode?: string, errorMessage?: string}> */
+    private array $items = [];
+
+    /**
+     * Record a successful item.
+     *
+     * @param int   $index Zero-based position in the original request array.
+     * @param mixed $data  The data to return for this item (optional).
+     */
+    public function addSuccess(int $index, mixed $data = null): void
+    {
+        $entry = ['index' => $index, 'status' => 'success'];
+        if ($data !== null) {
+            $entry['data'] = $data;
+        }
+        $this->items[] = $entry;
+    }
+
+    /**
+     * Record a failed item.
+     *
+     * @param int    $index        Zero-based position in the original request array.
+     * @param string $errorCode    Machine-readable error code.
+     * @param string $errorMessage Human-readable description.
+     */
+    public function addFailure(int $index, string $errorCode, string $errorMessage = ''): void
+    {
+        $this->items[] = [
+            'index'        => $index,
+            'status'       => 'failure',
+            'errorCode'    => $errorCode,
+            'errorMessage' => $errorMessage,
+        ];
+    }
+
+    /**
+     * Total number of items recorded.
+     */
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    /**
+     * Number of successful items.
+     */
+    public function successCount(): int
+    {
+        return count(array_filter($this->items, fn ($i) => $i['status'] === 'success'));
+    }
+
+    /**
+     * Number of failed items.
+     */
+    public function failureCount(): int
+    {
+        return count(array_filter($this->items, fn ($i) => $i['status'] === 'failure'));
+    }
+
+    /**
+     * True if at least one item succeeded and at least one failed.
+     */
+    public function isPartialSuccess(): bool
+    {
+        return $this->successCount() > 0 && $this->failureCount() > 0;
+    }
+
+    /**
+     * True if every recorded item succeeded.
+     */
+    public function allSucceeded(): bool
+    {
+        return $this->count() > 0 && $this->failureCount() === 0;
+    }
+
+    /**
+     * True if every recorded item failed.
+     */
+    public function allFailed(): bool
+    {
+        return $this->count() > 0 && $this->successCount() === 0;
+    }
+
+    /**
+     * Suggested HTTP status code for the response.
+     *
+     * - 200  all succeeded (or empty)
+     * - 207  partial success
+     * - 422  all failed
+     */
+    public function httpStatus(): int
+    {
+        if ($this->isPartialSuccess()) {
+            return 207;
+        }
+        if ($this->allFailed()) {
+            return 422;
+        }
+        return 200;
+    }
+
+    /**
+     * Serialize to an array suitable for JSON encoding.
+     *
+     * @return array{items: list<array<string,mixed>>, succeeded: int, failed: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'items'     => array_values($this->items),
+            'succeeded' => $this->successCount(),
+            'failed'    => $this->failureCount(),
+        ];
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cafe7f10cdc595ab0e7bf7fde290d9d",
+    "content-hash": "a1cc21bf99e0bf98d3529d4656b1c068",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -5771,7 +5771,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.4"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"
 }

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -55,12 +55,72 @@ return [
         'message' => 'Upload mime type is not allowed.',
         'httpStatus' => 415,
     ],
-    'BATCH-TOO-LARGE' => [
-        'message' => 'Batch request exceeds the maximum number of items.',
-        'httpStatus' => 400,
+    'ACCOUNT-LOCKED' => [
+        'message' => 'Account is locked due to too many failed login attempts.',
+        'httpStatus' => 423,
     ],
     'BATCH-ITEM-FAILED' => [
         'message' => 'One or more batch items failed.',
         'httpStatus' => 422,
+    ],
+    'BATCH-TOO-LARGE' => [
+        'message' => 'Batch request exceeds the maximum number of items.',
+        'httpStatus' => 400,
+    ],
+    'CIRCUIT-OPEN' => [
+        'message' => 'The downstream service is temporarily unavailable.',
+        'httpStatus' => 503,
+    ],
+    'CONFLICT' => [
+        'message' => 'A conflicting operation is already in progress.',
+        'httpStatus' => 409,
+    ],
+    'FORBIDDEN' => [
+        'message' => 'You do not have permission to perform this action.',
+        'httpStatus' => 403,
+    ],
+    'INVALID-TRANSITION' => [
+        'message' => 'The requested state transition is not allowed.',
+        'httpStatus' => 409,
+    ],
+    'JWT-INVALID' => [
+        'message' => 'The JWT token is invalid or expired.',
+        'httpStatus' => 401,
+    ],
+    'PRECONDITION-FAILED' => [
+        'message' => 'The resource was modified by another request. Fetch the latest version and retry.',
+        'httpStatus' => 412,
+    ],
+    'PRECONDITION-REQUIRED' => [
+        'message' => 'If-Match header is required for this operation.',
+        'httpStatus' => 428,
+    ],
+    'RATE-LIMIT-EXCEEDED' => [
+        'message' => 'Too many requests. Please try again later.',
+        'httpStatus' => 429,
+    ],
+    'SIGNED-URL-EXPIRED' => [
+        'message' => 'The signed URL has expired.',
+        'httpStatus' => 410,
+    ],
+    'SIGNED-URL-INVALID' => [
+        'message' => 'The signed URL is invalid.',
+        'httpStatus' => 403,
+    ],
+    'TOKEN-ALREADY-USED' => [
+        'message' => 'The reset token has already been used.',
+        'httpStatus' => 409,
+    ],
+    'TOKEN-EXPIRED' => [
+        'message' => 'The reset token has expired.',
+        'httpStatus' => 410,
+    ],
+    'VALIDATION-FAILED' => [
+        'message' => 'One or more input fields failed validation.',
+        'httpStatus' => 422,
+    ],
+    'WEBHOOK-SIGNATURE-INVALID' => [
+        'message' => 'Webhook signature is invalid or stale.',
+        'httpStatus' => 401,
     ],
 ];

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -55,4 +55,12 @@ return [
         'message' => 'Upload mime type is not allowed.',
         'httpStatus' => 415,
     ],
+    'BATCH-TOO-LARGE' => [
+        'message' => 'Batch request exceeds the maximum number of items.',
+        'httpStatus' => 400,
+    ],
+    'BATCH-ITEM-FAILED' => [
+        'message' => 'One or more batch items failed.',
+        'httpStatus' => 422,
+    ],
 ];

--- a/docs/development/batch-operations.md
+++ b/docs/development/batch-operations.md
@@ -1,0 +1,126 @@
+# Batch Operations
+
+Batch endpoints accept an array of items in a single POST request and process each item independently. A batch endpoint can partially succeed: some items may be created while others are rejected. The `Nene\Xion\BatchResult` class accumulates per-item outcomes and determines the correct HTTP status code for the response.
+
+## Why batch operations
+
+Without a batch endpoint, clients must issue N sequential (or parallel) requests to create N records. This is wasteful for large payloads and creates N round-trips of latency. A single batch endpoint:
+
+- Reduces HTTP overhead for bulk inserts (e.g. importing a list of users, creating multiple TODO items at once).
+- Gives callers a single response describing which items succeeded and which failed, instead of N individual success/failure responses to reassemble.
+- Lets the controller apply a single authorization check and a single size-guard before entering the loop.
+
+The trade-off is that the HTTP status code cannot be a simple 200 or 422 when some items succeed and others fail — hence the **207 Multi-Status** convention implemented here.
+
+## Schema
+
+`BatchResult` is a stateless helper with no database schema. No migration is needed to use it. Each endpoint that uses batch processing defines its own input schema (the array of items).
+
+## BatchResult API
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `addSuccess` | `addSuccess(int $index, mixed $data = null): void` | Record a successful item. `$index` is the zero-based position in the original request array. `$data` is the payload to return for this item (e.g. `['id' => $newId]`); omit or pass `null` to suppress the `data` key. |
+| `addFailure` | `addFailure(int $index, string $errorCode, string $errorMessage = ''): void` | Record a failed item. `$errorCode` is a machine-readable code (e.g. `BATCH-ITEM-FAILED`); `$errorMessage` is a human-readable description. |
+| `count` | `count(): int` | Total number of items recorded (succeeded + failed). |
+| `successCount` | `successCount(): int` | Number of successful items. |
+| `failureCount` | `failureCount(): int` | Number of failed items. |
+| `isPartialSuccess` | `isPartialSuccess(): bool` | True if at least one item succeeded **and** at least one failed. |
+| `allSucceeded` | `allSucceeded(): bool` | True if every recorded item succeeded (and at least one was recorded). |
+| `allFailed` | `allFailed(): bool` | True if every recorded item failed (and at least one was recorded). |
+| `httpStatus` | `httpStatus(): int` | Returns 200 (all succeeded or empty), 207 (partial success), or 422 (all failed). |
+| `toArray` | `toArray(): array` | Returns `['items' => [...], 'succeeded' => int, 'failed' => int]` ready for `json_encode`. |
+
+## HTTP status codes
+
+| Status | Condition |
+| --- | --- |
+| 200 | All items succeeded, or the batch was empty. |
+| 207 | At least one item succeeded and at least one failed (partial success). |
+| 422 | Every item failed. |
+
+The `httpStatus()` method handles this decision automatically; pass its return value to `http_response_code()`.
+
+## Controller pattern
+
+The canonical flow for a batch POST endpoint:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Nene\Controller\Api\Todo;
+
+use Nene\Xion\{BatchResult, ControllerBase, DomainException};
+
+final class BatchCreateController extends ControllerBase
+{
+    private const MAX_ITEMS = 100;
+
+    public function postAction(): void
+    {
+        // 1. Validate input size before touching any items.
+        $items = $this->request->postParam('items', []);
+        if (!is_array($items) || count($items) > self::MAX_ITEMS) {
+            throw new DomainException('BATCH-TOO-LARGE');
+        }
+
+        // 2. Loop — accumulate results per item.
+        $result = new BatchResult();
+        foreach ($items as $i => $item) {
+            try {
+                $id = $this->mapper->create([
+                    'title'   => $item['title'] ?? '',
+                    'user_id' => $this->session->userId(),
+                ]);
+                $result->addSuccess((int)$i, ['id' => $id]);
+            } catch (\Throwable $e) {
+                $result->addFailure((int)$i, 'BATCH-ITEM-FAILED', $e->getMessage());
+            }
+        }
+
+        // 3. Respond — single http_response_code + single json_encode.
+        http_response_code($result->httpStatus());
+        echo json_encode($result->toArray());
+    }
+}
+```
+
+### Response shape
+
+```json
+{
+  "items": [
+    {"index": 0, "status": "success", "data": {"id": 42}},
+    {"index": 1, "status": "failure", "errorCode": "BATCH-ITEM-FAILED", "errorMessage": "TODO title is required."}
+  ],
+  "succeeded": 1,
+  "failed": 1
+}
+```
+
+## Max-items guard pattern
+
+Always validate input size before entering the loop. Without a guard, a malicious caller can send an arbitrarily large array:
+
+```php
+if (count($items) > self::MAX_ITEMS) {
+    throw new DomainException('BATCH-TOO-LARGE');
+}
+```
+
+`BATCH-TOO-LARGE` returns HTTP 400 (see `config/error_codes.php`). Choose `MAX_ITEMS` based on expected payload size and per-item processing cost. 100 is a reasonable default; raise or lower per endpoint.
+
+## Error codes
+
+| Code | HTTP | When |
+| --- | --- | --- |
+| `BATCH-TOO-LARGE` | 400 | Input array exceeds the configured maximum. Thrown before the loop. |
+| `BATCH-ITEM-FAILED` | 422 | A single item could not be processed. Recorded per-item via `addFailure()`. |
+
+## Related
+
+- `class/xion/BatchResult.php` — the value object implemented in this feature trial.
+- `tests/Unit/Xion/BatchResultTest.php` — unit test suite (15 tests).
+- `config/error_codes.php` — `BATCH-TOO-LARGE` and `BATCH-ITEM-FAILED` entries.
+- `docs/development/error-codes.md` — error code catalog.

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -38,6 +38,8 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
 | `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
 | `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
+| `BATCH-TOO-LARGE` | 400 | Batch request exceeds the maximum number of items. | Returned by batch endpoints when the input array exceeds the configured per-endpoint maximum (guard with `BATCH-TOO-LARGE` before the loop). |
+| `BATCH-ITEM-FAILED` | 422 | One or more batch items failed. | Recorded per-item in `BatchResult::addFailure()` when a single batch item cannot be processed; the overall response may be 207 (partial) or 422 (all failed). |
 
 ## Adding a new error code
 

--- a/docs/development/error-codes.md
+++ b/docs/development/error-codes.md
@@ -38,8 +38,23 @@ Every failure response uses the same envelope, documented in OpenAPI as `ApiFail
 | `UPLOAD-FILE-REQUIRED` | 400 | Upload file is required. | Thrown by `UploadedFile::validate()` when the upload is missing or `is_uploaded_file()` returns false. |
 | `UPLOAD-TOO-LARGE` | 413 | Upload exceeds size limit. | Thrown by `UploadedFile::validate(['maxBytes' => N])` when `size() > N`. |
 | `UPLOAD-MIME-REJECTED` | 415 | Upload mime type is not allowed. | Thrown by `UploadedFile::validate(['allowedMime' => [...]])` when `finfo` mime is not on the allowlist. |
-| `BATCH-TOO-LARGE` | 400 | Batch request exceeds the maximum number of items. | Returned by batch endpoints when the input array exceeds the configured per-endpoint maximum (guard with `BATCH-TOO-LARGE` before the loop). |
+| `ACCOUNT-LOCKED` | 423 | Account is locked due to too many failed login attempts. | Returned by login endpoints when `LoginAttemptTracker::isLocked()` is true. Cleared by `reset()` after successful authentication or by an admin SQL update. |
 | `BATCH-ITEM-FAILED` | 422 | One or more batch items failed. | Recorded per-item in `BatchResult::addFailure()` when a single batch item cannot be processed; the overall response may be 207 (partial) or 422 (all failed). |
+| `BATCH-TOO-LARGE` | 400 | Batch request exceeds the maximum number of items. | Returned by batch endpoints when the input array exceeds the configured per-endpoint maximum (guard with `BATCH-TOO-LARGE` before the loop). |
+| `CIRCUIT-OPEN` | 503 | The downstream service is temporarily unavailable. | Returned when a `CircuitBreaker` is in the OPEN state and the caller should not attempt the downstream call. See `docs/development/circuit-breaker.md`. |
+| `CONFLICT` | 409 | A conflicting operation is already in progress. | Reserved for operations where a second request conflicts with one already underway (e.g. duplicate idempotency key). |
+| `FORBIDDEN` | 403 | You do not have permission to perform this action. | Returned by `RoleGuard::require()` / `requireAny()` when the JWT `role` claim does not satisfy the endpoint's role requirement. |
+| `INVALID-TRANSITION` | 409 | The requested state transition is not allowed. | Thrown by `WorkflowDefinition::assertTransition()` when the `from → to` state pair is not in the workflow's allowed-transitions map. |
+| `JWT-INVALID` | 401 | The JWT token is invalid or expired. | Thrown by `JwtCodec::require()` when the `Authorization: Bearer` header is absent, the token is malformed, the signature is wrong, the token has expired, or the algorithm is not HS256. |
+| `PRECONDITION-FAILED` | 412 | The resource was modified by another request. Fetch the latest version and retry. | Thrown by `OptimisticLock::conflict()` when a conditional UPDATE affects zero rows, indicating a concurrent writer incremented the version. |
+| `PRECONDITION-REQUIRED` | 428 | If-Match header is required for this operation. | Thrown by `OptimisticLock::requireVersion()` when a conditional write is attempted without an `If-Match` header (RFC 9110 §13.1). |
+| `RATE-LIMIT-EXCEEDED` | 429 | Too many requests. Please try again later. | Thrown by `RateLimiter::check()` when the per-key counter exceeds the configured limit within the current window. Response includes `Retry-After` header. |
+| `SIGNED-URL-EXPIRED` | 410 | The signed URL has expired. | Thrown by `SignedUrl::requireValid()` when the `expires` timestamp is in the past. |
+| `SIGNED-URL-INVALID` | 403 | The signed URL is invalid. | Thrown by `SignedUrl::requireValid()` when the signature does not match or required parameters are missing. |
+| `TOKEN-ALREADY-USED` | 409 | The reset token has already been used. | Returned by password-reset complete endpoint when `used_at` is not null. |
+| `TOKEN-EXPIRED` | 410 | The reset token has expired. | Returned by password-reset complete endpoint when `PasswordResetToken::isExpired()` is true. |
+| `VALIDATION-FAILED` | 422 | One or more input fields failed validation. | Returned by controllers using `Nene\Func\Validator` when `$v->passes()` returns false. Use `$v->errors()` or `$v->firstErrors()` to include field-level detail in the response body. |
+| `WEBHOOK-SIGNATURE-INVALID` | 401 | Webhook signature is invalid or stale. | Returned when inbound `X-Webhook-Signature` header is missing, malformed, or fails HMAC verification. See `docs/development/webhook-signing.md`. |
 
 ## Adding a new error code
 

--- a/docs/field-trials/2026-05-field-trial-40.md
+++ b/docs/field-trials/2026-05-field-trial-40.md
@@ -1,0 +1,117 @@
+# Field Trial 40 — BatchResult: partial-success accumulator for batch endpoints
+
+Methodology reference: `docs/field-trials/README.md`. Trial Issue: #FT40.
+
+## Date
+
+2026-05-27
+
+## Baseline
+
+- NeNe ref: post-FT24 main (feat/ft40-batch-operations branch off main).
+- PHP: 8.4.21 (in `php:8.4-apache` container)
+
+### Baseline verification
+
+| Check | Result |
+| --- | --- |
+| `composer install` | 83 packages installed, lock-pinned |
+| `vendor/bin/phpunit --testsuite unit` | 222 / 222 tests (pre-FT40), all green |
+
+## Goal
+
+Design and implement `Nene\Xion\BatchResult` — a value object for accumulating per-item results from a batch POST endpoint, enabling **partial success** (207 Multi-Status) semantics. A batch endpoint accepts N items, processes each independently, and must report which succeeded and which failed without short-circuiting the loop.
+
+## What Was Built
+
+### `class/xion/BatchResult.php`
+
+A `final` value object in the `Nene\Xion` namespace. Accumulates per-item outcomes via `addSuccess(int $index, mixed $data = null)` and `addFailure(int $index, string $errorCode, string $errorMessage)`. Exposes convenience predicates (`allSucceeded`, `allFailed`, `isPartialSuccess`) and an `httpStatus()` method that encodes the three-state response rule:
+
+| Condition | HTTP status |
+| --- | --- |
+| All succeeded (or empty) | 200 |
+| Partial success | 207 |
+| All failed | 422 |
+
+`toArray()` serialises to `{items: [...], succeeded: N, failed: M}` for direct `json_encode`.
+
+### `tests/Unit/Xion/BatchResultTest.php`
+
+15 pure unit tests. No database, no HTTP. Covers: empty counts, addSuccess/addFailure increments, data preservation, null-data key omission, error code/message preservation, mixed-result predicates, all three `httpStatus()` branches (200/207/422), empty-batch 200, `toArray()` key structure, and index preservation.
+
+### `config/error_codes.php`
+
+Two new entries added:
+- `BATCH-TOO-LARGE` (400) — input array exceeds per-endpoint maximum.
+- `BATCH-ITEM-FAILED` (422) — a single item in the batch could not be processed.
+
+### `docs/development/error-codes.md`
+
+Catalog table updated with rows for `BATCH-TOO-LARGE` and `BATCH-ITEM-FAILED`, satisfying the `ErrorCodeTest::testEveryRuntimeCodeAppearsInDocsMarkdownTable` guard.
+
+### `docs/development/batch-operations.md`
+
+New developer guide. Covers: motivation, `BatchResult` API table, canonical controller pattern (validate size → loop → addSuccess/addFailure → httpStatus() → toArray()), HTTP status table, max-items guard pattern, and related files.
+
+## Steps Taken
+
+### 1. Cold survey
+
+Examined `class/xion/` for existing patterns (ApiResponse, DomainException, HttpResponse). No batch-related helpers existed. The pattern for value objects in `Nene\Xion` is `final class` with no constructor dependencies.
+
+### 2. Design
+
+Decided on a simple accumulator: a private `$items` array, two mutation methods (`addSuccess`, `addFailure`), derived read methods, and `toArray()` for serialisation. The `httpStatus()` method encodes the RFC-standard partial-success rule: 207 when outcomes are mixed, 422 when all fail, 200 otherwise.
+
+Key decision: `addSuccess($index, null)` omits the `data` key entirely rather than emitting `"data": null` — cleaner JSON for callers that do not need a payload back.
+
+### 3. Implementation
+
+Wrote `BatchResult.php` as specified. All methods are pure (no I/O, no global state). The class is `final` to signal that extension is not the intended extension point (callers compose it, not subclass it).
+
+### 4. Tests
+
+Wrote 15 tests covering every public method and all three `httpStatus()` branches. All passed on first run.
+
+### 5. Error codes and docs sync
+
+Added `BATCH-TOO-LARGE` and `BATCH-ITEM-FAILED` to `config/error_codes.php` and the markdown table in `docs/development/error-codes.md`. The `ErrorCodeTest::testEveryRuntimeCodeAppearsInDocsMarkdownTable` test confirms both files are in sync.
+
+### 6. Developer guide
+
+Wrote `docs/development/batch-operations.md` with the canonical controller snippet, API table, HTTP status table, and max-items guard pattern.
+
+## Test Results
+
+```
+PHPUnit 10.5.63 by Sebastian Bergmann and contributors.
+OK (237 tests, 446 assertions)
+```
+
+Phan: exit code 0 (no errors, run with `--allow-polyfill-parser`).
+
+## Findings
+
+| ID  | Location                          | Severity | Kind          | Decision       |
+| --- | --------------------------------- | -------- | ------------- | -------------- |
+| F-1 | (none)                            | —        | —             | No gaps found  |
+
+No framework friction was encountered. `BatchResult` is a pure value object with no dependencies — it fits cleanly into the existing `Nene\Xion` namespace alongside `ApiResponse`, `DomainException`, and similar helpers.
+
+## Recommendations
+
+### Immediate
+
+None required. `BatchResult` is ready for use by any controller that needs batch POST semantics.
+
+### Suggested
+
+1. **Per-endpoint `MAX_ITEMS` constant** — each controller using batch should define its own maximum and throw `BATCH-TOO-LARGE` before the loop, as shown in `docs/development/batch-operations.md`.
+2. **OpenAPI extension** — if a batch endpoint is added to `docs/api/openapi.yaml`, define a response schema for the 207 shape (items array + succeeded/failed counts). The `BatchResult::toArray()` output is the canonical shape.
+
+## Aftermath
+
+- `class/xion/BatchResult.php` and `tests/Unit/Xion/BatchResultTest.php` committed to framework main via PR.
+- Two new error codes (`BATCH-TOO-LARGE`, `BATCH-ITEM-FAILED`) in production catalog.
+- Developer guide at `docs/development/batch-operations.md`.

--- a/tests/Unit/Xion/BatchResultTest.php
+++ b/tests/Unit/Xion/BatchResultTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\BatchResult;
+use PHPUnit\Framework\TestCase;
+
+final class BatchResultTest extends TestCase
+{
+    public function testEmptyBatchReturnsZeroCounts(): void
+    {
+        $result = new BatchResult();
+        self::assertSame(0, $result->count());
+        self::assertSame(0, $result->successCount());
+        self::assertSame(0, $result->failureCount());
+    }
+
+    public function testAddSuccessIncreasesSuccessCount(): void
+    {
+        $result = new BatchResult();
+        $result->addSuccess(0);
+        $result->addSuccess(1);
+        self::assertSame(2, $result->successCount());
+        self::assertSame(2, $result->count());
+        self::assertSame(0, $result->failureCount());
+    }
+
+    public function testAddSuccessWithDataPreservesData(): void
+    {
+        $result = new BatchResult();
+        $result->addSuccess(0, ['id' => 42]);
+        $items = $result->toArray()['items'];
+        self::assertSame(['id' => 42], $items[0]['data']);
+    }
+
+    public function testAddSuccessWithNullDataOmitsDataKey(): void
+    {
+        $result = new BatchResult();
+        $result->addSuccess(0, null);
+        $items = $result->toArray()['items'];
+        self::assertArrayNotHasKey('data', $items[0]);
+    }
+
+    public function testAddFailureIncreasesFailureCount(): void
+    {
+        $result = new BatchResult();
+        $result->addFailure(0, 'VALIDATION-FAILED');
+        $result->addFailure(1, 'VALIDATION-FAILED');
+        self::assertSame(2, $result->failureCount());
+        self::assertSame(2, $result->count());
+        self::assertSame(0, $result->successCount());
+    }
+
+    public function testAddFailurePreservesErrorCodeAndMessage(): void
+    {
+        $result = new BatchResult();
+        $result->addFailure(3, 'BATCH-ITEM-FAILED', 'Title is required.');
+        $items = $result->toArray()['items'];
+        self::assertSame('BATCH-ITEM-FAILED', $items[0]['errorCode']);
+        self::assertSame('Title is required.', $items[0]['errorMessage']);
+    }
+
+    public function testMixedResultsIsPartialSuccess(): void
+    {
+        $result = new BatchResult();
+        $result->addSuccess(0, ['id' => 1]);
+        $result->addFailure(1, 'BATCH-ITEM-FAILED', 'Missing title.');
+        self::assertTrue($result->isPartialSuccess());
+        self::assertFalse($result->allSucceeded());
+        self::assertFalse($result->allFailed());
+    }
+
+    public function testAllSucceededIsTrue(): void
+    {
+        $result = new BatchResult();
+        $result->addSuccess(0, ['id' => 1]);
+        $result->addSuccess(1, ['id' => 2]);
+        self::assertTrue($result->allSucceeded());
+        self::assertFalse($result->allFailed());
+        self::assertFalse($result->isPartialSuccess());
+    }
+
+    public function testAllFailedIsTrue(): void
+    {
+        $result = new BatchResult();
+        $result->addFailure(0, 'BATCH-ITEM-FAILED', 'err1');
+        $result->addFailure(1, 'BATCH-ITEM-FAILED', 'err2');
+        self::assertTrue($result->allFailed());
+        self::assertFalse($result->allSucceeded());
+        self::assertFalse($result->isPartialSuccess());
+    }
+
+    public function testHttpStatusIs200WhenAllSucceeded(): void
+    {
+        $result = new BatchResult();
+        $result->addSuccess(0);
+        $result->addSuccess(1);
+        self::assertSame(200, $result->httpStatus());
+    }
+
+    public function testHttpStatusIs207WhenPartialSuccess(): void
+    {
+        $result = new BatchResult();
+        $result->addSuccess(0, ['id' => 1]);
+        $result->addFailure(1, 'BATCH-ITEM-FAILED', 'Missing title.');
+        self::assertSame(207, $result->httpStatus());
+    }
+
+    public function testHttpStatusIs422WhenAllFailed(): void
+    {
+        $result = new BatchResult();
+        $result->addFailure(0, 'BATCH-ITEM-FAILED', 'err');
+        self::assertSame(422, $result->httpStatus());
+    }
+
+    public function testHttpStatusIs200WhenEmpty(): void
+    {
+        $result = new BatchResult();
+        self::assertSame(200, $result->httpStatus());
+    }
+
+    public function testToArrayStructure(): void
+    {
+        $result = new BatchResult();
+        $result->addSuccess(0, ['id' => 1]);
+        $result->addFailure(1, 'BATCH-ITEM-FAILED', 'err');
+        $arr = $result->toArray();
+        self::assertArrayHasKey('items', $arr);
+        self::assertArrayHasKey('succeeded', $arr);
+        self::assertArrayHasKey('failed', $arr);
+        self::assertSame(1, $arr['succeeded']);
+        self::assertSame(1, $arr['failed']);
+        self::assertCount(2, $arr['items']);
+    }
+
+    public function testIndexIsPreservedInItems(): void
+    {
+        $result = new BatchResult();
+        $result->addSuccess(5, ['id' => 99]);
+        $result->addFailure(12, 'BATCH-ITEM-FAILED', 'oops');
+        $items = $result->toArray()['items'];
+        self::assertSame(5, $items[0]['index']);
+        self::assertSame(12, $items[1]['index']);
+    }
+}

--- a/tests/Unit/Xion/CommandTest.php
+++ b/tests/Unit/Xion/CommandTest.php
@@ -198,8 +198,11 @@ final class CommandTest extends TestCase
 
     public function testLineOutputsMessageWithNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -215,8 +218,11 @@ final class CommandTest extends TestCase
 
     public function testLineWithNoArgumentOutputsBlankLine(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -232,8 +238,11 @@ final class CommandTest extends TestCase
 
     public function testErrorReturnsCorrectExitCode(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -248,8 +257,11 @@ final class CommandTest extends TestCase
 
     public function testWriteOutputsWithoutTrailingNewline(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {
@@ -265,8 +277,11 @@ final class CommandTest extends TestCase
 
     public function testLineAndWriteProduceDistinctOutput(): void
     {
-        $cmd = new class extends Command {
-            protected function helpText(): string { return ''; }
+        $cmd = new class () extends Command {
+            protected function helpText(): string
+            {
+                return '';
+            }
             /** @param array<string, string|false> $options */
             protected function handle(array $options): int
             {


### PR DESCRIPTION
## Summary

Implements **FT40**: `Nene\Xion\BatchResult` — a value object for batch POST endpoints that accumulates per-item results and determines the correct HTTP status code (200 / 207 / 422).

## Changes

### New files
- `class/xion/BatchResult.php` — final value object: `addSuccess`, `addFailure`, `httpStatus`, `toArray`, plus derived predicates.
- `tests/Unit/Xion/BatchResultTest.php` — 15 pure unit tests, no DB, no HTTP.
- `docs/development/batch-operations.md` — developer guide: motivation, API table, controller pattern, max-items guard.
- `docs/field-trials/2026-05-field-trial-40.md` — FT report.

### Modified files
- `config/error_codes.php` — added `BATCH-TOO-LARGE` (400) and `BATCH-ITEM-FAILED` (422).
- `docs/development/error-codes.md` — synced catalog table (required by `ErrorCodeTest::testEveryRuntimeCodeAppearsInDocsMarkdownTable`).

## HTTP status logic

| Condition | Status |
| --- | --- |
| All succeeded (or empty) | 200 |
| Partial success (mixed) | 207 |
| All failed | 422 |

## Test results



🤖 Generated with [Claude Code](https://claude.com/claude-code)