### PR TITLE
feat(xion): UserPreference — key-value user settings with type casting and default fallback (FT64)

### DIFF
--- a/class/xion/UserPreference.php
+++ b/class/xion/UserPreference.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * User preference key-value store with default-value fallback and type casting.
+ *
+ * Preferences are stored as strings; type casting methods convert on retrieval.
+ * Setting a key to null removes the preference, causing the default to be returned.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE user_preferences (
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     pref_key   VARCHAR(255) NOT NULL,
+ *     pref_value TEXT         NOT NULL,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     PRIMARY KEY (user_id, pref_key)
+ * );
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $prefs = new UserPreference($pdo);
+ *
+ * // Set
+ * $prefs->set('user:1', 'theme', 'dark');
+ * $prefs->set('user:1', 'items_per_page', '20');
+ *
+ * // Get with default fallback
+ * $prefs->get('user:1', 'theme', 'light');          // 'dark'
+ * $prefs->get('user:1', 'language', 'ja');          // 'ja' (default)
+ *
+ * // Type casting
+ * $prefs->getInt('user:1', 'items_per_page', 10);   // 20 (int)
+ * $prefs->getBool('user:1', 'notifications', true); // true (default)
+ *
+ * // Delete (revert to default)
+ * $prefs->delete('user:1', 'theme');
+ *
+ * // All preferences for a user
+ * $prefs->all('user:1');
+ * ```
+ */
+final class UserPreference
+{
+    private const TABLE = 'user_preferences';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Get a preference value.
+     *
+     * Returns the stored string value, or $default if the key is not set.
+     *
+     * @param string      $userId  Application-level user identifier.
+     * @param string      $key     Preference key.
+     * @param string|null $default Default value when key is not set.
+     */
+    public function get(string $userId, string $key, ?string $default = null): ?string
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT pref_value FROM ' . $this->table .
+            ' WHERE user_id = :u AND pref_key = :k LIMIT 1'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':k', $key, PDO::PARAM_STR);
+        $stmt->execute();
+
+        $value = $stmt->fetchColumn();
+        return $value !== false ? (string)$value : $default;
+    }
+
+    /**
+     * Get a preference as an integer.
+     *
+     * @param string $userId  Application-level user identifier.
+     * @param string $key     Preference key.
+     * @param int    $default Default value when key is not set.
+     */
+    public function getInt(string $userId, string $key, int $default = 0): int
+    {
+        $value = $this->get($userId, $key);
+        return $value !== null ? (int)$value : $default;
+    }
+
+    /**
+     * Get a preference as a boolean.
+     *
+     * Stored as '1'/'0', 'true'/'false', 'yes'/'no' (case-insensitive).
+     *
+     * @param string $userId  Application-level user identifier.
+     * @param string $key     Preference key.
+     * @param bool   $default Default value when key is not set.
+     */
+    public function getBool(string $userId, string $key, bool $default = false): bool
+    {
+        $value = $this->get($userId, $key);
+        if ($value === null) {
+            return $default;
+        }
+        return in_array(strtolower($value), ['1', 'true', 'yes'], true);
+    }
+
+    /**
+     * Set a preference value. Creates or overwrites the existing value.
+     *
+     * @param string $userId Application-level user identifier.
+     * @param string $key    Preference key.
+     * @param string $value  Value to store.
+     */
+    public function set(string $userId, string $key, string $value): void
+    {
+        $db     = $this->db ?? PdoConnection::getInstance();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $sql = 'INSERT OR REPLACE INTO ' . $this->table .
+                   ' (user_id, pref_key, pref_value, updated_at)' .
+                   ' VALUES (:u, :k, :v, :t)';
+        } else {
+            $sql = 'INSERT INTO ' . $this->table .
+                   ' (user_id, pref_key, pref_value, updated_at)' .
+                   ' VALUES (:u, :k, :v, :t)' .
+                   ' ON DUPLICATE KEY UPDATE pref_value = VALUES(pref_value), updated_at = VALUES(updated_at)';
+        }
+
+        $updatedAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        $stmt      = $db->prepare($sql);
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':k', $key, PDO::PARAM_STR);
+        $stmt->bindValue(':v', $value, PDO::PARAM_STR);
+        $stmt->bindValue(':t', $updatedAt, PDO::PARAM_STR);
+        $stmt->execute();
+    }
+
+    /**
+     * Delete a preference. After deletion, get() returns the default.
+     *
+     * Returns true if a row was deleted, false if the key did not exist.
+     *
+     * @param string $userId Application-level user identifier.
+     * @param string $key    Preference key to remove.
+     */
+    public function delete(string $userId, string $key): bool
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'DELETE FROM ' . $this->table .
+            ' WHERE user_id = :u AND pref_key = :k'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':k', $key, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Get all preferences for a user as a key→value map.
+     *
+     * @param  string $userId Application-level user identifier.
+     * @return array<string, string>
+     */
+    public function all(string $userId): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT pref_key, pref_value FROM ' . $this->table .
+            ' WHERE user_id = :u ORDER BY pref_key ASC'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+        $rows   = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(string)$row['pref_key']] = (string)$row['pref_value'];
+        }
+        return $result;
+    }
+}

--- a/docs/development/user-preference.md
+++ b/docs/development/user-preference.md
@@ -1,0 +1,92 @@
+# User Preference
+
+`Nene\Xion\UserPreference` — user preference key-value store with default-value fallback and type casting.
+
+## Schema
+
+```sql
+CREATE TABLE user_preferences (
+    user_id    VARCHAR(255) NOT NULL,
+    pref_key   VARCHAR(255) NOT NULL,
+    pref_value TEXT         NOT NULL,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, pref_key)
+);
+```
+
+The composite primary key `(user_id, pref_key)` ensures one value per user per key. `pref_value` is always stored as a string; type conversion happens at the application layer.
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `get(string $userId, string $key, ?string $default = null): ?string` | Get preference as string, or $default if not set. |
+| `getInt(string $userId, string $key, int $default = 0): int` | Get preference cast to int. |
+| `getBool(string $userId, string $key, bool $default = false): bool` | Get preference cast to bool. |
+| `set(string $userId, string $key, string $value): void` | Create or overwrite a preference. |
+| `delete(string $userId, string $key): bool` | Remove a preference. Returns true if deleted. |
+| `all(string $userId): array<string, string>` | Get all preferences as a key→value map. |
+
+## Usage
+
+```php
+$prefs = new UserPreference($pdo);
+
+// Set
+$prefs->set('user:1', 'theme', 'dark');
+$prefs->set('user:1', 'items_per_page', '20');
+$prefs->set('user:1', 'notifications', '1');
+
+// Get with default fallback
+$prefs->get('user:1', 'theme', 'light');            // 'dark' (stored)
+$prefs->get('user:1', 'language', 'ja');            // 'ja' (default — not stored)
+
+// Type casting
+$prefs->getInt('user:1', 'items_per_page', 10);     // 20
+$prefs->getBool('user:1', 'notifications', false);  // true
+
+// Overwrite
+$prefs->set('user:1', 'theme', 'light');
+$prefs->get('user:1', 'theme');                     // 'light'
+
+// Delete (revert to default)
+$prefs->delete('user:1', 'theme');                  // true
+$prefs->get('user:1', 'theme', 'light');            // 'light' (default)
+
+// All preferences
+$prefs->all('user:1');
+// ['items_per_page' => '20', 'notifications' => '1']
+```
+
+## Boolean storage conventions
+
+`getBool()` returns `true` for values `'1'`, `'true'`, `'yes'` (case-insensitive) and `false` for everything else.
+
+Store booleans as `'1'` or `'0'` for consistency:
+
+```php
+$prefs->set('user:1', 'dark_mode', $isDark ? '1' : '0');
+$prefs->getBool('user:1', 'dark_mode');  // true or false
+```
+
+## Key design points
+
+- **String storage**: all values stored as `TEXT`; no type coercion in DB.
+- **Upsert**: `set()` uses `INSERT OR REPLACE` (SQLite) / `INSERT … ON DUPLICATE KEY UPDATE` (MySQL).
+- **Delete = revert to default**: removing a key causes `get()` to return the provided default.
+- **User isolation**: all queries are scoped by `user_id`.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE user_preferences (
+    user_id    VARCHAR(255) NOT NULL,
+    pref_key   VARCHAR(255) NOT NULL,
+    pref_value TEXT         NOT NULL,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, pref_key)
+)');
+$prefs = new UserPreference($db);
+```

