### PR TITLE
feat(func): JsonSchemaValidator — lightweight JSON Schema-subset validator (FT54)

### DIFF
--- a/class/func/JsonSchemaValidator.php
+++ b/class/func/JsonSchemaValidator.php
@@ -109,7 +109,7 @@ final class JsonSchemaValidator
                 $errors[] = self::path($pointer) . " must be at most {$schema['maxLength']} characters";
             }
             if (isset($schema['pattern']) && !preg_match($schema['pattern'], $data)) {
-                $errors[] = self::path($pointer) . " does not match required pattern";
+                $errors[] = self::path($pointer) . ' does not match required pattern';
             }
         }
 

--- a/class/func/JsonSchemaValidator.php
+++ b/class/func/JsonSchemaValidator.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * AYANE : ayane.co.jp
+ * powered by NENE.
+ *
+ * PHP Version >= 8.4
+ *
+ * @package   AYANE
+ * @author    hideyukiMORI <info@ayane.co.jp>
+ * @copyright 2021 AYANE
+ * @license   https://opensource.org/licenses/MIT MIT License
+ * @link      https://ayane.co.jp/
+ */
+
+declare(strict_types=1);
+
+namespace Nene\Func;
+
+/**
+ * Lightweight JSON Schema-subset validator for decoded request bodies.
+ *
+ * Validates a PHP value (typically the result of `json_decode($body, true)`)
+ * against a schema definition. Error messages use JSON Pointer paths
+ * (e.g. `/address/city`, `/items/0/price`) to identify the failing location.
+ *
+ * ## Supported keywords
+ *
+ * | Keyword | Types | Description |
+ * |---------|-------|-------------|
+ * | `type` | all | `'string'`, `'integer'`, `'number'`, `'boolean'`, `'array'`, `'object'`, `'null'` |
+ * | `nullable` | all | `true` allows `null` in addition to the declared type |
+ * | `required` | object | List of required property names |
+ * | `properties` | object | Sub-schemas keyed by property name |
+ * | `minLength` | string | Minimum character count (mb_strlen) |
+ * | `maxLength` | string | Maximum character count (mb_strlen) |
+ * | `pattern` | string | PCRE pattern the value must match |
+ * | `minimum` | integer/number | Inclusive lower bound |
+ * | `maximum` | integer/number | Inclusive upper bound |
+ * | `enum` | all | Value must be in the given list (strict comparison) |
+ * | `items` | array | Sub-schema applied to every element |
+ *
+ * ## Basic usage
+ *
+ * ```php
+ * $schema = [
+ *     'type'       => 'object',
+ *     'required'   => ['name', 'age'],
+ *     'properties' => [
+ *         'name' => ['type' => 'string', 'minLength' => 1, 'maxLength' => 100],
+ *         'age'  => ['type' => 'integer', 'minimum' => 0, 'maximum' => 150],
+ *         'role' => ['type' => 'string', 'enum' => ['admin', 'user', 'guest']],
+ *     ],
+ * ];
+ *
+ * $body = json_decode($request->body(), true);
+ * $errors = JsonSchemaValidator::validate($body, $schema);
+ *
+ * if ($errors !== []) {
+ *     // respond 422 with error list
+ * }
+ * ```
+ *
+ * ## Notes
+ *
+ * - PHP arrays serve as both JSON objects (string-keyed) and JSON arrays
+ *   (integer-keyed). Use `type: 'object'` for JSON objects and `type: 'array'`
+ *   for JSON arrays; both accept PHP arrays.
+ * - Unknown keywords are silently ignored, making forward compatibility easy.
+ * - The `$pointer` parameter in `validate()` is used internally for recursion;
+ *   callers should omit it.
+ */
+final class JsonSchemaValidator
+{
+    /**
+     * Validate $data against $schema and return a list of error messages.
+     *
+     * Returns an empty array when validation passes.
+     *
+     * @param  mixed                $data    The value to validate.
+     * @param  array<string, mixed> $schema  Schema definition (JSON Schema subset).
+     * @param  string               $pointer JSON Pointer prefix for error paths (internal use).
+     * @return list<string>                  Validation error messages; empty when valid.
+     */
+    public static function validate(mixed $data, array $schema, string $pointer = ''): array
+    {
+        $errors = [];
+
+        // null + nullable: bypass all further checks
+        if ($data === null && ($schema['nullable'] ?? false)) {
+            return [];
+        }
+
+        // Type check
+        if (isset($schema['type'])) {
+            $typeError = self::checkType($data, $schema['type'], $pointer);
+            if ($typeError !== null) {
+                return [$typeError]; // type mismatch blocks all further checks
+            }
+        }
+
+        // String constraints
+        if (is_string($data)) {
+            $len = mb_strlen($data);
+            if (isset($schema['minLength']) && $len < $schema['minLength']) {
+                $errors[] = self::path($pointer) . " must be at least {$schema['minLength']} characters";
+            }
+            if (isset($schema['maxLength']) && $len > $schema['maxLength']) {
+                $errors[] = self::path($pointer) . " must be at most {$schema['maxLength']} characters";
+            }
+            if (isset($schema['pattern']) && !preg_match($schema['pattern'], $data)) {
+                $errors[] = self::path($pointer) . " does not match required pattern";
+            }
+        }
+
+        // Numeric constraints
+        if (is_int($data) || is_float($data)) {
+            if (isset($schema['minimum']) && $data < $schema['minimum']) {
+                $errors[] = self::path($pointer) . " must be at least {$schema['minimum']}";
+            }
+            if (isset($schema['maximum']) && $data > $schema['maximum']) {
+                $errors[] = self::path($pointer) . " must be at most {$schema['maximum']}";
+            }
+        }
+
+        // Enum
+        if (isset($schema['enum'])) {
+            if (!in_array($data, $schema['enum'], true)) {
+                $allowed = implode(', ', array_map(
+                    static fn (mixed $v): string => json_encode($v) ?: '',
+                    $schema['enum'],
+                ));
+                $errors[] = self::path($pointer) . " must be one of: {$allowed}";
+            }
+        }
+
+        // Object constraints (properties + required)
+        if (is_array($data) && (isset($schema['properties']) || isset($schema['required']))) {
+            foreach ($schema['required'] ?? [] as $field) {
+                if (!array_key_exists($field, $data)) {
+                    $errors[] = self::join($pointer, (string) $field) . ' is required';
+                }
+            }
+            foreach ($schema['properties'] ?? [] as $field => $subSchema) {
+                if (array_key_exists($field, $data)) {
+                    $sub = self::validate($data[$field], $subSchema, self::join($pointer, (string) $field));
+                    $errors = array_merge($errors, $sub);
+                }
+            }
+        }
+
+        // Array items
+        if (is_array($data) && isset($schema['items'])) {
+            foreach ($data as $i => $item) {
+                $sub = self::validate($item, $schema['items'], self::join($pointer, (string) $i));
+                $errors = array_merge($errors, $sub);
+            }
+        }
+
+        return $errors;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return a type-mismatch error string, or null if the value matches.
+     */
+    private static function checkType(mixed $data, string $type, string $pointer): ?string
+    {
+        $ok = match ($type) {
+            'string'  => is_string($data),
+            'integer' => is_int($data),
+            'number'  => is_int($data) || is_float($data),
+            'boolean' => is_bool($data),
+            'array'   => is_array($data),
+            'object'  => is_array($data),
+            'null'    => $data === null,
+            default   => true,
+        };
+        return $ok ? null : self::path($pointer) . " must be of type {$type}";
+    }
+
+    /**
+     * Produce a human-readable path label from a JSON Pointer string.
+     * Empty pointer → `'/'`; `/foo/bar` → `'/foo/bar'`.
+     */
+    private static function path(string $pointer): string
+    {
+        return $pointer === '' ? '/' : $pointer;
+    }
+
+    /**
+     * Append a segment to a JSON Pointer string.
+     * `/foo` + `bar` → `/foo/bar`.  `` + `name` → `/name`.
+     */
+    private static function join(string $pointer, string $segment): string
+    {
+        return $pointer . '/' . $segment;
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          cacheDirectory=".phpunit.cache">
     <testsuites>

--- a/tests/Unit/Func/JsonSchemaValidatorTest.php
+++ b/tests/Unit/Func/JsonSchemaValidatorTest.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Func;
+
+use Nene\Func\JsonSchemaValidator;
+use PHPUnit\Framework\TestCase;
+
+final class JsonSchemaValidatorTest extends TestCase
+{
+    // --- no schema keywords → always valid ---
+
+    public function testEmptySchemaAlwaysPasses(): void
+    {
+        self::assertSame([], JsonSchemaValidator::validate('anything', []));
+        self::assertSame([], JsonSchemaValidator::validate(42, []));
+        self::assertSame([], JsonSchemaValidator::validate(null, []));
+    }
+
+    // --- type: string ---
+
+    public function testTypeStringPassesForString(): void
+    {
+        self::assertSame([], JsonSchemaValidator::validate('hello', ['type' => 'string']));
+    }
+
+    public function testTypeStringFailsForInteger(): void
+    {
+        $errors = JsonSchemaValidator::validate(42, ['type' => 'string']);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('string', $errors[0]);
+    }
+
+    // --- type: integer ---
+
+    public function testTypeIntegerPassesForInt(): void
+    {
+        self::assertSame([], JsonSchemaValidator::validate(0, ['type' => 'integer']));
+    }
+
+    public function testTypeIntegerFailsForFloat(): void
+    {
+        $errors = JsonSchemaValidator::validate(1.5, ['type' => 'integer']);
+        self::assertCount(1, $errors);
+    }
+
+    // --- type: number ---
+
+    public function testTypeNumberPassesForIntAndFloat(): void
+    {
+        self::assertSame([], JsonSchemaValidator::validate(3, ['type' => 'number']));
+        self::assertSame([], JsonSchemaValidator::validate(3.14, ['type' => 'number']));
+    }
+
+    public function testTypeNumberFailsForString(): void
+    {
+        self::assertNotSame([], JsonSchemaValidator::validate('3', ['type' => 'number']));
+    }
+
+    // --- type: boolean ---
+
+    public function testTypeBooleanPassesForBool(): void
+    {
+        self::assertSame([], JsonSchemaValidator::validate(true, ['type' => 'boolean']));
+        self::assertSame([], JsonSchemaValidator::validate(false, ['type' => 'boolean']));
+    }
+
+    public function testTypeBooleanFailsForInteger(): void
+    {
+        self::assertNotSame([], JsonSchemaValidator::validate(1, ['type' => 'boolean']));
+    }
+
+    // --- type: null ---
+
+    public function testTypeNullPassesForNull(): void
+    {
+        self::assertSame([], JsonSchemaValidator::validate(null, ['type' => 'null']));
+    }
+
+    public function testTypeNullFailsForString(): void
+    {
+        self::assertNotSame([], JsonSchemaValidator::validate('', ['type' => 'null']));
+    }
+
+    // --- nullable ---
+
+    public function testNullableAllowsNull(): void
+    {
+        $schema = ['type' => 'string', 'nullable' => true];
+        self::assertSame([], JsonSchemaValidator::validate(null, $schema));
+    }
+
+    public function testNullableStringStillValidatesWhenNotNull(): void
+    {
+        $schema = ['type' => 'string', 'nullable' => true];
+        self::assertSame([], JsonSchemaValidator::validate('hello', $schema));
+        self::assertNotSame([], JsonSchemaValidator::validate(42, $schema));
+    }
+
+    public function testNonNullableFailsForNull(): void
+    {
+        $errors = JsonSchemaValidator::validate(null, ['type' => 'string']);
+        self::assertNotSame([], $errors);
+    }
+
+    // --- minLength / maxLength ---
+
+    public function testMinLengthPass(): void
+    {
+        self::assertSame([], JsonSchemaValidator::validate('abc', ['minLength' => 3]));
+    }
+
+    public function testMinLengthFail(): void
+    {
+        $errors = JsonSchemaValidator::validate('ab', ['minLength' => 3]);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('3', $errors[0]);
+    }
+
+    public function testMaxLengthPass(): void
+    {
+        self::assertSame([], JsonSchemaValidator::validate('hi', ['maxLength' => 5]));
+    }
+
+    public function testMaxLengthFail(): void
+    {
+        $errors = JsonSchemaValidator::validate('toolong', ['maxLength' => 5]);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('5', $errors[0]);
+    }
+
+    public function testMinAndMaxLengthBothApply(): void
+    {
+        $schema = ['minLength' => 2, 'maxLength' => 4];
+        self::assertSame([], JsonSchemaValidator::validate('abc', $schema));
+        self::assertCount(1, JsonSchemaValidator::validate('a', $schema));
+        self::assertCount(1, JsonSchemaValidator::validate('abcde', $schema));
+    }
+
+    // --- pattern ---
+
+    public function testPatternPass(): void
+    {
+        self::assertSame(
+            [],
+            JsonSchemaValidator::validate('hello123', ['pattern' => '/^[a-z0-9]+$/'])
+        );
+    }
+
+    public function testPatternFail(): void
+    {
+        $errors = JsonSchemaValidator::validate('Hello!', ['pattern' => '/^[a-z0-9]+$/']);
+        self::assertCount(1, $errors);
+    }
+
+    // --- minimum / maximum ---
+
+    public function testMinimumPass(): void
+    {
+        self::assertSame([], JsonSchemaValidator::validate(5, ['minimum' => 5]));
+        self::assertSame([], JsonSchemaValidator::validate(6, ['minimum' => 5]));
+    }
+
+    public function testMinimumFail(): void
+    {
+        $errors = JsonSchemaValidator::validate(4, ['minimum' => 5]);
+        self::assertCount(1, $errors);
+    }
+
+    public function testMaximumPass(): void
+    {
+        self::assertSame([], JsonSchemaValidator::validate(10, ['maximum' => 10]));
+    }
+
+    public function testMaximumFail(): void
+    {
+        $errors = JsonSchemaValidator::validate(11, ['maximum' => 10]);
+        self::assertCount(1, $errors);
+    }
+
+    // --- enum ---
+
+    public function testEnumPass(): void
+    {
+        $schema = ['enum' => ['admin', 'user', 'guest']];
+        self::assertSame([], JsonSchemaValidator::validate('admin', $schema));
+    }
+
+    public function testEnumFail(): void
+    {
+        $schema = ['enum' => ['admin', 'user', 'guest']];
+        $errors = JsonSchemaValidator::validate('root', $schema);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('admin', $errors[0]);
+    }
+
+    public function testEnumStrictComparison(): void
+    {
+        // '1' is not the same as 1 (strict)
+        $errors = JsonSchemaValidator::validate('1', ['enum' => [1, 2, 3]]);
+        self::assertCount(1, $errors);
+    }
+
+    // --- required ---
+
+    public function testRequiredPass(): void
+    {
+        $schema = ['required' => ['name', 'age']];
+        self::assertSame([], JsonSchemaValidator::validate(['name' => 'x', 'age' => 1], $schema));
+    }
+
+    public function testRequiredFail(): void
+    {
+        $schema = ['required' => ['name', 'email']];
+        $errors = JsonSchemaValidator::validate(['name' => 'x'], $schema);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('email', $errors[0]);
+        self::assertStringContainsString('required', $errors[0]);
+    }
+
+    public function testMultipleRequiredFieldsMissing(): void
+    {
+        $schema = ['required' => ['a', 'b', 'c']];
+        $errors = JsonSchemaValidator::validate([], $schema);
+        self::assertCount(3, $errors);
+    }
+
+    // --- properties ---
+
+    public function testPropertiesValidateNestedFields(): void
+    {
+        $schema = [
+            'type'       => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'age'  => ['type' => 'integer'],
+            ],
+        ];
+        self::assertSame([], JsonSchemaValidator::validate(['name' => 'Taro', 'age' => 30], $schema));
+    }
+
+    public function testPropertiesErrorIncludesPath(): void
+    {
+        $schema = [
+            'properties' => [
+                'age' => ['type' => 'integer'],
+            ],
+        ];
+        $errors = JsonSchemaValidator::validate(['age' => 'thirty'], $schema);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('/age', $errors[0]);
+    }
+
+    public function testPropertiesSkipsAbsentOptionalFields(): void
+    {
+        $schema = [
+            'properties' => [
+                'optional' => ['type' => 'string'],
+            ],
+        ];
+        // 'optional' key is absent — no error
+        self::assertSame([], JsonSchemaValidator::validate([], $schema));
+    }
+
+    // --- items ---
+
+    public function testItemsPassForAllMatchingElements(): void
+    {
+        $schema = ['type' => 'array', 'items' => ['type' => 'integer']];
+        self::assertSame([], JsonSchemaValidator::validate([1, 2, 3], $schema));
+    }
+
+    public function testItemsErrorIncludesIndex(): void
+    {
+        $schema = ['items' => ['type' => 'integer']];
+        $errors = JsonSchemaValidator::validate([1, 'bad', 3], $schema);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('/1', $errors[0]);
+    }
+
+    public function testItemsMultipleErrors(): void
+    {
+        $schema = ['items' => ['type' => 'integer']];
+        $errors = JsonSchemaValidator::validate(['a', 'b'], $schema);
+        self::assertCount(2, $errors);
+    }
+
+    // --- nested object ---
+
+    public function testDeepNestedValidation(): void
+    {
+        $schema = [
+            'type'       => 'object',
+            'required'   => ['address'],
+            'properties' => [
+                'address' => [
+                    'type'       => 'object',
+                    'required'   => ['city'],
+                    'properties' => [
+                        'city'    => ['type' => 'string'],
+                        'zipcode' => ['type' => 'string', 'pattern' => '/^\d{3}-\d{4}$/'],
+                    ],
+                ],
+            ],
+        ];
+
+        // Valid
+        $valid = ['address' => ['city' => 'Tokyo', 'zipcode' => '100-0001']];
+        self::assertSame([], JsonSchemaValidator::validate($valid, $schema));
+
+        // Missing nested required
+        $missingCity = ['address' => ['zipcode' => '100-0001']];
+        $errors      = JsonSchemaValidator::validate($missingCity, $schema);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('/address/city', $errors[0]);
+
+        // Wrong type in nested
+        $wrongType = ['address' => ['city' => 123]];
+        $errors    = JsonSchemaValidator::validate($wrongType, $schema);
+        self::assertCount(1, $errors); // city missing (required) not caught, but type wrong
+    }
+
+    // --- array of objects ---
+
+    public function testArrayOfObjects(): void
+    {
+        $schema = [
+            'type'  => 'array',
+            'items' => [
+                'type'       => 'object',
+                'required'   => ['id', 'name'],
+                'properties' => [
+                    'id'   => ['type' => 'integer'],
+                    'name' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $valid = [
+            ['id' => 1, 'name' => 'first'],
+            ['id' => 2, 'name' => 'second'],
+        ];
+        self::assertSame([], JsonSchemaValidator::validate($valid, $schema));
+
+        $invalid = [
+            ['id' => 1, 'name' => 'ok'],
+            ['id' => 'bad'],           // id is wrong type, name missing
+        ];
+        $errors = JsonSchemaValidator::validate($invalid, $schema);
+        self::assertCount(2, $errors); // type error for id + required name
+        self::assertStringContainsString('/1/', $errors[0]);
+    }
+
+    // --- JSON pointer path ---
+
+    public function testRootPointerLabel(): void
+    {
+        $errors = JsonSchemaValidator::validate(42, ['type' => 'string']);
+        self::assertStringContainsString('/', $errors[0]);
+    }
+
+    public function testNestedPointerPath(): void
+    {
+        $schema = ['properties' => ['a' => ['properties' => ['b' => ['type' => 'string']]]]];
+        $errors = JsonSchemaValidator::validate(['a' => ['b' => 99]], $schema);
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('/a/b', $errors[0]);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,24 @@
+<?php
+// Local-dev bootstrap for git worktrees.
+// On CI the vendor/ directory is freshly installed and Composer's generated
+// autoload_psr4.php already maps Nene\Func\, Nene\Xion\, and Nene\Tests\
+// relative to the project root, so this file is a no-op there.
+//
+// Locally the vendor/ directory is a symlink to the main NeNe checkout, whose
+// generated paths do NOT include this worktree's class/ or tests/ directories.
+// We therefore add them manually so phpunit can resolve classes without
+// needing a full `composer install` inside the worktree.
+
+$loader = require __DIR__ . '/../vendor/autoload.php';
+$root   = dirname(__DIR__);
+
+// Only add if not already registered (avoids double-registration on CI or when
+// running from the main NeNe checkout where the path already matches).
+$existing = $loader->getPrefixesPsr4()['Nene\\Func\\'] ?? [];
+if (!in_array($root . '/class/func', $existing, true)) {
+    $loader->addPsr4('Nene\\Func\\', [$root . '/class/func']);
+}
+$existingTests = $loader->getPrefixesPsr4()['Nene\\Tests\\'] ?? [];
+if (!in_array($root . '/tests', $existingTests, true)) {
+    $loader->addPsr4('Nene\\Tests\\', [$root . '/tests']);
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 // Local-dev bootstrap for git worktrees.
 // On CI the vendor/ directory is freshly installed and Composer's generated
 // autoload_psr4.php already maps Nene\Func\, Nene\Xion\, and Nene\Tests\


### PR DESCRIPTION
## Summary

Adds `Nene\Func\JsonSchemaValidator` — a zero-dependency, pure-PHP validator for JSON-decoded request bodies.

## Supported keywords

| Keyword | Types | Description |
|---------|-------|-------------|
| `type` | all | `'string'`, `'integer'`, `'number'`, `'boolean'`, `'array'`, `'object'`, `'null'` |
| `nullable` | all | `true` allows `null` in addition to the declared type |
| `required` | object | List of required property names |
| `properties` | object | Sub-schemas keyed by property name |
| `minLength` | string | Minimum character count (mb_strlen) |
| `maxLength` | string | Maximum character count (mb_strlen) |
| `pattern` | string | PCRE pattern the value must match |
| `minimum` | integer/number | Inclusive lower bound |
| `maximum` | integer/number | Inclusive upper bound |
| `enum` | all | Value must be in the given list (strict comparison) |
| `items` | array | Sub-schema applied to every element |

## Error paths

Errors use JSON Pointer notation (`/address/city`, `/items/0/price`) to identify the failing field.

## Changes

- `class/func/JsonSchemaValidator.php` — implementation
- `tests/Unit/Func/JsonSchemaValidatorTest.php` — 41 tests, 63 assertions
- `tests/bootstrap.php` — worktree-aware PHPUnit bootstrap (adds local `class/` to autoloader; no-op on CI)
- `phpunit.xml` — updated bootstrap path to `tests/bootstrap.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)