### PR TITLE
feat(xion): PersonalAccessToken — user-managed PATs with ability auth and last-used tracking (FT65)

### DIFF
--- a/class/xion/PersonalAccessToken.php
+++ b/class/xion/PersonalAccessToken.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Personal Access Token (PAT) management for user-facing dashboards.
+ *
+ * PATs are long-lived, user-managed credentials — analogous to GitHub PATs.
+ * Each token carries a named set of abilities, and authenticate() records
+ * the last-used timestamp for auditability.
+ *
+ * Token format: `pat_{base64url(32 random bytes)}` — 256-bit entropy, type-prefixed.
+ * Storage: only the SHA-256 hash is stored. The raw token is returned once at creation.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE personal_access_tokens (
+ *     id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     prefix       VARCHAR(16)  NOT NULL,
+ *     token_hash   VARCHAR(64)  NOT NULL UNIQUE,
+ *     user_id      VARCHAR(255) NOT NULL,
+ *     name         VARCHAR(255) NOT NULL DEFAULT '',
+ *     abilities    TEXT         NOT NULL DEFAULT '*',
+ *     expires_at   DATETIME     DEFAULT NULL,
+ *     last_used_at DATETIME     DEFAULT NULL,
+ *     revoked_at   DATETIME     DEFAULT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE INDEX idx_personal_access_tokens_prefix ON personal_access_tokens (prefix);
+ * ```
+ *
+ * ## Abilities
+ *
+ * Abilities are stored as a JSON array, e.g. `["read","write"]`.
+ * The wildcard string `'*'` (stored verbatim) grants all abilities.
+ * `authenticate($token, 'write')` succeeds if abilities contains `'*'` or `'write'`.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $pat = new PersonalAccessToken($pdo);
+ *
+ * // Create
+ * ['rawToken' => $raw, 'id' => $id] = $pat->create('user:42', 'CI deploy', ['deploy']);
+ *
+ * // Authenticate (updates last_used_at)
+ * $token = $pat->authenticate($raw, 'deploy');
+ * if ($token === null) { http_response_code(401); exit; }
+ *
+ * // List
+ * $pat->list('user:42');
+ *
+ * // Revoke
+ * $pat->revoke($id, 'user:42');
+ * ```
+ */
+final class PersonalAccessToken
+{
+    private const TABLE  = 'personal_access_tokens';
+    private const PREFIX = 'pat';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Create a new Personal Access Token.
+     *
+     * @param  string      $userId     Application-level user identifier.
+     * @param  string      $name       Human-readable label (e.g. "GitHub Actions").
+     * @param  list<string>|string $abilities Array of abilities, or '*' for all.
+     * @param  int|null    $expiresIn  Seconds until expiry. Null = no expiry.
+     * @return array{rawToken: string, id: int}
+     */
+    public function create(
+        string $userId,
+        string $name = '',
+        array|string $abilities = '*',
+        ?int $expiresIn = null,
+    ): array {
+        $rawToken  = $this->generate();
+        $prefix    = substr($rawToken, 0, 16);
+        $tokenHash = $this->hash($rawToken);
+        $encoded   = is_array($abilities) ? json_encode($abilities, JSON_THROW_ON_ERROR) : '*';
+        $expiresAt = $expiresIn !== null
+            ? (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+                ->modify('+' . $expiresIn . ' seconds')
+                ->format('Y-m-d H:i:s')
+            : null;
+
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->table .
+            ' (prefix, token_hash, user_id, name, abilities, expires_at)' .
+            ' VALUES (:prefix, :hash, :user, :name, :abilities, :exp)'
+        );
+        $stmt->bindValue(':prefix', $prefix, PDO::PARAM_STR);
+        $stmt->bindValue(':hash', $tokenHash, PDO::PARAM_STR);
+        $stmt->bindValue(':user', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':name', $name, PDO::PARAM_STR);
+        $stmt->bindValue(':abilities', $encoded, PDO::PARAM_STR);
+        $stmt->bindValue(':exp', $expiresAt, $expiresAt !== null ? PDO::PARAM_STR : PDO::PARAM_NULL);
+        $stmt->execute();
+
+        return ['rawToken' => $rawToken, 'id' => (int)$db->lastInsertId()];
+    }
+
+    /**
+     * Authenticate a raw token and check the required ability.
+     *
+     * On success, records last_used_at and returns the token record (without token_hash).
+     * Returns null for any failure (invalid, expired, revoked, insufficient ability).
+     *
+     * @param  string $rawToken        Raw token provided by the client.
+     * @param  string $requiredAbility Ability to check. '*' always passes.
+     * @return array{id:int,user_id:string,name:string,abilities:string,last_used_at:string|null,expires_at:string|null,created_at:string}|null
+     */
+    public function authenticate(string $rawToken, string $requiredAbility = '*'): ?array
+    {
+        if ($rawToken === '') {
+            return null;
+        }
+
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, prefix, token_hash, user_id, name, abilities, expires_at, revoked_at, last_used_at, created_at' .
+            ' FROM ' . $this->table .
+            ' WHERE prefix = :p AND revoked_at IS NULL LIMIT 1'
+        );
+        $stmt->bindValue(':p', substr($rawToken, 0, 16), PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        if (!hash_equals((string)$row['token_hash'], $this->hash($rawToken))) {
+            return null;
+        }
+
+        // Expiry check
+        if ($row['expires_at'] !== null) {
+            $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+            if ((string)$row['expires_at'] <= $now) {
+                return null;
+            }
+        }
+
+        // Ability check
+        if (!$this->hasAbility((string)$row['abilities'], $requiredAbility)) {
+            return null;
+        }
+
+        // Record last used
+        $lastUsedAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        $upd        = $db->prepare(
+            'UPDATE ' . $this->table . ' SET last_used_at = :t WHERE id = :id'
+        );
+        $upd->bindValue(':t', $lastUsedAt, PDO::PARAM_STR);
+        $upd->bindValue(':id', (int)$row['id'], PDO::PARAM_INT);
+        $upd->execute();
+
+        return [
+            'id'           => (int)$row['id'],
+            'user_id'      => (string)$row['user_id'],
+            'name'         => (string)$row['name'],
+            'abilities'    => (string)$row['abilities'],
+            'last_used_at' => $lastUsedAt,
+            'expires_at'   => $row['expires_at'] !== null ? (string)$row['expires_at'] : null,
+            'created_at'   => (string)$row['created_at'],
+        ];
+    }
+
+    /**
+     * List active (non-revoked) tokens for a user. token_hash is never returned.
+     *
+     * @param  string $userId Application-level user identifier.
+     * @return list<array{id:int,name:string,abilities:string,last_used_at:string|null,expires_at:string|null,created_at:string}>
+     */
+    public function list(string $userId): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, name, abilities, last_used_at, expires_at, created_at' .
+            ' FROM ' . $this->table .
+            ' WHERE user_id = :u AND revoked_at IS NULL' .
+            ' ORDER BY id ASC'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => [
+            'id'           => (int)$r['id'],
+            'name'         => (string)$r['name'],
+            'abilities'    => (string)$r['abilities'],
+            'last_used_at' => $r['last_used_at'] !== null ? (string)$r['last_used_at'] : null,
+            'expires_at'   => $r['expires_at'] !== null ? (string)$r['expires_at'] : null,
+            'created_at'   => (string)$r['created_at'],
+        ], $rows);
+    }
+
+    /**
+     * Revoke a token. Only the owning user can revoke their own token.
+     *
+     * Returns true if revoked, false if not found or wrong owner.
+     *
+     * @param int    $tokenId Row ID returned by create().
+     * @param string $userId  Must match the user_id used in create().
+     */
+    public function revoke(int $tokenId, string $userId): bool
+    {
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $revokedAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->table .
+            ' SET revoked_at = :t WHERE id = :id AND user_id = :u AND revoked_at IS NULL'
+        );
+        $stmt->bindValue(':t', $revokedAt, PDO::PARAM_STR);
+        $stmt->bindValue(':id', $tokenId, PDO::PARAM_INT);
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function generate(): string
+    {
+        return self::PREFIX . '_' . rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+
+    public function hash(string $rawToken): string
+    {
+        return hash('sha256', $rawToken);
+    }
+
+    /**
+     * Check whether the stored abilities JSON (or '*') includes $requiredAbility.
+     */
+    private function hasAbility(string $stored, string $requiredAbility): bool
+    {
+        if ($stored === '*' || $requiredAbility === '*') {
+            return true;
+        }
+        $abilities = json_decode($stored, true);
+        if (!is_array($abilities)) {
+            return false;
+        }
+        return in_array('*', $abilities, true) || in_array($requiredAbility, $abilities, true);
+    }
+}