--- a/docs/field-trials/2026-05-field-trial-64.md
+++ b/docs/field-trials/2026-05-field-trial-64.md
@@ -1,0 +1,71 @@
+# Field Trial 64 — User Preferences / Settings
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft64-user-preference`
+**Baseline**: post FT63 merge
+
+## Goal
+
+Establish a user-preference persistence pattern for NeNe applications. Provide a key-value store with default fallback and type casting so applications can persist per-user settings without a dedicated ORM.
+
+## What was built
+
+### `Nene\Xion\UserPreference` (`class/xion/UserPreference.php`)
+
+DB-backed key-value preference store providing:
+
+| Method | Description |
+| --- | --- |
+| `get(string $userId, string $key, ?string $default = null): ?string` | Get as string with default fallback. |
+| `getInt(string $userId, string $key, int $default = 0): int` | Get cast to int. |
+| `getBool(string $userId, string $key, bool $default = false): bool` | Get cast to bool. |
+| `set(string $userId, string $key, string $value): void` | Upsert a preference. |
+| `delete(string $userId, string $key): bool` | Delete; returns true if row existed. |
+| `all(string $userId): array<string, string>` | All preferences as key→value map. |
+
+Key design points:
+
+- **Upsert pattern**: `INSERT OR REPLACE` (SQLite) / `INSERT … ON DUPLICATE KEY UPDATE` (MySQL).
+- **Type casting at application layer**: `TEXT` column stores all values as strings; `getInt()`/`getBool()` convert on read.
+- **Boolean conventions**: `getBool()` truthy values: `'1'`, `'true'`, `'yes'` (case-insensitive).
+- **User isolation**: all queries scoped by `user_id`.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/UserPreferenceTest.php`)
+
+20 unit tests covering:
+
+- get returns stored value
+- get returns null default when key not set
+- get returns custom default when key not set
+- get is user-isolated
+- set overwrites existing value
+- set multiple keys
+- getInt returns stored value as int
+- getInt returns default when key not set
+- getInt default is zero when not specified
+- getBool returns true for '1'
+- getBool returns true for 'true'
+- getBool returns true for 'yes'
+- getBool returns false for '0'
+- getBool returns default when key not set
+- delete returns true when key exists
+- delete returns false when key not set
+- delete reverts to default
+- all returns key-value map
+- all returns empty map when no prefs
+- all is user-isolated
+
+### Howto (`docs/development/user-preference.md`)
+
+Covers: schema, API table, usage examples, boolean storage conventions, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`UserPreference` is a clean `Nene\Xion` helper with upsert and PDO injection. 20 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/UserPreferenceTest.php
+++ b/tests/Unit/Xion/UserPreferenceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\UserPreference;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for UserPreference using an in-memory SQLite database.
+ */
+final class UserPreferenceTest extends TestCase
+{
+    private PDO $db;
+    private UserPreference $prefs;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE user_preferences (
+                user_id    VARCHAR(255) NOT NULL,
+                pref_key   VARCHAR(255) NOT NULL,
+                pref_value TEXT         NOT NULL,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (user_id, pref_key)
+            )'
+        );
+        $this->prefs = new UserPreference($this->db);
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsStoredValue(): void
+    {
+        $this->prefs->set('user:1', 'theme', 'dark');
+        $this->assertSame('dark', $this->prefs->get('user:1', 'theme'));
+    }
+
+    public function testGetReturnsNullDefaultWhenKeyNotSet(): void
+    {
+        $this->assertNull($this->prefs->get('user:1', 'theme'));
+    }
+
+    public function testGetReturnsCustomDefaultWhenKeyNotSet(): void
+    {
+        $this->assertSame('light', $this->prefs->get('user:1', 'theme', 'light'));
+    }
+
+    public function testGetIsUserIsolated(): void
+    {
+        $this->prefs->set('user:1', 'theme', 'dark');
+        $this->assertNull($this->prefs->get('user:2', 'theme'));
+    }
+
+    // ── set ───────────────────────────────────────────────────────────────────
+
+    public function testSetOverwritesExistingValue(): void
+    {
+        $this->prefs->set('user:1', 'theme', 'dark');
+        $this->prefs->set('user:1', 'theme', 'light');
+        $this->assertSame('light', $this->prefs->get('user:1', 'theme'));
+    }
+
+    public function testSetMultipleKeys(): void
+    {
+        $this->prefs->set('user:1', 'theme', 'dark');
+        $this->prefs->set('user:1', 'lang', 'ja');
+        $this->assertSame('dark', $this->prefs->get('user:1', 'theme'));
+        $this->assertSame('ja', $this->prefs->get('user:1', 'lang'));
+    }
+
+    // ── getInt ────────────────────────────────────────────────────────────────
+
+    public function testGetIntReturnsStoredValueAsInt(): void
+    {
+        $this->prefs->set('user:1', 'per_page', '20');
+        $this->assertSame(20, $this->prefs->getInt('user:1', 'per_page'));
+    }
+
+    public function testGetIntReturnsDefaultWhenKeyNotSet(): void
+    {
+        $this->assertSame(10, $this->prefs->getInt('user:1', 'per_page', 10));
+    }
+
+    public function testGetIntDefaultIsZeroWhenNotSpecified(): void
+    {
+        $this->assertSame(0, $this->prefs->getInt('user:1', 'per_page'));
+    }
+
+    // ── getBool ───────────────────────────────────────────────────────────────
+
+    public function testGetBoolReturnsTrueFor1(): void
+    {
+        $this->prefs->set('user:1', 'notif', '1');
+        $this->assertTrue($this->prefs->getBool('user:1', 'notif'));
+    }
+
+    public function testGetBoolReturnsTrueForTrue(): void
+    {
+        $this->prefs->set('user:1', 'notif', 'true');
+        $this->assertTrue($this->prefs->getBool('user:1', 'notif'));
+    }
+
+    public function testGetBoolReturnsTrueForYes(): void
+    {
+        $this->prefs->set('user:1', 'notif', 'yes');
+        $this->assertTrue($this->prefs->getBool('user:1', 'notif'));
+    }
+
+    public function testGetBoolReturnsFalseFor0(): void
+    {
+        $this->prefs->set('user:1', 'notif', '0');
+        $this->assertFalse($this->prefs->getBool('user:1', 'notif'));
+    }
+
+    public function testGetBoolReturnsDefaultWhenKeyNotSet(): void
+    {
+        $this->assertTrue($this->prefs->getBool('user:1', 'notif', true));
+        $this->assertFalse($this->prefs->getBool('user:1', 'notif', false));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteReturnsTrueWhenKeyExists(): void
+    {
+        $this->prefs->set('user:1', 'theme', 'dark');
+        $this->assertTrue($this->prefs->delete('user:1', 'theme'));
+    }
+
+    public function testDeleteReturnsFalseWhenKeyNotSet(): void
+    {
+        $this->assertFalse($this->prefs->delete('user:1', 'theme'));
+    }
+
+    public function testDeleteRevertsToDefault(): void
+    {
+        $this->prefs->set('user:1', 'theme', 'dark');
+        $this->prefs->delete('user:1', 'theme');
+        $this->assertSame('light', $this->prefs->get('user:1', 'theme', 'light'));
+    }
+
+    // ── all ───────────────────────────────────────────────────────────────────
+
+    public function testAllReturnsKeyValueMap(): void
+    {
+        $this->prefs->set('user:1', 'theme', 'dark');
+        $this->prefs->set('user:1', 'lang', 'ja');
+        $all = $this->prefs->all('user:1');
+        $this->assertSame('dark', $all['theme']);
+        $this->assertSame('ja', $all['lang']);
+    }
+
+    public function testAllReturnsEmptyMapWhenNoPrefs(): void
+    {
+        $this->assertSame([], $this->prefs->all('user:1'));
+    }
+
+    public function testAllIsUserIsolated(): void
+    {
+        $this->prefs->set('user:1', 'theme', 'dark');
+        $this->assertSame([], $this->prefs->all('user:2'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT64 — User Preferences / Settings.

### `Nene\Xion\UserPreference`

DB-backed per-user key-value preference store:

- `get/set/delete/all` — core operations
- `getInt/getBool` — typed accessors with default fallback
- Upsert via `INSERT OR REPLACE` (SQLite) / `ON DUPLICATE KEY UPDATE` (MySQL)
- User isolation; PDO injection pattern

### Tests

20 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)