### PR TITLE
feat(xion): Leaderboard — best-score retention, ranked listing, tied-score handling (FT61)

### DIFF
--- a/class/xion/Leaderboard.php
+++ b/class/xion/Leaderboard.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Score-based leaderboard with best-score retention, ranking, and personal rank lookup.
+ *
+ * One score row per user per leaderboard (`UNIQUE (leaderboard_id, user_id)`).
+ * Submit always keeps the personal best — lower scores are silently discarded.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE leaderboard_scores (
+ *     id             INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     leaderboard_id VARCHAR(255) NOT NULL,
+ *     user_id        VARCHAR(255) NOT NULL,
+ *     score          INTEGER      NOT NULL,
+ *     submitted_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (leaderboard_id, user_id)
+ * );
+ * CREATE INDEX idx_lb_scores ON leaderboard_scores (leaderboard_id, score DESC);
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $lb = new Leaderboard();
+ *
+ * // Submit a score (only kept if it's a new personal best)
+ * $result = $lb->submit('game:tetris', 'user:1', 42000);
+ * // $result['is_best'] is true if this is a new personal best
+ *
+ * // Get top rankings
+ * $rankings = $lb->rankings('game:tetris', limit: 10);
+ *
+ * // Get a user's rank and score
+ * $rank = $lb->rank('game:tetris', 'user:1');
+ * // ['rank' => 3, 'score' => 42000] or null if no score
+ *
+ * // Remove a score
+ * $lb->remove('game:tetris', 'user:1');
+ * ```
+ */
+final class Leaderboard
+{
+    private const TABLE     = 'leaderboard_scores';
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Submit a score. Only kept if it exceeds the user's current personal best.
+     *
+     * @param  string|int $leaderboardId Leaderboard identifier.
+     * @param  string|int $userId        User identifier.
+     * @param  int        $score         Score value (integer only — no floats).
+     * @return array{is_best: bool, score: int} Whether this is a new best and current best score.
+     */
+    public function submit(string|int $leaderboardId, string|int $userId, int $score): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $lbId = (string)$leaderboardId;
+        $uId  = (string)$userId;
+        $now  = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        // Check existing score
+        $stmt = $db->prepare(
+            'SELECT id, score FROM ' . $this->table .
+            ' WHERE leaderboard_id = :l AND user_id = :u LIMIT 1'
+        );
+        $stmt->bindValue(':l', $lbId, PDO::PARAM_STR);
+        $stmt->bindValue(':u', $uId, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            // First submission — INSERT
+            $stmt = $db->prepare(
+                'INSERT INTO ' . $this->table .
+                ' (leaderboard_id, user_id, score, submitted_at)' .
+                ' VALUES (:l, :u, :s, :t)'
+            );
+            $stmt->bindValue(':l', $lbId, PDO::PARAM_STR);
+            $stmt->bindValue(':u', $uId, PDO::PARAM_STR);
+            $stmt->bindValue(':s', $score, PDO::PARAM_INT);
+            $stmt->bindValue(':t', $now, PDO::PARAM_STR);
+            $stmt->execute();
+            return ['is_best' => true, 'score' => $score];
+        }
+
+        $currentBest = (int)$row['score'];
+        if ($score > $currentBest) {
+            // New personal best — UPDATE
+            $stmt = $db->prepare(
+                'UPDATE ' . $this->table .
+                ' SET score = :s, submitted_at = :t' .
+                ' WHERE leaderboard_id = :l AND user_id = :u'
+            );
+            $stmt->bindValue(':s', $score, PDO::PARAM_INT);
+            $stmt->bindValue(':t', $now, PDO::PARAM_STR);
+            $stmt->bindValue(':l', $lbId, PDO::PARAM_STR);
+            $stmt->bindValue(':u', $uId, PDO::PARAM_STR);
+            $stmt->execute();
+            return ['is_best' => true, 'score' => $score];
+        }
+
+        // Score is not a new best — no change
+        return ['is_best' => false, 'score' => $currentBest];
+    }
+
+    /**
+     * Get the top N rankings for a leaderboard, highest score first.
+     *
+     * Ties are broken by submission time (earlier submission wins same rank).
+     * `$limit` is clamped to 1–100.
+     *
+     * @param  string|int $leaderboardId Leaderboard identifier.
+     * @param  int        $limit         Maximum entries (1–100, default 10).
+     * @return list<array{rank: int, user_id: string, score: int, submitted_at: string}>
+     */
+    public function rankings(string|int $leaderboardId, int $limit = 10): array
+    {
+        $db    = $this->db ?? PdoConnection::getInstance();
+        $limit = max(1, min($limit, self::MAX_LIMIT));
+
+        $stmt = $db->prepare(
+            'SELECT user_id, score, submitted_at FROM ' . $this->table .
+            ' WHERE leaderboard_id = :l ORDER BY score DESC, submitted_at ASC LIMIT :n'
+        );
+        $stmt->bindValue(':l', (string)$leaderboardId, PDO::PARAM_STR);
+        $stmt->bindValue(':n', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $rank    = 1;
+        $result  = [];
+        $prevScore = null;
+        $tiedRank  = 1;
+
+        foreach ($rows as $i => $row) {
+            $s = (int)$row['score'];
+            if ($prevScore !== null && $s < $prevScore) {
+                $tiedRank = $i + 1; // rank advances only when score changes
+            }
+            $result[] = [
+                'rank'         => $tiedRank,
+                'user_id'      => (string)$row['user_id'],
+                'score'        => $s,
+                'submitted_at' => (string)$row['submitted_at'],
+            ];
+            $prevScore = $s;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get a user's rank and score on a leaderboard.
+     *
+     * Rank is calculated as the number of users with a strictly higher score + 1
+     * (tied users share the same rank).
+     *
+     * @param  string|int $leaderboardId Leaderboard identifier.
+     * @param  string|int $userId        User identifier.
+     * @return array{rank: int, score: int}|null Null if user has no score.
+     */
+    public function rank(string|int $leaderboardId, string|int $userId): ?array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $lbId = (string)$leaderboardId;
+        $uId  = (string)$userId;
+
+        // Get user's current score
+        $stmt = $db->prepare(
+            'SELECT score FROM ' . $this->table .
+            ' WHERE leaderboard_id = :l AND user_id = :u LIMIT 1'
+        );
+        $stmt->bindValue(':l', $lbId, PDO::PARAM_STR);
+        $stmt->bindValue(':u', $uId, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        $score = (int)$row['score'];
+
+        // Count users with strictly higher score
+        $stmt = $db->prepare(
+            'SELECT COUNT(*) FROM ' . $this->table .
+            ' WHERE leaderboard_id = :l AND score > :s'
+        );
+        $stmt->bindValue(':l', $lbId, PDO::PARAM_STR);
+        $stmt->bindValue(':s', $score, PDO::PARAM_INT);
+        $stmt->execute();
+        $above = (int)$stmt->fetchColumn();
+
+        return ['rank' => $above + 1, 'score' => $score];
+    }
+
+    /**
+     * Remove a user's score from a leaderboard.
+     *
+     * Returns true if a row was removed, false if the user had no score.
+     *
+     * @param string|int $leaderboardId Leaderboard identifier.
+     * @param string|int $userId        User identifier.
+     */
+    public function remove(string|int $leaderboardId, string|int $userId): bool
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'DELETE FROM ' . $this->table .
+            ' WHERE leaderboard_id = :l AND user_id = :u'
+        );
+        $stmt->bindValue(':l', (string)$leaderboardId, PDO::PARAM_STR);
+        $stmt->bindValue(':u', (string)$userId, PDO::PARAM_STR);
+        $stmt->execute();
+        return $stmt->rowCount() > 0;
+    }
+}

--- a/docs/development/leaderboard.md
+++ b/docs/development/leaderboard.md
@@ -1,0 +1,92 @@
+# Leaderboard
+
+`Nene\Xion\Leaderboard` provides score submission with best-score retention, ranked listing, and personal rank lookup.
+
+## Schema
+
+```sql
+CREATE TABLE leaderboard_scores (
+    id             INTEGER      PRIMARY KEY AUTOINCREMENT,
+    leaderboard_id VARCHAR(255) NOT NULL,
+    user_id        VARCHAR(255) NOT NULL,
+    score          INTEGER      NOT NULL,
+    submitted_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (leaderboard_id, user_id)
+);
+CREATE INDEX idx_lb_scores ON leaderboard_scores (leaderboard_id, score DESC);
+```
+
+`UNIQUE (leaderboard_id, user_id)` enforces one row per user per leaderboard at the DB level.
+
+## API
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `submit(leaderboardId, userId, score)` | `{is_best, score}` | Submit score. Kept only if it's a new personal best. |
+| `rankings(leaderboardId, limit)` | `array[]` | Top entries. Tied scores share rank. Limit clamped to 1–100. |
+| `rank(leaderboardId, userId)` | `{rank, score}\|null` | Personal rank and best score. Null if no score. |
+| `remove(leaderboardId, userId)` | `bool` | Remove a user's score. |
+
+## Basic usage
+
+```php
+use Nene\Xion\Leaderboard;
+
+$lb = new Leaderboard();
+
+// Submit a score
+$result = $lb->submit('game:tetris', $userId, 42000);
+if ($result['is_best']) {
+    // New personal best!
+}
+
+// Get top 10
+$rankings = $lb->rankings('game:tetris', limit: 10);
+foreach ($rankings as $entry) {
+    echo "#{$entry['rank']} {$entry['user_id']}: {$entry['score']}";
+}
+
+// Personal rank
+$rank = $lb->rank('game:tetris', $userId);
+if ($rank !== null) {
+    echo "Your rank: #{$rank['rank']} with score {$rank['score']}";
+}
+```
+
+## Best-score retention
+
+`submit()` checks the existing score first:
+- No existing score → INSERT (first submission)
+- New score > current best → UPDATE (personal best achieved)
+- New score ≤ current best → no change, `is_best: false`
+
+## Tied scores
+
+Users with identical scores share the same rank. The `rankings()` response uses dense-like ranking (the rank after two tied 1st-place entries is 3, not 2).
+
+## Leaderboard ID convention
+
+Use a namespaced string to support multiple leaderboards in one table:
+
+```php
+$lb->submit('game:tetris:daily', $userId, 1000);
+$lb->submit('game:tetris:alltime', $userId, 1000);
+$lb->submit('quiz:geography:weekly', $userId, 88);
+```
+
+## Score type
+
+Scores must be integers. Reject floats at the input layer:
+
+```php
+$score = $requestBody['score'] ?? null;
+if (!is_int($score)) {
+    http_response_code(422);
+    echo json_encode(['error' => 'VALIDATION-FAILED']);
+    exit;
+}
+```
+
+## Limit clamping
+
+`rankings()` clamps `$limit` to 1–100 automatically. Passing `limit: 99999` does not cause a full table scan — the query is always bounded.

--- a/docs/field-trials/2026-05-field-trial-61.md
+++ b/docs/field-trials/2026-05-field-trial-61.md
@@ -1,0 +1,58 @@
+# Field Trial 61 — Leaderboard
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft61-leaderboard`
+**Baseline**: `b71f4b6` (post FT51–FT53 merge)
+**NENE2 reference**: FT141 (ranklog)
+
+## Goal
+
+Establish a score-based leaderboard pattern for NeNe: best-score retention, ranked listing with tie handling, and personal rank lookup.
+
+## What was built
+
+### `Nene\Xion\Leaderboard` (`class/xion/Leaderboard.php`)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `submit(leaderboardId, userId, score)` | `{is_best, score}` | Submit. Retained only if new personal best. |
+| `rankings(leaderboardId, limit=10)` | `array[]` | Top entries, score DESC. Limit clamped 1–100. |
+| `rank(leaderboardId, userId)` | `{rank, score}\|null` | Personal rank via `COUNT(score > ?)`. |
+| `remove(leaderboardId, userId)` | `bool` | Remove score. |
+
+Key design points:
+
+- **Best-score retention**: SELECT + conditional INSERT/UPDATE pattern; `UNIQUE (leaderboard_id, user_id)` as DB-level guard.
+- **`is_best` response**: `submit()` signals whether a new personal best was achieved — useful for achievement triggers.
+- **Rank via `COUNT(*)`**: `SELECT COUNT(*) WHERE score > ?` + 1. Works on all DB versions without window functions.
+- **Tied scores share rank**: users with identical scores get the same rank; the next rank skips appropriately.
+- **Tie-breaking in `rankings()`**: `ORDER BY score DESC, submitted_at ASC` — earlier submission wins when scores are equal.
+- **Limit clamping**: `max(1, min($limit, 100))` — prevents accidental full-table scans from large limit values.
+- **Namespaced leaderboard IDs**: supports multiple leaderboards in one table (`game:tetris:daily`, `quiz:weekly`, etc.).
+
+### Tests (`tests/Unit/Xion/LeaderboardTest.php`)
+
+18 unit tests covering:
+
+- submit: first score is best, higher score is best, lower score not best, same score not best, multiple users, isolation per leaderboard
+- rankings: highest first, limit applied, limit clamped to max, tied score same rank, empty for no scores
+- rank: returns position + score, null for unranked, first place is 1, tied users share rank
+- remove: returns true when found, false when not found, deletes score
+
+### Howto (`docs/development/leaderboard.md`)
+
+Schema, API table, basic usage, best-score retention logic, tied scores, leaderboard ID convention, score type enforcement, limit clamping.
+
+## Findings
+
+### F-1 — Limit clamping ported from NENE2 FT141
+
+NENE2 FT141 identified `?limit=99999` as a potential DoS vector. Applied proactively: `max(1, min($limit, 100))`.
+
+### F-2 — No other findings
+
+All 18 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/LeaderboardTest.php
+++ b/tests/Unit/Xion/LeaderboardTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\Leaderboard;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Leaderboard using an in-memory SQLite database.
+ */
+final class LeaderboardTest extends TestCase
+{
+    private PDO $db;
+    private Leaderboard $lb;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE leaderboard_scores (
+                id             INTEGER      PRIMARY KEY AUTOINCREMENT,
+                leaderboard_id VARCHAR(255) NOT NULL,
+                user_id        VARCHAR(255) NOT NULL,
+                score          INTEGER      NOT NULL,
+                submitted_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (leaderboard_id, user_id)
+            )'
+        );
+        $this->lb = new Leaderboard($this->db);
+    }
+
+    // ── submit ────────────────────────────────────────────────────────────────
+
+    public function testSubmitFirstScoreIsBest(): void
+    {
+        $result = $this->lb->submit('game:1', 'user:1', 1000);
+        $this->assertTrue($result['is_best']);
+        $this->assertSame(1000, $result['score']);
+    }
+
+    public function testSubmitHigherScoreIsBest(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 1000);
+        $result = $this->lb->submit('game:1', 'user:1', 2000);
+        $this->assertTrue($result['is_best']);
+        $this->assertSame(2000, $result['score']);
+    }
+
+    public function testSubmitLowerScoreIsNotBest(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 1000);
+        $result = $this->lb->submit('game:1', 'user:1', 500);
+        $this->assertFalse($result['is_best']);
+        $this->assertSame(1000, $result['score']); // still the previous best
+    }
+
+    public function testSubmitSameScoreIsNotBest(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 1000);
+        $result = $this->lb->submit('game:1', 'user:1', 1000);
+        $this->assertFalse($result['is_best']);
+    }
+
+    public function testSubmitMultipleUsersOneRowEach(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 1000);
+        $this->lb->submit('game:1', 'user:2', 2000);
+        $rankings = $this->lb->rankings('game:1');
+        $this->assertCount(2, $rankings);
+    }
+
+    public function testSubmitIsolatedPerLeaderboard(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 1000);
+        $this->lb->submit('game:2', 'user:1', 9999);
+        $this->assertSame(1000, $this->lb->rank('game:1', 'user:1')['score']);
+        $this->assertSame(9999, $this->lb->rank('game:2', 'user:1')['score']);
+    }
+
+    // ── rankings ─────────────────────────────────────────────────────────────
+
+    public function testRankingsReturnHighestFirst(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 500);
+        $this->lb->submit('game:1', 'user:2', 1000);
+        $this->lb->submit('game:1', 'user:3', 750);
+
+        $rankings = $this->lb->rankings('game:1');
+        $this->assertSame(1000, $rankings[0]['score']);
+        $this->assertSame(750, $rankings[1]['score']);
+        $this->assertSame(500, $rankings[2]['score']);
+    }
+
+    public function testRankingsLimitClamped(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->lb->submit('game:1', "user:{$i}", $i * 100);
+        }
+        $rankings = $this->lb->rankings('game:1', limit: 3);
+        $this->assertCount(3, $rankings);
+    }
+
+    public function testRankingsLimitClampedToMax(): void
+    {
+        // Max is 100 — requesting 999 should clamp
+        for ($i = 1; $i <= 3; $i++) {
+            $this->lb->submit('game:1', "user:{$i}", $i * 100);
+        }
+        $rankings = $this->lb->rankings('game:1', limit: 999);
+        $this->assertCount(3, $rankings); // only 3 users
+    }
+
+    public function testRankingsTiedScoreSameRank(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 1000);
+        $this->lb->submit('game:1', 'user:2', 1000);
+        $this->lb->submit('game:1', 'user:3', 500);
+
+        $rankings = $this->lb->rankings('game:1');
+        $this->assertSame(1, $rankings[0]['rank']); // user:1 or user:2
+        $this->assertSame(1, $rankings[1]['rank']); // same rank for tied score
+        $this->assertSame(3, $rankings[2]['rank']); // rank 3, not 2
+    }
+
+    public function testRankingsEmptyForNoScores(): void
+    {
+        $this->assertEmpty($this->lb->rankings('game:empty'));
+    }
+
+    // ── rank ─────────────────────────────────────────────────────────────────
+
+    public function testRankReturnsPositionAndScore(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 500);
+        $this->lb->submit('game:1', 'user:2', 1000);
+        $this->lb->submit('game:1', 'user:3', 750);
+
+        $rank = $this->lb->rank('game:1', 'user:3');
+        $this->assertSame(2, $rank['rank']);
+        $this->assertSame(750, $rank['score']);
+    }
+
+    public function testRankReturnsNullForUnrankedUser(): void
+    {
+        $this->assertNull($this->lb->rank('game:1', 'user:99'));
+    }
+
+    public function testRankFirstPlaceIsOne(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 9999);
+        $this->lb->submit('game:1', 'user:2', 5000);
+        $rank = $this->lb->rank('game:1', 'user:1');
+        $this->assertSame(1, $rank['rank']);
+    }
+
+    public function testRankTiedUsersShareRank(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 1000);
+        $this->lb->submit('game:1', 'user:2', 1000);
+        $rank1 = $this->lb->rank('game:1', 'user:1');
+        $rank2 = $this->lb->rank('game:1', 'user:2');
+        $this->assertSame($rank1['rank'], $rank2['rank']);
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveReturnsTrueWhenFound(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 1000);
+        $this->assertTrue($this->lb->remove('game:1', 'user:1'));
+    }
+
+    public function testRemoveReturnsFalseWhenNotFound(): void
+    {
+        $this->assertFalse($this->lb->remove('game:1', 'user:99'));
+    }
+
+    public function testRemoveDeletesScore(): void
+    {
+        $this->lb->submit('game:1', 'user:1', 1000);
+        $this->lb->remove('game:1', 'user:1');
+        $this->assertNull($this->lb->rank('game:1', 'user:1'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\Leaderboard` — score leaderboard with personal-best retention, ranked listing, tie handling, and personal rank lookup.

## Changes

- `class/xion/Leaderboard.php` — implementation
- `tests/Unit/Xion/LeaderboardTest.php` — 18 tests
- `docs/development/leaderboard.md` — howto
- `docs/field-trials/2026-05-field-trial-61.md` — report

🤖 Generated with [Claude Code](https://claude.com/claude-code)