--- a/docs/development/personal-access-token.md
+++ b/docs/development/personal-access-token.md
@@ -1,0 +1,111 @@
+# Personal Access Token
+
+`Nene\Xion\PersonalAccessToken` — user-managed Personal Access Tokens (PATs) with ability-based authorization and last-used tracking.
+
+PATs are long-lived credentials managed by users through a dashboard — analogous to GitHub's Personal Access Tokens. Each token carries a named set of abilities, and every successful authentication records a `last_used_at` timestamp.
+
+## Schema
+
+```sql
+CREATE TABLE personal_access_tokens (
+    id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+    prefix       VARCHAR(16)  NOT NULL,
+    token_hash   VARCHAR(64)  NOT NULL UNIQUE,
+    user_id      VARCHAR(255) NOT NULL,
+    name         VARCHAR(255) NOT NULL DEFAULT '',
+    abilities    TEXT         NOT NULL DEFAULT '*',
+    expires_at   DATETIME     DEFAULT NULL,
+    last_used_at DATETIME     DEFAULT NULL,
+    revoked_at   DATETIME     DEFAULT NULL,
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_personal_access_tokens_prefix ON personal_access_tokens (prefix);
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `create(string $userId, string $name = '', array\|string $abilities = '*', ?int $expiresIn = null): array{rawToken: string, id: int}` | Create a token. Returns raw token once. |
+| `authenticate(string $rawToken, string $requiredAbility = '*'): ?array` | Authenticate and record last used. Returns record or null. |
+| `list(string $userId): array` | Active tokens for a user (no token_hash). |
+| `revoke(int $tokenId, string $userId): bool` | Revoke by owner. Returns true if revoked. |
+
+## Usage
+
+```php
+$pat = new PersonalAccessToken($pdo);
+
+// Create a wildcard token
+['rawToken' => $raw, 'id' => $id] = $pat->create('user:42', 'My token');
+
+// Create an ability-scoped token
+['rawToken' => $raw2] = $pat->create('user:42', 'CI Deploy', ['read', 'deploy']);
+
+// Authenticate (updates last_used_at on success)
+$token = $pat->authenticate($raw, 'read');
+if ($token === null) {
+    http_response_code(401); exit;
+}
+echo $token['user_id'];        // 'user:42'
+echo $token['last_used_at'];   // '2026-05-27 12:34:56'
+
+// List (token_hash never exposed)
+$tokens = $pat->list('user:42');
+// [['id' => 1, 'name' => 'My token', 'abilities' => '*', 'last_used_at' => '...', ...]]
+
+// Revoke
+$pat->revoke($id, 'user:42');  // true
+$pat->revoke($id, 'user:42');  // false — already revoked
+```
+
+## Abilities
+
+Abilities are stored as JSON array text or the literal `'*'` wildcard:
+
+| Stored | Meaning |
+| --- | --- |
+| `*` | All abilities granted |
+| `["read","write"]` | Only `read` and `write` |
+| `["*"]` | All abilities (wildcard in array) |
+
+`authenticate($token, 'deploy')` succeeds if:
+- `abilities === '*'`
+- `requiredAbility === '*'`
+- abilities array contains `'*'` or `'deploy'`
+
+## vs ApiKey (FT56)
+
+| Feature | `ApiKey` | `PersonalAccessToken` |
+| --- | --- | --- |
+| Token prefix | `nk_` | `pat_` |
+| Authorization model | Scope hierarchy (`read⊃write⊃admin`) | Ability list / wildcard |
+| Last-used tracking | No | Yes — updated on every authenticate |
+| Target use case | Server-to-server API access | User-managed dashboard tokens |
+
+## Key design points
+
+- **Hash storage**: SHA-256 of raw token; raw token shown once at creation.
+- **Prefix lookup**: first 16 chars stored for O(1) indexed lookup before hash comparison.
+- **last_used_at**: updated within the same `authenticate()` call, not a separate explicit call.
+- **token_hash never exposed**: neither `authenticate()` nor `list()` include `token_hash` in results.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE personal_access_tokens (
+    id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+    prefix       VARCHAR(16)  NOT NULL,
+    token_hash   VARCHAR(64)  NOT NULL UNIQUE,
+    user_id      VARCHAR(255) NOT NULL,
+    name         VARCHAR(255) NOT NULL DEFAULT \'\',
+    abilities    TEXT         NOT NULL DEFAULT \'*\',
+    expires_at   DATETIME     DEFAULT NULL,
+    last_used_at DATETIME     DEFAULT NULL,
+    revoked_at   DATETIME     DEFAULT NULL,
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+)');
+$pat = new PersonalAccessToken($db);
+```

