### PR TITLE
feat(xion): VotingBooth — upvote/downvote with toggle semantics and score (FT59)

### DIFF
--- a/class/xion/VotingBooth.php
+++ b/class/xion/VotingBooth.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Upvote / downvote system with toggle semantics and per-user vote state.
+ *
+ * One vote per user per target. Same-direction vote toggles (removes) the vote.
+ * Opposite-direction vote switches direction. UNIQUE constraint enforces the
+ * one-vote rule at the DB level.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE votes (
+ *     id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     target_id  VARCHAR(255) NOT NULL,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     direction  VARCHAR(4)   NOT NULL CHECK (direction IN ('up', 'down')),
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (target_id, user_id)
+ * );
+ * CREATE INDEX idx_votes_target ON votes (target_id);
+ * ```
+ *
+ * ## Toggle semantics
+ *
+ * | Previous vote | New vote | Result |
+ * |---------------|----------|--------|
+ * | none          | up/down  | INSERT (vote added) |
+ * | up            | up       | DELETE (vote removed — toggle) |
+ * | down          | down     | DELETE (vote removed — toggle) |
+ * | up            | down     | UPDATE (direction switched) |
+ * | down          | up       | UPDATE (direction switched) |
+ *
+ * ## Usage
+ *
+ * ```php
+ * $booth = new VotingBooth();
+ *
+ * // Cast / toggle / switch a vote
+ * $result = $booth->cast('post:42', 'user:1', 'up');
+ * // $result['vote'] is 'up', 'down', or null (removed)
+ * // $result['score'] is the current score (upvotes - downvotes)
+ *
+ * // Validate direction input
+ * if (!VotingBooth::validDirection($input)) {
+ *     // 422
+ * }
+ *
+ * // Get score
+ * $score = $booth->score('post:42'); // ['up' => 3, 'down' => 1, 'score' => 2]
+ *
+ * // Get user's current vote
+ * $vote = $booth->userVote('post:42', 'user:1'); // 'up', 'down', or null
+ * ```
+ */
+final class VotingBooth
+{
+    private const TABLE      = 'votes';
+    private const VALID_DIRS = ['up', 'down'];
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Cast, toggle, or switch a vote.
+     *
+     * @param  string|int $targetId  Votable resource identifier (e.g. "post:42").
+     * @param  string|int $userId    Voter identifier.
+     * @param  string     $direction 'up' or 'down'.
+     * @return array{vote: string|null, score: int} Current vote state and score.
+     * @throws \InvalidArgumentException If direction is not 'up' or 'down'.
+     */
+    public function cast(string|int $targetId, string|int $userId, string $direction): array
+    {
+        if (!self::validDirection($direction)) {
+            throw new \InvalidArgumentException(
+                "Invalid direction '{$direction}'. Allowed: up, down."
+            );
+        }
+
+        $db       = $this->db ?? PdoConnection::getInstance();
+        $tId      = (string)$targetId;
+        $uId      = (string)$userId;
+        $existing = $this->userVote($targetId, $userId);
+
+        if ($existing === $direction) {
+            // Same direction — toggle (remove)
+            $stmt = $db->prepare(
+                'DELETE FROM ' . $this->table . ' WHERE target_id = :t AND user_id = :u'
+            );
+            $stmt->bindValue(':t', $tId, PDO::PARAM_STR);
+            $stmt->bindValue(':u', $uId, PDO::PARAM_STR);
+            $stmt->execute();
+            $currentVote = null;
+        } elseif ($existing !== null) {
+            // Opposite direction — switch
+            $stmt = $db->prepare(
+                'UPDATE ' . $this->table .
+                ' SET direction = :d WHERE target_id = :t AND user_id = :u'
+            );
+            $stmt->bindValue(':d', $direction, PDO::PARAM_STR);
+            $stmt->bindValue(':t', $tId, PDO::PARAM_STR);
+            $stmt->bindValue(':u', $uId, PDO::PARAM_STR);
+            $stmt->execute();
+            $currentVote = $direction;
+        } else {
+            // No existing vote — insert
+            $now  = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+            $stmt = $db->prepare(
+                'INSERT INTO ' . $this->table .
+                ' (target_id, user_id, direction, created_at) VALUES (:t, :u, :d, :c)'
+            );
+            $stmt->bindValue(':t', $tId, PDO::PARAM_STR);
+            $stmt->bindValue(':u', $uId, PDO::PARAM_STR);
+            $stmt->bindValue(':d', $direction, PDO::PARAM_STR);
+            $stmt->bindValue(':c', $now, PDO::PARAM_STR);
+            $stmt->execute();
+            $currentVote = $direction;
+        }
+
+        $score = $this->score($targetId);
+        return ['vote' => $currentVote, 'score' => $score['score']];
+    }
+
+    /**
+     * Get vote score for a target.
+     *
+     * @param  string|int $targetId Votable resource identifier.
+     * @return array{up: int, down: int, score: int}
+     */
+    public function score(string|int $targetId): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $tId  = (string)$targetId;
+
+        $stmt = $db->prepare(
+            'SELECT direction, COUNT(*) AS cnt FROM ' . $this->table .
+            ' WHERE target_id = :t GROUP BY direction'
+        );
+        $stmt->bindValue(':t', $tId, PDO::PARAM_STR);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $up   = 0;
+        $down = 0;
+        foreach ($rows as $row) {
+            if ($row['direction'] === 'up') {
+                $up = (int)$row['cnt'];
+            } elseif ($row['direction'] === 'down') {
+                $down = (int)$row['cnt'];
+            }
+        }
+
+        return ['up' => $up, 'down' => $down, 'score' => $up - $down];
+    }
+
+    /**
+     * Get the current vote direction for a specific user on a target.
+     *
+     * @param  string|int $targetId Votable resource identifier.
+     * @param  string|int $userId   Voter identifier.
+     * @return string|null 'up', 'down', or null (no vote).
+     */
+    public function userVote(string|int $targetId, string|int $userId): ?string
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT direction FROM ' . $this->table .
+            ' WHERE target_id = :t AND user_id = :u LIMIT 1'
+        );
+        $stmt->bindValue(':t', (string)$targetId, PDO::PARAM_STR);
+        $stmt->bindValue(':u', (string)$userId, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return is_array($row) ? (string)$row['direction'] : null;
+    }
+
+    /**
+     * Validate a direction string.
+     */
+    public static function validDirection(string $direction): bool
+    {
+        return in_array($direction, self::VALID_DIRS, true);
+    }
+}

--- a/docs/development/voting-booth.md
+++ b/docs/development/voting-booth.md
@@ -1,0 +1,88 @@
+# Voting Booth
+
+`Nene\Xion\VotingBooth` provides an upvote/downvote system with toggle semantics, score retrieval, and per-user vote state.
+
+## Toggle semantics
+
+| Previous vote | New vote | Result |
+|---------------|----------|--------|
+| none | up or down | INSERT (vote added) |
+| up | up | DELETE (toggle — vote removed) |
+| down | down | DELETE (toggle — vote removed) |
+| up | down | UPDATE (direction switched) |
+| down | up | UPDATE (direction switched) |
+
+Clicking the same button twice removes the vote. Clicking the opposite button switches it.
+
+## Schema
+
+```sql
+CREATE TABLE votes (
+    id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+    target_id  VARCHAR(255) NOT NULL,
+    user_id    VARCHAR(255) NOT NULL,
+    direction  VARCHAR(4)   NOT NULL CHECK (direction IN ('up', 'down')),
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (target_id, user_id)
+);
+CREATE INDEX idx_votes_target ON votes (target_id);
+```
+
+`UNIQUE (target_id, user_id)` enforces one-vote-per-user at the DB level as a second safeguard.
+
+## API
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `cast(targetId, userId, direction)` | `{vote, score}` | Cast, toggle, or switch. Returns current vote and net score. |
+| `score(targetId)` | `{up, down, score}` | Vote counts and net score (`up - down`). |
+| `userVote(targetId, userId)` | `string\|null` | Current vote direction (`'up'`, `'down'`, or `null`). |
+| `validDirection(direction)` | `bool` | Static helper: check if string is `'up'` or `'down'`. |
+
+## Basic usage
+
+```php
+use Nene\Xion\VotingBooth;
+
+$booth = new VotingBooth();
+
+// Validate input
+$direction = $requestBody['direction'] ?? '';
+if (!VotingBooth::validDirection($direction)) {
+    http_response_code(422);
+    echo json_encode(['error' => 'VALIDATION-FAILED']);
+    exit;
+}
+
+// Cast a vote (cast also handles toggle and switch)
+$result = $booth->cast('post:42', 'user:1', $direction);
+// $result['vote']  → 'up', 'down', or null (removed)
+// $result['score'] → net score (upvotes - downvotes)
+
+// Current vote state (for rendering the active button in UI)
+$currentVote = $booth->userVote('post:42', 'user:1');
+
+// Score without voting
+$score = $booth->score('post:42');
+// ['up' => 5, 'down' => 2, 'score' => 3]
+```
+
+## Target ID convention
+
+Use a namespaced string to allow multiple votable types in one table:
+
+```php
+$booth->cast('post:42', 'user:1', 'up');
+$booth->cast('comment:17', 'user:1', 'up');
+$booth->cast('answer:99', 'user:2', 'down');
+```
+
+## Security note
+
+`cast()` does not enforce that `$userId` belongs to the authenticated user. Bind the user ID from the JWT claims or session to prevent impersonation:
+
+```php
+$claims = $jwt->require(); // from JwtCodec
+$userId = $claims['sub'];
+$booth->cast($targetId, $userId, $direction);
+```

--- a/docs/field-trials/2026-05-field-trial-59.md
+++ b/docs/field-trials/2026-05-field-trial-59.md
@@ -1,0 +1,56 @@
+# Field Trial 59 — Voting System
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft59-voting-system`
+**Baseline**: `b71f4b6` (post FT51–FT53 merge)
+**NENE2 reference**: FT131 (votelog)
+
+## Goal
+
+Establish an upvote/downvote voting pattern for NeNe with toggle semantics, score retrieval, and per-user vote state.
+
+## What was built
+
+### `Nene\Xion\VotingBooth` (`class/xion/VotingBooth.php`)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `cast(targetId, userId, direction)` | `{vote, score}` | Cast/toggle/switch vote. |
+| `score(targetId)` | `{up, down, score}` | Vote counts and net score. |
+| `userVote(targetId, userId)` | `string\|null` | Current user vote direction. |
+| `validDirection(direction)` | `bool` | Static input validator. |
+
+Key design points:
+
+- **Toggle semantics**: same-direction re-vote DELETEs the row (vote removed); opposite-direction switches via UPDATE; new vote INSERTs.
+- **Single entry point**: `cast()` handles all three state transitions — handler stays thin.
+- **Score in cast response**: returns current score alongside the new vote state, avoiding a client round-trip for counter updates.
+- **UNIQUE constraint**: `UNIQUE (target_id, user_id)` at DB level as a race-safe second layer.
+- **`CHECK (direction IN ('up', 'down'))`**: DB-level guard against invalid values.
+- **Namespaced `target_id`**: supports multiple votable types in one table (`post:42`, `comment:17`, etc.).
+- **Auth note documented**: `cast()` does not enforce user identity — callers must bind `$userId` from JWT claims.
+
+### Tests (`tests/Unit/Xion/VotingBoothTest.php`)
+
+16 unit tests covering:
+
+- cast new upvote/downvote, invalid direction throws
+- toggle: same direction removes vote (up→up, down→down)
+- switch: opposite direction changes vote (up→down, down→up)
+- score: no votes, net calculation, isolation per target
+- userVote: null before vote, direction after vote, null after toggle, isolation per user
+- validDirection: accepts 'up'/'down', rejects empty/other/uppercase
+
+### Howto (`docs/development/voting-booth.md`)
+
+Toggle semantics table, schema, API table, basic usage, target ID convention, security note.
+
+## Findings
+
+### F-1 — No findings (clean trial)
+
+The implementation required no NeNe-core changes. `VotingBooth` is self-contained. All 16 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/VotingBoothTest.php
+++ b/tests/Unit/Xion/VotingBoothTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\VotingBooth;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for VotingBooth using an in-memory SQLite database.
+ */
+final class VotingBoothTest extends TestCase
+{
+    private PDO $db;
+    private VotingBooth $booth;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE votes (
+                id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+                target_id  VARCHAR(255) NOT NULL,
+                user_id    VARCHAR(255) NOT NULL,
+                direction  VARCHAR(4)   NOT NULL CHECK (direction IN (\'up\', \'down\')),
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (target_id, user_id)
+            )'
+        );
+        $this->booth = new VotingBooth($this->db);
+    }
+
+    // ── cast — new vote ───────────────────────────────────────────────────────
+
+    public function testCastUpvoteReturnsUpVoteAndScore(): void
+    {
+        $result = $this->booth->cast('post:1', 'user:1', 'up');
+        $this->assertSame('up', $result['vote']);
+        $this->assertSame(1, $result['score']);
+    }
+
+    public function testCastDownvoteReturnsDownVoteAndNegativeScore(): void
+    {
+        $result = $this->booth->cast('post:1', 'user:1', 'down');
+        $this->assertSame('down', $result['vote']);
+        $this->assertSame(-1, $result['score']);
+    }
+
+    public function testCastInvalidDirectionThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->booth->cast('post:1', 'user:1', 'sideways');
+    }
+
+    // ── cast — toggle (same direction removes vote) ───────────────────────────
+
+    public function testCastSameDirectionTogglesOff(): void
+    {
+        $this->booth->cast('post:1', 'user:1', 'up');
+        $result = $this->booth->cast('post:1', 'user:1', 'up'); // toggle
+        $this->assertNull($result['vote']);
+        $this->assertSame(0, $result['score']);
+    }
+
+    public function testCastToggleDownvote(): void
+    {
+        $this->booth->cast('post:1', 'user:1', 'down');
+        $result = $this->booth->cast('post:1', 'user:1', 'down');
+        $this->assertNull($result['vote']);
+        $this->assertSame(0, $result['score']);
+    }
+
+    // ── cast — switch direction ────────────────────────────────────────────────
+
+    public function testCastOppositeDirectionSwitches(): void
+    {
+        $this->booth->cast('post:1', 'user:1', 'up');
+        $result = $this->booth->cast('post:1', 'user:1', 'down'); // switch
+        $this->assertSame('down', $result['vote']);
+        $this->assertSame(-1, $result['score']);
+    }
+
+    public function testCastSwitchFromDownToUp(): void
+    {
+        $this->booth->cast('post:1', 'user:1', 'down');
+        $result = $this->booth->cast('post:1', 'user:1', 'up');
+        $this->assertSame('up', $result['vote']);
+        $this->assertSame(1, $result['score']);
+    }
+
+    // ── score ─────────────────────────────────────────────────────────────────
+
+    public function testScoreWithNoVotes(): void
+    {
+        $score = $this->booth->score('post:1');
+        $this->assertSame(['up' => 0, 'down' => 0, 'score' => 0], $score);
+    }
+
+    public function testScoreCalculatesNetScore(): void
+    {
+        $this->booth->cast('post:1', 'user:1', 'up');
+        $this->booth->cast('post:1', 'user:2', 'up');
+        $this->booth->cast('post:1', 'user:3', 'down');
+
+        $score = $this->booth->score('post:1');
+        $this->assertSame(2, $score['up']);
+        $this->assertSame(1, $score['down']);
+        $this->assertSame(1, $score['score']);
+    }
+
+    public function testScoreIsIsolatedPerTarget(): void
+    {
+        $this->booth->cast('post:1', 'user:1', 'up');
+        $this->booth->cast('post:2', 'user:1', 'down');
+
+        $this->assertSame(1, $this->booth->score('post:1')['score']);
+        $this->assertSame(-1, $this->booth->score('post:2')['score']);
+    }
+
+    // ── userVote ──────────────────────────────────────────────────────────────
+
+    public function testUserVoteReturnsNullWhenNoVote(): void
+    {
+        $this->assertNull($this->booth->userVote('post:1', 'user:1'));
+    }
+
+    public function testUserVoteReturnsDirection(): void
+    {
+        $this->booth->cast('post:1', 'user:1', 'up');
+        $this->assertSame('up', $this->booth->userVote('post:1', 'user:1'));
+    }
+
+    public function testUserVoteReturnsNullAfterToggle(): void
+    {
+        $this->booth->cast('post:1', 'user:1', 'up');
+        $this->booth->cast('post:1', 'user:1', 'up'); // toggle off
+        $this->assertNull($this->booth->userVote('post:1', 'user:1'));
+    }
+
+    public function testUserVoteIsIsolatedPerUser(): void
+    {
+        $this->booth->cast('post:1', 'user:1', 'up');
+        $this->assertNull($this->booth->userVote('post:1', 'user:2'));
+    }
+
+    // ── validDirection ────────────────────────────────────────────────────────
+
+    public function testValidDirectionAcceptsUpAndDown(): void
+    {
+        $this->assertTrue(VotingBooth::validDirection('up'));
+        $this->assertTrue(VotingBooth::validDirection('down'));
+    }
+
+    public function testValidDirectionRejectsInvalid(): void
+    {
+        $this->assertFalse(VotingBooth::validDirection(''));
+        $this->assertFalse(VotingBooth::validDirection('left'));
+        $this->assertFalse(VotingBooth::validDirection('UP'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\VotingBooth` — upvote/downvote system with toggle semantics (same direction removes vote), score retrieval, and per-user state.

## Changes

- `class/xion/VotingBooth.php` — implementation
- `tests/Unit/Xion/VotingBoothTest.php` — 16 tests
- `docs/development/voting-booth.md` — howto
- `docs/field-trials/2026-05-field-trial-59.md` — report

🤖 Generated with [Claude Code](https://claude.com/claude-code)