### PR TITLE
feat(xion): CouponCode — promo code management with usage limits and per-user redemption tracking (FT66)

### DIFF
--- a/class/xion/CouponCode.php
+++ b/class/xion/CouponCode.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Coupon / promo code management with usage limits and per-user redemption tracking.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE coupon_codes (
+ *     id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     code       VARCHAR(64)  NOT NULL UNIQUE,
+ *     discount   INTEGER      NOT NULL DEFAULT 0,
+ *     max_uses   INTEGER      DEFAULT NULL,
+ *     expires_at DATETIME     DEFAULT NULL,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE coupon_redemptions (
+ *     id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     coupon_id   INTEGER      NOT NULL,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     redeemed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (coupon_id, user_id)
+ * );
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $coupons = new CouponCode($pdo);
+ *
+ * // Create a coupon: code, discount value, max uses, TTL
+ * $id = $coupons->create('SUMMER20', 20, maxUses: 100, expiresIn: 86400 * 30);
+ *
+ * // Validate without redeeming
+ * $coupons->isValid('SUMMER20', 'user:1');  // true
+ *
+ * // Redeem (atomic)
+ * $result = $coupons->redeem('SUMMER20', 'user:1');
+ * if ($result === null) {
+ *     // invalid, expired, over limit, or already used
+ * }
+ * echo $result['discount'];  // 20
+ *
+ * // Lookup
+ * $coupons->find('SUMMER20');
+ * ```
+ */
+final class CouponCode
+{
+    private const TABLE_COUPONS      = 'coupon_codes';
+    private const TABLE_REDEMPTIONS  = 'coupon_redemptions';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $tableCoupons     = self::TABLE_COUPONS,
+        private readonly string $tableRedemptions = self::TABLE_REDEMPTIONS,
+    ) {
+    }
+
+    /**
+     * Create a new coupon code.
+     *
+     * @param  string   $code      Unique promo code (e.g. 'SUMMER20').
+     * @param  int      $discount  Discount value (application-defined semantics).
+     * @param  int|null $maxUses   Maximum total redemptions. Null = unlimited.
+     * @param  int|null $expiresIn Seconds until expiry. Null = no expiry.
+     * @return int New coupon ID.
+     */
+    public function create(
+        string $code,
+        int $discount = 0,
+        ?int $maxUses = null,
+        ?int $expiresIn = null,
+    ): int {
+        $expiresAt = $expiresIn !== null
+            ? (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+                ->modify('+' . $expiresIn . ' seconds')
+                ->format('Y-m-d H:i:s')
+            : null;
+
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->tableCoupons .
+            ' (code, discount, max_uses, expires_at)' .
+            ' VALUES (:code, :discount, :max, :exp)'
+        );
+        $stmt->bindValue(':code', $code, PDO::PARAM_STR);
+        $stmt->bindValue(':discount', $discount, PDO::PARAM_INT);
+        $stmt->bindValue(':max', $maxUses, $maxUses !== null ? PDO::PARAM_INT : PDO::PARAM_NULL);
+        $stmt->bindValue(':exp', $expiresAt, $expiresAt !== null ? PDO::PARAM_STR : PDO::PARAM_NULL);
+        $stmt->execute();
+
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Check whether a coupon is valid for a specific user.
+     *
+     * A coupon is valid when:
+     * - The code exists
+     * - It has not expired
+     * - The usage limit has not been reached
+     * - The user has not already redeemed it
+     *
+     * @param string $code   Promo code to validate.
+     * @param string $userId User attempting to use the coupon.
+     */
+    public function isValid(string $code, string $userId): bool
+    {
+        return $this->resolve($code, $userId) !== null;
+    }
+
+    /**
+     * Redeem a coupon for a user.
+     *
+     * Atomically validates and records the redemption. Returns coupon data on success,
+     * null on any failure (invalid code, expired, over limit, already used by this user).
+     *
+     * @param  string $code   Promo code to redeem.
+     * @param  string $userId User redeeming the coupon.
+     * @return array{id:int,code:string,discount:int,max_uses:int|null,expires_at:string|null,redeemed_at:string}|null
+     */
+    public function redeem(string $code, string $userId): ?array
+    {
+        $db = $this->db ?? PdoConnection::getInstance();
+        $db->beginTransaction();
+
+        try {
+            $coupon = $this->resolve($code, $userId, $db);
+            if ($coupon === null) {
+                $db->rollBack();
+                return null;
+            }
+
+            $redeemedAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+            $driver     = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+            $ignore     = $driver === 'sqlite' ? 'OR IGNORE' : 'IGNORE';
+
+            $stmt = $db->prepare(
+                'INSERT ' . $ignore . ' INTO ' . $this->tableRedemptions .
+                ' (coupon_id, user_id, redeemed_at) VALUES (:cid, :uid, :t)'
+            );
+            $stmt->bindValue(':cid', $coupon['id'], PDO::PARAM_INT);
+            $stmt->bindValue(':uid', $userId, PDO::PARAM_STR);
+            $stmt->bindValue(':t', $redeemedAt, PDO::PARAM_STR);
+            $stmt->execute();
+
+            if ($stmt->rowCount() === 0) {
+                // Race condition: another process redeemed first
+                $db->rollBack();
+                return null;
+            }
+
+            $db->commit();
+
+            return [
+                'id'          => $coupon['id'],
+                'code'        => $coupon['code'],
+                'discount'    => $coupon['discount'],
+                'max_uses'    => $coupon['max_uses'],
+                'expires_at'  => $coupon['expires_at'],
+                'redeemed_at' => $redeemedAt,
+            ];
+        } catch (\Throwable $e) {
+            $db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Find a coupon by code, or null if not found.
+     *
+     * @param  string $code Promo code to look up.
+     * @return array{id:int,code:string,discount:int,max_uses:int|null,expires_at:string|null,created_at:string}|null
+     */
+    public function find(string $code): ?array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, code, discount, max_uses, expires_at, created_at' .
+            ' FROM ' . $this->tableCoupons . ' WHERE code = :code LIMIT 1'
+        );
+        $stmt->bindValue(':code', $code, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        return [
+            'id'         => (int)$row['id'],
+            'code'       => (string)$row['code'],
+            'discount'   => (int)$row['discount'],
+            'max_uses'   => $row['max_uses'] !== null ? (int)$row['max_uses'] : null,
+            'expires_at' => $row['expires_at'] !== null ? (string)$row['expires_at'] : null,
+            'created_at' => (string)$row['created_at'],
+        ];
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    /**
+     * Resolve and validate a coupon for a user. Returns null if invalid.
+     *
+     * @return array{id:int,code:string,discount:int,max_uses:int|null,expires_at:string|null}|null
+     */
+    private function resolve(string $code, string $userId, ?PDO $db = null): ?array
+    {
+        $db = $db ?? ($this->db ?? PdoConnection::getInstance());
+
+        $stmt = $db->prepare(
+            'SELECT id, code, discount, max_uses, expires_at' .
+            ' FROM ' . $this->tableCoupons . ' WHERE code = :code LIMIT 1'
+        );
+        $stmt->bindValue(':code', $code, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        // Expiry check
+        if ($row['expires_at'] !== null) {
+            $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+            if ((string)$row['expires_at'] <= $now) {
+                return null;
+            }
+        }
+
+        $couponId = (int)$row['id'];
+
+        // Max uses check
+        if ($row['max_uses'] !== null) {
+            $count = $db->prepare(
+                'SELECT COUNT(*) FROM ' . $this->tableRedemptions . ' WHERE coupon_id = :cid'
+            );
+            $count->bindValue(':cid', $couponId, PDO::PARAM_INT);
+            $count->execute();
+            if ((int)$count->fetchColumn() >= (int)$row['max_uses']) {
+                return null;
+            }
+        }
+
+        // Per-user duplicate check
+        $dup = $db->prepare(
+            'SELECT 1 FROM ' . $this->tableRedemptions .
+            ' WHERE coupon_id = :cid AND user_id = :uid LIMIT 1'
+        );
+        $dup->bindValue(':cid', $couponId, PDO::PARAM_INT);
+        $dup->bindValue(':uid', $userId, PDO::PARAM_STR);
+        $dup->execute();
+        if ($dup->fetchColumn() !== false) {
+            return null;
+        }
+
+        return [
+            'id'         => $couponId,
+            'code'       => (string)$row['code'],
+            'discount'   => (int)$row['discount'],
+            'max_uses'   => $row['max_uses'] !== null ? (int)$row['max_uses'] : null,
+            'expires_at' => $row['expires_at'] !== null ? (string)$row['expires_at'] : null,
+        ];
+    }
+}

--- a/docs/development/coupon-code.md
+++ b/docs/development/coupon-code.md
@@ -1,0 +1,116 @@
+# Coupon Code
+
+`Nene\Xion\CouponCode` — coupon / promo code management with usage limits, expiry, and per-user redemption tracking.
+
+## Schema
+
+```sql
+CREATE TABLE coupon_codes (
+    id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+    code       VARCHAR(64)  NOT NULL UNIQUE,
+    discount   INTEGER      NOT NULL DEFAULT 0,
+    max_uses   INTEGER      DEFAULT NULL,
+    expires_at DATETIME     DEFAULT NULL,
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE coupon_redemptions (
+    id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+    coupon_id   INTEGER      NOT NULL,
+    user_id     VARCHAR(255) NOT NULL,
+    redeemed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (coupon_id, user_id)
+);
+```
+
+The `UNIQUE (coupon_id, user_id)` constraint in `coupon_redemptions` prevents duplicate redemptions at the DB layer.
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `create(string $code, int $discount = 0, ?int $maxUses = null, ?int $expiresIn = null): int` | Create coupon. Returns new ID. |
+| `isValid(string $code, string $userId): bool` | Check validity without redeeming. |
+| `redeem(string $code, string $userId): ?array` | Atomically redeem. Returns coupon data or null on failure. |
+| `find(string $code): ?array` | Get coupon info. Returns null if not found. |
+
+## Usage
+
+```php
+$coupons = new CouponCode($pdo);
+
+// Create
+$id = $coupons->create('SUMMER20', discount: 20, maxUses: 100, expiresIn: 86400 * 30);
+
+// Validate without redeeming
+$coupons->isValid('SUMMER20', 'user:1');  // true
+
+// Redeem (atomic)
+$result = $coupons->redeem('SUMMER20', 'user:1');
+if ($result === null) {
+    // invalid code, expired, over limit, or already used by this user
+    http_response_code(422); exit;
+}
+echo $result['discount'];     // 20
+echo $result['redeemed_at'];  // '2026-05-27 12:34:56'
+
+// Duplicate redemption by same user
+$coupons->redeem('SUMMER20', 'user:1');  // null
+
+// Different user can still redeem
+$coupons->redeem('SUMMER20', 'user:2');  // array (if max_uses not reached)
+
+// Find
+$coupons->find('SUMMER20');
+// ['id' => 1, 'code' => 'SUMMER20', 'discount' => 20, 'max_uses' => 100, ...]
+```
+
+## Validation rules
+
+`redeem()` (and `isValid()`) fails with `null`/`false` when:
+
+| Condition | Result |
+| --- | --- |
+| Code does not exist | null |
+| `expires_at` is in the past | null |
+| `max_uses` reached | null |
+| User already redeemed this code | null |
+
+All failures return null — no specific error code is exposed to prevent oracle attacks.
+
+## `discount` semantics
+
+`discount` is an application-defined integer. CouponCode does not interpret it — your app decides whether it's a percentage, a fixed amount, or a product SKU. This keeps the helper generic.
+
+## Atomicity
+
+`redeem()` wraps validation and the `INSERT` into a transaction. The `UNIQUE (coupon_id, user_id)` constraint + `INSERT OR IGNORE` / `INSERT IGNORE` ensures that concurrent redemption attempts by the same user are idempotent — only one succeeds; the second gets `rowCount() === 0` and returns null.
+
+## Key design points
+
+- **Two tables**: `coupon_codes` (definition) + `coupon_redemptions` (audit trail). Usage count derived from `COUNT(*)`.
+- **Per-user prevention**: DB-enforced `UNIQUE (coupon_id, user_id)`.
+- **Atomic redeem**: transaction + UNIQUE constraint together prevent double-redemption races.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE coupon_codes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    code VARCHAR(64) NOT NULL UNIQUE,
+    discount INTEGER NOT NULL DEFAULT 0,
+    max_uses INTEGER DEFAULT NULL,
+    expires_at DATETIME DEFAULT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+)');
+$db->exec('CREATE TABLE coupon_redemptions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    coupon_id INTEGER NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    redeemed_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (coupon_id, user_id)
+)');
+$coupons = new CouponCode($db);
+```

--- a/docs/field-trials/2026-05-field-trial-66.md
+++ b/docs/field-trials/2026-05-field-trial-66.md
@@ -1,0 +1,69 @@
+# Field Trial 66 — Coupon / Promo Code
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft66-coupon-code`
+**Baseline**: post FT65 merge
+
+## Goal
+
+Establish a coupon/promo-code management pattern for NeNe applications. Handle usage limits, expiry, and per-user duplicate redemption prevention with transactional atomicity.
+
+## What was built
+
+### `Nene\Xion\CouponCode` (`class/xion/CouponCode.php`)
+
+Two-table DB-backed coupon manager providing:
+
+| Method | Description |
+| --- | --- |
+| `create(string $code, int $discount = 0, ?int $maxUses = null, ?int $expiresIn = null): int` | Create coupon. Returns ID. |
+| `isValid(string $code, string $userId): bool` | Validate without redeeming. |
+| `redeem(string $code, string $userId): ?array` | Atomic validate-and-record. |
+| `find(string $code): ?array` | Lookup coupon info. |
+
+Key design points:
+
+- **Two tables**: `coupon_codes` (definition) + `coupon_redemptions` (audit trail per user).
+- **Usage count**: derived from `COUNT(*)` on redemptions — no drift from a counter column.
+- **Per-user prevention**: `UNIQUE (coupon_id, user_id)` DB constraint.
+- **Atomic redeem**: transaction + `INSERT OR IGNORE` — `rowCount() === 0` catches concurrent races.
+- **Generic discount**: integer value; semantics defined by the application.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/CouponCodeTest.php`)
+
+19 unit tests covering:
+
+- create returns id
+- create with discount
+- create with max_uses
+- create with expiry stores expires_at
+- isValid true for valid code
+- isValid false for unknown code
+- isValid false for expired coupon
+- isValid false when max_uses reached
+- isValid false if user already redeemed
+- redeem valid coupon returns array
+- redeem returns null for unknown code
+- redeem returns null for expired coupon
+- redeem returns null if already redeemed by user
+- redeem returns null when max_uses reached
+- different users can redeem same coupon (up to limit)
+- redeem result contains redeemed_at
+- find returns array for existing code
+- find returns null for unknown code
+- find max_uses is null when unlimited
+
+### Howto (`docs/development/coupon-code.md`)
+
+Covers: schema, API table, usage examples, validation rules, discount semantics, atomicity, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`CouponCode` is a clean `Nene\Xion` helper. 19 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/CouponCodeTest.php
+++ b/tests/Unit/Xion/CouponCodeTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\CouponCode;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for CouponCode using an in-memory SQLite database.
+ */
+final class CouponCodeTest extends TestCase
+{
+    private PDO $db;
+    private CouponCode $coupons;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE coupon_codes (
+                id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+                code       VARCHAR(64)  NOT NULL UNIQUE,
+                discount   INTEGER      NOT NULL DEFAULT 0,
+                max_uses   INTEGER      DEFAULT NULL,
+                expires_at DATETIME     DEFAULT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->db->exec(
+            'CREATE TABLE coupon_redemptions (
+                id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+                coupon_id   INTEGER      NOT NULL,
+                user_id     VARCHAR(255) NOT NULL,
+                redeemed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (coupon_id, user_id)
+            )'
+        );
+        $this->coupons = new CouponCode($this->db);
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsId(): void
+    {
+        $id = $this->coupons->create('SAVE10');
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testCreateWithDiscount(): void
+    {
+        $this->coupons->create('SAVE20', 20);
+        $coupon = $this->coupons->find('SAVE20');
+        $this->assertNotNull($coupon);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(20, $coupon['discount']);
+    }
+
+    public function testCreateWithMaxUses(): void
+    {
+        $this->coupons->create('LIMITED', 10, maxUses: 5);
+        $coupon = $this->coupons->find('LIMITED');
+        $this->assertNotNull($coupon);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(5, $coupon['max_uses']);
+    }
+
+    public function testCreateWithExpiryStoresExpiresAt(): void
+    {
+        $this->coupons->create('EXPIRE', 0, expiresIn: 3600);
+        $coupon = $this->coupons->find('EXPIRE');
+        $this->assertNotNull($coupon);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertNotNull($coupon['expires_at']);
+    }
+
+    // ── isValid ───────────────────────────────────────────────────────────────
+
+    public function testIsValidReturnsTrueForValidCode(): void
+    {
+        $this->coupons->create('VALID10');
+        $this->assertTrue($this->coupons->isValid('VALID10', 'user:1'));
+    }
+
+    public function testIsValidReturnsFalseForUnknownCode(): void
+    {
+        $this->assertFalse($this->coupons->isValid('UNKNOWN', 'user:1'));
+    }
+
+    public function testIsValidReturnsFalseForExpiredCoupon(): void
+    {
+        $id = $this->coupons->create('EXPIRED', 0, expiresIn: 3600);
+        $this->db->exec("UPDATE coupon_codes SET expires_at = '2000-01-01 00:00:00' WHERE id = {$id}");
+        $this->assertFalse($this->coupons->isValid('EXPIRED', 'user:1'));
+    }
+
+    public function testIsValidReturnsFalseWhenMaxUsesReached(): void
+    {
+        $this->coupons->create('MAXED', 0, maxUses: 1);
+        $this->coupons->redeem('MAXED', 'user:1');
+        $this->assertFalse($this->coupons->isValid('MAXED', 'user:2'));
+    }
+
+    public function testIsValidReturnsFalseIfUserAlreadyRedeemed(): void
+    {
+        $this->coupons->create('USED');
+        $this->coupons->redeem('USED', 'user:1');
+        $this->assertFalse($this->coupons->isValid('USED', 'user:1'));
+    }
+
+    // ── redeem ────────────────────────────────────────────────────────────────
+
+    public function testRedeemValidCouponReturnsArray(): void
+    {
+        $this->coupons->create('PROMO10', 10);
+        $result = $this->coupons->redeem('PROMO10', 'user:1');
+        $this->assertIsArray($result);
+        $this->assertSame(10, $result['discount']);
+        $this->assertSame('PROMO10', $result['code']);
+    }
+
+    public function testRedeemReturnsNullForUnknownCode(): void
+    {
+        $this->assertNull($this->coupons->redeem('UNKNOWN', 'user:1'));
+    }
+
+    public function testRedeemReturnsNullForExpiredCoupon(): void
+    {
+        $id = $this->coupons->create('OLD', 0, expiresIn: 3600);
+        $this->db->exec("UPDATE coupon_codes SET expires_at = '2000-01-01 00:00:00' WHERE id = {$id}");
+        $this->assertNull($this->coupons->redeem('OLD', 'user:1'));
+    }
+
+    public function testRedeemReturnsNullIfAlreadyRedeemedByUser(): void
+    {
+        $this->coupons->create('ONCE');
+        $this->coupons->redeem('ONCE', 'user:1');
+        $this->assertNull($this->coupons->redeem('ONCE', 'user:1'));
+    }
+
+    public function testRedeemReturnsNullWhenMaxUsesReached(): void
+    {
+        $this->coupons->create('LIMIT1', 0, maxUses: 1);
+        $this->coupons->redeem('LIMIT1', 'user:1');
+        $this->assertNull($this->coupons->redeem('LIMIT1', 'user:2'));
+    }
+
+    public function testDifferentUsersCanRedeemSameCoupon(): void
+    {
+        $this->coupons->create('MULTI', 5, maxUses: 3);
+        $this->assertNotNull($this->coupons->redeem('MULTI', 'user:1'));
+        $this->assertNotNull($this->coupons->redeem('MULTI', 'user:2'));
+        $this->assertNotNull($this->coupons->redeem('MULTI', 'user:3'));
+        $this->assertNull($this->coupons->redeem('MULTI', 'user:4'));
+    }
+
+    public function testRedeemResultContainsRedeemedAt(): void
+    {
+        $this->coupons->create('STAMP');
+        $result = $this->coupons->redeem('STAMP', 'user:1');
+        $this->assertNotNull($result);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertArrayHasKey('redeemed_at', $result);
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsArrayForExistingCode(): void
+    {
+        $this->coupons->create('FIND10', 10);
+        $coupon = $this->coupons->find('FIND10');
+        $this->assertIsArray($coupon);
+        $this->assertSame('FIND10', $coupon['code']);
+    }
+
+    public function testFindReturnsNullForUnknownCode(): void
+    {
+        $this->assertNull($this->coupons->find('NOTFOUND'));
+    }
+
+    public function testFindMaxUsesIsNullWhenUnlimited(): void
+    {
+        $this->coupons->create('UNLIMITED');
+        $coupon = $this->coupons->find('UNLIMITED');
+        $this->assertNotNull($coupon);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertNull($coupon['max_uses']);
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT66 — Coupon / Promo Code.

### `Nene\Xion\CouponCode`

Two-table coupon manager with atomic redemption:

- `create/isValid/redeem/find` — full lifecycle
- Usage limits via `COUNT(*)` on redemptions table
- Per-user duplicate prevention via `UNIQUE (coupon_id, user_id)`
- Atomic `redeem()`: transaction + INSERT OR IGNORE
- Generic `discount` integer — app defines semantics

### Tests

19 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)