### PR TITLE
feat(xion): DistributedLock — DB-backed distributed lock with TTL and owner enforcement (FT55)

### DIFF
--- a/class/xion/DistributedLock.php
+++ b/class/xion/DistributedLock.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * DB-backed distributed lock with TTL, owner enforcement, and stale-lock reclaim.
+ *
+ * Suitable for low-to-medium contention workloads (batch jobs, scheduled tasks,
+ * deduplication windows). For high-contention hot paths, prefer Redis SETNX.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE distributed_locks (
+ *     resource    VARCHAR(255) PRIMARY KEY,
+ *     owner       VARCHAR(255) NOT NULL,
+ *     expires_at  DATETIME     NOT NULL,
+ *     acquired_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $lock = new DistributedLock();
+ * $owner = bin2hex(random_bytes(8)); // unique per process/request
+ *
+ * if ($lock->acquire('report:monthly', $owner, ttlSeconds: 30)) {
+ *     try {
+ *         // ... do work ...
+ *     } finally {
+ *         $lock->release('report:monthly', $owner);
+ *     }
+ * } else {
+ *     // Another process holds the lock — retry later or skip
+ * }
+ * ```
+ *
+ * ## Stale lock reclaim
+ *
+ * If a process crashes while holding a lock, the TTL ensures the lock expires
+ * and can be claimed by the next caller. No manual cleanup is required.
+ *
+ * ## Owner identity
+ *
+ * Use a per-process or per-request unique string (UUID, random hex) as `$owner`.
+ * A fixed hostname like `worker-1` becomes ambiguous after a restart.
+ */
+final class DistributedLock
+{
+    private const TABLE = 'distributed_locks';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Try to acquire a lock on $resource for $owner with the given TTL.
+     *
+     * Returns true if the lock was acquired (including stale-lock reclaim
+     * and same-owner re-acquisition). Returns false if another owner holds
+     * an unexpired lock.
+     *
+     * @param string $resource   Unique lock key (e.g. "import:users", "report:2024-01").
+     * @param string $owner      Unique identifier for the caller (UUID or random hex).
+     * @param int    $ttlSeconds Seconds until the lock expires.
+     */
+    public function acquire(string $resource, string $owner, int $ttlSeconds = 30): bool
+    {
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $now       = $this->now();
+        $expiresAt = $this->addSeconds($now, $ttlSeconds);
+
+        $stmt = $db->prepare(
+            'SELECT owner, expires_at FROM ' . $this->table .
+            ' WHERE resource = :r LIMIT 1'
+        );
+        $stmt->bindValue(':r', $resource, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            // No existing lock — try INSERT
+            return $this->insert($db, $resource, $owner, $expiresAt, $now);
+        }
+
+        $existingOwner     = (string)$row['owner'];
+        $existingExpiresAt = (string)$row['expires_at'];
+
+        if ($existingOwner === $owner || $existingExpiresAt <= $now) {
+            // Same owner (re-acquire) or expired lock (stale reclaim) — UPDATE
+            $stmt = $db->prepare(
+                'UPDATE ' . $this->table .
+                ' SET owner = :o, expires_at = :e, acquired_at = :a WHERE resource = :r'
+            );
+            $stmt->bindValue(':o', $owner, PDO::PARAM_STR);
+            $stmt->bindValue(':e', $expiresAt, PDO::PARAM_STR);
+            $stmt->bindValue(':a', $now, PDO::PARAM_STR);
+            $stmt->bindValue(':r', $resource, PDO::PARAM_STR);
+            $stmt->execute();
+            return true;
+        }
+
+        // Held by another owner and not expired
+        return false;
+    }
+
+    /**
+     * Release a lock. Only the owner can release their own lock.
+     *
+     * Returns true if the lock was released.
+     * Returns false if the resource is not locked or the owner does not match.
+     *
+     * @param string $resource Unique lock key.
+     * @param string $owner    Must match the owner used in acquire().
+     */
+    public function release(string $resource, string $owner): bool
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'DELETE FROM ' . $this->table .
+            ' WHERE resource = :r AND owner = :o'
+        );
+        $stmt->bindValue(':r', $resource, PDO::PARAM_STR);
+        $stmt->bindValue(':o', $owner, PDO::PARAM_STR);
+        $stmt->execute();
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Extend the TTL of an existing lock. Only the current owner can renew.
+     *
+     * Returns true if the lock was successfully renewed.
+     * Returns false if the lock does not exist, is expired, or the owner differs.
+     *
+     * @param string $resource   Unique lock key.
+     * @param string $owner      Must match the owner used in acquire().
+     * @param int    $ttlSeconds New TTL from now.
+     */
+    public function renew(string $resource, string $owner, int $ttlSeconds = 30): bool
+    {
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $now       = $this->now();
+        $expiresAt = $this->addSeconds($now, $ttlSeconds);
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->table .
+            ' SET expires_at = :e WHERE resource = :r AND owner = :o AND expires_at > :n'
+        );
+        $stmt->bindValue(':e', $expiresAt, PDO::PARAM_STR);
+        $stmt->bindValue(':r', $resource, PDO::PARAM_STR);
+        $stmt->bindValue(':o', $owner, PDO::PARAM_STR);
+        $stmt->bindValue(':n', $now, PDO::PARAM_STR);
+        $stmt->execute();
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Check whether any owner currently holds an unexpired lock on $resource.
+     *
+     * @param string $resource Unique lock key.
+     */
+    public function isHeld(string $resource): bool
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $now  = $this->now();
+        $stmt = $db->prepare(
+            'SELECT 1 FROM ' . $this->table .
+            ' WHERE resource = :r AND expires_at > :n LIMIT 1'
+        );
+        $stmt->bindValue(':r', $resource, PDO::PARAM_STR);
+        $stmt->bindValue(':n', $now, PDO::PARAM_STR);
+        $stmt->execute();
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Insert a new lock row. Returns false on UNIQUE violation (concurrent race).
+     */
+    private function insert(PDO $db, string $resource, string $owner, string $expiresAt, string $now): bool
+    {
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $sql    = $driver === 'sqlite'
+            ? 'INSERT OR IGNORE INTO ' . $this->table . ' (resource, owner, expires_at, acquired_at) VALUES (:r, :o, :e, :a)'
+            : 'INSERT IGNORE INTO '    . $this->table . ' (resource, owner, expires_at, acquired_at) VALUES (:r, :o, :e, :a)';
+
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':r', $resource, PDO::PARAM_STR);
+        $stmt->bindValue(':o', $owner, PDO::PARAM_STR);
+        $stmt->bindValue(':e', $expiresAt, PDO::PARAM_STR);
+        $stmt->bindValue(':a', $now, PDO::PARAM_STR);
+
+        try {
+            $stmt->execute();
+        } catch (\PDOException) {
+            return false;
+        }
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Current timestamp as ISO 8601 string (Y-m-d H:i:s).
+     */
+    private function now(): string
+    {
+        return (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Add seconds to an ISO 8601 timestamp string.
+     */
+    private function addSeconds(string $base, int $seconds): string
+    {
+        return (new \DateTimeImmutable($base, new \DateTimeZone('UTC')))
+            ->modify('+' . $seconds . ' seconds')
+            ->format('Y-m-d H:i:s');
+    }
+}

--- a/docs/development/distributed-lock.md
+++ b/docs/development/distributed-lock.md
@@ -1,0 +1,115 @@
+# Distributed Lock
+
+`Nene\Xion\DistributedLock` provides a DB-backed mutual exclusion lock for coordinating work across multiple processes or instances.
+
+## When to use
+
+- Preventing duplicate execution of scheduled jobs (cron, batch)
+- Deduplication windows for idempotent operations
+- Single-writer enforcement across multiple app instances
+
+For high-contention hot paths (many requests per second competing for the same lock), prefer Redis `SETNX`; the DB-backed approach is well-suited to low-to-medium contention.
+
+## Schema
+
+```sql
+CREATE TABLE distributed_locks (
+    resource    VARCHAR(255) PRIMARY KEY,
+    owner       VARCHAR(255) NOT NULL,
+    expires_at  DATETIME     NOT NULL,
+    acquired_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+## API
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `acquire(resource, owner, ttlSeconds)` | `bool` | Try to acquire the lock. Returns `true` on success, `false` if held by another owner. |
+| `release(resource, owner)` | `bool` | Release the lock. Returns `false` if not owned by `$owner`. |
+| `renew(resource, owner, ttlSeconds)` | `bool` | Extend the TTL. Returns `false` if expired, not found, or wrong owner. |
+| `isHeld(resource)` | `bool` | Check whether any unexpired lock exists on `$resource`. |
+
+## Basic usage
+
+```php
+use Nene\Xion\DistributedLock;
+
+$lock  = new DistributedLock();
+$owner = bin2hex(random_bytes(8)); // unique per process/request
+
+if ($lock->acquire('report:monthly', $owner, ttlSeconds: 30)) {
+    try {
+        // ... do the exclusive work ...
+    } finally {
+        $lock->release('report:monthly', $owner);
+    }
+} else {
+    // Another process holds the lock — skip or retry later
+}
+```
+
+## Stale lock reclaim
+
+If a process crashes while holding a lock, the TTL ensures the lock expires and the next caller can claim it automatically — no manual cleanup needed.
+
+```php
+// Stale lock left by crashed process:
+// owner='worker-A', expires_at='2024-01-01 00:00:00' (past)
+
+$lock->acquire('job:import', 'worker-B', 30);
+// → true (expired lock claimed by worker-B)
+```
+
+## Renewing long-running jobs
+
+For jobs that run longer than the initial TTL, renew periodically:
+
+```php
+$lock->acquire('job:heavy', $owner, 60);
+
+foreach ($items as $item) {
+    process($item);
+    $lock->renew('job:heavy', $owner, 60); // reset TTL each iteration
+}
+
+$lock->release('job:heavy', $owner);
+```
+
+## Owner identity
+
+Use a per-process or per-request unique string — never a fixed hostname:
+
+```php
+// Bad: same value after restart
+$owner = gethostname();
+
+// Good: unique per execution
+$owner = bin2hex(random_bytes(8));   // 16-char hex
+$owner = \Ramsey\Uuid\Uuid::uuid4()->toString(); // UUIDv4
+```
+
+A fixed hostname like `worker-1` becomes the same after restart, allowing a new process to accidentally reclaim a lock held by a crashed sibling with the same name.
+
+## Error semantics
+
+| Scenario | `release()` | `renew()` |
+|----------|-------------|-----------|
+| Lock found, correct owner | `true` | `true` |
+| Lock found, wrong owner | `false` | `false` |
+| Lock expired | `false` (DELETE matched 0 rows) | `false` (UPDATE matched 0 rows) |
+| Lock not found | `false` | `false` |
+
+## Testing without `sleep()`
+
+Inject a PDO instance backed by SQLite in-memory and insert rows with crafted `expires_at` values to simulate expiry without sleeping:
+
+```php
+$db = new PDO('sqlite::memory:');
+// ... create table ...
+$db->exec("INSERT INTO distributed_locks (resource, owner, expires_at, acquired_at)
+           VALUES ('job:x', 'owner-A', '2000-01-01 00:00:00', '2000-01-01 00:00:00')");
+
+$lock = new DistributedLock($db);
+$result = $lock->acquire('job:x', 'owner-B', 30); // stale reclaim → true
+```

--- a/docs/field-trials/2026-05-field-trial-55.md
+++ b/docs/field-trials/2026-05-field-trial-55.md
@@ -1,0 +1,57 @@
+# Field Trial 55 — Distributed Lock
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft55-distributed-lock`
+**Baseline**: `b71f4b6` (post FT51–FT53 merge)
+
+## Goal
+
+Establish a DB-backed distributed lock pattern for NeNe. Enables mutual exclusion across multiple processes or instances without an external Redis dependency — suitable for scheduled jobs, batch deduplication, and single-writer enforcement.
+
+## What was built
+
+### `Nene\Xion\DistributedLock` (`class/xion/DistributedLock.php`)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `acquire(resource, owner, ttlSeconds=30)` | `bool` | Try to acquire the lock. Reclaims stale (expired) locks. |
+| `release(resource, owner)` | `bool` | Release. Returns `false` if not owned by `$owner`. |
+| `renew(resource, owner, ttlSeconds=30)` | `bool` | Extend TTL. Returns `false` if expired, not found, or wrong owner. |
+| `isHeld(resource)` | `bool` | Check whether any unexpired lock exists. |
+
+Key design points:
+
+- **Stale-lock reclaim**: expired lock claimed by the next caller automatically — no manual cleanup.
+- **Same-owner idempotency**: re-acquiring an active lock with the same owner updates the TTL (safe for retry).
+- **INSERT OR IGNORE / INSERT IGNORE**: race-safe insert for SQLite and MySQL respectively; concurrent INSERT on the same resource returns `false` rather than throwing.
+- **Owner-only release**: `release()` uses `WHERE resource = ? AND owner = ?`; wrong-owner release returns `false` without error.
+- **Renewal guard**: `renew()` adds `AND expires_at > NOW` — an expired lock cannot be renewed (the claim may already be gone or taken by another process).
+- **No `sleep()` in tests**: inject PDO + crafted `expires_at` past timestamps to simulate expiry deterministically.
+
+### Tests (`tests/Unit/Xion/DistributedLockTest.php`)
+
+17 unit tests covering:
+
+- Acquire new resource
+- Same-owner re-acquire (idempotent)
+- Contested lock returns `false`
+- Stale lock reclaimed by new owner
+- Acquire multiple distinct resources
+- Release: correct owner (true), wrong owner (false), not found (false)
+- After release, new owner can acquire
+- Renew: correct owner (true), wrong owner (false), expired (false), not found (false)
+- isHeld: active lock (true), no lock (false), after release (false), expired lock (false)
+
+### Howto (`docs/development/distributed-lock.md`)
+
+API table, basic usage, stale-lock reclaim, TTL renewal pattern, owner identity guidance, error semantics table, testing without `sleep()`.
+
+## Findings
+
+### F-1 — No framework findings (clean trial)
+
+The implementation required no changes to existing NeNe core classes. `DistributedLock` is a self-contained `Nene\Xion` helper that follows the same PDO injection pattern as `IdempotencyStore` and `LoginAttemptTracker`. All 17 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/DistributedLockTest.php
+++ b/tests/Unit/Xion/DistributedLockTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\DistributedLock;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for DistributedLock using an in-memory SQLite database.
+ */
+final class DistributedLockTest extends TestCase
+{
+    private PDO $db;
+    private DistributedLock $lock;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE distributed_locks (
+                resource    VARCHAR(255) PRIMARY KEY,
+                owner       VARCHAR(255) NOT NULL,
+                expires_at  DATETIME     NOT NULL,
+                acquired_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->lock = new DistributedLock($this->db);
+    }
+
+    // ── acquire ──────────────────────────────────────────────────────────────
+
+    public function testAcquireNewResource(): void
+    {
+        $result = $this->lock->acquire('job:report', 'owner-A', 30);
+        $this->assertTrue($result);
+    }
+
+    public function testAcquireSameOwnerIsIdempotent(): void
+    {
+        $this->lock->acquire('job:report', 'owner-A', 30);
+        $result = $this->lock->acquire('job:report', 'owner-A', 30);
+        $this->assertTrue($result);
+    }
+
+    public function testAcquireContestedLockReturnsFalse(): void
+    {
+        $this->lock->acquire('job:report', 'owner-A', 30);
+        $result = $this->lock->acquire('job:report', 'owner-B', 30);
+        $this->assertFalse($result);
+    }
+
+    public function testAcquireStaleLockIsReclaimed(): void
+    {
+        // Insert an already-expired lock directly
+        $this->db->exec(
+            "INSERT INTO distributed_locks (resource, owner, expires_at, acquired_at)
+             VALUES ('job:report', 'owner-A', '2000-01-01 00:00:00', '2000-01-01 00:00:00')"
+        );
+
+        $result = $this->lock->acquire('job:report', 'owner-B', 30);
+        $this->assertTrue($result);
+    }
+
+    public function testAcquireMultipleDistinctResources(): void
+    {
+        $this->assertTrue($this->lock->acquire('res:alpha', 'owner-A', 30));
+        $this->assertTrue($this->lock->acquire('res:beta', 'owner-B', 30));
+    }
+
+    // ── release ──────────────────────────────────────────────────────────────
+
+    public function testReleaseByCorrectOwnerReturnsTrue(): void
+    {
+        $this->lock->acquire('job:report', 'owner-A', 30);
+        $result = $this->lock->release('job:report', 'owner-A');
+        $this->assertTrue($result);
+    }
+
+    public function testReleaseByWrongOwnerReturnsFalse(): void
+    {
+        $this->lock->acquire('job:report', 'owner-A', 30);
+        $result = $this->lock->release('job:report', 'owner-B');
+        $this->assertFalse($result);
+    }
+
+    public function testReleaseNonExistentResourceReturnsFalse(): void
+    {
+        $result = $this->lock->release('job:nonexistent', 'owner-A');
+        $this->assertFalse($result);
+    }
+
+    public function testAfterReleaseNewOwnerCanAcquire(): void
+    {
+        $this->lock->acquire('job:report', 'owner-A', 30);
+        $this->lock->release('job:report', 'owner-A');
+        $result = $this->lock->acquire('job:report', 'owner-B', 30);
+        $this->assertTrue($result);
+    }
+
+    // ── renew ─────────────────────────────────────────────────────────────────
+
+    public function testRenewByCorrectOwnerReturnsTrue(): void
+    {
+        $this->lock->acquire('job:report', 'owner-A', 30);
+        $result = $this->lock->renew('job:report', 'owner-A', 60);
+        $this->assertTrue($result);
+    }
+
+    public function testRenewByWrongOwnerReturnsFalse(): void
+    {
+        $this->lock->acquire('job:report', 'owner-A', 30);
+        $result = $this->lock->renew('job:report', 'owner-B', 60);
+        $this->assertFalse($result);
+    }
+
+    public function testRenewExpiredLockReturnsFalse(): void
+    {
+        // Insert an already-expired lock directly
+        $this->db->exec(
+            "INSERT INTO distributed_locks (resource, owner, expires_at, acquired_at)
+             VALUES ('job:report', 'owner-A', '2000-01-01 00:00:00', '2000-01-01 00:00:00')"
+        );
+
+        $result = $this->lock->renew('job:report', 'owner-A', 30);
+        $this->assertFalse($result);
+    }
+
+    public function testRenewNonExistentResourceReturnsFalse(): void
+    {
+        $result = $this->lock->renew('job:nonexistent', 'owner-A', 30);
+        $this->assertFalse($result);
+    }
+
+    // ── isHeld ───────────────────────────────────────────────────────────────
+
+    public function testIsHeldReturnsTrueWhenLockActive(): void
+    {
+        $this->lock->acquire('job:report', 'owner-A', 30);
+        $this->assertTrue($this->lock->isHeld('job:report'));
+    }
+
+    public function testIsHeldReturnsFalseWhenNoLock(): void
+    {
+        $this->assertFalse($this->lock->isHeld('job:report'));
+    }
+
+    public function testIsHeldReturnsFalseAfterRelease(): void
+    {
+        $this->lock->acquire('job:report', 'owner-A', 30);
+        $this->lock->release('job:report', 'owner-A');
+        $this->assertFalse($this->lock->isHeld('job:report'));
+    }
+
+    public function testIsHeldReturnsFalseForExpiredLock(): void
+    {
+        // Insert an already-expired lock directly
+        $this->db->exec(
+            "INSERT INTO distributed_locks (resource, owner, expires_at, acquired_at)
+             VALUES ('job:report', 'owner-A', '2000-01-01 00:00:00', '2000-01-01 00:00:00')"
+        );
+
+        $this->assertFalse($this->lock->isHeld('job:report'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\DistributedLock` — a DB-backed mutual exclusion lock for coordinating work across multiple processes or instances.

## API

| Method | Returns | Description |
|--------|---------|-------------|
| `acquire(resource, owner, ttlSeconds)` | `bool` | Try to acquire. Reclaims expired locks. |
| `release(resource, owner)` | `bool` | Release. Returns `false` if not owned by caller. |
| `renew(resource, owner, ttlSeconds)` | `bool` | Extend TTL. Returns `false` if expired or wrong owner. |
| `isHeld(resource)` | `bool` | Check if any unexpired lock exists. |

## Schema

```sql
CREATE TABLE distributed_locks (
    resource    VARCHAR(255) PRIMARY KEY,
    owner       VARCHAR(255) NOT NULL,
    expires_at  DATETIME     NOT NULL,
    acquired_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## Changes

- `class/xion/DistributedLock.php` — implementation
- `tests/Unit/Xion/DistributedLockTest.php` — 17 tests
- `docs/development/distributed-lock.md` — howto
- `docs/field-trials/2026-05-field-trial-55.md` — report

🤖 Generated with [Claude Code](https://claude.com/claude-code)