### PR TITLE
feat(func): I18n — lightweight i18n message-catalog helper (FT51)

### DIFF
--- a/class/func/I18n.php
+++ b/class/func/I18n.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Func;
+
+/**
+ * Lightweight i18n message-catalog helper.
+ *
+ * Provides a static registry of locale → key → message string mappings,
+ * with `{placeholder}` substitution and locale fallback.
+ *
+ * ## Basic usage
+ *
+ * ```php
+ * I18n::setLocale('ja');
+ * I18n::load('ja', [
+ *     'greeting' => 'こんにちは、{name}さん！',
+ *     'items'    => '{count}件のアイテムがあります',
+ * ]);
+ * I18n::load('en', [
+ *     'greeting' => 'Hello, {name}!',
+ *     'items'    => 'You have {count} item(s)',
+ * ]);
+ *
+ * echo I18n::t('greeting', ['name' => '太郎']);  // こんにちは、太郎さん！
+ * echo I18n::t('greeting', ['name' => 'Taro'], 'en');  // Hello, Taro!
+ * echo I18n::t('unknown.key');  // 'unknown.key' (key returned as-is)
+ * ```
+ *
+ * ## Placeholder syntax
+ *
+ * Placeholders are written as `{key}`. The `$params` array is substituted
+ * by matching keys. Unknown placeholders are left as-is.
+ *
+ * ## Fallback chain
+ *
+ * 1. Requested locale (or default locale when no locale given).
+ * 2. Default locale (if different from requested).
+ * 3. The key string itself.
+ */
+final class I18n
+{
+    /**
+     * Active default locale (e.g. 'en', 'ja').
+     *
+     * @var string
+     */
+    private static string $defaultLocale = 'en';
+
+    /**
+     * Message catalogs keyed by locale.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private static array $catalogs = [];
+
+    /**
+     * Set the default locale used when no locale is passed to t().
+     */
+    public static function setLocale(string $locale): void
+    {
+        self::$defaultLocale = $locale;
+    }
+
+    /**
+     * Get the current default locale.
+     */
+    public static function locale(): string
+    {
+        return self::$defaultLocale;
+    }
+
+    /**
+     * Register (or merge) a message catalog for the given locale.
+     *
+     * Calling load() twice with the same locale merges the arrays; later keys
+     * win.
+     *
+     * @param string               $locale   Locale identifier (e.g. 'en', 'ja').
+     * @param array<string,string> $messages Key → message string map.
+     */
+    public static function load(string $locale, array $messages): void
+    {
+        self::$catalogs[$locale] = array_merge(
+            self::$catalogs[$locale] ?? [],
+            $messages
+        );
+    }
+
+    /**
+     * Translate a key with optional placeholder substitution.
+     *
+     * Looks up `$key` in:
+     * 1. `$locale` (or the default locale when empty string is passed).
+     * 2. The default locale, if different from the requested one.
+     * 3. Falls back to the key itself when no match is found.
+     *
+     * Placeholders are written as `{name}` and replaced with `$params['name']`.
+     * Unknown placeholders are left as-is.
+     *
+     * @param string               $key    Message key.
+     * @param array<string,string> $params Placeholder values.
+     * @param string               $locale Locale override; uses default locale when empty.
+     *
+     * @return string Translated and substituted string, or $key if not found.
+     */
+    public static function t(string $key, array $params = [], string $locale = ''): string
+    {
+        $resolved = $locale !== '' ? $locale : self::$defaultLocale;
+
+        // 1. Try requested locale
+        $message = self::$catalogs[$resolved][$key] ?? null;
+
+        // 2. Fallback to default locale if different
+        if ($message === null && $resolved !== self::$defaultLocale) {
+            $message = self::$catalogs[self::$defaultLocale][$key] ?? null;
+        }
+
+        // 3. Key itself as last resort
+        if ($message === null) {
+            return $key;
+        }
+
+        return self::substitute($message, $params);
+    }
+
+    /**
+     * Replace `{key}` placeholders in a message string.
+     *
+     * @param string               $message Raw message with `{key}` placeholders.
+     * @param array<string,string> $params  Replacement values.
+     */
+    private static function substitute(string $message, array $params): string
+    {
+        if ($params === []) {
+            return $message;
+        }
+
+        return preg_replace_callback(
+            '/\{([^}]+)\}/',
+            static function (array $m) use ($params): string {
+                return $params[$m[1]] ?? $m[0];
+            },
+            $message
+        ) ?? $message;
+    }
+
+    /**
+     * Reset all catalogs and restore the default locale.
+     *
+     * Intended for use in tests — call in tearDown() to isolate test state.
+     */
+    public static function reset(): void
+    {
+        self::$defaultLocale = 'en';
+        self::$catalogs      = [];
+    }
+}