--- a/docs/field-trials/2026-05-field-trial-65.md
+++ b/docs/field-trials/2026-05-field-trial-65.md
@@ -1,0 +1,74 @@
+# Field Trial 65 — Personal Access Token Management
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft65-personal-access-token`
+**Baseline**: post FT64 merge
+
+## Goal
+
+Establish a user-managed Personal Access Token (PAT) pattern for NeNe applications. Provide ability-based authorization and `last_used_at` tracking for user-facing dashboard credential management.
+
+## What was built
+
+### `Nene\Xion\PersonalAccessToken` (`class/xion/PersonalAccessToken.php`)
+
+DB-backed PAT manager providing:
+
+| Method | Description |
+| --- | --- |
+| `create(string $userId, string $name = '', array\|string $abilities = '*', ?int $expiresIn = null): array{rawToken: string, id: int}` | Create token. Returns raw token once. |
+| `authenticate(string $rawToken, string $requiredAbility = '*'): ?array` | Authenticate + update last_used_at. |
+| `list(string $userId): array` | Active tokens (no token_hash). |
+| `revoke(int $tokenId, string $userId): bool` | Owner-enforced revocation. |
+
+Key design points:
+
+- **Token format**: `pat_{base64url(32 bytes)}` — 256-bit entropy, prefix-differentiated from `nk_` API keys.
+- **Ability model**: JSON array stored as TEXT or literal `'*'` wildcard. `authenticate()` checks for `'*'` in array or exact ability match.
+- **last_used_at**: updated inside `authenticate()` on success — no separate call needed.
+- **Hash storage**: SHA-256; prefix 16-char lookup; raw token shown once.
+- **token_hash never exposed**: neither `authenticate()` nor `list()` results include it.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/PersonalAccessTokenTest.php`)
+
+24 unit tests covering:
+
+- create returns rawToken and id
+- created token starts with `pat_`
+- create with name
+- create with abilities array
+- create with wildcard ability string
+- create with expiry stores expires_at
+- authenticate valid token returns record
+- authenticate empty token returns null
+- authenticate invalid token returns null
+- authenticate revoked token returns null
+- authenticate expired token returns null
+- authenticate updates last_used_at
+- token_hash never exposed in auth result
+- wildcard ability satisfies any requirement
+- specific ability satisfies exact match
+- specific ability fails missing ability
+- wildcard in abilities array satisfies all
+- list returns only owner tokens
+- list excludes revoked tokens
+- list does not expose token_hash
+- list initial last_used_at is null
+- revoke by correct owner returns true
+- revoke by wrong owner returns false
+- revoke already revoked returns false
+
+### Howto (`docs/development/personal-access-token.md`)
+
+Covers: schema, API table, usage examples, abilities model, comparison vs ApiKey (FT56), key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`PersonalAccessToken` is a clean `Nene\Xion` helper. 24 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/PersonalAccessTokenTest.php
+++ b/tests/Unit/Xion/PersonalAccessTokenTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\PersonalAccessToken;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PersonalAccessToken using an in-memory SQLite database.
+ */
+final class PersonalAccessTokenTest extends TestCase
+{
+    private PDO $db;
+    private PersonalAccessToken $pat;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE personal_access_tokens (
+                id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+                prefix       VARCHAR(16)  NOT NULL,
+                token_hash   VARCHAR(64)  NOT NULL UNIQUE,
+                user_id      VARCHAR(255) NOT NULL,
+                name         VARCHAR(255) NOT NULL DEFAULT \'\',
+                abilities    TEXT         NOT NULL DEFAULT \'*\',
+                expires_at   DATETIME     DEFAULT NULL,
+                last_used_at DATETIME     DEFAULT NULL,
+                revoked_at   DATETIME     DEFAULT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->pat = new PersonalAccessToken($this->db);
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsRawTokenAndId(): void
+    {
+        $result = $this->pat->create('user:1');
+        $this->assertArrayHasKey('rawToken', $result);
+        $this->assertArrayHasKey('id', $result);
+        $this->assertIsString($result['rawToken']);
+        $this->assertIsInt($result['id']);
+    }
+
+    public function testCreatedTokenStartsWithPat(): void
+    {
+        $result = $this->pat->create('user:1');
+        $this->assertStringStartsWith('pat_', $result['rawToken']);
+    }
+
+    public function testCreateWithName(): void
+    {
+        $this->pat->create('user:1', 'CI deploy');
+        $list = $this->pat->list('user:1');
+        $this->assertSame('CI deploy', $list[0]['name']);
+    }
+
+    public function testCreateWithAbilitiesArray(): void
+    {
+        $this->pat->create('user:1', 'deploy', ['read', 'write']);
+        $list = $this->pat->list('user:1');
+        $this->assertSame('["read","write"]', $list[0]['abilities']);
+    }
+
+    public function testCreateWithWildcardAbility(): void
+    {
+        $this->pat->create('user:1', 'admin', '*');
+        $list = $this->pat->list('user:1');
+        $this->assertSame('*', $list[0]['abilities']);
+    }
+
+    public function testCreateWithExpiryStoresExpiresAt(): void
+    {
+        $this->pat->create('user:1', expiresIn: 3600);
+        $list = $this->pat->list('user:1');
+        $this->assertNotNull($list[0]['expires_at']);
+    }
+
+    // ── authenticate ──────────────────────────────────────────────────────────
+
+    public function testAuthenticateValidTokenReturnsRecord(): void
+    {
+        ['rawToken' => $raw] = $this->pat->create('user:1', 'my-key', ['read']);
+        $result = $this->pat->authenticate($raw, 'read');
+        $this->assertIsArray($result);
+        $this->assertSame('user:1', $result['user_id']);
+    }
+
+    public function testAuthenticateEmptyTokenReturnsNull(): void
+    {
+        $this->assertNull($this->pat->authenticate('', 'read'));
+    }
+
+    public function testAuthenticateInvalidTokenReturnsNull(): void
+    {
+        $this->pat->create('user:1');
+        $this->assertNull($this->pat->authenticate('pat_invalidtoken', 'read'));
+    }
+
+    public function testAuthenticateRevokedTokenReturnsNull(): void
+    {
+        ['rawToken' => $raw, 'id' => $id] = $this->pat->create('user:1');
+        $this->pat->revoke($id, 'user:1');
+        $this->assertNull($this->pat->authenticate($raw, '*'));
+    }
+
+    public function testAuthenticateExpiredTokenReturnsNull(): void
+    {
+        ['rawToken' => $raw, 'id' => $id] = $this->pat->create('user:1', expiresIn: 3600);
+        $this->db->exec("UPDATE personal_access_tokens SET expires_at = '2000-01-01 00:00:00' WHERE id = {$id}");
+        $this->assertNull($this->pat->authenticate($raw, '*'));
+    }
+
+    public function testAuthenticateUpdatesLastUsedAt(): void
+    {
+        ['rawToken' => $raw, 'id' => $id] = $this->pat->create('user:1');
+        // last_used_at should be null before first use
+        $stmt = $this->db->query("SELECT last_used_at FROM personal_access_tokens WHERE id = {$id}");
+        $this->assertNull($stmt->fetchColumn());
+
+        $this->pat->authenticate($raw, '*');
+        $stmt = $this->db->query("SELECT last_used_at FROM personal_access_tokens WHERE id = {$id}");
+        $this->assertNotNull($stmt->fetchColumn());
+    }
+
+    public function testTokenHashNeverExposedInAuthResult(): void
+    {
+        ['rawToken' => $raw] = $this->pat->create('user:1');
+        $result = $this->pat->authenticate($raw, '*');
+        $this->assertNotNull($result);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertArrayNotHasKey('token_hash', $result);
+    }
+
+    // ── ability check ─────────────────────────────────────────────────────────
+
+    public function testWildcardAbilitySatisfiesAnyRequirement(): void
+    {
+        ['rawToken' => $raw] = $this->pat->create('user:1', abilities: '*');
+        $this->assertNotNull($this->pat->authenticate($raw, 'read'));
+        $this->assertNotNull($this->pat->authenticate($raw, 'write'));
+        $this->assertNotNull($this->pat->authenticate($raw, 'deploy'));
+    }
+
+    public function testSpecificAbilitySatisfiesExactMatch(): void
+    {
+        ['rawToken' => $raw] = $this->pat->create('user:1', abilities: ['read']);
+        $this->assertNotNull($this->pat->authenticate($raw, 'read'));
+    }
+
+    public function testSpecificAbilityFailsMissingAbility(): void
+    {
+        ['rawToken' => $raw] = $this->pat->create('user:1', abilities: ['read']);
+        $this->assertNull($this->pat->authenticate($raw, 'write'));
+    }
+
+    public function testWildcardInAbilitiesArraySatisfiesAll(): void
+    {
+        ['rawToken' => $raw] = $this->pat->create('user:1', abilities: ['*']);
+        $this->assertNotNull($this->pat->authenticate($raw, 'deploy'));
+    }
+
+    // ── list ──────────────────────────────────────────────────────────────────
+
+    public function testListReturnsOnlyOwnerTokens(): void
+    {
+        $this->pat->create('user:1');
+        $this->pat->create('user:2');
+        $this->assertCount(1, $this->pat->list('user:1'));
+    }
+
+    public function testListExcludesRevokedTokens(): void
+    {
+        ['id' => $id] = $this->pat->create('user:1');
+        $this->pat->revoke($id, 'user:1');
+        $this->assertEmpty($this->pat->list('user:1'));
+    }
+
+    public function testListDoesNotExposeTokenHash(): void
+    {
+        $this->pat->create('user:1');
+        $list = $this->pat->list('user:1');
+        $this->assertArrayNotHasKey('token_hash', $list[0]);
+    }
+
+    public function testListInitialLastUsedAtIsNull(): void
+    {
+        $this->pat->create('user:1');
+        $list = $this->pat->list('user:1');
+        $this->assertNull($list[0]['last_used_at']);
+    }
+
+    // ── revoke ────────────────────────────────────────────────────────────────
+
+    public function testRevokeByCorrectOwnerReturnsTrue(): void
+    {
+        ['id' => $id] = $this->pat->create('user:1');
+        $this->assertTrue($this->pat->revoke($id, 'user:1'));
+    }
+
+    public function testRevokeByWrongOwnerReturnsFalse(): void
+    {
+        ['id' => $id] = $this->pat->create('user:1');
+        $this->assertFalse($this->pat->revoke($id, 'user:999'));
+    }
+
+    public function testRevokeAlreadyRevokedReturnsFalse(): void
+    {
+        ['id' => $id] = $this->pat->create('user:1');
+        $this->pat->revoke($id, 'user:1');
+        $this->assertFalse($this->pat->revoke($id, 'user:1'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT65 — Access Token Management (Personal Access Tokens).

### `Nene\Xion\PersonalAccessToken`

User-managed PATs with ability-based auth and last-used tracking:

- `create/authenticate/list/revoke` — core lifecycle
- Ability model: JSON array or `'*'` wildcard
- `last_used_at` updated on every authenticate
- `pat_` prefix differentiates from `nk_` API keys (FT56)
- SHA-256 hash storage; token_hash never exposed

### Tests

24 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)