### PR TITLE
feat(func): PersonalDataExport — GDPR Article 20 data portability helper (#487)

### DIFF
--- a/class/func/PersonalDataExport.php
+++ b/class/func/PersonalDataExport.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Func;
+
+/**
+ * GDPR Article 20-style personal data export aggregator.
+ *
+ * Collects user data from multiple registered providers and assembles it into
+ * a portable JSON structure. Each provider is responsible for one logical
+ * "section" of the export (profile, orders, activity, etc.).
+ *
+ * ## Basic usage
+ *
+ * ```php
+ * $export = new PersonalDataExport();
+ *
+ * $export->register('profile', function (int|string $userId) use ($pdo): array {
+ *     $stmt = $pdo->prepare('SELECT name, email, created_at FROM users WHERE id = ?');
+ *     $stmt->execute([$userId]);
+ *     return $stmt->fetch(\PDO::FETCH_ASSOC) ?: [];
+ * });
+ *
+ * $export->register('orders', function (int|string $userId) use ($pdo): array {
+ *     $stmt = $pdo->prepare('SELECT id, total, created_at FROM orders WHERE user_id = ?');
+ *     $stmt->execute([$userId]);
+ *     return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+ * });
+ *
+ * $json = $export->exportJson(42);
+ * ```
+ *
+ * ## Output format
+ *
+ * ```json
+ * {
+ *   "exportedAt": "2026-05-27T12:00:00+00:00",
+ *   "userId": 42,
+ *   "data": {
+ *     "profile": { "name": "Taro", "email": "taro@example.com" },
+ *     "orders":  [{ "id": 1, "total": 1500 }]
+ *   }
+ * }
+ * ```
+ *
+ * ## Design notes
+ *
+ * - **Instance-based**: each `PersonalDataExport` object holds its own provider
+ *   registry, making it straightforward to configure per-request or per-test.
+ * - **Provider signature**: `callable(int|string $userId): array<string, mixed>`.
+ *   The return value is the section data; shape is entirely up to the provider.
+ * - **Section ordering**: sections appear in registration order.
+ * - **No database coupling**: providers capture their own DB connection via closure,
+ *   keeping the aggregator free of infrastructure dependencies.
+ */
+final class PersonalDataExport
+{
+    /**
+     * Registered providers keyed by section name.
+     *
+     * @var array<string, callable>
+     */
+    private array $providers = [];
+
+    /**
+     * Register a data provider for the given section.
+     *
+     * The provider is a callable that receives the user ID and returns an array
+     * representing that section's data. Multiple registrations for the same
+     * section name overwrite the previous provider.
+     *
+     * @param  string                           $section  Section name (e.g. 'profile', 'orders').
+     * @param  callable $provider Callable that accepts a user ID and returns data.
+     * @return static                                      Fluent — allows chaining.
+     */
+    public function register(string $section, callable $provider): static
+    {
+        $this->providers[$section] = $provider;
+        return $this;
+    }
+
+    /**
+     * Run all providers for the given user ID and return the aggregated export.
+     *
+     * The returned array has three top-level keys:
+     *  - `exportedAt` (string) — ISO 8601 timestamp of the export.
+     *  - `userId`    (int|string) — the requested user ID.
+     *  - `data`      (array) — section name → section data, in registration order.
+     *
+     * @param  int|string $userId User identifier.
+     * @return array{exportedAt: string, userId: int|string, data: array<string, array<mixed>>}
+     */
+    public function export(int|string $userId): array
+    {
+        $data = [];
+        foreach ($this->providers as $section => $provider) {
+            $data[$section] = $provider($userId);
+        }
+
+        return [
+            'exportedAt' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+            'userId'     => $userId,
+            'data'       => $data,
+        ];
+    }
+
+    /**
+     * Run all providers and return a JSON-encoded export string.
+     *
+     * Default flags produce pretty-printed, Unicode-safe output.
+     *
+     * @param  int|string $userId User identifier.
+     * @param  int        $flags  `json_encode()` flags (default: JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE).
+     * @return string     JSON string.
+     *
+     * @throws \JsonException On encoding failure (triggered by JSON_THROW_ON_ERROR).
+     */
+    public function exportJson(
+        int|string $userId,
+        int $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE,
+    ): string {
+        return json_encode($this->export($userId), $flags | JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Return the list of registered section names, in registration order.
+     *
+     * Useful in tests to verify that all expected providers are registered.
+     *
+     * @return list<string>
+     */
+    public function sections(): array
+    {
+        return array_keys($this->providers);
+    }
+}

--- a/docs/development/personal-data-export.md
+++ b/docs/development/personal-data-export.md
@@ -1,0 +1,157 @@
+# Personal Data Export
+
+`Nene\Func\PersonalDataExport` is a GDPR Article 20-style personal data portability helper. It aggregates user data from multiple registered provider closures and assembles it into a portable JSON structure.
+
+## When to use
+
+Use `PersonalDataExport` when you need to:
+
+- Respond to user data portability requests (GDPR Article 20, CCPA)
+- Build a "Download your data" feature
+- Aggregate data spread across multiple tables into one JSON file
+- Test data exports without coupling the aggregator to specific database schemas
+
+## API
+
+```php
+use Nene\Func\PersonalDataExport;
+```
+
+| Method | Description |
+| --- | --- |
+| `register(string $section, callable $provider): static` | Register a provider for a section. Returns `$this` for fluent chaining. |
+| `export(int\|string $userId): array` | Run all providers and return the aggregated array. |
+| `exportJson(int\|string $userId, int $flags = …): string` | Run all providers and return a JSON string. |
+| `sections(): array` | Return registered section names in registration order (for tests). |
+
+## Registering providers
+
+Register one provider per logical data category at bootstrap or in a service initializer:
+
+```php
+$export = new PersonalDataExport();
+
+$export
+    ->register('profile', function (int|string $userId) use ($pdo): array {
+        $stmt = $pdo->prepare(
+            'SELECT name, email, created_at FROM users WHERE id = ?'
+        );
+        $stmt->execute([$userId]);
+        return $stmt->fetch(\PDO::FETCH_ASSOC) ?: [];
+    })
+    ->register('orders', function (int|string $userId) use ($pdo): array {
+        $stmt = $pdo->prepare(
+            'SELECT id, total, status, created_at FROM orders WHERE user_id = ?'
+        );
+        $stmt->execute([$userId]);
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    })
+    ->register('activity', function (int|string $userId) use ($pdo): array {
+        $stmt = $pdo->prepare(
+            'SELECT event, occurred_at FROM activity_log WHERE user_id = ? ORDER BY occurred_at DESC'
+        );
+        $stmt->execute([$userId]);
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    });
+```
+
+- Providers fire in **registration order**.
+- Registering the same section name twice **overwrites** the previous provider.
+- The provider's return value can be any array shape — a flat record, a list of rows, or a nested structure.
+
+## Generating the export
+
+```php
+// Structured array
+$result = $export->export($userId);
+// $result['exportedAt'] — ISO 8601 timestamp
+// $result['userId']     — the requested user ID
+// $result['data']       — section → data map
+
+// JSON for download
+$json = $export->exportJson($userId);
+header('Content-Type: application/json');
+header('Content-Disposition: attachment; filename="my-data.json"');
+echo $json;
+```
+
+### Output structure
+
+```json
+{
+  "exportedAt": "2026-05-27T12:00:00+00:00",
+  "userId": 42,
+  "data": {
+    "profile": {
+      "name": "Taro Yamada",
+      "email": "taro@example.com",
+      "created_at": "2024-01-15 09:23:00"
+    },
+    "orders": [
+      { "id": 1, "total": 1500, "status": "completed" }
+    ],
+    "activity": [
+      { "event": "login", "occurred_at": "2026-05-27 10:00:00" }
+    ]
+  }
+}
+```
+
+## Custom JSON flags
+
+`exportJson()` defaults to `JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE`. Pass custom flags for compact output or different encoding:
+
+```php
+// Compact JSON
+$json = $export->exportJson($userId, 0);
+
+// Compact + Unicode-safe
+$json = $export->exportJson($userId, JSON_UNESCAPED_UNICODE);
+```
+
+`JSON_THROW_ON_ERROR` is always added internally — encoding errors throw `\JsonException`.
+
+## Provider signature
+
+Every provider receives one argument: the user ID passed to `export()` or `exportJson()`.
+
+```php
+$provider = function (int|string $userId): array {
+    // fetch and return data for this user
+    return [];
+};
+```
+
+The user ID type is `int|string` to support both integer primary keys and UUID string identifiers.
+
+## Empty sections
+
+A provider may return `[]`. The section key is still included in the export with an empty array value. This makes the output schema predictable regardless of whether the user has data in that category.
+
+## Testing
+
+Because providers are plain callables, no real database is needed in tests:
+
+```php
+$export = new PersonalDataExport();
+
+$export->register('profile', function (int|string $userId): array {
+    return ['name' => 'Test User', 'userId' => $userId];
+});
+
+$result = $export->export(42);
+
+self::assertSame(42, $result['userId']);
+self::assertSame('Test User', $result['data']['profile']['name']);
+```
+
+Use `sections()` to assert provider registration without triggering data fetching:
+
+```php
+self::assertSame(['profile', 'orders'], $export->sections());
+```
+
+## Related
+
+- `Nene\Func\I18n` — for localising the export filename or section labels.
+- `Nene\Func\EventDispatcher` — emit a `user.data-exported` event after a successful export for audit logging.

--- a/docs/field-trials/2026-05-field-trial-53.md
+++ b/docs/field-trials/2026-05-field-trial-53.md
@@ -1,0 +1,68 @@
+# Field Trial 53 — Personal Data Export
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft53-personal-data-export`
+**Baseline**: `d3c6720` (post FT25–FT50 merge wave)
+
+## Goal
+
+Establish a GDPR Article 20-style personal data portability pattern for NeNe applications. Provide a dependency-free helper that aggregates user data from multiple tables into a portable JSON export.
+
+## What was built
+
+### `Nene\Func\PersonalDataExport` (`class/func/PersonalDataExport.php`)
+
+Instance-based aggregator providing:
+
+| Method | Description |
+| --- | --- |
+| `register(string $section, callable $provider): static` | Register a provider callable for a named section. Fluent — returns `$this`. |
+| `export(int\|string $userId): array` | Run all providers, return `['exportedAt', 'userId', 'data']` envelope. |
+| `exportJson(int\|string $userId, int $flags): string` | JSON-encode the export. Adds `JSON_THROW_ON_ERROR`; defaults to pretty + `JSON_UNESCAPED_UNICODE`. |
+| `sections(): array` | Return registered section names in order (for tests). |
+
+Key design points:
+
+- **Instance-based**: each `PersonalDataExport` holds its own provider registry, easy to configure per-request or per-test.
+- **Provider signature**: `callable(int|string $userId): array` — providers capture their own DB connections via closure; the aggregator has no infrastructure dependency.
+- **Section ordering**: sections appear in registration order (FIFO).
+- **Overwrite semantics**: re-registering the same section name replaces the previous provider.
+- **Empty sections included**: providers returning `[]` still produce their key in the export, keeping the output schema predictable.
+- **ISO 8601 timestamp**: `exportedAt` uses `DateTimeInterface::ATOM` for maximum interoperability.
+
+### Tests (`tests/Unit/Func/PersonalDataExportTest.php`)
+
+18 unit tests covering:
+
+- Export envelope contains `exportedAt`, `userId`, `data`
+- `exportedAt` is ATOM-format ISO 8601
+- `userId` preserved as integer
+- `userId` preserved as string (UUID)
+- No providers → `data` is `[]`
+- Single provider section present and populated
+- Multiple providers, all sections present
+- Sections appear in registration order
+- Provider receives the correct user ID
+- Re-registering a section overwrites the previous provider
+- `register()` returns `$this` (fluent)
+- Fluent chaining via method chain
+- `sections()` returns registered names
+- `sections()` returns `[]` when no providers
+- `exportJson()` returns valid JSON
+- `exportJson()` preserves Unicode characters (Japanese characters not escaped)
+- `exportJson()` with custom flags (compact mode)
+- Provider returning empty array — section still present
+
+### Howto (`docs/development/personal-data-export.md`)
+
+Covers: API table, provider registration pattern, output structure sample, custom JSON flags, provider signature, empty sections, test patterns without DB.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+The implementation required no framework changes. `PersonalDataExport` is a pure `Nene\Func` helper with no external dependencies or NeNe-core coupling. All 18 tests pass; CS fixer and Phan both clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Func/PersonalDataExportTest.php
+++ b/tests/Unit/Func/PersonalDataExportTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Func;
+
+use Nene\Func\PersonalDataExport;
+use PHPUnit\Framework\TestCase;
+
+final class PersonalDataExportTest extends TestCase
+{
+    // --- export structure ---
+
+    public function testExportContainsTopLevelKeys(): void
+    {
+        $export = new PersonalDataExport();
+        $result = $export->export(1);
+
+        self::assertArrayHasKey('exportedAt', $result);
+        self::assertArrayHasKey('userId', $result);
+        self::assertArrayHasKey('data', $result);
+    }
+
+    public function testExportedAtIsIso8601(): void
+    {
+        $export = new PersonalDataExport();
+        $result = $export->export(1);
+
+        // DateTimeInterface::ATOM produces e.g. 2026-05-27T12:00:00+00:00
+        $dt = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $result['exportedAt']);
+        self::assertNotFalse($dt, 'exportedAt must be ATOM format');
+    }
+
+    public function testUserIdPreservedAsInteger(): void
+    {
+        $export = new PersonalDataExport();
+        self::assertSame(42, $export->export(42)['userId']);
+    }
+
+    public function testUserIdPreservedAsString(): void
+    {
+        $export = new PersonalDataExport();
+        self::assertSame('uuid-abc', $export->export('uuid-abc')['userId']);
+    }
+
+    // --- no providers ---
+
+    public function testExportWithNoProvidersReturnsEmptyData(): void
+    {
+        $export = new PersonalDataExport();
+        self::assertSame([], $export->export(1)['data']);
+    }
+
+    // --- single provider ---
+
+    public function testSingleProviderSectionPresent(): void
+    {
+        $export = new PersonalDataExport();
+        $export->register('profile', function (int|string $id): array {
+            return ['name' => 'Taro', 'userId' => $id];
+        });
+
+        $data = $export->export(7)['data'];
+
+        self::assertArrayHasKey('profile', $data);
+        self::assertSame('Taro', $data['profile']['name']);
+        self::assertSame(7, $data['profile']['userId']);
+    }
+
+    // --- multiple providers ---
+
+    public function testMultipleProvidersSectionsAllPresent(): void
+    {
+        $export = new PersonalDataExport();
+        $export->register('profile', fn (int|string $id): array => ['id' => $id]);
+        $export->register('orders', fn (int|string $id): array => [['orderId' => 1]]);
+        $export->register('activity', fn (int|string $id): array => []);
+
+        $data = $export->export(99)['data'];
+
+        self::assertArrayHasKey('profile', $data);
+        self::assertArrayHasKey('orders', $data);
+        self::assertArrayHasKey('activity', $data);
+    }
+
+    public function testSectionsAppearInRegistrationOrder(): void
+    {
+        $export = new PersonalDataExport();
+        $export->register('c', fn (int|string $id): array => []);
+        $export->register('a', fn (int|string $id): array => []);
+        $export->register('b', fn (int|string $id): array => []);
+
+        self::assertSame(['c', 'a', 'b'], array_keys($export->export(1)['data']));
+    }
+
+    // --- provider receives userId ---
+
+    public function testProviderReceivesCorrectUserId(): void
+    {
+        $captured = null;
+        $export   = new PersonalDataExport();
+        $export->register('test', function (int|string $id) use (&$captured): array {
+            $captured = $id;
+            return [];
+        });
+
+        $export->export(123);
+
+        self::assertSame(123, $captured);
+    }
+
+    // --- overwrite ---
+
+    public function testRegisteringAgainOverwritesPreviousProvider(): void
+    {
+        $export = new PersonalDataExport();
+        $export->register('section', fn (int|string $id): array => ['version' => 1]);
+        $export->register('section', fn (int|string $id): array => ['version' => 2]);
+
+        $data = $export->export(1)['data'];
+
+        self::assertSame(2, $data['section']['version']);
+        self::assertCount(1, $data); // still one section
+    }
+
+    // --- fluent register ---
+
+    public function testRegisterReturnsSelf(): void
+    {
+        $export = new PersonalDataExport();
+        $result = $export->register('x', fn (int|string $id): array => []);
+        self::assertSame($export, $result);
+    }
+
+    public function testFluentChaining(): void
+    {
+        $export = (new PersonalDataExport())
+            ->register('a', fn (int|string $id): array => ['a'])
+            ->register('b', fn (int|string $id): array => ['b']);
+
+        self::assertSame(['a', 'b'], $export->sections());
+    }
+
+    // --- sections() ---
+
+    public function testSectionsReturnsRegisteredNames(): void
+    {
+        $export = new PersonalDataExport();
+        $export->register('profile', fn (int|string $id): array => []);
+        $export->register('orders', fn (int|string $id): array => []);
+
+        self::assertSame(['profile', 'orders'], $export->sections());
+    }
+
+    public function testSectionsEmptyWhenNoProviders(): void
+    {
+        self::assertSame([], (new PersonalDataExport())->sections());
+    }
+
+    // --- exportJson ---
+
+    public function testExportJsonReturnsValidJson(): void
+    {
+        $export = new PersonalDataExport();
+        $export->register('profile', fn (int|string $id): array => ['name' => 'Taro']);
+
+        $json   = $export->exportJson(1);
+        $decoded = json_decode($json, true);
+
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('exportedAt', $decoded);
+        self::assertArrayHasKey('userId', $decoded);
+        self::assertArrayHasKey('data', $decoded);
+    }
+
+    public function testExportJsonContainsProviderData(): void
+    {
+        $export = new PersonalDataExport();
+        $export->register('profile', fn (int|string $id): array => ['name' => '太郎']);
+
+        $json    = $export->exportJson(1);
+        $decoded = json_decode($json, true);
+
+        // JSON_UNESCAPED_UNICODE — Japanese must not be escaped
+        self::assertStringContainsString('太郎', $json);
+        self::assertSame('太郎', $decoded['data']['profile']['name']);
+    }
+
+    public function testExportJsonCustomFlags(): void
+    {
+        $export = new PersonalDataExport();
+        $json   = $export->exportJson(1, 0); // compact (no pretty-print)
+
+        // compact JSON has no newlines
+        self::assertStringNotContainsString("\n", $json);
+    }
+
+    // --- provider returning empty array ---
+
+    public function testEmptyProviderArrayIsIncludedInExport(): void
+    {
+        $export = new PersonalDataExport();
+        $export->register('empty_section', fn (int|string $id): array => []);
+
+        $data = $export->export(1)['data'];
+
+        self::assertArrayHasKey('empty_section', $data);
+        self::assertSame([], $data['empty_section']);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Func\PersonalDataExport`: a lightweight, dependency-free GDPR Article 20 personal data portability aggregator.

## Changes

- `class/func/PersonalDataExport.php` — `register / export / exportJson / sections`
- `tests/Unit/Func/PersonalDataExportTest.php` — 18 unit tests, all passing
- `docs/development/personal-data-export.md` — howto doc
- `docs/field-trials/2026-05-field-trial-53.md` — FT report

## Design

- **Instance-based**: each object holds its own provider registry
- **Provider signature**: `callable(int|string $userId): array` — providers capture their own DB connections; the aggregator has no infrastructure dependency
- **FIFO section order**: sections appear in registration order
- **ISO 8601 timestamp**: `exportedAt` uses `DateTimeInterface::ATOM`
- **Empty sections included**: keeps output schema predictable

## Field Trial

F-1: Clean trial — no framework changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)