--- a/docs/development/i18n.md
+++ b/docs/development/i18n.md
@@ -1,0 +1,142 @@
+# i18n — Message Catalog
+
+`Nene\Func\I18n` is a lightweight, dependency-free message-catalog helper that provides locale-aware string translation with `{placeholder}` substitution.
+
+## When to use
+
+Use `I18n` when you need to:
+
+- Return user-facing messages in more than one language
+- Keep translatable strings out of controller logic
+- Substitute dynamic values (user name, counts, etc.) into translated messages
+
+For large, complex projects consider a dedicated i18n library. `I18n` is intentionally minimal.
+
+## API
+
+```php
+use Nene\Func\I18n;
+```
+
+| Method | Description |
+| --- | --- |
+| `I18n::setLocale(string $locale): void` | Set the default locale used when no locale is passed to `t()`. |
+| `I18n::locale(): string` | Get the current default locale (default: `'en'`). |
+| `I18n::load(string $locale, array $messages): void` | Register (or merge) a key→message map for the locale. |
+| `I18n::t(string $key, array $params = [], string $locale = ''): string` | Look up and substitute a message. |
+| `I18n::reset(): void` | Clear all catalogs and restore defaults. Use in test tearDown. |
+
+## Registering messages
+
+Call `load()` once at bootstrap (e.g. in `ini/xSystemIni.php` or a controller's `preAction()`):
+
+```php
+I18n::setLocale('ja');
+
+I18n::load('ja', [
+    'greeting'   => 'こんにちは、{name}さん！',
+    'item.count' => '{count}件あります',
+    'error.auth' => '認証が必要です',
+]);
+
+I18n::load('en', [
+    'greeting'   => 'Hello, {name}!',
+    'item.count' => '{count} item(s) found',
+    'error.auth' => 'Authentication required',
+]);
+```
+
+Calling `load()` twice with the same locale **merges** the arrays (later keys win).
+
+## Translating
+
+```php
+// Uses the current default locale ('ja')
+echo I18n::t('greeting', ['name' => '太郎']);
+// → こんにちは、太郎さん！
+
+// Explicit locale override
+echo I18n::t('greeting', ['name' => 'Taro'], 'en');
+// → Hello, Taro!
+
+// No params needed for static strings
+echo I18n::t('error.auth');
+// → 認証が必要です
+```
+
+## Placeholder syntax
+
+Placeholders are written as `{key}` and replaced by the matching key in `$params`:
+
+```php
+I18n::load('en', ['msg' => 'Dear {title} {last},']);
+echo I18n::t('msg', ['title' => 'Dr.', 'last' => 'Smith']);
+// → Dear Dr. Smith,
+```
+
+- Unknown placeholders are **left as-is** (not removed).
+- A key may appear multiple times in one message.
+
+## Fallback chain
+
+1. Requested locale (or default locale when no locale argument is given).
+2. Default locale, if different from the requested one.
+3. The key string itself when no translation is found.
+
+```php
+I18n::setLocale('en');
+I18n::load('en', ['hello' => 'Hello!']);
+// 'ja' has no 'hello' → falls back to 'en'
+echo I18n::t('hello', [], 'ja');  // → Hello!
+
+// Completely unknown key → key returned as-is
+echo I18n::t('no.such.key');  // → no.such.key
+```
+
+## Locale naming
+
+Any string is accepted as a locale identifier. Common conventions:
+
+| Identifier | Use |
+| --- | --- |
+| `'en'` | English |
+| `'ja'` | Japanese |
+| `'zh-TW'` | Traditional Chinese |
+| `'fr'` | French |
+
+Use a consistent convention across your project.
+
+## Testing
+
+Call `I18n::reset()` in `tearDown()` to prevent catalog state from leaking between tests:
+
+```php
+protected function tearDown(): void
+{
+    I18n::reset();
+}
+```
+
+## Organising catalogs
+
+For larger projects, keep catalogs in dedicated PHP files:
+
+```
+resources/
+  lang/
+    ja.php   → returns array<string,string>
+    en.php   → returns array<string,string>
+```
+
+Load at bootstrap:
+
+```php
+I18n::setLocale($userLocale);
+I18n::load('ja', require __DIR__ . '/../resources/lang/ja.php');
+I18n::load('en', require __DIR__ . '/../resources/lang/en.php');
+```
+
+## Related
+
+- `Nene\Func\Validator` — input validation with translatable error messages.
+- `config/error_codes.php` — framework-level error messages (not translated through `I18n`, returned as-is in the JSON envelope).

--- a/docs/field-trials/2026-05-field-trial-51.md
+++ b/docs/field-trials/2026-05-field-trial-51.md
@@ -1,0 +1,60 @@
+# Field Trial 51 — i18n / Message Catalog
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft51-i18n`
+**Baseline**: `d3c6720` (post FT25–FT50 merge wave)
+
+## Goal
+
+Establish a lightweight, dependency-free i18n message-catalog pattern for NeNe applications.  
+NENE2 対応: FT155 (i18nlog).
+
+## What was built
+
+### `Nene\Func\I18n` (`class/func/I18n.php`)
+
+Static helper providing:
+
+| Method | Description |
+| --- | --- |
+| `setLocale(string)` | Set the default locale. |
+| `locale(): string` | Get the current default locale (`'en'` initially). |
+| `load(string $locale, array $messages)` | Register/merge a key→message catalog. |
+| `t(string $key, array $params, string $locale): string` | Translate with `{placeholder}` substitution, locale fallback, and key-as-last-resort. |
+| `reset()` | Clear all state (for tests). |
+
+**Placeholder syntax**: `{name}` in the message string is replaced by `$params['name']`.
+
+**Fallback chain**: requested locale → default locale → key string itself.
+
+### Tests (`tests/Unit/Func/I18nTest.php`)
+
+19 unit tests covering:
+
+- Default locale (`en`)
+- `setLocale` / `locale`
+- Simple key lookup and explicit locale override
+- Single and multiple placeholders
+- Repeated placeholder in same message
+- Unknown placeholder left as-is
+- Fallback to default locale when key missing
+- Key returned as-is when not found anywhere
+- `load` merging and last-writer-wins
+- `reset` clears all state
+- Empty message string
+- Empty key
+- Region-code locale (`zh-TW`)
+
+### Howto (`docs/development/i18n.md`)
+
+Covers: API table, `load` at bootstrap, placeholder syntax, fallback chain, locale naming conventions, test isolation with `reset()`, organising catalogs in separate files.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+The implementation required no framework changes. `I18n` is a pure `Nene\Func` helper with no external dependencies or NeNe-core coupling. All 19 tests pass; CS fixer and Phan both clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Func/I18nTest.php
+++ b/tests/Unit/Func/I18nTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Func;
+
+use Nene\Func\I18n;
+use PHPUnit\Framework\TestCase;
+
+final class I18nTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        I18n::reset();
+    }
+
+    // --- setLocale / locale ---
+
+    public function testDefaultLocaleIsEn(): void
+    {
+        self::assertSame('en', I18n::locale());
+    }
+
+    public function testSetLocaleChangesDefault(): void
+    {
+        I18n::setLocale('ja');
+        self::assertSame('ja', I18n::locale());
+    }
+
+    // --- load / t: basic lookup ---
+
+    public function testTranslateSimpleKey(): void
+    {
+        I18n::load('en', ['hello' => 'Hello!']);
+        self::assertSame('Hello!', I18n::t('hello'));
+    }
+
+    public function testTranslateWithExplicitLocale(): void
+    {
+        I18n::load('en', ['hello' => 'Hello!']);
+        I18n::load('ja', ['hello' => 'こんにちは！']);
+        self::assertSame('こんにちは！', I18n::t('hello', [], 'ja'));
+    }
+
+    public function testTranslateUsesDefaultLocale(): void
+    {
+        I18n::setLocale('ja');
+        I18n::load('ja', ['hello' => 'こんにちは！']);
+        self::assertSame('こんにちは！', I18n::t('hello'));
+    }
+
+    // --- placeholder substitution ---
+
+    public function testSinglePlaceholder(): void
+    {
+        I18n::load('en', ['greeting' => 'Hello, {name}!']);
+        self::assertSame('Hello, Taro!', I18n::t('greeting', ['name' => 'Taro']));
+    }
+
+    public function testMultiplePlaceholders(): void
+    {
+        I18n::load('en', ['msg' => '{a} and {b}']);
+        self::assertSame('foo and bar', I18n::t('msg', ['a' => 'foo', 'b' => 'bar']));
+    }
+
+    public function testPlaceholderRepeatedInMessage(): void
+    {
+        I18n::load('en', ['msg' => '{x}-{x}-{x}']);
+        self::assertSame('go-go-go', I18n::t('msg', ['x' => 'go']));
+    }
+
+    public function testUnknownPlaceholderLeftAsIs(): void
+    {
+        I18n::load('en', ['msg' => 'Hello, {name}!']);
+        // no 'name' in params — placeholder stays
+        self::assertSame('Hello, {name}!', I18n::t('msg'));
+    }
+
+    public function testNoPlaceholdersInMessage(): void
+    {
+        I18n::load('en', ['msg' => 'Static text']);
+        self::assertSame('Static text', I18n::t('msg', ['unused' => 'x']));
+    }
+
+    // --- fallback behaviour ---
+
+    public function testFallsBackToDefaultLocaleWhenKeyMissingInRequested(): void
+    {
+        I18n::setLocale('en');
+        I18n::load('en', ['greeting' => 'Hello!']);
+        // 'ja' has no 'greeting' — should fall back to 'en'
+        self::assertSame('Hello!', I18n::t('greeting', [], 'ja'));
+    }
+
+    public function testReturnsKeyWhenNotFoundAnywhere(): void
+    {
+        self::assertSame('missing.key', I18n::t('missing.key'));
+    }
+
+    public function testReturnsKeyWhenLocaleEmpty(): void
+    {
+        // no catalog loaded — key fallback
+        self::assertSame('app.title', I18n::t('app.title'));
+    }
+
+    // --- load merging ---
+
+    public function testLoadMergesWithExistingCatalog(): void
+    {
+        I18n::load('en', ['a' => 'A']);
+        I18n::load('en', ['b' => 'B']);
+        self::assertSame('A', I18n::t('a'));
+        self::assertSame('B', I18n::t('b'));
+    }
+
+    public function testLoadLaterKeyWins(): void
+    {
+        I18n::load('en', ['msg' => 'first']);
+        I18n::load('en', ['msg' => 'second']);
+        self::assertSame('second', I18n::t('msg'));
+    }
+
+    // --- reset ---
+
+    public function testResetClearsAllState(): void
+    {
+        I18n::setLocale('ja');
+        I18n::load('ja', ['k' => 'v']);
+        I18n::reset();
+        self::assertSame('en', I18n::locale());
+        self::assertSame('k', I18n::t('k'));
+    }
+
+    // --- edge cases ---
+
+    public function testEmptyMessageString(): void
+    {
+        I18n::load('en', ['empty' => '']);
+        self::assertSame('', I18n::t('empty'));
+    }
+
+    public function testEmptyKeyReturnsEmptyKey(): void
+    {
+        self::assertSame('', I18n::t(''));
+    }
+
+    public function testLocaleWithRegionCode(): void
+    {
+        I18n::load('zh-TW', ['hello' => '你好！']);
+        self::assertSame('你好！', I18n::t('hello', [], 'zh-TW'));
+    }
+}


### PR DESCRIPTION
## FT51 — i18n / Message Catalog

**NENE2 対応**: FT155

### What
- `Nene\Func\I18n`: `setLocale / locale / load / t / reset`
- `{placeholder}` substitution, locale fallback (requested → default → key)
- 19 unit tests; CS fixer + Phan clean
- `docs/development/i18n.md` howto doc
- FT report

### Files
- `class/func/I18n.php`
- `tests/Unit/Func/I18nTest.php`
- `docs/development/i18n.md`
- `docs/field-trials/2026-05-field-trial-51.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)