### PR TITLE
feat(xion): FollowRelation — user follow/unfollow with mutual-follow detection (FT63)

### DIFF
--- a/class/xion/FollowRelation.php
+++ b/class/xion/FollowRelation.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * User follow/unfollow relationship management.
+ *
+ * Manages directed follower–followee relationships between users.
+ * Self-follow is prevented at the application layer.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE follow_relations (
+ *     follower_id VARCHAR(255) NOT NULL,
+ *     followee_id VARCHAR(255) NOT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     PRIMARY KEY (follower_id, followee_id)
+ * );
+ * CREATE INDEX idx_follow_relations_followee ON follow_relations (followee_id);
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $fr = new FollowRelation($pdo);
+ *
+ * $fr->follow('user:1', 'user:2');          // user:1 follows user:2
+ * $fr->isFollowing('user:1', 'user:2');     // true
+ * $fr->followers('user:2');                 // [['follower_id' => 'user:1', 'created_at' => '...']]
+ * $fr->following('user:1');                 // [['followee_id' => 'user:2', 'created_at' => '...']]
+ * $fr->isMutual('user:1', 'user:2');        // false (user:2 hasn't followed back)
+ * $fr->unfollow('user:1', 'user:2');        // true
+ * ```
+ */
+final class FollowRelation
+{
+    private const TABLE = 'follow_relations';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Follow a user.
+     *
+     * Returns true if the follow was created, false if already following or self-follow.
+     *
+     * @param string $followerId The user who is following.
+     * @param string $followeeId The user being followed.
+     */
+    public function follow(string $followerId, string $followeeId): bool
+    {
+        if ($followerId === $followeeId) {
+            return false;
+        }
+
+        $db     = $this->db ?? PdoConnection::getInstance();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $ignore = $driver === 'sqlite' ? 'OR IGNORE' : 'IGNORE';
+
+        $stmt = $db->prepare(
+            'INSERT ' . $ignore . ' INTO ' . $this->table .
+            ' (follower_id, followee_id) VALUES (:follower, :followee)'
+        );
+        $stmt->bindValue(':follower', $followerId, PDO::PARAM_STR);
+        $stmt->bindValue(':followee', $followeeId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Unfollow a user.
+     *
+     * Returns true if the follow was removed, false if not following.
+     *
+     * @param string $followerId The user who is unfollowing.
+     * @param string $followeeId The user being unfollowed.
+     */
+    public function unfollow(string $followerId, string $followeeId): bool
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'DELETE FROM ' . $this->table .
+            ' WHERE follower_id = :follower AND followee_id = :followee'
+        );
+        $stmt->bindValue(':follower', $followerId, PDO::PARAM_STR);
+        $stmt->bindValue(':followee', $followeeId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Check whether $followerId follows $followeeId.
+     */
+    public function isFollowing(string $followerId, string $followeeId): bool
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT 1 FROM ' . $this->table .
+            ' WHERE follower_id = :follower AND followee_id = :followee LIMIT 1'
+        );
+        $stmt->bindValue(':follower', $followerId, PDO::PARAM_STR);
+        $stmt->bindValue(':followee', $followeeId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * List users who follow $userId, ordered by created_at ASC.
+     *
+     * @param  string $userId The user whose followers are returned.
+     * @return list<array{follower_id: string, created_at: string}>
+     */
+    public function followers(string $userId): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT follower_id, created_at FROM ' . $this->table .
+            ' WHERE followee_id = :u ORDER BY created_at ASC, follower_id ASC'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => [
+            'follower_id' => (string)$r['follower_id'],
+            'created_at'  => (string)$r['created_at'],
+        ], $rows);
+    }
+
+    /**
+     * List users that $userId is following, ordered by created_at ASC.
+     *
+     * @param  string $userId The user whose followed list is returned.
+     * @return list<array{followee_id: string, created_at: string}>
+     */
+    public function following(string $userId): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT followee_id, created_at FROM ' . $this->table .
+            ' WHERE follower_id = :u ORDER BY created_at ASC, followee_id ASC'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => [
+            'followee_id' => (string)$r['followee_id'],
+            'created_at'  => (string)$r['created_at'],
+        ], $rows);
+    }
+
+    /**
+     * Check whether $userA and $userB mutually follow each other.
+     */
+    public function isMutual(string $userA, string $userB): bool
+    {
+        return $this->isFollowing($userA, $userB) && $this->isFollowing($userB, $userA);
+    }
+}

--- a/docs/development/follow-relation.md
+++ b/docs/development/follow-relation.md
@@ -1,0 +1,76 @@
+# Follow Relation
+
+`Nene\Xion\FollowRelation` — directed user follow/unfollow relationships with mutual-follow detection.
+
+## Schema
+
+```sql
+CREATE TABLE follow_relations (
+    follower_id VARCHAR(255) NOT NULL,
+    followee_id VARCHAR(255) NOT NULL,
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (follower_id, followee_id)
+);
+CREATE INDEX idx_follow_relations_followee ON follow_relations (followee_id);
+```
+
+The composite primary key `(follower_id, followee_id)` ensures uniqueness and serves as the main lookup index. The secondary index on `followee_id` speeds up `followers()` queries.
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `follow(string $followerId, string $followeeId): bool` | Follow a user. Returns `true` on success, `false` if already following or self-follow attempt. |
+| `unfollow(string $followerId, string $followeeId): bool` | Unfollow a user. Returns `true` if removed, `false` if not following. |
+| `isFollowing(string $followerId, string $followeeId): bool` | Check whether $followerId follows $followeeId. |
+| `followers(string $userId): array` | List users following $userId. |
+| `following(string $userId): array` | List users $userId follows. |
+| `isMutual(string $userA, string $userB): bool` | Check whether both users follow each other. |
+
+## Usage
+
+```php
+$fr = new FollowRelation($pdo);
+
+// Follow
+$fr->follow('user:1', 'user:2');   // true
+$fr->follow('user:1', 'user:2');   // false — already following
+$fr->follow('user:1', 'user:1');   // false — self-follow
+
+// Check
+$fr->isFollowing('user:1', 'user:2');  // true
+$fr->isFollowing('user:2', 'user:1');  // false — directional
+
+// Lists
+$fr->followers('user:2');   // [['follower_id' => 'user:1', 'created_at' => '...']]
+$fr->following('user:1');   // [['followee_id' => 'user:2', 'created_at' => '...']]
+
+// Mutual follow
+$fr->follow('user:2', 'user:1');
+$fr->isMutual('user:1', 'user:2');  // true
+
+// Unfollow
+$fr->unfollow('user:1', 'user:2');  // true
+$fr->unfollow('user:1', 'user:2');  // false — not following
+```
+
+## Key design points
+
+- **Self-follow prevention**: `follow($id, $id)` returns `false` without touching the DB.
+- **Idempotent follow**: `INSERT OR IGNORE` / `INSERT IGNORE` — duplicate follow is a no-op returning `false`.
+- **Directional**: A→B does not imply B→A. `isFollowing` reflects only the stated direction.
+- **`isMutual` symmetry**: `isMutual(A, B) === isMutual(B, A)`.
+- **No framework dependency**: Constructor accepts `?PDO`, falls back to `PdoConnection::getInstance()`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE follow_relations (
+    follower_id VARCHAR(255) NOT NULL,
+    followee_id VARCHAR(255) NOT NULL,
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (follower_id, followee_id)
+)');
+$fr = new FollowRelation($db);
+```

