### PR TITLE
feat(xion): ContentDraft — draft/publish/archive lifecycle with author enforcement (FT60)

### DIFF
--- a/class/xion/ContentDraft.php
+++ b/class/xion/ContentDraft.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Content draft lifecycle: draft → published → archived.
+ *
+ * Content always starts as a draft. Only drafts can be published;
+ * only published content can be archived. Reverse transitions are not allowed.
+ *
+ * Access control:
+ * - List returns published content only.
+ * - find() returns draft/archived content only to the author; others get null (hidden as 404).
+ * - update() and publish() require draft status and author ownership.
+ * - archive() requires published status and author ownership.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE contents (
+ *     id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     author_id    VARCHAR(255) NOT NULL,
+ *     title        VARCHAR(255) NOT NULL,
+ *     body         TEXT         NOT NULL DEFAULT '',
+ *     status       VARCHAR(16)  NOT NULL DEFAULT 'draft',
+ *     published_at DATETIME     DEFAULT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE INDEX idx_contents_published ON contents (status, published_at);
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $content = new ContentDraft();
+ *
+ * // Create
+ * $id = $content->create('user:1', 'My Post', 'Draft body...');
+ *
+ * // Edit (draft only)
+ * $content->update($id, 'user:1', 'My Post', 'Updated body...');
+ *
+ * // Publish
+ * $content->publish($id, 'user:1');
+ *
+ * // Archive
+ * $content->archive($id, 'user:1');
+ *
+ * // Find (non-author sees null for draft/archived)
+ * $item = $content->find($id, viewerId: 'user:2');
+ *
+ * // List published (newest first)
+ * $items = $content->listPublished();
+ * ```
+ */
+final class ContentDraft
+{
+    public const STATUS_DRAFT     = 'draft';
+    public const STATUS_PUBLISHED = 'published';
+    public const STATUS_ARCHIVED  = 'archived';
+
+    private const TABLE = 'contents';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Create a new draft.
+     *
+     * @param  string|int $authorId Application-level author identifier.
+     * @param  string     $title    Content title.
+     * @param  string     $body     Content body.
+     * @return int        New content row ID.
+     */
+    public function create(string|int $authorId, string $title, string $body = ''): int
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->table .
+            ' (author_id, title, body, status, created_at, updated_at)' .
+            ' VALUES (:a, :ti, :b, :s, :c, :u)'
+        );
+        $stmt->bindValue(':a', (string)$authorId, PDO::PARAM_STR);
+        $stmt->bindValue(':ti', $title, PDO::PARAM_STR);
+        $stmt->bindValue(':b', $body, PDO::PARAM_STR);
+        $stmt->bindValue(':s', self::STATUS_DRAFT, PDO::PARAM_STR);
+        $stmt->bindValue(':c', $now, PDO::PARAM_STR);
+        $stmt->bindValue(':u', $now, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Update a draft. Returns false if not found, not a draft, or wrong author.
+     *
+     * @param int         $contentId  Row ID.
+     * @param string|int  $authorId   Must match the content's author.
+     * @param string      $title      New title.
+     * @param string      $body       New body.
+     */
+    public function update(int $contentId, string|int $authorId, string $title, string $body = ''): bool
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->table .
+            ' SET title = :ti, body = :b, updated_at = :u' .
+            ' WHERE id = :id AND author_id = :a AND status = :s'
+        );
+        $stmt->bindValue(':ti', $title, PDO::PARAM_STR);
+        $stmt->bindValue(':b', $body, PDO::PARAM_STR);
+        $stmt->bindValue(':u', $now, PDO::PARAM_STR);
+        $stmt->bindValue(':id', $contentId, PDO::PARAM_INT);
+        $stmt->bindValue(':a', (string)$authorId, PDO::PARAM_STR);
+        $stmt->bindValue(':s', self::STATUS_DRAFT, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Publish a draft. Returns false if not a draft or wrong author.
+     *
+     * @param int         $contentId Row ID.
+     * @param string|int  $authorId  Must match the content's author.
+     */
+    public function publish(int $contentId, string|int $authorId): bool
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->table .
+            ' SET status = :ns, published_at = :p, updated_at = :u' .
+            ' WHERE id = :id AND author_id = :a AND status = :os'
+        );
+        $stmt->bindValue(':ns', self::STATUS_PUBLISHED, PDO::PARAM_STR);
+        $stmt->bindValue(':p', $now, PDO::PARAM_STR);
+        $stmt->bindValue(':u', $now, PDO::PARAM_STR);
+        $stmt->bindValue(':id', $contentId, PDO::PARAM_INT);
+        $stmt->bindValue(':a', (string)$authorId, PDO::PARAM_STR);
+        $stmt->bindValue(':os', self::STATUS_DRAFT, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Archive a published item. Returns false if not published or wrong author.
+     *
+     * @param int         $contentId Row ID.
+     * @param string|int  $authorId  Must match the content's author.
+     */
+    public function archive(int $contentId, string|int $authorId): bool
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->table .
+            ' SET status = :ns, updated_at = :u' .
+            ' WHERE id = :id AND author_id = :a AND status = :os'
+        );
+        $stmt->bindValue(':ns', self::STATUS_ARCHIVED, PDO::PARAM_STR);
+        $stmt->bindValue(':u', $now, PDO::PARAM_STR);
+        $stmt->bindValue(':id', $contentId, PDO::PARAM_INT);
+        $stmt->bindValue(':a', (string)$authorId, PDO::PARAM_STR);
+        $stmt->bindValue(':os', self::STATUS_PUBLISHED, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Find a content item by ID.
+     *
+     * Draft and archived items are visible only to their author.
+     * Non-author viewers receive null for non-published content (hidden as 404).
+     *
+     * @param  int               $contentId Row ID.
+     * @param  string|int|null   $viewerId  Current viewer. Null = anonymous.
+     * @return array{id:int,author_id:string,title:string,body:string,status:string,published_at:string|null,created_at:string,updated_at:string}|null
+     */
+    public function find(int $contentId, string|int|null $viewerId = null): ?array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, author_id, title, body, status, published_at, created_at, updated_at' .
+            ' FROM ' . $this->table . ' WHERE id = :id LIMIT 1'
+        );
+        $stmt->bindValue(':id', $contentId, PDO::PARAM_INT);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        // Non-published content is hidden from non-authors
+        if ($row['status'] !== self::STATUS_PUBLISHED) {
+            if ($viewerId === null || (string)$viewerId !== (string)$row['author_id']) {
+                return null;
+            }
+        }
+
+        return [
+            'id'           => (int)$row['id'],
+            'author_id'    => (string)$row['author_id'],
+            'title'        => (string)$row['title'],
+            'body'         => (string)$row['body'],
+            'status'       => (string)$row['status'],
+            'published_at' => $row['published_at'] !== null ? (string)$row['published_at'] : null,
+            'created_at'   => (string)$row['created_at'],
+            'updated_at'   => (string)$row['updated_at'],
+        ];
+    }
+
+    /**
+     * List published content, newest first.
+     *
+     * Sorted by (published_at DESC, id DESC) for stable order when multiple
+     * items are published within the same second.
+     *
+     * @return list<array{id:int,author_id:string,title:string,body:string,published_at:string,created_at:string}>
+     */
+    public function listPublished(): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, author_id, title, body, published_at, created_at' .
+            ' FROM ' . $this->table .
+            ' WHERE status = :s ORDER BY published_at DESC, id DESC'
+        );
+        $stmt->bindValue(':s', self::STATUS_PUBLISHED, PDO::PARAM_STR);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => [
+            'id'           => (int)$r['id'],
+            'author_id'    => (string)$r['author_id'],
+            'title'        => (string)$r['title'],
+            'body'         => (string)$r['body'],
+            'published_at' => (string)$r['published_at'],
+            'created_at'   => (string)$r['created_at'],
+        ], $rows);
+    }
+}

--- a/docs/development/content-draft.md
+++ b/docs/development/content-draft.md
@@ -1,0 +1,95 @@
+# Content Draft
+
+`Nene\Xion\ContentDraft` manages a content lifecycle with three states: `draft → published → archived`. Reverse transitions are not allowed.
+
+## State transitions
+
+```
+draft ──publish()──▶ published ──archive()──▶ archived
+  ↑
+create() always starts here
+```
+
+| Transition | Method | Who can do it |
+|------------|--------|---------------|
+| (new) → draft | `create()` | anyone |
+| draft → published | `publish()` | author only |
+| published → archived | `archive()` | author only |
+| draft ← published | ❌ not allowed | — |
+| published ← archived | ❌ not allowed | — |
+
+## Schema
+
+```sql
+CREATE TABLE contents (
+    id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+    author_id    VARCHAR(255) NOT NULL,
+    title        VARCHAR(255) NOT NULL,
+    body         TEXT         NOT NULL DEFAULT '',
+    status       VARCHAR(16)  NOT NULL DEFAULT 'draft',
+    published_at DATETIME     DEFAULT NULL,
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_contents_published ON contents (status, published_at);
+```
+
+## API
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `create(authorId, title, body)` | `int` | Create a draft. Returns row ID. |
+| `update(contentId, authorId, title, body)` | `bool` | Edit a draft. Author-enforced. |
+| `publish(contentId, authorId)` | `bool` | draft → published. Author-enforced. |
+| `archive(contentId, authorId)` | `bool` | published → archived. Author-enforced. |
+| `find(contentId, viewerId)` | `array\|null` | Get item. Non-author sees null for draft/archived. |
+| `listPublished()` | `array[]` | Published items, newest first. |
+
+## Basic usage
+
+```php
+use Nene\Xion\ContentDraft;
+
+$content = new ContentDraft();
+
+// Create a draft
+$id = $content->create('user:1', 'My Article', 'Initial draft...');
+
+// Edit (draft only)
+if (!$content->update($id, $authorId, 'My Article', 'Revised body...')) {
+    // Not found, not a draft, or wrong author → 403/422
+}
+
+// Publish
+if (!$content->publish($id, $authorId)) {
+    // Not a draft or wrong author → 422
+}
+
+// Get (non-author sees null for draft/archived)
+$item = $content->find($id, viewerId: $userId);
+if ($item === null) {
+    http_response_code(404); exit;
+}
+
+// List published
+$published = $content->listPublished();
+```
+
+## Access control: 404 not 403 for hidden content
+
+Non-published content returns `null` from `find()` rather than a permission error. Callers should return 404, not 403:
+
+- **403** tells the client the resource exists but access is denied — disclosing that a draft exists.
+- **404** hides the existence, preventing content enumeration.
+
+## `ORDER BY published_at DESC, id DESC`
+
+The secondary `id DESC` sort ensures stable ordering when multiple items are published within the same second. Without it, same-second publishes would have indeterminate relative order.
+
+## Status constants
+
+```php
+ContentDraft::STATUS_DRAFT     // 'draft'
+ContentDraft::STATUS_PUBLISHED // 'published'
+ContentDraft::STATUS_ARCHIVED  // 'archived'
+```

--- a/docs/field-trials/2026-05-field-trial-60.md
+++ b/docs/field-trials/2026-05-field-trial-60.md
@@ -1,0 +1,61 @@
+# Field Trial 60 — Content Draft Lifecycle
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft60-content-draft`
+**Baseline**: `b71f4b6` (post FT51–FT53 merge)
+**NENE2 reference**: FT142 (draftlog)
+
+## Goal
+
+Establish a content draft/publish/archive lifecycle pattern for NeNe. Three states: `draft → published → archived`. Reverse transitions forbidden.
+
+## What was built
+
+### `Nene\Xion\ContentDraft` (`class/xion/ContentDraft.php`)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `create(authorId, title, body)` | `int` | Create draft. Returns row ID. |
+| `update(contentId, authorId, title, body)` | `bool` | Edit draft. Author + draft status guard. |
+| `publish(contentId, authorId)` | `bool` | draft → published. |
+| `archive(contentId, authorId)` | `bool` | published → archived. |
+| `find(contentId, viewerId)` | `array\|null` | Get item. Draft/archived hidden from non-authors. |
+| `listPublished()` | `array[]` | Published only, `ORDER BY published_at DESC, id DESC`. |
+
+Key design points:
+
+- **Transition guards via SQL**: the WHERE clause includes the required `status` — no separate fetch. If the row count is 0, the guard failed.
+- **Reverse transitions blocked**: `publish()` requires `status = 'draft'`; `archive()` requires `status = 'published'`; `update()` requires `status = 'draft'`.
+- **Author enforcement**: all mutating methods include `author_id = ?` in the WHERE clause.
+- **404 not 403 for hidden content**: `find()` returns `null` for non-author access to drafts/archived — no disclosure that the content exists.
+- **Stable sort**: `ORDER BY published_at DESC, id DESC` for deterministic order when two items are published in the same second. Ported from NENE2 FT142 bug-fix learning.
+- **Status constants**: `ContentDraft::STATUS_DRAFT`, `STATUS_PUBLISHED`, `STATUS_ARCHIVED`.
+
+### Tests (`tests/Unit/Xion/ContentDraftTest.php`)
+
+24 unit tests covering:
+
+- create: returns ID, default status is draft, author stored
+- update: success, title changed, wrong author (false), published content (false)
+- publish: success, status changes, published_at set, wrong author (false), already published (false)
+- archive: success, status changes, on draft (false), wrong author (false)
+- find: published visible to all, draft hidden from non-author, draft visible to author, archived hidden from non-author, not found
+- listPublished: only published, newest first, excludes drafts + archived
+
+### Howto (`docs/development/content-draft.md`)
+
+State transition diagram, schema, API table, basic usage, 404 vs 403 rationale, stable sort explanation, status constants.
+
+## Findings
+
+### F-1 — Stable sort: `ORDER BY published_at DESC, id DESC` (ported from NENE2 FT142)
+
+NENE2 FT142 discovered this bug in-trial: `ORDER BY published_at DESC` alone gives indeterminate order for same-second publishes. Applied proactively in NeNe.
+
+### F-2 — No other framework findings
+
+All 24 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/ContentDraftTest.php
+++ b/tests/Unit/Xion/ContentDraftTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ContentDraft;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ContentDraft using an in-memory SQLite database.
+ */
+final class ContentDraftTest extends TestCase
+{
+    private PDO $db;
+    private ContentDraft $content;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE contents (
+                id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+                author_id    VARCHAR(255) NOT NULL,
+                title        VARCHAR(255) NOT NULL,
+                body         TEXT         NOT NULL DEFAULT \'\',
+                status       VARCHAR(16)  NOT NULL DEFAULT \'draft\',
+                published_at DATETIME     DEFAULT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->content = new ContentDraft($this->db);
+    }
+
+    // ── create ───────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsId(): void
+    {
+        $id = $this->content->create('user:1', 'Title', 'Body');
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testCreatedContentIsDraft(): void
+    {
+        $id   = $this->content->create('user:1', 'Title');
+        $item = $this->content->find($id, 'user:1');
+        $this->assertSame(ContentDraft::STATUS_DRAFT, $item['status']);
+    }
+
+    public function testCreatedContentAuthor(): void
+    {
+        $id   = $this->content->create('user:1', 'Title', 'Body');
+        $item = $this->content->find($id, 'user:1');
+        $this->assertSame('user:1', $item['author_id']);
+    }
+
+    // ── update ───────────────────────────────────────────────────────────────
+
+    public function testUpdateDraftByAuthorReturnsTrue(): void
+    {
+        $id     = $this->content->create('user:1', 'Old Title');
+        $result = $this->content->update($id, 'user:1', 'New Title', 'New Body');
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateDraftChangesTitle(): void
+    {
+        $id = $this->content->create('user:1', 'Old Title');
+        $this->content->update($id, 'user:1', 'New Title', 'Body');
+        $item = $this->content->find($id, 'user:1');
+        $this->assertSame('New Title', $item['title']);
+    }
+
+    public function testUpdateByWrongAuthorReturnsFalse(): void
+    {
+        $id     = $this->content->create('user:1', 'Title');
+        $result = $this->content->update($id, 'user:2', 'Hacked', 'Body');
+        $this->assertFalse($result);
+    }
+
+    public function testUpdatePublishedReturnsFalse(): void
+    {
+        $id = $this->content->create('user:1', 'Title');
+        $this->content->publish($id, 'user:1');
+        $result = $this->content->update($id, 'user:1', 'Changed', 'Body');
+        $this->assertFalse($result);
+    }
+
+    // ── publish ───────────────────────────────────────────────────────────────
+
+    public function testPublishDraftByAuthorReturnsTrue(): void
+    {
+        $id     = $this->content->create('user:1', 'Title');
+        $result = $this->content->publish($id, 'user:1');
+        $this->assertTrue($result);
+    }
+
+    public function testPublishSetsStatusToPublished(): void
+    {
+        $id = $this->content->create('user:1', 'Title');
+        $this->content->publish($id, 'user:1');
+        $item = $this->content->find($id);
+        $this->assertSame(ContentDraft::STATUS_PUBLISHED, $item['status']);
+    }
+
+    public function testPublishSetsPublishedAt(): void
+    {
+        $id = $this->content->create('user:1', 'Title');
+        $this->content->publish($id, 'user:1');
+        $item = $this->content->find($id);
+        $this->assertNotNull($item['published_at']);
+    }
+
+    public function testPublishByWrongAuthorReturnsFalse(): void
+    {
+        $id     = $this->content->create('user:1', 'Title');
+        $result = $this->content->publish($id, 'user:2');
+        $this->assertFalse($result);
+    }
+
+    public function testPublishAlreadyPublishedReturnsFalse(): void
+    {
+        $id = $this->content->create('user:1', 'Title');
+        $this->content->publish($id, 'user:1');
+        $result = $this->content->publish($id, 'user:1'); // already published
+        $this->assertFalse($result);
+    }
+
+    // ── archive ───────────────────────────────────────────────────────────────
+
+    public function testArchivePublishedByAuthorReturnsTrue(): void
+    {
+        $id = $this->content->create('user:1', 'Title');
+        $this->content->publish($id, 'user:1');
+        $result = $this->content->archive($id, 'user:1');
+        $this->assertTrue($result);
+    }
+
+    public function testArchiveSetsStatusToArchived(): void
+    {
+        $id = $this->content->create('user:1', 'Title');
+        $this->content->publish($id, 'user:1');
+        $this->content->archive($id, 'user:1');
+        // Author can still see it
+        $item = $this->content->find($id, 'user:1');
+        $this->assertSame(ContentDraft::STATUS_ARCHIVED, $item['status']);
+    }
+
+    public function testArchiveDraftReturnsFalse(): void
+    {
+        $id     = $this->content->create('user:1', 'Title');
+        $result = $this->content->archive($id, 'user:1'); // draft → archived not allowed
+        $this->assertFalse($result);
+    }
+
+    public function testArchiveByWrongAuthorReturnsFalse(): void
+    {
+        $id = $this->content->create('user:1', 'Title');
+        $this->content->publish($id, 'user:1');
+        $result = $this->content->archive($id, 'user:2');
+        $this->assertFalse($result);
+    }
+
+    // ── find ─────────────────────────────────────────────────────────────────
+
+    public function testFindPublishedByAnyoneReturnsItem(): void
+    {
+        $id = $this->content->create('user:1', 'Title');
+        $this->content->publish($id, 'user:1');
+        $this->assertNotNull($this->content->find($id));
+        $this->assertNotNull($this->content->find($id, 'user:2'));
+        $this->assertNotNull($this->content->find($id, null));
+    }
+
+    public function testFindDraftByNonAuthorReturnsNull(): void
+    {
+        $id = $this->content->create('user:1', 'Title');
+        $this->assertNull($this->content->find($id, 'user:2'));
+        $this->assertNull($this->content->find($id, null));
+    }
+
+    public function testFindDraftByAuthorReturnsItem(): void
+    {
+        $id   = $this->content->create('user:1', 'Title');
+        $item = $this->content->find($id, 'user:1');
+        $this->assertNotNull($item);
+        $this->assertSame('Title', $item['title']);
+    }
+
+    public function testFindArchivedByNonAuthorReturnsNull(): void
+    {
+        $id = $this->content->create('user:1', 'Title');
+        $this->content->publish($id, 'user:1');
+        $this->content->archive($id, 'user:1');
+        $this->assertNull($this->content->find($id, 'user:2'));
+    }
+
+    public function testFindNotFoundReturnsNull(): void
+    {
+        $this->assertNull($this->content->find(9999));
+    }
+
+    // ── listPublished ─────────────────────────────────────────────────────────
+
+    public function testListPublishedReturnsOnlyPublished(): void
+    {
+        $id1 = $this->content->create('user:1', 'Draft');
+        $id2 = $this->content->create('user:1', 'Published');
+        $this->content->publish($id2, 'user:1');
+
+        $items = $this->content->listPublished();
+        $this->assertCount(1, $items);
+        $this->assertSame('Published', $items[0]['title']);
+    }
+
+    public function testListPublishedOrderedNewestFirst(): void
+    {
+        $id1 = $this->content->create('user:1', 'First');
+        $this->content->publish($id1, 'user:1');
+        $id2 = $this->content->create('user:1', 'Second');
+        $this->content->publish($id2, 'user:1');
+
+        $items = $this->content->listPublished();
+        // id2 was published after id1 (higher id → newer)
+        $this->assertSame('Second', $items[0]['title']);
+    }
+
+    public function testListPublishedExcludesDraftsAndArchived(): void
+    {
+        $id1 = $this->content->create('user:1', 'Draft');
+        $id2 = $this->content->create('user:1', 'Published');
+        $id3 = $this->content->create('user:1', 'ToArchive');
+        $this->content->publish($id2, 'user:1');
+        $this->content->publish($id3, 'user:1');
+        $this->content->archive($id3, 'user:1');
+
+        $items = $this->content->listPublished();
+        $this->assertCount(1, $items);
+        $this->assertSame('Published', $items[0]['title']);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\ContentDraft` — content lifecycle management with three states: `draft → published → archived`. Reverse transitions are blocked.

## Changes

- `class/xion/ContentDraft.php` — implementation
- `tests/Unit/Xion/ContentDraftTest.php` — 24 tests
- `docs/development/content-draft.md` — howto
- `docs/field-trials/2026-05-field-trial-60.md` — report

🤖 Generated with [Claude Code](https://claude.com/claude-code)