### PR TITLE
feat(xion): ApiKey — API key management with prefix lookup, scope hierarchy, revocation, rotation (FT56)

### DIFF
--- a/class/xion/ApiKey.php
+++ b/class/xion/ApiKey.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * API key management: generation, hashed storage, scope-based auth, revocation, rotation.
+ *
+ * Key format: `nk_{base64url(32 random bytes)}`  — 256-bit entropy, type-prefixed.
+ * Storage: only the SHA-256 hash is stored. The raw key is returned once at creation.
+ * Lookup: a 16-character prefix enables O(1) indexed lookup before hash comparison.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE api_keys (
+ *     id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     prefix     VARCHAR(16)  NOT NULL,           -- first 16 chars of raw key (indexed)
+ *     key_hash   VARCHAR(64)  NOT NULL UNIQUE,    -- SHA-256 of raw key
+ *     owner_id   VARCHAR(255) NOT NULL,
+ *     scope      VARCHAR(32)  NOT NULL DEFAULT 'read',  -- 'read', 'write', or 'admin'
+ *     label      VARCHAR(255) NOT NULL DEFAULT '',
+ *     expires_at DATETIME     DEFAULT NULL,       -- NULL = no expiry
+ *     revoked_at DATETIME     DEFAULT NULL,       -- NULL = active
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE INDEX idx_api_keys_prefix ON api_keys (prefix);
+ * ```
+ *
+ * ## Scope hierarchy
+ *
+ * `admin` ⊃ `write` ⊃ `read`
+ *
+ * An `admin` key satisfies any scope requirement. A `read` key is rejected by
+ * endpoints that require `write` or `admin`.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $manager = new ApiKey();
+ *
+ * // Create
+ * ['rawKey' => $raw, 'id' => $id] = $manager->create('user:42', scope: 'write', label: 'CI key');
+ * // Send $raw to the client once. Never store it.
+ *
+ * // Authenticate
+ * $key = $manager->authenticate($raw, requiredScope: 'write');
+ * if ($key === null) {
+ *     http_response_code(401); exit;
+ * }
+ *
+ * // Revoke
+ * $manager->revoke($id, ownerId: 'user:42');
+ *
+ * // Rotate (create-first, revoke-after — no lockout risk)
+ * ['rawKey' => $newRaw] = $manager->rotate($id, ownerId: 'user:42');
+ * ```
+ */
+final class ApiKey
+{
+    private const TABLE  = 'api_keys';
+    private const PREFIX = 'nk';
+
+    /** Scope hierarchy: higher index = broader access */
+    private const SCOPE_LEVELS = ['read' => 0, 'write' => 1, 'admin' => 2];
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Create a new API key.
+     *
+     * @param  string      $ownerId   Application-level owner identifier.
+     * @param  string      $scope     'read', 'write', or 'admin'.
+     * @param  string      $label     Human-readable label (e.g. "GitHub Actions").
+     * @param  int|null    $expiresIn Seconds until expiry. Null = no expiry.
+     * @return array{rawKey: string, id: int} Raw key (show once) and new row ID.
+     */
+    public function create(
+        string $ownerId,
+        string $scope = 'read',
+        string $label = '',
+        ?int $expiresIn = null,
+    ): array {
+        $this->assertScope($scope);
+
+        $rawKey    = $this->generate();
+        $prefix    = $this->extractPrefix($rawKey);
+        $keyHash   = $this->hash($rawKey);
+        $expiresAt = $expiresIn !== null
+            ? (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+                ->modify('+' . $expiresIn . ' seconds')
+                ->format('Y-m-d H:i:s')
+            : null;
+
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->table .
+            ' (prefix, key_hash, owner_id, scope, label, expires_at)' .
+            ' VALUES (:prefix, :hash, :owner, :scope, :label, :exp)'
+        );
+        $stmt->bindValue(':prefix', $prefix, PDO::PARAM_STR);
+        $stmt->bindValue(':hash', $keyHash, PDO::PARAM_STR);
+        $stmt->bindValue(':owner', $ownerId, PDO::PARAM_STR);
+        $stmt->bindValue(':scope', $scope, PDO::PARAM_STR);
+        $stmt->bindValue(':label', $label, PDO::PARAM_STR);
+        $stmt->bindValue(':exp', $expiresAt, $expiresAt !== null ? PDO::PARAM_STR : PDO::PARAM_NULL);
+        $stmt->execute();
+
+        return ['rawKey' => $rawKey, 'id' => (int)$db->lastInsertId()];
+    }
+
+    /**
+     * Authenticate a raw API key and check its scope.
+     *
+     * Returns the key record on success, null on any failure (missing, invalid,
+     * expired, revoked, or insufficient scope). All failures produce the same
+     * null result to prevent oracle attacks.
+     *
+     * @param  string $rawKey        Raw key provided by the client.
+     * @param  string $requiredScope Minimum required scope.
+     * @return array{id:int,owner_id:string,scope:string,label:string,expires_at:string|null,created_at:string}|null
+     */
+    public function authenticate(string $rawKey, string $requiredScope = 'read'): ?array
+    {
+        if ($rawKey === '') {
+            return null;
+        }
+
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, prefix, key_hash, owner_id, scope, label, expires_at, revoked_at, created_at' .
+            ' FROM ' . $this->table .
+            ' WHERE prefix = :p AND revoked_at IS NULL LIMIT 1'
+        );
+        $stmt->bindValue(':p', $this->extractPrefix($rawKey), PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        // Timing-safe comparison
+        if (!hash_equals((string)$row['key_hash'], $this->hash($rawKey))) {
+            return null;
+        }
+
+        // Expiry check
+        if ($row['expires_at'] !== null) {
+            $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+            if ((string)$row['expires_at'] <= $now) {
+                return null;
+            }
+        }
+
+        // Scope check
+        if (!$this->scopeAllows((string)$row['scope'], $requiredScope)) {
+            return null;
+        }
+
+        return [
+            'id'         => (int)$row['id'],
+            'owner_id'   => (string)$row['owner_id'],
+            'scope'      => (string)$row['scope'],
+            'label'      => (string)$row['label'],
+            'expires_at' => $row['expires_at'] !== null ? (string)$row['expires_at'] : null,
+            'created_at' => (string)$row['created_at'],
+        ];
+    }
+
+    /**
+     * List active (non-revoked) keys for an owner. key_hash is never returned.
+     *
+     * @param  string $ownerId Application-level owner identifier.
+     * @return list<array{id:int,scope:string,label:string,expires_at:string|null,created_at:string}>
+     */
+    public function list(string $ownerId): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, scope, label, expires_at, created_at' .
+            ' FROM ' . $this->table .
+            ' WHERE owner_id = :o AND revoked_at IS NULL' .
+            ' ORDER BY id ASC'
+        );
+        $stmt->bindValue(':o', $ownerId, PDO::PARAM_STR);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => [
+            'id'         => (int)$r['id'],
+            'scope'      => (string)$r['scope'],
+            'label'      => (string)$r['label'],
+            'expires_at' => $r['expires_at'] !== null ? (string)$r['expires_at'] : null,
+            'created_at' => (string)$r['created_at'],
+        ], $rows);
+    }
+
+    /**
+     * Revoke a key. Only the owner can revoke their own key.
+     *
+     * Returns true if revoked, false if not found or wrong owner.
+     *
+     * @param int    $keyId   Row ID returned by create().
+     * @param string $ownerId Must match the owner_id used in create().
+     */
+    public function revoke(int $keyId, string $ownerId): bool
+    {
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $revokedAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->table .
+            ' SET revoked_at = :t WHERE id = :id AND owner_id = :o AND revoked_at IS NULL'
+        );
+        $stmt->bindValue(':t', $revokedAt, PDO::PARAM_STR);
+        $stmt->bindValue(':id', $keyId, PDO::PARAM_INT);
+        $stmt->bindValue(':o', $ownerId, PDO::PARAM_STR);
+        $stmt->execute();
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Rotate a key: create new first, then revoke old (no lockout risk).
+     *
+     * Returns the new raw key, or null if the old key is not found or wrong owner.
+     *
+     * @param int    $oldKeyId Row ID of the key to replace.
+     * @param string $ownerId  Must match the owner_id of the old key.
+     * @return array{rawKey: string, id: int}|null
+     */
+    public function rotate(int $oldKeyId, string $ownerId): ?array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT scope, label, expires_at FROM ' . $this->table .
+            ' WHERE id = :id AND owner_id = :o AND revoked_at IS NULL LIMIT 1'
+        );
+        $stmt->bindValue(':id', $oldKeyId, PDO::PARAM_INT);
+        $stmt->bindValue(':o', $ownerId, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        // Create-first to avoid lockout if revoke fails
+        $newKey = $this->create($ownerId, (string)$row['scope'], (string)$row['label']);
+        $this->revoke($oldKeyId, $ownerId);
+
+        return $newKey;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    /**
+     * Generate a new raw API key: `nk_{base64url(32 random bytes)}`.
+     */
+    private function generate(): string
+    {
+        $raw = random_bytes(32);
+        return self::PREFIX . '_' . rtrim(strtr(base64_encode($raw), '+/', '-_'), '=');
+    }
+
+    /**
+     * Extract the first 16 characters for DB-level prefix lookup.
+     * Includes the type prefix + 13 chars of random material (≈78 bits differentiation).
+     */
+    private function extractPrefix(string $rawKey): string
+    {
+        return substr($rawKey, 0, 16);
+    }
+
+    /**
+     * SHA-256 hash of the raw key for safe DB storage.
+     */
+    public function hash(string $rawKey): string
+    {
+        return hash('sha256', $rawKey);
+    }
+
+    /**
+     * Check whether $actualScope satisfies $requiredScope in the hierarchy.
+     */
+    private function scopeAllows(string $actualScope, string $requiredScope): bool
+    {
+        $levels = self::SCOPE_LEVELS;
+        return isset($levels[$actualScope], $levels[$requiredScope])
+            && $levels[$actualScope] >= $levels[$requiredScope];
+    }
+
+    private function assertScope(string $scope): void
+    {
+        if (!isset(self::SCOPE_LEVELS[$scope])) {
+            throw new \InvalidArgumentException(
+                "Invalid scope '{$scope}'. Allowed: read, write, admin."
+            );
+        }
+    }
+}

