### PR TITLE
feat(xion): PointLedger — append-only point/loyalty system with negative-balance prevention (FT67)

### DIFF
--- a/class/xion/PointLedger.php
+++ b/class/xion/PointLedger.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Append-only point / loyalty system with negative-balance prevention.
+ *
+ * Points are stored as signed `delta` entries. The current balance is the
+ * sum of all deltas for a user. The ledger is never modified — only appended.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE point_ledger (
+ *     id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     delta       INTEGER      NOT NULL,
+ *     description VARCHAR(255) NOT NULL DEFAULT '',
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE INDEX idx_point_ledger_user ON point_ledger (user_id);
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ledger = new PointLedger($pdo);
+ *
+ * $ledger->earn('user:1', 100, 'Purchase reward');   // +100
+ * $ledger->earn('user:1', 50,  'Referral bonus');    // +50
+ * $ledger->balance('user:1');                        // 150
+ *
+ * $ledger->spend('user:1', 30, 'Redeem discount');   // true  (balance: 120)
+ * $ledger->spend('user:1', 200, 'Too many');         // false (insufficient)
+ * $ledger->balance('user:1');                        // 120
+ *
+ * $ledger->history('user:1');  // most recent first
+ * ```
+ */
+final class PointLedger
+{
+    private const TABLE = 'point_ledger';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Earn points for a user.
+     *
+     * @param  string $userId      Application-level user identifier.
+     * @param  int    $points      Positive number of points to add.
+     * @param  string $description Optional description for the ledger entry.
+     * @return int New ledger entry ID.
+     * @throws \InvalidArgumentException if $points is not positive.
+     */
+    public function earn(string $userId, int $points, string $description = ''): int
+    {
+        if ($points <= 0) {
+            throw new \InvalidArgumentException(
+                "Points to earn must be positive, got {$points}."
+            );
+        }
+
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $createdAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->table .
+            ' (user_id, delta, description, created_at)' .
+            ' VALUES (:u, :d, :desc, :t)'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':d', $points, PDO::PARAM_INT);
+        $stmt->bindValue(':desc', $description, PDO::PARAM_STR);
+        $stmt->bindValue(':t', $createdAt, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Spend points. Returns false if the user has insufficient balance.
+     *
+     * The check and insert are wrapped in a transaction to prevent races.
+     *
+     * @param  string $userId      Application-level user identifier.
+     * @param  int    $points      Positive number of points to deduct.
+     * @param  string $description Optional description for the ledger entry.
+     * @return bool True if spent successfully, false if balance would go negative.
+     * @throws \InvalidArgumentException if $points is not positive.
+     */
+    public function spend(string $userId, int $points, string $description = ''): bool
+    {
+        if ($points <= 0) {
+            throw new \InvalidArgumentException(
+                "Points to spend must be positive, got {$points}."
+            );
+        }
+
+        $db = $this->db ?? PdoConnection::getInstance();
+        $db->beginTransaction();
+
+        try {
+            $current = $this->balanceQuery($userId, $db);
+            if ($current < $points) {
+                $db->rollBack();
+                return false;
+            }
+
+            $createdAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+            $stmt = $db->prepare(
+                'INSERT INTO ' . $this->table .
+                ' (user_id, delta, description, created_at)' .
+                ' VALUES (:u, :d, :desc, :t)'
+            );
+            $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+            $stmt->bindValue(':d', -$points, PDO::PARAM_INT);
+            $stmt->bindValue(':desc', $description, PDO::PARAM_STR);
+            $stmt->bindValue(':t', $createdAt, PDO::PARAM_STR);
+            $stmt->execute();
+
+            $db->commit();
+            return true;
+        } catch (\Throwable $e) {
+            $db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Get the current point balance for a user.
+     *
+     * Returns 0 if the user has no ledger entries.
+     *
+     * @param string $userId Application-level user identifier.
+     */
+    public function balance(string $userId): int
+    {
+        return $this->balanceQuery($userId, $this->db ?? PdoConnection::getInstance());
+    }
+
+    /**
+     * Get recent ledger entries for a user, newest first.
+     *
+     * @param  string $userId Application-level user identifier.
+     * @param  int    $limit  Maximum number of entries to return (1–100).
+     * @return list<array{id:int,delta:int,description:string,created_at:string}>
+     */
+    public function history(string $userId, int $limit = 20): array
+    {
+        $limit = max(1, min(100, $limit));
+
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, delta, description, created_at' .
+            ' FROM ' . $this->table .
+            ' WHERE user_id = :u' .
+            ' ORDER BY id DESC' .
+            ' LIMIT :lim'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => [
+            'id'          => (int)$r['id'],
+            'delta'       => (int)$r['delta'],
+            'description' => (string)$r['description'],
+            'created_at'  => (string)$r['created_at'],
+        ], $rows);
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function balanceQuery(string $userId, PDO $db): int
+    {
+        $stmt = $db->prepare(
+            'SELECT COALESCE(SUM(delta), 0) FROM ' . $this->table . ' WHERE user_id = :u'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return (int)$stmt->fetchColumn();
+    }
+}

--- a/docs/development/point-ledger.md
+++ b/docs/development/point-ledger.md
@@ -1,0 +1,99 @@
+# Point Ledger
+
+`Nene\Xion\PointLedger` — append-only point / loyalty system with negative-balance prevention.
+
+Points are stored as signed `delta` entries. The balance is the sum of all deltas. The ledger is never modified — only appended.
+
+## Schema
+
+```sql
+CREATE TABLE point_ledger (
+    id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+    user_id     VARCHAR(255) NOT NULL,
+    delta       INTEGER      NOT NULL,
+    description VARCHAR(255) NOT NULL DEFAULT '',
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_point_ledger_user ON point_ledger (user_id);
+```
+
+`delta > 0` for earn entries, `delta < 0` for spend entries.
+Balance = `COALESCE(SUM(delta), 0)` for a given user.
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `earn(string $userId, int $points, string $description = ''): int` | Add points. Returns new ledger entry ID. Throws if $points ≤ 0. |
+| `spend(string $userId, int $points, string $description = ''): bool` | Deduct points atomically. Returns false if balance insufficient. Throws if $points ≤ 0. |
+| `balance(string $userId): int` | Current balance. Returns 0 for new users. |
+| `history(string $userId, int $limit = 20): array` | Recent entries, newest first. Limit clamped to 1–100. |
+
+## Usage
+
+```php
+$ledger = new PointLedger($pdo);
+
+// Earn
+$ledger->earn('user:1', 100, 'Purchase reward');  // balance: 100
+$ledger->earn('user:1', 50,  'Referral bonus');   // balance: 150
+
+// Balance
+$ledger->balance('user:1');  // 150
+
+// Spend
+$ledger->spend('user:1', 30, 'Redeem discount');   // true  (balance: 120)
+$ledger->spend('user:1', 200, 'Too many');          // false (insufficient, balance stays 120)
+
+// History (newest first)
+$ledger->history('user:1');
+// [
+//   ['id' => 4, 'delta' => -30, 'description' => 'Redeem discount', 'created_at' => '...'],
+//   ['id' => 3, 'delta' =>  50, 'description' => 'Referral bonus',  'created_at' => '...'],
+//   ...
+// ]
+
+// Limit history results
+$ledger->history('user:1', 5);
+```
+
+## Negative-balance prevention
+
+`spend()` wraps the balance check and INSERT in a transaction:
+
+1. `SELECT COALESCE(SUM(delta), 0)` — check current balance
+2. If `balance < points` → rollback, return `false`
+3. `INSERT … delta = -$points` — record the spend
+4. Commit
+
+This prevents concurrent spends from overdrawing in single-DB deployments. For high-concurrency MySQL deployments, consider adding `SELECT … FOR UPDATE` before the balance check.
+
+## Append-only design
+
+The ledger table is **never updated or deleted** — only appended. This gives you:
+
+- Full audit trail of all transactions
+- Easy point history for users
+- Simple reconciliation: `SUM(delta)` is the balance at any point in time
+
+## Key design points
+
+- **`delta` sign**: positive for earn, negative for spend. Balance = `SUM(delta)`.
+- **`COALESCE(SUM, 0)`**: balance returns 0 for users with no entries.
+- **`history()` limit**: clamped to 1–100 to prevent runaway queries.
+- **User isolation**: all queries scoped by `user_id`.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE point_ledger (
+    id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+    user_id     VARCHAR(255) NOT NULL,
+    delta       INTEGER      NOT NULL,
+    description VARCHAR(255) NOT NULL DEFAULT \'\',
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+)');
+$ledger = new PointLedger($db);
+```

--- a/docs/field-trials/2026-05-field-trial-67.md
+++ b/docs/field-trials/2026-05-field-trial-67.md
@@ -1,0 +1,71 @@
+# Field Trial 67 — Point / Loyalty System
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft67-point-ledger`
+**Baseline**: post FT66 merge
+
+## Goal
+
+Establish an append-only point / loyalty system pattern for NeNe applications. Provide earn/spend/balance/history operations with negative-balance prevention and a full audit trail.
+
+## What was built
+
+### `Nene\Xion\PointLedger` (`class/xion/PointLedger.php`)
+
+Append-only DB-backed point ledger providing:
+
+| Method | Description |
+| --- | --- |
+| `earn(string $userId, int $points, string $description = ''): int` | Add points. Returns ledger entry ID. |
+| `spend(string $userId, int $points, string $description = ''): bool` | Deduct points atomically. False if insufficient. |
+| `balance(string $userId): int` | Current balance (`SUM(delta)`). |
+| `history(string $userId, int $limit = 20): array` | Recent entries, newest first, limit 1–100. |
+
+Key design points:
+
+- **Append-only**: no UPDATE or DELETE — full audit trail.
+- **`delta` sign**: positive for earn, negative for spend; `COALESCE(SUM(delta), 0)` = balance.
+- **Negative-balance prevention**: `spend()` wraps balance check + INSERT in a transaction.
+- **Validation**: `earn()` and `spend()` throw `InvalidArgumentException` for non-positive amounts.
+- **`history()` limit**: clamped to 1–100.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/PointLedgerTest.php`)
+
+21 unit tests covering:
+
+- earn returns id
+- earn increases balance
+- earn accumulates
+- earn with description
+- earn zero points throws
+- earn negative points throws
+- spend returns true on success
+- spend decreases balance
+- spend returns false when insufficient balance
+- spend does not alter balance when insufficient
+- spend exact balance
+- spend zero points throws
+- spend negative points throws
+- balance is zero for new user
+- balance is user-isolated
+- history returns entries newest first
+- history returns empty for new user
+- history shows positive delta for earn
+- history shows negative delta for spend
+- history limit clamps
+- history is user-isolated
+
+### Howto (`docs/development/point-ledger.md`)
+
+Covers: schema, API table, usage examples, negative-balance prevention mechanism, append-only design rationale, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`PointLedger` is a clean `Nene\Xion` helper. 21 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/PointLedgerTest.php
+++ b/tests/Unit/Xion/PointLedgerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\PointLedger;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PointLedger using an in-memory SQLite database.
+ */
+final class PointLedgerTest extends TestCase
+{
+    private PDO $db;
+    private PointLedger $ledger;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE point_ledger (
+                id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+                user_id     VARCHAR(255) NOT NULL,
+                delta       INTEGER      NOT NULL,
+                description VARCHAR(255) NOT NULL DEFAULT \'\',
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->ledger = new PointLedger($this->db);
+    }
+
+    // ── earn ──────────────────────────────────────────────────────────────────
+
+    public function testEarnReturnsId(): void
+    {
+        $id = $this->ledger->earn('user:1', 100);
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testEarnIncreasesBalance(): void
+    {
+        $this->ledger->earn('user:1', 100);
+        $this->assertSame(100, $this->ledger->balance('user:1'));
+    }
+
+    public function testEarnAccumulates(): void
+    {
+        $this->ledger->earn('user:1', 100);
+        $this->ledger->earn('user:1', 50);
+        $this->assertSame(150, $this->ledger->balance('user:1'));
+    }
+
+    public function testEarnWithDescription(): void
+    {
+        $this->ledger->earn('user:1', 100, 'Purchase reward');
+        $history = $this->ledger->history('user:1');
+        $this->assertSame('Purchase reward', $history[0]['description']);
+    }
+
+    public function testEarnZeroPointsThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ledger->earn('user:1', 0);
+    }
+
+    public function testEarnNegativePointsThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ledger->earn('user:1', -10);
+    }
+
+    // ── spend ─────────────────────────────────────────────────────────────────
+
+    public function testSpendReturnsTrueOnSuccess(): void
+    {
+        $this->ledger->earn('user:1', 100);
+        $this->assertTrue($this->ledger->spend('user:1', 30));
+    }
+
+    public function testSpendDecreasesBalance(): void
+    {
+        $this->ledger->earn('user:1', 100);
+        $this->ledger->spend('user:1', 30);
+        $this->assertSame(70, $this->ledger->balance('user:1'));
+    }
+
+    public function testSpendReturnsFalseWhenInsufficientBalance(): void
+    {
+        $this->ledger->earn('user:1', 50);
+        $this->assertFalse($this->ledger->spend('user:1', 100));
+    }
+
+    public function testSpendDoesNotAlterBalanceWhenInsufficient(): void
+    {
+        $this->ledger->earn('user:1', 50);
+        $this->ledger->spend('user:1', 100);
+        $this->assertSame(50, $this->ledger->balance('user:1'));
+    }
+
+    public function testSpendExactBalance(): void
+    {
+        $this->ledger->earn('user:1', 100);
+        $this->assertTrue($this->ledger->spend('user:1', 100));
+        $this->assertSame(0, $this->ledger->balance('user:1'));
+    }
+
+    public function testSpendZeroPointsThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ledger->spend('user:1', 0);
+    }
+
+    public function testSpendNegativePointsThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ledger->spend('user:1', -5);
+    }
+
+    // ── balance ───────────────────────────────────────────────────────────────
+
+    public function testBalanceIsZeroForNewUser(): void
+    {
+        $this->assertSame(0, $this->ledger->balance('user:1'));
+    }
+
+    public function testBalanceIsUserIsolated(): void
+    {
+        $this->ledger->earn('user:1', 100);
+        $this->assertSame(0, $this->ledger->balance('user:2'));
+    }
+
+    // ── history ───────────────────────────────────────────────────────────────
+
+    public function testHistoryReturnsEntriesNewestFirst(): void
+    {
+        $this->ledger->earn('user:1', 100, 'first');
+        $this->ledger->earn('user:1', 50, 'second');
+        $history = $this->ledger->history('user:1');
+        $this->assertSame('second', $history[0]['description']);
+        $this->assertSame('first', $history[1]['description']);
+    }
+
+    public function testHistoryReturnsEmptyForNewUser(): void
+    {
+        $this->assertEmpty($this->ledger->history('user:1'));
+    }
+
+    public function testHistoryShowsPositiveDeltaForEarn(): void
+    {
+        $this->ledger->earn('user:1', 100);
+        $history = $this->ledger->history('user:1');
+        $this->assertGreaterThan(0, $history[0]['delta']);
+    }
+
+    public function testHistoryShowsNegativeDeltaForSpend(): void
+    {
+        $this->ledger->earn('user:1', 100);
+        $this->ledger->spend('user:1', 30);
+        $history = $this->ledger->history('user:1');
+        $this->assertLessThan(0, $history[0]['delta']);
+    }
+
+    public function testHistoryLimitClampsToMax(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->ledger->earn('user:1', 10, "entry {$i}");
+        }
+        $history = $this->ledger->history('user:1', 3);
+        $this->assertCount(3, $history);
+    }
+
+    public function testHistoryIsUserIsolated(): void
+    {
+        $this->ledger->earn('user:1', 100);
+        $this->assertEmpty($this->ledger->history('user:2'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT67 — Point / Loyalty System.

### `Nene\Xion\PointLedger`

Append-only point ledger:

- `earn/spend/balance/history` — core operations
- Negative-balance prevention via transaction (balance check + INSERT)
- Append-only design: full audit trail, never UPDATE/DELETE
- `delta` sign: positive = earn, negative = spend
- `history()` limit clamped 1–100

### Tests

21 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)