### PR TITLE
feat(func): EventDispatcher — in-process pub-sub dispatcher (#486)

### DIFF
--- a/class/func/EventDispatcher.php
+++ b/class/func/EventDispatcher.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Func;
+
+/**
+ * Lightweight in-process publish-subscribe event dispatcher.
+ *
+ * Decouples the emitter of an event from the listeners that react to it,
+ * without requiring an external message broker or background queue.
+ *
+ * ## Basic usage
+ *
+ * ```php
+ * // Register listeners (e.g. in a bootstrap/Service layer)
+ * EventDispatcher::listen('user.registered', function (array $payload): void {
+ *     // send welcome email
+ * });
+ *
+ * EventDispatcher::listen('user.registered', function (array $payload): void {
+ *     // create audit log entry
+ * });
+ *
+ * // Emit from a controller or service
+ * EventDispatcher::emit('user.registered', ['userId' => 42, 'email' => 'a@b.com']);
+ * ```
+ *
+ * ## Listener signature
+ *
+ * Every listener receives one argument: the `$payload` array passed to `emit()`.
+ * The return value is ignored.
+ *
+ * ## Error handling
+ *
+ * By default, exceptions thrown by listeners propagate immediately (fail-fast).
+ * Set `$stopOnError = false` in `emit()` to continue dispatching remaining
+ * listeners and collect exceptions in the returned array.
+ *
+ * ## Priority
+ *
+ * Listeners fire in **registration order** (FIFO). Higher-priority listeners
+ * should be registered first.
+ *
+ * ## Scope
+ *
+ * All state is held in static properties — one shared registry per PHP process.
+ * Call `EventDispatcher::reset()` in test tearDown() to isolate tests.
+ */
+final class EventDispatcher
+{
+    /**
+     * Registered listeners keyed by event name.
+     *
+     * @var array<string, list<callable(array<string,mixed>): void>>
+     */
+    private static array $listeners = [];
+
+    /**
+     * Register a listener for the given event.
+     *
+     * Multiple calls with the same event name append listeners in order.
+     *
+     * @param string                           $event    Event name (e.g. 'user.registered').
+     * @param callable(array<string,mixed>): void $listener Callable that receives the payload array.
+     */
+    public static function listen(string $event, callable $listener): void
+    {
+        self::$listeners[$event][] = $listener;
+    }
+
+    /**
+     * Emit an event and invoke all registered listeners.
+     *
+     * When `$stopOnError` is true (default), the first listener exception
+     * propagates immediately. When false, all listeners run and any thrown
+     * exceptions are returned as a list.
+     *
+     * @param string                $event       Event name.
+     * @param array<string, mixed>  $payload     Arbitrary data passed to every listener.
+     * @param bool                  $stopOnError Stop on first exception (default) or collect all.
+     *
+     * @return list<\Throwable> Collected exceptions when $stopOnError is false; always empty when true.
+     *
+     * @throws \Throwable When $stopOnError is true and a listener throws.
+     */
+    public static function emit(
+        string $event,
+        array $payload = [],
+        bool $stopOnError = true,
+    ): array {
+        $errors = [];
+
+        foreach (self::$listeners[$event] ?? [] as $listener) {
+            try {
+                $listener($payload);
+            } catch (\Throwable $e) {
+                if ($stopOnError) {
+                    throw $e;
+                }
+                $errors[] = $e;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Return all registered listeners for an event (useful for testing).
+     *
+     * @return list<callable(array<string,mixed>): void>
+     */
+    public static function listeners(string $event): array
+    {
+        return self::$listeners[$event] ?? [];
+    }
+
+    /**
+     * Remove all listeners for the given event, or all events when null.
+     */
+    public static function forget(?string $event = null): void
+    {
+        if ($event === null) {
+            self::$listeners = [];
+        } else {
+            unset(self::$listeners[$event]);
+        }
+    }
+
+    /**
+     * Reset all listeners and event registry.
+     *
+     * Intended for use in tests — call in tearDown() to isolate test state.
+     */
+    public static function reset(): void
+    {
+        self::$listeners = [];
+    }
+}

--- a/docs/development/event-dispatcher.md
+++ b/docs/development/event-dispatcher.md
@@ -1,0 +1,139 @@
+# Event Dispatcher
+
+`Nene\Func\EventDispatcher` is a lightweight in-process publish-subscribe event dispatcher. It decouples the emitter of an event from the listeners that react to it, without requiring an external message broker or background queue.
+
+## When to use
+
+Use `EventDispatcher` when you need to:
+
+- Notify multiple subsystems of a domain event (user registered, order placed, etc.) without coupling them to each other
+- Run side-effects (email, audit log, cache invalidation) after a core action, without littering that action with unrelated code
+- Build a plugin or hook system where modules register behaviour dynamically
+
+For cross-process or persistent queues, use a dedicated message broker instead.
+
+## API
+
+```php
+use Nene\Func\EventDispatcher;
+```
+
+| Method | Description |
+| --- | --- |
+| `EventDispatcher::listen(string $event, callable $listener): void` | Register a listener for the given event. Multiple listeners per event are allowed; fired FIFO. |
+| `EventDispatcher::emit(string $event, array $payload = [], bool $stopOnError = true): array` | Emit an event, invoking all registered listeners. Returns collected `\Throwable`s when `$stopOnError = false`; always `[]` when `true`. |
+| `EventDispatcher::listeners(string $event): array` | Return all registered listeners for the event (useful in tests). |
+| `EventDispatcher::forget(?string $event = null): void` | Remove all listeners for one event, or all events when `null`. |
+| `EventDispatcher::reset(): void` | Clear the entire registry. Use in test `tearDown()`. |
+
+## Registering listeners
+
+Call `listen()` at bootstrap or in a service-provider equivalent (e.g. `ini/xSystemIni.php` or a controller's `preAction()`):
+
+```php
+// Send a welcome e-mail when a user registers
+EventDispatcher::listen('user.registered', function (array $payload): void {
+    Mailer::sendWelcome($payload['email']);
+});
+
+// Write an audit log entry for the same event
+EventDispatcher::listen('user.registered', function (array $payload): void {
+    AuditLog::write('user.registered', $payload['userId']);
+});
+```
+
+Listeners fire in **registration order** (FIFO). If priority matters, register higher-priority listeners first.
+
+## Emitting events
+
+```php
+// Emit with a payload
+EventDispatcher::emit('user.registered', [
+    'userId' => 42,
+    'email'  => 'taro@example.com',
+]);
+
+// Emit with no payload (listeners receive an empty array)
+EventDispatcher::emit('cache.cleared');
+```
+
+`emit()` returns an empty array when `$stopOnError = true` (the default) — exceptions from listeners propagate immediately.
+
+## Listener signature
+
+Every listener receives one argument: the `$payload` array passed to `emit()`.
+
+```php
+EventDispatcher::listen('order.placed', function (array $payload): void {
+    // $payload is a local copy — mutations do not affect other listeners
+    $orderId = $payload['orderId'];
+});
+```
+
+**Payload immutability**: PHP arrays have copy-on-assign semantics. Mutations inside one listener are invisible to the next.
+
+Return values from listeners are ignored.
+
+## Error handling
+
+### Default (fail-fast)
+
+By default, the first exception thrown by any listener propagates immediately, aborting further dispatch:
+
+```php
+EventDispatcher::listen('job.run', function (): void {
+    throw new \RuntimeException('step failed');
+});
+EventDispatcher::listen('job.run', function (): void {
+    // never reached if the first listener throws
+});
+
+EventDispatcher::emit('job.run'); // throws \RuntimeException
+```
+
+### Collect all errors
+
+Pass `stopOnError: false` to run all listeners regardless of failures, and collect exceptions in the return value:
+
+```php
+$errors = EventDispatcher::emit('report.generated', $payload, stopOnError: false);
+
+foreach ($errors as $e) {
+    Logger::error($e->getMessage());
+}
+```
+
+This is useful for fan-out notifications where one failing notifier should not block others.
+
+## Removing listeners
+
+```php
+// Remove all listeners for one event
+EventDispatcher::forget('cache.cleared');
+
+// Remove listeners for every event
+EventDispatcher::forget();
+```
+
+## Testing
+
+Call `EventDispatcher::reset()` in `tearDown()` to prevent listener state from leaking between tests:
+
+```php
+protected function tearDown(): void
+{
+    EventDispatcher::reset();
+}
+```
+
+Use `EventDispatcher::listeners('event.name')` to assert that the expected listeners were registered without actually emitting the event.
+
+```php
+EventDispatcher::listen('user.deleted', [$cleanup, 'handle']);
+self::assertCount(1, EventDispatcher::listeners('user.deleted'));
+```
+
+## Related
+
+- `Nene\Func\I18n` — message catalog; can be used inside listeners to build localised notifications.
+- `Nene\Xion\HttpTermination` — use `emit()` before throwing termination to give listeners a chance to log or clean up.

--- a/docs/field-trials/2026-05-field-trial-52.md
+++ b/docs/field-trials/2026-05-field-trial-52.md
@@ -1,0 +1,62 @@
+# Field Trial 52 — Event Dispatcher
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft52-event-dispatcher`
+**Baseline**: `d3c6720` (post FT25–FT50 merge wave)
+
+## Goal
+
+Establish a lightweight, in-process publish-subscribe event dispatcher for NeNe applications, enabling loose coupling between domain events and their side-effect handlers.
+
+## What was built
+
+### `Nene\Func\EventDispatcher` (`class/func/EventDispatcher.php`)
+
+Static dispatcher providing:
+
+| Method | Description |
+| --- | --- |
+| `listen(string $event, callable $listener)` | Register a listener FIFO. |
+| `emit(string $event, array $payload, bool $stopOnError): array` | Dispatch to all listeners; returns collected `\Throwable`s when `$stopOnError = false`. |
+| `listeners(string $event): array` | Introspect registered listeners (for testing). |
+| `forget(?string $event)` | Remove listeners for one event, or all events. |
+| `reset()` | Clear the full registry (for tests). |
+
+Key design points:
+
+- **FIFO order**: listeners fire in registration order.
+- **Payload immutability**: PHP arrays are passed by value; one listener's mutations are invisible to the next.
+- **Dual error modes**: fail-fast (default) or collect-all (`stopOnError: false`).
+- **No external dependencies**: pure static helper, zero I/O.
+
+### Tests (`tests/Unit/Func/EventDispatcherTest.php`)
+
+13 unit tests covering:
+
+- Listener receives payload
+- Multiple listeners fire in registration order
+- Emit with no listeners returns empty array
+- Emit with empty payload defaults to `[]`
+- Exception propagates when `stopOnError = true`
+- All listeners run when `stopOnError = false`; exceptions collected
+- `emit()` returns `[]` when no errors occur
+- `listeners()` returns registered callables
+- `listeners()` returns `[]` for unknown event
+- `forget(string)` removes one event's listeners
+- `forget()` (null) removes all listeners
+- `reset()` clears everything
+- Listener cannot mutate payload visible to next listener
+
+### Howto (`docs/development/event-dispatcher.md`)
+
+Covers: API table, bootstrap pattern, listener signature, payload immutability, fail-fast vs collect-all error handling, `forget()`, test isolation with `reset()`.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+The implementation required no framework changes. `EventDispatcher` is a pure `Nene\Func` helper with no external dependencies or NeNe-core coupling. All 13 tests pass; CS fixer and Phan both clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Func/EventDispatcherTest.php
+++ b/tests/Unit/Func/EventDispatcherTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Func;
+
+use Nene\Func\EventDispatcher;
+use PHPUnit\Framework\TestCase;
+
+final class EventDispatcherTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        EventDispatcher::reset();
+    }
+
+    // --- listen / emit ---
+
+    public function testListenerReceivesPayload(): void
+    {
+        $received = null;
+        EventDispatcher::listen('test.event', function (array $p) use (&$received): void {
+            $received = $p;
+        });
+
+        EventDispatcher::emit('test.event', ['key' => 'value']);
+
+        self::assertSame(['key' => 'value'], $received);
+    }
+
+    public function testMultipleListenersFiredInOrder(): void
+    {
+        $order = [];
+        EventDispatcher::listen('order.test', function (array $p) use (&$order): void {
+            $order[] = 'first';
+        });
+        EventDispatcher::listen('order.test', function (array $p) use (&$order): void {
+            $order[] = 'second';
+        });
+        EventDispatcher::listen('order.test', function (array $p) use (&$order): void {
+            $order[] = 'third';
+        });
+
+        EventDispatcher::emit('order.test');
+
+        self::assertSame(['first', 'second', 'third'], $order);
+    }
+
+    public function testEmitWithNoListenersDoesNothing(): void
+    {
+        $errors = EventDispatcher::emit('no.listeners');
+        self::assertSame([], $errors);
+    }
+
+    public function testEmitWithEmptyPayloadDefaultsToEmptyArray(): void
+    {
+        $received = 'not-called';
+        EventDispatcher::listen('empty.payload', function (array $p) use (&$received): void {
+            $received = $p;
+        });
+
+        EventDispatcher::emit('empty.payload');
+
+        self::assertSame([], $received);
+    }
+
+    // --- stopOnError: true (default) ---
+
+    public function testExceptionPropagatesWhenStopOnErrorTrue(): void
+    {
+        $secondCalled = false;
+        EventDispatcher::listen('err.event', function (): void {
+            throw new \RuntimeException('boom');
+        });
+        EventDispatcher::listen('err.event', function () use (&$secondCalled): void {
+            $secondCalled = true;
+        });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        EventDispatcher::emit('err.event');
+
+        self::assertFalse($secondCalled, 'Second listener must not run');
+    }
+
+    // --- stopOnError: false ---
+
+    public function testCollectErrorsWhenStopOnErrorFalse(): void
+    {
+        $ran = [];
+        EventDispatcher::listen('multi.err', function () use (&$ran): void {
+            $ran[] = 'a';
+            throw new \RuntimeException('err-a');
+        });
+        EventDispatcher::listen('multi.err', function () use (&$ran): void {
+            $ran[] = 'b';
+            throw new \LogicException('err-b');
+        });
+        EventDispatcher::listen('multi.err', function () use (&$ran): void {
+            $ran[] = 'c';
+        });
+
+        $errors = EventDispatcher::emit('multi.err', [], stopOnError: false);
+
+        self::assertSame(['a', 'b', 'c'], $ran, 'All listeners should run');
+        self::assertCount(2, $errors);
+        self::assertInstanceOf(\RuntimeException::class, $errors[0]);
+        self::assertInstanceOf(\LogicException::class, $errors[1]);
+    }
+
+    public function testReturnsEmptyArrayWhenNoErrors(): void
+    {
+        EventDispatcher::listen('ok.event', function (): void {
+        });
+        $errors = EventDispatcher::emit('ok.event', [], stopOnError: false);
+        self::assertSame([], $errors);
+    }
+
+    // --- listeners() ---
+
+    public function testListenersReturnsRegisteredCallables(): void
+    {
+        $cb1 = function (): void {
+        };
+        $cb2 = function (): void {
+        };
+        EventDispatcher::listen('q', $cb1);
+        EventDispatcher::listen('q', $cb2);
+
+        $list = EventDispatcher::listeners('q');
+        self::assertCount(2, $list);
+        self::assertSame($cb1, $list[0]);
+        self::assertSame($cb2, $list[1]);
+    }
+
+    public function testListenersReturnsEmptyForUnknownEvent(): void
+    {
+        self::assertSame([], EventDispatcher::listeners('unknown'));
+    }
+
+    // --- forget ---
+
+    public function testForgetRemovesListenersForEvent(): void
+    {
+        EventDispatcher::listen('a', function (): void {
+        });
+        EventDispatcher::listen('b', function (): void {
+        });
+
+        EventDispatcher::forget('a');
+
+        self::assertSame([], EventDispatcher::listeners('a'));
+        self::assertCount(1, EventDispatcher::listeners('b'));
+    }
+
+    public function testForgetNullRemovesAllListeners(): void
+    {
+        EventDispatcher::listen('a', function (): void {
+        });
+        EventDispatcher::listen('b', function (): void {
+        });
+
+        EventDispatcher::forget();
+
+        self::assertSame([], EventDispatcher::listeners('a'));
+        self::assertSame([], EventDispatcher::listeners('b'));
+    }
+
+    // --- reset ---
+
+    public function testResetClearsAll(): void
+    {
+        EventDispatcher::listen('x', function (): void {
+        });
+        EventDispatcher::reset();
+        self::assertSame([], EventDispatcher::listeners('x'));
+    }
+
+    // --- same-event multiple listeners, payload mutation ---
+
+    public function testListenerCannotMutatePayloadForNextListener(): void
+    {
+        // Payload is passed by value (PHP array copy semantics)
+        $seenBySecond = null;
+        EventDispatcher::listen('immutable', function (array $p): void {
+            $p['extra'] = 'added';   // local copy only
+        });
+        EventDispatcher::listen('immutable', function (array $p) use (&$seenBySecond): void {
+            $seenBySecond = $p;
+        });
+
+        EventDispatcher::emit('immutable', ['original' => true]);
+
+        self::assertArrayNotHasKey('extra', $seenBySecond ?? []);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Func\EventDispatcher`: a lightweight, dependency-free in-process publish-subscribe event dispatcher.

## Changes

- `class/func/EventDispatcher.php` — static registry with `listen / emit / listeners / forget / reset`
- `tests/Unit/Func/EventDispatcherTest.php` — 13 unit tests, all passing
- `docs/development/event-dispatcher.md` — howto doc
- `docs/field-trials/2026-05-field-trial-52.md` — FT report

## Design

- **FIFO order**: listeners fire in registration order
- **Payload immutability**: PHP array copy-on-assign — mutations inside one listener are invisible to the next
- **Dual error mode**: fail-fast (default `stopOnError=true`) or collect-all (`stopOnError=false`)
- No external dependencies; pure static helper

## Field Trial

F-1: Clean trial — no framework changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)