--- a/docs/development/api-key.md
+++ b/docs/development/api-key.md
@@ -1,0 +1,105 @@
+# API Key Management
+
+`Nene\Xion\ApiKey` provides API key generation, hashed storage, scope-based authorization, revocation, and rotation.
+
+## Key design
+
+| Property | Detail |
+|----------|--------|
+| Format | `nk_{base64url(32 random bytes)}` — type-prefixed, 256-bit entropy |
+| Storage | SHA-256 hash only. The raw key is returned once at creation and never stored. |
+| Lookup | 16-character prefix stored in `prefix` column (indexed) → O(1) lookup before hash comparison |
+| Hash comparison | `hash_equals()` — timing-safe, prevents prefix oracle attacks |
+
+## Schema
+
+```sql
+CREATE TABLE api_keys (
+    id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+    prefix     VARCHAR(16)  NOT NULL,
+    key_hash   VARCHAR(64)  NOT NULL UNIQUE,
+    owner_id   VARCHAR(255) NOT NULL,
+    scope      VARCHAR(32)  NOT NULL DEFAULT 'read',
+    label      VARCHAR(255) NOT NULL DEFAULT '',
+    expires_at DATETIME     DEFAULT NULL,   -- NULL = no expiry
+    revoked_at DATETIME     DEFAULT NULL,   -- NULL = active
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_api_keys_prefix ON api_keys (prefix);
+```
+
+## Scope hierarchy
+
+`admin` ⊃ `write` ⊃ `read`
+
+An `admin` key satisfies any scope requirement. A `read` key is rejected by endpoints requiring `write` or `admin`.
+
+## API
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `create(ownerId, scope, label, expiresIn)` | `{rawKey, id}` | Create a key. Return the raw key once — never store it. |
+| `authenticate(rawKey, requiredScope)` | `array\|null` | Verify and scope-check. Returns `null` on any failure. |
+| `list(ownerId)` | `array[]` | Active keys for the owner. `key_hash` never included. |
+| `revoke(keyId, ownerId)` | `bool` | Mark key revoked. Owner-enforced. |
+| `rotate(oldKeyId, ownerId)` | `{rawKey, id}\|null` | Create new + revoke old (create-first to avoid lockout). |
+
+## Basic usage
+
+```php
+use Nene\Xion\ApiKey;
+
+$manager = new ApiKey();
+
+// Create a key
+['rawKey' => $raw, 'id' => $id] = $manager->create(
+    'user:42',
+    scope: 'write',
+    label: 'GitHub Actions CI',
+);
+// Return $raw to the client. Never log or store the raw key.
+
+// Authenticate incoming requests
+$incomingKey = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+$incomingKey = ltrim($incomingKey, 'Bearer ');
+
+$key = $manager->authenticate($incomingKey, requiredScope: 'write');
+if ($key === null) {
+    http_response_code(401);
+    echo json_encode(['error' => 'UNAUTHORIZED']);
+    exit;
+}
+// $key['owner_id'], $key['scope'], $key['label'] are available
+
+// Revoke
+$manager->revoke($id, ownerId: 'user:42');
+```
+
+## Rotation pattern
+
+Rotate creates a new key **before** revoking the old one. If creation fails, the old key remains active — no lockout risk.
+
+```php
+$result = $manager->rotate($oldKeyId, ownerId: 'user:42');
+if ($result === null) {
+    // Key not found or wrong owner
+}
+['rawKey' => $newRaw, 'id' => $newId] = $result;
+// Send $newRaw to the client. Old key is now revoked.
+```
+
+## Expiring keys
+
+Pass `expiresIn` (seconds) to set an expiry. Expired keys are rejected by `authenticate()` without requiring an explicit revoke.
+
+```php
+// 90-day expiry
+$manager->create('user:42', scope: 'read', expiresIn: 90 * 86400);
+```
+
+## Security notes
+
+- **SHA-256 without HMAC is acceptable** for API keys because 256-bit random values cannot be brute-forced regardless. HMAC would provide marginal defense-in-depth at added operational complexity.
+- **Unified 401** for all `authenticate()` failures (invalid, expired, revoked, wrong scope) — prevents state disclosure.
+- **`key_hash` never exposed** in `authenticate()` or `list()` return values.
+- **Ownership check on revoke/rotate** — returns `false`/`null` for wrong owner (not 403, to avoid disclosing key existence to non-owners).

