### PR TITLE
feat(xion): NotificationInbox — user notification inbox with read_at tracking (FT58)

### DIFF
--- a/class/xion/NotificationInbox.php
+++ b/class/xion/NotificationInbox.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * User notification inbox: push, list, mark-as-read, unread count.
+ *
+ * Uses `read_at` nullable timestamp instead of `is_read` boolean —
+ * preserves *when* the notification was read and is directly indexable.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE notifications (
+ *     id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     type       VARCHAR(64)  NOT NULL,
+ *     title      VARCHAR(255) NOT NULL,
+ *     body       TEXT         NOT NULL DEFAULT '',
+ *     read_at    DATETIME     DEFAULT NULL,   -- NULL = unread
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE INDEX idx_notifications_user ON notifications (user_id, id);
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $inbox = new NotificationInbox();
+ *
+ * // Push a notification (e.g. from a service after a user action)
+ * $inbox->push($userId, 'order.shipped', 'Your order has shipped', 'Tracking: 1Z999...');
+ *
+ * // List all notifications for a user (newest first)
+ * $items = $inbox->list($userId);
+ *
+ * // List unread only
+ * $unread = $inbox->list($userId, unreadOnly: true);
+ *
+ * // Mark one as read (idempotent, owner-enforced)
+ * $ok = $inbox->markRead($notificationId, $userId);
+ *
+ * // Mark all as read
+ * $marked = $inbox->markAllRead($userId);
+ *
+ * // Unread count (for badge)
+ * $count = $inbox->unreadCount($userId);
+ * ```
+ */
+final class NotificationInbox
+{
+    private const TABLE = 'notifications';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Push a notification to a user's inbox.
+     *
+     * @param  string|int $userId Application-level user identifier.
+     * @param  string     $type   Machine-readable event type (e.g. 'order.shipped').
+     * @param  string     $title  Short human-readable title.
+     * @param  string     $body   Optional longer body text.
+     * @return int        New notification row ID.
+     */
+    public function push(
+        string|int $userId,
+        string $type,
+        string $title,
+        string $body = '',
+    ): int {
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $createdAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->table .
+            ' (user_id, type, title, body, created_at)' .
+            ' VALUES (:u, :t, :ti, :b, :c)'
+        );
+        $stmt->bindValue(':u', (string)$userId, PDO::PARAM_STR);
+        $stmt->bindValue(':t', $type, PDO::PARAM_STR);
+        $stmt->bindValue(':ti', $title, PDO::PARAM_STR);
+        $stmt->bindValue(':b', $body, PDO::PARAM_STR);
+        $stmt->bindValue(':c', $createdAt, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * List notifications for a user, newest first (ORDER BY id DESC).
+     *
+     * `id DESC` is used instead of `created_at DESC` for stable ordering
+     * when multiple notifications are inserted within the same second.
+     *
+     * @param  string|int $userId     Application-level user identifier.
+     * @param  bool       $unreadOnly Return only unread (read_at IS NULL) if true.
+     * @return list<array{id:int,type:string,title:string,body:string,read:bool,read_at:string|null,created_at:string}>
+     */
+    public function list(string|int $userId, bool $unreadOnly = false): array
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $sql = 'SELECT id, type, title, body, read_at, created_at' .
+               ' FROM ' . $this->table .
+               ' WHERE user_id = :u';
+        if ($unreadOnly) {
+            $sql .= ' AND read_at IS NULL';
+        }
+        $sql .= ' ORDER BY id DESC';
+
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':u', (string)$userId, PDO::PARAM_STR);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => [
+            'id'         => (int)$r['id'],
+            'type'       => (string)$r['type'],
+            'title'      => (string)$r['title'],
+            'body'       => (string)$r['body'],
+            'read'       => $r['read_at'] !== null,
+            'read_at'    => $r['read_at'] !== null ? (string)$r['read_at'] : null,
+            'created_at' => (string)$r['created_at'],
+        ], $rows);
+    }
+
+    /**
+     * Mark a single notification as read. Idempotent: preserves original read_at.
+     *
+     * Returns true if the notification was found for this user, false otherwise.
+     * Cross-user access silently returns false (not 403) to prevent ID enumeration.
+     *
+     * @param int         $notificationId Row ID.
+     * @param string|int  $userId         Must match the notification's owner.
+     */
+    public function markRead(int $notificationId, string|int $userId): bool
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+
+        // Check ownership first
+        $stmt = $db->prepare(
+            'SELECT id, read_at FROM ' . $this->table .
+            ' WHERE id = :id AND user_id = :u LIMIT 1'
+        );
+        $stmt->bindValue(':id', $notificationId, PDO::PARAM_INT);
+        $stmt->bindValue(':u', (string)$userId, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return false;
+        }
+
+        // Already read — preserve original read_at
+        if ($row['read_at'] !== null) {
+            return true;
+        }
+
+        $readAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        $stmt   = $db->prepare(
+            'UPDATE ' . $this->table . ' SET read_at = :t WHERE id = :id'
+        );
+        $stmt->bindValue(':t', $readAt, PDO::PARAM_STR);
+        $stmt->bindValue(':id', $notificationId, PDO::PARAM_INT);
+        $stmt->execute();
+
+        return true;
+    }
+
+    /**
+     * Mark all unread notifications as read for a user.
+     *
+     * Returns the number of notifications that were marked (0 if all were already read).
+     *
+     * @param string|int $userId Application-level user identifier.
+     */
+    public function markAllRead(string|int $userId): int
+    {
+        $db     = $this->db ?? PdoConnection::getInstance();
+        $readAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->table .
+            ' SET read_at = :t WHERE user_id = :u AND read_at IS NULL'
+        );
+        $stmt->bindValue(':t', $readAt, PDO::PARAM_STR);
+        $stmt->bindValue(':u', (string)$userId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Count unread notifications for a user (for badge display).
+     *
+     * @param string|int $userId Application-level user identifier.
+     */
+    public function unreadCount(string|int $userId): int
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT COUNT(*) FROM ' . $this->table .
+            ' WHERE user_id = :u AND read_at IS NULL'
+        );
+        $stmt->bindValue(':u', (string)$userId, PDO::PARAM_STR);
+        $stmt->execute();
+        return (int)$stmt->fetchColumn();
+    }
+}

--- a/docs/development/notification-inbox.md
+++ b/docs/development/notification-inbox.md
@@ -1,0 +1,106 @@
+# Notification Inbox
+
+`Nene\Xion\NotificationInbox` provides a user notification inbox: push delivery, list with unread filtering, single and bulk mark-as-read, and unread count for badge display.
+
+## Schema
+
+```sql
+CREATE TABLE notifications (
+    id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+    user_id    VARCHAR(255) NOT NULL,
+    type       VARCHAR(64)  NOT NULL,
+    title      VARCHAR(255) NOT NULL,
+    body       TEXT         NOT NULL DEFAULT '',
+    read_at    DATETIME     DEFAULT NULL,   -- NULL = unread
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_notifications_user ON notifications (user_id, id);
+```
+
+## `read_at` vs `is_read`
+
+Use a nullable `read_at` timestamp instead of a boolean `is_read` column:
+
+| Pattern | Advantage |
+|---------|-----------|
+| `read_at DATETIME NULL` | Preserves *when* read. `WHERE read_at IS NULL` is indexable. |
+| `is_read TINYINT(1)` | Simpler but loses the timestamp. Needs a separate `read_at` column if the time ever matters. |
+
+## API
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `push(userId, type, title, body)` | `int` | Insert a notification. Returns new row ID. |
+| `list(userId, unreadOnly)` | `array[]` | Notifications newest-first (`ORDER BY id DESC`). |
+| `markRead(notificationId, userId)` | `bool` | Mark one as read. Idempotent; owner-enforced. |
+| `markAllRead(userId)` | `int` | Mark all unread. Returns count of rows marked. |
+| `unreadCount(userId)` | `int` | Count unread for badge display. |
+
+## Basic usage
+
+```php
+use Nene\Xion\NotificationInbox;
+
+$inbox = new NotificationInbox();
+
+// Push from a service after a user action
+$inbox->push($userId, 'order.shipped', 'Your order has shipped', 'Tracking: 1Z999...');
+
+// List all (controller / REST response)
+$items       = $inbox->list($userId);
+$unreadCount = $inbox->unreadCount($userId);
+
+// List unread only
+$unread = $inbox->list($userId, unreadOnly: true);
+
+// Mark one as read
+if (!$inbox->markRead($notificationId, $userId)) {
+    http_response_code(404); // not found or wrong user
+    exit;
+}
+
+// Mark all as read
+$markedCount = $inbox->markAllRead($userId);
+```
+
+## Response shape
+
+Each item returned by `list()`:
+
+```json
+{
+  "id": 42,
+  "type": "order.shipped",
+  "title": "Your order has shipped",
+  "body": "Tracking: 1Z999...",
+  "read": false,
+  "read_at": null,
+  "created_at": "2026-05-27 10:00:00"
+}
+```
+
+Include `unread_count` in list responses to save the client an extra round-trip for badge updates.
+
+## `ORDER BY id DESC` (not `created_at DESC`)
+
+Sorting by `id` gives a stable order when multiple notifications are inserted within the same second. `created_at` has second-level precision in most DBs — same-second inserts would have indeterminate relative order with `ORDER BY created_at DESC`.
+
+## Idempotency
+
+- **`markRead()`**: checks `read_at` before updating. Re-calling preserves the original timestamp.
+- **`markAllRead()`**: uses `WHERE read_at IS NULL` — already-read rows are untouched.
+
+## Cross-user access
+
+`markRead()` returns `false` for wrong-user access without throwing or returning a specific error status. Callers should return 404, not 403, to avoid confirming that a given notification ID exists for another user.
+
+## Pagination
+
+The current implementation returns all notifications. Add cursor-based pagination before production if the inbox can grow large:
+
+```sql
+-- cursor = last seen id
+SELECT ... WHERE user_id = ? AND id < :cursor ORDER BY id DESC LIMIT 20
+```
+
+See `Cursor` + `CursorPage` (FT25) for the NeNe cursor pagination helpers.

--- a/docs/field-trials/2026-05-field-trial-58.md
+++ b/docs/field-trials/2026-05-field-trial-58.md
@@ -1,0 +1,62 @@
+# Field Trial 58 — Notification Inbox
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft58-notification-inbox`
+**Baseline**: `b71f4b6` (post FT51–FT53 merge)
+**NENE2 reference**: FT130 (notificationlog)
+
+## Goal
+
+Establish a user notification inbox pattern for NeNe: push delivery, list with unread filtering, single and bulk mark-as-read, and unread count for badge display.
+
+## What was built
+
+### `Nene\Xion\NotificationInbox` (`class/xion/NotificationInbox.php`)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `push(userId, type, title, body)` | `int` | Insert notification. Returns row ID. |
+| `list(userId, unreadOnly=false)` | `array[]` | Newest-first (ORDER BY id DESC). |
+| `markRead(notificationId, userId)` | `bool` | Mark one read. Idempotent; owner-enforced. |
+| `markAllRead(userId)` | `int` | Mark all unread. Returns count marked. |
+| `unreadCount(userId)` | `int` | Count unread (for badge). |
+
+Key design points:
+
+- **`read_at` nullable timestamp**: captures *when* the notification was read; `WHERE read_at IS NULL` is indexable. Avoids a separate `updated_at` column for the read event.
+- **`ORDER BY id DESC`**: stable sort for same-second inserts; `created_at DESC` has ambiguous order when multiple rows share the same timestamp.
+- **`markRead()` idempotency**: checks `read_at` before UPDATE — re-calling preserves the original timestamp.
+- **`markAllRead()` idempotency**: `WHERE read_at IS NULL` — already-read rows untouched.
+- **Cross-user 404 not 403**: `markRead()` returns `false` for wrong-user access to prevent notification ID enumeration.
+- **`read` convenience field**: list items include `'read' => $r['read_at'] !== null` so clients don't need to check `read_at`.
+- **`unreadCount` in list response (recommended)**: returning the count alongside the list saves the client an extra round-trip for badge updates.
+
+### Tests (`tests/Unit/Xion/NotificationInboxTest.php`)
+
+19 unit tests covering:
+
+- push: returns ID, unread by default, with body, int userId, distinct IDs
+- list: newest-first, owner isolation, empty for new user, unreadOnly filter, field presence
+- markRead: returns true + sets read_at, idempotent (preserves original read_at), wrong user (false), not found (false)
+- markAllRead: returns count, idempotent (returns 0 second time), does not affect other users
+- unreadCount: correct count, zero for new user, decreases after markAllRead
+
+### Howto (`docs/development/notification-inbox.md`)
+
+`read_at` vs `is_read` comparison, API table, basic usage, response shape, `ORDER BY id DESC` rationale, idempotency, cross-user access policy, pagination note with cursor reference.
+
+## Findings
+
+### F-1 — Pagination is a future concern (deferred)
+
+The current implementation returns all notifications for a user. For large inboxes, cursor-based pagination (`id < :cursor`) is needed before production. Deferred — the `Cursor` + `CursorPage` helpers (FT25) provide the building blocks.
+
+**Re-evaluation trigger**: a trial or real app surfaces an inbox with >100 notifications as a performance issue.
+
+### F-2 — No other framework findings
+
+All 19 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. F-1 deferred per methodology (document now, implement when triggered). No follow-up Issues raised.

--- a/tests/Unit/Xion/NotificationInboxTest.php
+++ b/tests/Unit/Xion/NotificationInboxTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\NotificationInbox;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for NotificationInbox using an in-memory SQLite database.
+ */
+final class NotificationInboxTest extends TestCase
+{
+    private PDO $db;
+    private NotificationInbox $inbox;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE notifications (
+                id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL,
+                type       VARCHAR(64)  NOT NULL,
+                title      VARCHAR(255) NOT NULL,
+                body       TEXT         NOT NULL DEFAULT \'\',
+                read_at    DATETIME     DEFAULT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->inbox = new NotificationInbox($this->db);
+    }
+
+    // ── push ─────────────────────────────────────────────────────────────────
+
+    public function testPushReturnsId(): void
+    {
+        $id = $this->inbox->push('user:1', 'order.shipped', 'Shipped!');
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testPushedNotificationIsUnread(): void
+    {
+        $this->inbox->push('user:1', 'order.shipped', 'Shipped!');
+        $items = $this->inbox->list('user:1');
+        $this->assertFalse($items[0]['read']);
+        $this->assertNull($items[0]['read_at']);
+    }
+
+    public function testPushWithBody(): void
+    {
+        $this->inbox->push('user:1', 'order.shipped', 'Shipped!', 'Tracking: ABC123');
+        $items = $this->inbox->list('user:1');
+        $this->assertSame('Tracking: ABC123', $items[0]['body']);
+    }
+
+    public function testPushWithIntUserId(): void
+    {
+        $this->inbox->push(42, 'alert', 'Alert');
+        $items = $this->inbox->list(42);
+        $this->assertCount(1, $items);
+    }
+
+    // ── list ─────────────────────────────────────────────────────────────────
+
+    public function testListReturnsNewestFirst(): void
+    {
+        $id1 = $this->inbox->push('user:1', 'a', 'First');
+        $id2 = $this->inbox->push('user:1', 'b', 'Second');
+        $items = $this->inbox->list('user:1');
+        $this->assertSame($id2, $items[0]['id']);
+        $this->assertSame($id1, $items[1]['id']);
+    }
+
+    public function testListReturnsOnlyOwnerItems(): void
+    {
+        $this->inbox->push('user:1', 'a', 'For user 1');
+        $this->inbox->push('user:2', 'b', 'For user 2');
+        $items = $this->inbox->list('user:1');
+        $this->assertCount(1, $items);
+        $this->assertSame('For user 1', $items[0]['title']);
+    }
+
+    public function testListEmptyForNewUser(): void
+    {
+        $this->assertEmpty($this->inbox->list('user:99'));
+    }
+
+    public function testListUnreadOnlyFiltersRead(): void
+    {
+        $id = $this->inbox->push('user:1', 'a', 'A');
+        $this->inbox->push('user:1', 'b', 'B');
+        $this->inbox->markRead($id, 'user:1');
+
+        $unread = $this->inbox->list('user:1', unreadOnly: true);
+        $this->assertCount(1, $unread);
+        $this->assertSame('B', $unread[0]['title']);
+    }
+
+    public function testListItemHasExpectedFields(): void
+    {
+        $this->inbox->push('user:1', 'order.shipped', 'Title', 'Body');
+        $items = $this->inbox->list('user:1');
+        $item  = $items[0];
+        $this->assertArrayHasKey('id', $item);
+        $this->assertArrayHasKey('type', $item);
+        $this->assertArrayHasKey('title', $item);
+        $this->assertArrayHasKey('body', $item);
+        $this->assertArrayHasKey('read', $item);
+        $this->assertArrayHasKey('read_at', $item);
+        $this->assertArrayHasKey('created_at', $item);
+    }
+
+    // ── markRead ─────────────────────────────────────────────────────────────
+
+    public function testMarkReadReturnsTrueAndSetsReadAt(): void
+    {
+        $id = $this->inbox->push('user:1', 'a', 'A');
+        $result = $this->inbox->markRead($id, 'user:1');
+        $this->assertTrue($result);
+
+        $items = $this->inbox->list('user:1');
+        $this->assertTrue($items[0]['read']);
+        $this->assertNotNull($items[0]['read_at']);
+    }
+
+    public function testMarkReadIsIdempotent(): void
+    {
+        $id = $this->inbox->push('user:1', 'a', 'A');
+        $this->inbox->markRead($id, 'user:1');
+        $firstReadAt = $this->inbox->list('user:1')[0]['read_at'];
+
+        // Small sleep to ensure time would differ if read_at were overwritten
+        usleep(1000);
+        $this->inbox->markRead($id, 'user:1');
+        $secondReadAt = $this->inbox->list('user:1')[0]['read_at'];
+
+        $this->assertSame($firstReadAt, $secondReadAt);
+    }
+
+    public function testMarkReadWrongUserReturnsFalse(): void
+    {
+        $id = $this->inbox->push('user:1', 'a', 'A');
+        $result = $this->inbox->markRead($id, 'user:999');
+        $this->assertFalse($result);
+    }
+
+    public function testMarkReadNotFoundReturnsFalse(): void
+    {
+        $result = $this->inbox->markRead(9999, 'user:1');
+        $this->assertFalse($result);
+    }
+
+    // ── markAllRead ───────────────────────────────────────────────────────────
+
+    public function testMarkAllReadReturnsCount(): void
+    {
+        $this->inbox->push('user:1', 'a', 'A');
+        $this->inbox->push('user:1', 'b', 'B');
+        $count = $this->inbox->markAllRead('user:1');
+        $this->assertSame(2, $count);
+    }
+
+    public function testMarkAllReadIsIdempotent(): void
+    {
+        $this->inbox->push('user:1', 'a', 'A');
+        $this->inbox->markAllRead('user:1');
+        $count = $this->inbox->markAllRead('user:1');
+        $this->assertSame(0, $count);
+    }
+
+    public function testMarkAllReadDoesNotAffectOtherUsers(): void
+    {
+        $this->inbox->push('user:1', 'a', 'A');
+        $this->inbox->push('user:2', 'b', 'B');
+        $this->inbox->markAllRead('user:1');
+
+        $this->assertSame(0, $this->inbox->unreadCount('user:1'));
+        $this->assertSame(1, $this->inbox->unreadCount('user:2'));
+    }
+
+    // ── unreadCount ───────────────────────────────────────────────────────────
+
+    public function testUnreadCountReturnsCorrectNumber(): void
+    {
+        $this->inbox->push('user:1', 'a', 'A');
+        $this->inbox->push('user:1', 'b', 'B');
+        $id = $this->inbox->push('user:1', 'c', 'C');
+        $this->inbox->markRead($id, 'user:1');
+
+        $this->assertSame(2, $this->inbox->unreadCount('user:1'));
+    }
+
+    public function testUnreadCountIsZeroForNewUser(): void
+    {
+        $this->assertSame(0, $this->inbox->unreadCount('user:99'));
+    }
+
+    public function testUnreadCountDecreasesAfterMarkAllRead(): void
+    {
+        $this->inbox->push('user:1', 'a', 'A');
+        $this->inbox->push('user:1', 'b', 'B');
+        $this->assertSame(2, $this->inbox->unreadCount('user:1'));
+
+        $this->inbox->markAllRead('user:1');
+        $this->assertSame(0, $this->inbox->unreadCount('user:1'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\NotificationInbox` — user notification inbox with push, list, mark-as-read, and unread count.

## Key design

- `read_at` nullable timestamp (not boolean `is_read`) — captures when read, indexable
- `ORDER BY id DESC` for stable newest-first sort
- Idempotent `markRead()` and `markAllRead()`
- Cross-user 404 (not 403) to prevent ID enumeration

## Changes

- `class/xion/NotificationInbox.php` — implementation
- `tests/Unit/Xion/NotificationInboxTest.php` — 19 tests
- `docs/development/notification-inbox.md` — howto
- `docs/field-trials/2026-05-field-trial-58.md` — report

🤖 Generated with [Claude Code](https://claude.com/claude-code)