--- a/docs/field-trials/2026-05-field-trial-63.md
+++ b/docs/field-trials/2026-05-field-trial-63.md
@@ -1,0 +1,71 @@
+# Field Trial 63 — User Follow System
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft63-follow-relation`
+**Baseline**: post FT56–FT62 merge wave
+
+## Goal
+
+Establish a user follow/unfollow relationship pattern for NeNe applications. Provide a DB-backed helper that manages directed follower–followee relationships with mutual-follow detection and self-follow prevention.
+
+## What was built
+
+### `Nene\Xion\FollowRelation` (`class/xion/FollowRelation.php`)
+
+DB-backed follow relationship manager providing:
+
+| Method | Description |
+| --- | --- |
+| `follow(string $followerId, string $followeeId): bool` | Follow a user. Returns `false` if already following or self-follow. |
+| `unfollow(string $followerId, string $followeeId): bool` | Unfollow a user. Returns `false` if not following. |
+| `isFollowing(string $followerId, string $followeeId): bool` | Directional follow-status check. |
+| `followers(string $userId): array` | List users following $userId. |
+| `following(string $userId): array` | List users $userId follows. |
+| `isMutual(string $userA, string $userB): bool` | Check mutual follow (both directions). |
+
+Key design points:
+
+- **Composite PK**: `(follower_id, followee_id)` ensures uniqueness and serves as the lookup index.
+- **Self-follow prevention**: Application-layer guard — returns `false` without DB access.
+- **Idempotent follow**: `INSERT OR IGNORE` / `INSERT IGNORE`; duplicate returns `false` via `rowCount()`.
+- **Directional semantics**: A→B and B→A are independent rows.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)` — falls back to `PdoConnection::getInstance()`.
+
+### Tests (`tests/Unit/Xion/FollowRelationTest.php`)
+
+20 unit tests covering:
+
+- follow returns true on first call
+- follow returns false on duplicate
+- follow returns false for self-follow
+- unfollow returns true when following
+- unfollow returns false when not following
+- unfollow removes relationship
+- isFollowing true after follow
+- isFollowing false before follow
+- isFollowing is directional (A→B ≠ B→A)
+- followers returns users following target
+- followers returns empty when none
+- followers result shape (follower_id, created_at)
+- following returns users followed by target
+- following returns empty when none
+- following result shape (followee_id, created_at)
+- isMutual true when both follow
+- isMutual false when only one follows
+- isMutual false when neither follows
+- isMutual is symmetric
+- followers only returns followers of specified user
+
+### Howto (`docs/development/follow-relation.md`)
+
+Covers: schema, API table, usage examples, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`FollowRelation` is a clean `Nene\Xion` helper with PDO injection and no framework coupling. 20 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/FollowRelationTest.php
+++ b/tests/Unit/Xion/FollowRelationTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\FollowRelation;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for FollowRelation using an in-memory SQLite database.
+ */
+final class FollowRelationTest extends TestCase
+{
+    private PDO $db;
+    private FollowRelation $fr;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE follow_relations (
+                follower_id VARCHAR(255) NOT NULL,
+                followee_id VARCHAR(255) NOT NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (follower_id, followee_id)
+            )'
+        );
+        $this->fr = new FollowRelation($this->db);
+    }
+
+    // ── follow ────────────────────────────────────────────────────────────────
+
+    public function testFollowReturnsTrueOnSuccess(): void
+    {
+        $this->assertTrue($this->fr->follow('user:1', 'user:2'));
+    }
+
+    public function testFollowReturnsFalseIfAlreadyFollowing(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $this->assertFalse($this->fr->follow('user:1', 'user:2'));
+    }
+
+    public function testFollowReturnsFalseForSelfFollow(): void
+    {
+        $this->assertFalse($this->fr->follow('user:1', 'user:1'));
+    }
+
+    // ── unfollow ──────────────────────────────────────────────────────────────
+
+    public function testUnfollowReturnsTrueWhenFollowing(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $this->assertTrue($this->fr->unfollow('user:1', 'user:2'));
+    }
+
+    public function testUnfollowReturnsFalseWhenNotFollowing(): void
+    {
+        $this->assertFalse($this->fr->unfollow('user:1', 'user:2'));
+    }
+
+    public function testUnfollowRemovesRelationship(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $this->fr->unfollow('user:1', 'user:2');
+        $this->assertFalse($this->fr->isFollowing('user:1', 'user:2'));
+    }
+
+    // ── isFollowing ───────────────────────────────────────────────────────────
+
+    public function testIsFollowingReturnsTrueAfterFollow(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $this->assertTrue($this->fr->isFollowing('user:1', 'user:2'));
+    }
+
+    public function testIsFollowingReturnsFalseBeforeFollow(): void
+    {
+        $this->assertFalse($this->fr->isFollowing('user:1', 'user:2'));
+    }
+
+    public function testIsFollowingIsDirectional(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        // user:2 has NOT followed user:1
+        $this->assertFalse($this->fr->isFollowing('user:2', 'user:1'));
+    }
+
+    // ── followers ─────────────────────────────────────────────────────────────
+
+    public function testFollowersReturnsUsersFollowingTarget(): void
+    {
+        $this->fr->follow('user:1', 'user:3');
+        $this->fr->follow('user:2', 'user:3');
+        $list = $this->fr->followers('user:3');
+        $this->assertCount(2, $list);
+    }
+
+    public function testFollowersReturnsEmptyWhenNone(): void
+    {
+        $this->assertEmpty($this->fr->followers('user:3'));
+    }
+
+    public function testFollowersResultContainsFollowerIdAndCreatedAt(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $list = $this->fr->followers('user:2');
+        $this->assertSame('user:1', $list[0]['follower_id']);
+        $this->assertArrayHasKey('created_at', $list[0]);
+    }
+
+    // ── following ─────────────────────────────────────────────────────────────
+
+    public function testFollowingReturnsUsersFollowedByTarget(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $this->fr->follow('user:1', 'user:3');
+        $list = $this->fr->following('user:1');
+        $this->assertCount(2, $list);
+    }
+
+    public function testFollowingReturnsEmptyWhenNone(): void
+    {
+        $this->assertEmpty($this->fr->following('user:1'));
+    }
+
+    public function testFollowingResultContainsFolloweeIdAndCreatedAt(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $list = $this->fr->following('user:1');
+        $this->assertSame('user:2', $list[0]['followee_id']);
+        $this->assertArrayHasKey('created_at', $list[0]);
+    }
+
+    // ── isMutual ──────────────────────────────────────────────────────────────
+
+    public function testIsMutualReturnsTrueWhenBothFollow(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $this->fr->follow('user:2', 'user:1');
+        $this->assertTrue($this->fr->isMutual('user:1', 'user:2'));
+    }
+
+    public function testIsMutualReturnsFalseWhenOnlyOneFollows(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $this->assertFalse($this->fr->isMutual('user:1', 'user:2'));
+    }
+
+    public function testIsMutualReturnsFalseWhenNeitherFollows(): void
+    {
+        $this->assertFalse($this->fr->isMutual('user:1', 'user:2'));
+    }
+
+    public function testIsMutualIsSymmetric(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $this->fr->follow('user:2', 'user:1');
+        $this->assertSame(
+            $this->fr->isMutual('user:1', 'user:2'),
+            $this->fr->isMutual('user:2', 'user:1')
+        );
+    }
+
+    // ── isolation ─────────────────────────────────────────────────────────────
+
+    public function testFollowersOnlyReturnsFollowersOfSpecifiedUser(): void
+    {
+        $this->fr->follow('user:1', 'user:2');
+        $this->fr->follow('user:1', 'user:3');
+        // user:2's followers should not include user:3's followers
+        $this->assertCount(1, $this->fr->followers('user:2'));
+        $this->assertSame('user:1', $this->fr->followers('user:2')[0]['follower_id']);
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT63 — User Follow System.

### `Nene\Xion\FollowRelation`

DB-backed directed follow relationship manager:

- `follow/unfollow/isFollowing` — core operations
- `followers/following` — list queries
- `isMutual` — mutual-follow detection
- Self-follow prevention (application layer)
- Idempotent follow via `INSERT OR IGNORE`
- PDO injection pattern

### Tests

20 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)