--- a/docs/field-trials/2026-05-field-trial-56.md
+++ b/docs/field-trials/2026-05-field-trial-56.md
@@ -1,0 +1,63 @@
+# Field Trial 56 — API Key Management
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft56-api-key-management`
+**Baseline**: `b71f4b6` (post FT51–FT53 merge)
+**NENE2 reference**: FT117 (apikeylog)
+
+## Goal
+
+Establish an API key management pattern for NeNe: key generation with type prefix, SHA-256 hashed storage, scope-based authorization, revocation, and rotation.
+
+## What was built
+
+### `Nene\Xion\ApiKey` (`class/xion/ApiKey.php`)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `create(ownerId, scope, label, expiresIn)` | `{rawKey, id}` | Generate and store a key. Raw key returned once. |
+| `authenticate(rawKey, requiredScope)` | `array\|null` | Verify key + scope. Null for any failure (unified 401 policy). |
+| `list(ownerId)` | `array[]` | Active keys for owner. `key_hash` excluded. |
+| `revoke(keyId, ownerId)` | `bool` | Mark revoked. Owner-enforced. |
+| `rotate(oldKeyId, ownerId)` | `{rawKey, id}\|null` | Create-first + revoke-after (no lockout risk). |
+
+Key design points:
+
+- **Format**: `nk_{base64url(32 random bytes)}` — 256-bit entropy, type-prefixed for log searchability.
+- **Storage**: SHA-256 hash only. Raw key returned once at creation, never stored.
+- **Prefix-based lookup**: first 16 chars stored in indexed `prefix` column → O(1) DB lookup before `hash_equals()` comparison. Avoids the FT117 vulnerability V1 (full table scan when prefix = type prefix only).
+- **Scope hierarchy**: `admin ⊃ write ⊃ read`, encoded in `SCOPE_LEVELS` map; `scopeAllows()` is a simple integer comparison.
+- **Rotation safety**: create-first, revoke-after — worst case is two active keys briefly; no lockout path.
+- **Unified null return**: all `authenticate()` failures (invalid, expired, revoked, wrong scope) return `null` — no oracle for key state.
+- **`key_hash` never returned**: omitted from `authenticate()` and `list()` results.
+
+### Tests (`tests/Unit/Xion/ApiKeyTest.php`)
+
+27 unit tests covering:
+
+- create: returns rawKey + id, key starts with `nk_`, explicit scope/label/expiry, invalid scope throws
+- authenticate: valid key, empty key, invalid key, revoked key, expired key, key_hash not exposed
+- scope enforcement: read→read (pass), read→write (fail), write→read (pass), admin→all (pass), write→admin (fail)
+- list: owner isolation, excludes revoked, no key_hash
+- revoke: correct owner, wrong owner, already revoked
+- rotate: returns new key, revokes old key, new key inherits scope, wrong owner
+
+### Howto (`docs/development/api-key.md`)
+
+Key design table, schema, scope hierarchy, API table, basic usage, rotation pattern, expiring keys, security notes.
+
+## Findings
+
+### F-1 — Prefix length: type-only prefix causes full table scan (ported from NENE2 FT117 V1)
+
+**Symptom** (NENE2): `extractPrefix()` returned `nk` (the type prefix) for all keys. `WHERE prefix = 'nk'` scanned every row on every authentication.
+
+**Fix applied proactively**: `extractPrefix()` returns `substr($rawKey, 0, 16)` — includes `nk_` plus 13 chars of random material, giving ≈78 bits of differentiation (effectively unique per key).
+
+### F-2 — No other framework findings
+
+All 27 tests pass; CS Fixer and Phan clean. No changes to existing NeNe core classes.
+
+## Decision
+
+Merge as-is. F-1 ported from NENE2 as a proactive fix. No follow-up Issues raised.

--- a/tests/Unit/Xion/ApiKeyTest.php
+++ b/tests/Unit/Xion/ApiKeyTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ApiKey;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ApiKey using an in-memory SQLite database.
+ */
+final class ApiKeyTest extends TestCase
+{
+    private PDO $db;
+    private ApiKey $manager;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE api_keys (
+                id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+                prefix     VARCHAR(16)  NOT NULL,
+                key_hash   VARCHAR(64)  NOT NULL UNIQUE,
+                owner_id   VARCHAR(255) NOT NULL,
+                scope      VARCHAR(32)  NOT NULL DEFAULT \'read\',
+                label      VARCHAR(255) NOT NULL DEFAULT \'\',
+                expires_at DATETIME     DEFAULT NULL,
+                revoked_at DATETIME     DEFAULT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->manager = new ApiKey($this->db);
+    }
+
+    // ── create ───────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsRawKeyAndId(): void
+    {
+        $result = $this->manager->create('user:1');
+        $this->assertArrayHasKey('rawKey', $result);
+        $this->assertArrayHasKey('id', $result);
+        $this->assertIsString($result['rawKey']);
+        $this->assertIsInt($result['id']);
+    }
+
+    public function testCreatedKeyStartsWithPrefix(): void
+    {
+        $result = $this->manager->create('user:1');
+        $this->assertStringStartsWith('nk_', $result['rawKey']);
+    }
+
+    public function testCreateWithExplicitScope(): void
+    {
+        $result = $this->manager->create('user:1', scope: 'admin');
+        $keys   = $this->manager->list('user:1');
+        $this->assertSame('admin', $keys[0]['scope']);
+    }
+
+    public function testCreateWithLabel(): void
+    {
+        $this->manager->create('user:1', label: 'CI key');
+        $keys = $this->manager->list('user:1');
+        $this->assertSame('CI key', $keys[0]['label']);
+    }
+
+    public function testCreateWithExpiryStoresExpiresAt(): void
+    {
+        $this->manager->create('user:1', expiresIn: 3600);
+        $keys = $this->manager->list('user:1');
+        $this->assertNotNull($keys[0]['expires_at']);
+    }
+
+    public function testCreateWithInvalidScopeThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->manager->create('user:1', scope: 'superadmin');
+    }
+
+    // ── authenticate ─────────────────────────────────────────────────────────
+
+    public function testAuthenticateValidKeyReturnsRecord(): void
+    {
+        ['rawKey' => $raw] = $this->manager->create('user:1', scope: 'write');
+        $result = $this->manager->authenticate($raw, 'write');
+        $this->assertIsArray($result);
+        $this->assertSame('user:1', $result['owner_id']);
+        $this->assertSame('write', $result['scope']);
+    }
+
+    public function testAuthenticateEmptyKeyReturnsNull(): void
+    {
+        $this->assertNull($this->manager->authenticate('', 'read'));
+    }
+
+    public function testAuthenticateInvalidKeyReturnsNull(): void
+    {
+        $this->manager->create('user:1');
+        $this->assertNull($this->manager->authenticate('nk_invalidkeyvalue', 'read'));
+    }
+
+    public function testAuthenticateRevokedKeyReturnsNull(): void
+    {
+        ['rawKey' => $raw, 'id' => $id] = $this->manager->create('user:1');
+        $this->manager->revoke($id, 'user:1');
+        $this->assertNull($this->manager->authenticate($raw, 'read'));
+    }
+
+    public function testAuthenticateExpiredKeyReturnsNull(): void
+    {
+        ['rawKey' => $raw, 'id' => $id] = $this->manager->create('user:1', expiresIn: 3600);
+        // Force expires_at into the past
+        $this->db->exec("UPDATE api_keys SET expires_at = '2000-01-01 00:00:00' WHERE id = {$id}");
+        $this->assertNull($this->manager->authenticate($raw, 'read'));
+    }
+
+    public function testKeyHashNeverExposedInAuthResult(): void
+    {
+        ['rawKey' => $raw] = $this->manager->create('user:1');
+        $result = $this->manager->authenticate($raw, 'read');
+        $this->assertIsArray($result);
+        $this->assertArrayNotHasKey('key_hash', $result);
+    }
+
+    // ── scope enforcement ─────────────────────────────────────────────────────
+
+    public function testReadKeySatisfiesReadScope(): void
+    {
+        ['rawKey' => $raw] = $this->manager->create('user:1', scope: 'read');
+        $this->assertNotNull($this->manager->authenticate($raw, 'read'));
+    }
+
+    public function testReadKeyFailsWriteScope(): void
+    {
+        ['rawKey' => $raw] = $this->manager->create('user:1', scope: 'read');
+        $this->assertNull($this->manager->authenticate($raw, 'write'));
+    }
+
+    public function testWriteKeySatisfiesReadScope(): void
+    {
+        ['rawKey' => $raw] = $this->manager->create('user:1', scope: 'write');
+        $this->assertNotNull($this->manager->authenticate($raw, 'read'));
+    }
+
+    public function testAdminKeySatisfiesAllScopes(): void
+    {
+        ['rawKey' => $raw] = $this->manager->create('user:1', scope: 'admin');
+        $this->assertNotNull($this->manager->authenticate($raw, 'read'));
+        $this->assertNotNull($this->manager->authenticate($raw, 'write'));
+        $this->assertNotNull($this->manager->authenticate($raw, 'admin'));
+    }
+
+    public function testWriteKeyFailsAdminScope(): void
+    {
+        ['rawKey' => $raw] = $this->manager->create('user:1', scope: 'write');
+        $this->assertNull($this->manager->authenticate($raw, 'admin'));
+    }
+
+    // ── list ─────────────────────────────────────────────────────────────────
+
+    public function testListReturnsOnlyOwnerKeys(): void
+    {
+        $this->manager->create('user:1');
+        $this->manager->create('user:2');
+        $keys = $this->manager->list('user:1');
+        $this->assertCount(1, $keys);
+    }
+
+    public function testListExcludesRevokedKeys(): void
+    {
+        ['id' => $id] = $this->manager->create('user:1');
+        $this->manager->revoke($id, 'user:1');
+        $this->assertEmpty($this->manager->list('user:1'));
+    }
+
+    public function testListDoesNotExposeKeyHash(): void
+    {
+        $this->manager->create('user:1');
+        $keys = $this->manager->list('user:1');
+        $this->assertArrayNotHasKey('key_hash', $keys[0]);
+    }
+
+    // ── revoke ────────────────────────────────────────────────────────────────
+
+    public function testRevokeByCorrectOwnerReturnsTrue(): void
+    {
+        ['id' => $id] = $this->manager->create('user:1');
+        $this->assertTrue($this->manager->revoke($id, 'user:1'));
+    }
+
+    public function testRevokeByWrongOwnerReturnsFalse(): void
+    {
+        ['id' => $id] = $this->manager->create('user:1');
+        $this->assertFalse($this->manager->revoke($id, 'user:999'));
+    }
+
+    public function testRevokeAlreadyRevokedReturnsFalse(): void
+    {
+        ['id' => $id] = $this->manager->create('user:1');
+        $this->manager->revoke($id, 'user:1');
+        $this->assertFalse($this->manager->revoke($id, 'user:1'));
+    }
+
+    // ── rotate ────────────────────────────────────────────────────────────────
+
+    public function testRotateReturnsNewKey(): void
+    {
+        ['rawKey' => $old, 'id' => $id] = $this->manager->create('user:1', scope: 'write');
+        $result = $this->manager->rotate($id, 'user:1');
+        $this->assertIsArray($result);
+        $this->assertNotSame($old, $result['rawKey']);
+    }
+
+    public function testRotateRevokesOldKey(): void
+    {
+        ['rawKey' => $old, 'id' => $id] = $this->manager->create('user:1');
+        $this->manager->rotate($id, 'user:1');
+        $this->assertNull($this->manager->authenticate($old, 'read'));
+    }
+
+    public function testRotateNewKeyInheritsScope(): void
+    {
+        ['id' => $id] = $this->manager->create('user:1', scope: 'admin');
+        ['rawKey' => $newRaw] = $this->manager->rotate($id, 'user:1');
+        $result = $this->manager->authenticate($newRaw, 'admin');
+        $this->assertSame('admin', $result['scope']);
+    }
+
+    public function testRotateWrongOwnerReturnsNull(): void
+    {
+        ['id' => $id] = $this->manager->create('user:1');
+        $this->assertNull($this->manager->rotate($id, 'user:999'));
+    }
+}

--- a/tests/Unit/Xion/ApiKeyTest.php
+++ b/tests/Unit/Xion/ApiKeyTest.php
@@ -121,7 +121,8 @@ final class ApiKeyTest extends TestCase
     {
         ['rawKey' => $raw] = $this->manager->create('user:1');
         $result = $this->manager->authenticate($raw, 'read');
-        $this->assertIsArray($result);
+        $this->assertNotNull($result);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
         $this->assertArrayNotHasKey('key_hash', $result);
     }
 


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\ApiKey` — API key management with hashed storage, scope-based authorization, revocation, and rotation.

## Key design

- Format: `nk_{base64url(32 random bytes)}` — 256-bit entropy, type-prefixed
- Storage: SHA-256 hash only. Raw key returned once at creation.
- Lookup: 16-char prefix (indexed) + `hash_equals()` — O(1), timing-safe
- Scope hierarchy: `admin ⊃ write ⊃ read`
- Rotation: create-first, revoke-after (no lockout risk)

## Changes

- `class/xion/ApiKey.php` — implementation
- `tests/Unit/Xion/ApiKeyTest.php` — 27 tests
- `docs/development/api-key.md` — howto
- `docs/field-trials/2026-05-field-trial-56.md` — report

🤖 Generated with [Claude Code](https://claude.com/claude-code)