### PR TITLE
feat(xion): TagManager — generic M:N tag system for any entity type (FT68)

### DIFF
--- a/class/xion/TagManager.php
+++ b/class/xion/TagManager.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Generic tag/label system for M:N entity-tag relationships.
+ *
+ * Tags are stored in a `tags` table, and the M:N relationship between
+ * entities and tags is stored in a `tag_attachments` table.
+ * Entity identity is expressed as (entity_type, entity_id) pairs, making
+ * this helper reusable across any entity type in the same application.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE tags (
+ *     id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     name       VARCHAR(100) NOT NULL UNIQUE,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE tag_attachments (
+ *     tag_id      INTEGER      NOT NULL,
+ *     entity_type VARCHAR(64)  NOT NULL,
+ *     entity_id   VARCHAR(255) NOT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     PRIMARY KEY (tag_id, entity_type, entity_id)
+ * );
+ * CREATE INDEX idx_tag_attachments_entity ON tag_attachments (entity_type, entity_id);
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $tags = new TagManager($pdo);
+ *
+ * // Attach tags (creates them if they don't exist)
+ * $tags->attach('post', '42', ['php', 'oop', 'design-patterns']);
+ *
+ * // Get tags for an entity
+ * $tags->tagsFor('post', '42');
+ * // ['design-patterns', 'oop', 'php']
+ *
+ * // Detach a single tag
+ * $tags->detach('post', '42', 'oop');
+ *
+ * // Sync (replace all tags atomically)
+ * $tags->syncTags('post', '42', ['php', 'solid']);
+ *
+ * // Find entities with a tag
+ * $tags->entitiesWithTag('php', 'post');
+ * // ['42', '99', ...]
+ * ```
+ */
+final class TagManager
+{
+    private const TABLE_TAGS        = 'tags';
+    private const TABLE_ATTACHMENTS = 'tag_attachments';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $tableTags        = self::TABLE_TAGS,
+        private readonly string $tableAttachments = self::TABLE_ATTACHMENTS,
+    ) {
+    }
+
+    /**
+     * Attach one or more tags to an entity.
+     *
+     * Tags are created automatically if they don't exist. Already-attached tags
+     * are silently skipped (idempotent).
+     *
+     * @param string        $entityType Entity type identifier (e.g. 'post', 'product').
+     * @param string        $entityId   Entity ID.
+     * @param list<string>  $tagNames   Tag names to attach.
+     */
+    public function attach(string $entityType, string $entityId, array $tagNames): void
+    {
+        if ($tagNames === []) {
+            return;
+        }
+
+        $db     = $this->db ?? PdoConnection::getInstance();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $ignore = $driver === 'sqlite' ? 'OR IGNORE' : 'IGNORE';
+
+        foreach ($tagNames as $name) {
+            $tagId = $this->findOrCreateTag($name, $db, $ignore);
+
+            $stmt = $db->prepare(
+                'INSERT ' . $ignore . ' INTO ' . $this->tableAttachments .
+                ' (tag_id, entity_type, entity_id)' .
+                ' VALUES (:tid, :etype, :eid)'
+            );
+            $stmt->bindValue(':tid', $tagId, PDO::PARAM_INT);
+            $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
+            $stmt->bindValue(':eid', $entityId, PDO::PARAM_STR);
+            $stmt->execute();
+        }
+    }
+
+    /**
+     * Detach a single tag from an entity.
+     *
+     * Returns true if detached, false if the tag was not attached.
+     *
+     * @param string $entityType Entity type identifier.
+     * @param string $entityId   Entity ID.
+     * @param string $tagName    Tag name to remove.
+     */
+    public function detach(string $entityType, string $entityId, string $tagName): bool
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'DELETE FROM ' . $this->tableAttachments .
+            ' WHERE entity_type = :etype AND entity_id = :eid' .
+            ' AND tag_id = (SELECT id FROM ' . $this->tableTags . ' WHERE name = :name LIMIT 1)'
+        );
+        $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
+        $stmt->bindValue(':eid', $entityId, PDO::PARAM_STR);
+        $stmt->bindValue(':name', $tagName, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Sync tags for an entity: replaces all existing tags with the given set.
+     *
+     * Tags not in $tagNames are removed; new tags are created and attached.
+     * Passing an empty array removes all tags.
+     *
+     * @param string        $entityType Entity type identifier.
+     * @param string        $entityId   Entity ID.
+     * @param list<string>  $tagNames   New complete set of tag names.
+     */
+    public function syncTags(string $entityType, string $entityId, array $tagNames): void
+    {
+        $db = $this->db ?? PdoConnection::getInstance();
+        $db->beginTransaction();
+
+        try {
+            // Remove all current attachments
+            $del = $db->prepare(
+                'DELETE FROM ' . $this->tableAttachments .
+                ' WHERE entity_type = :etype AND entity_id = :eid'
+            );
+            $del->bindValue(':etype', $entityType, PDO::PARAM_STR);
+            $del->bindValue(':eid', $entityId, PDO::PARAM_STR);
+            $del->execute();
+
+            // Re-attach the new set
+            if ($tagNames !== []) {
+                $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+                $ignore = $driver === 'sqlite' ? 'OR IGNORE' : 'IGNORE';
+
+                foreach ($tagNames as $name) {
+                    $tagId = $this->findOrCreateTag($name, $db, $ignore);
+
+                    $ins = $db->prepare(
+                        'INSERT ' . $ignore . ' INTO ' . $this->tableAttachments .
+                        ' (tag_id, entity_type, entity_id) VALUES (:tid, :etype, :eid)'
+                    );
+                    $ins->bindValue(':tid', $tagId, PDO::PARAM_INT);
+                    $ins->bindValue(':etype', $entityType, PDO::PARAM_STR);
+                    $ins->bindValue(':eid', $entityId, PDO::PARAM_STR);
+                    $ins->execute();
+                }
+            }
+
+            $db->commit();
+        } catch (\Throwable $e) {
+            $db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Get all tag names attached to an entity, sorted alphabetically.
+     *
+     * @param  string $entityType Entity type identifier.
+     * @param  string $entityId   Entity ID.
+     * @return list<string>
+     */
+    public function tagsFor(string $entityType, string $entityId): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT t.name FROM ' . $this->tableTags . ' t' .
+            ' INNER JOIN ' . $this->tableAttachments . ' a ON a.tag_id = t.id' .
+            ' WHERE a.entity_type = :etype AND a.entity_id = :eid' .
+            ' ORDER BY t.name ASC'
+        );
+        $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
+        $stmt->bindValue(':eid', $entityId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'name');
+    }
+
+    /**
+     * Get entity IDs that have a specific tag, optionally filtered by entity type.
+     *
+     * @param  string      $tagName    Tag name to search.
+     * @param  string|null $entityType Limit to this entity type. Null = all types.
+     * @return list<string>
+     */
+    public function entitiesWithTag(string $tagName, ?string $entityType = null): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $sql  = 'SELECT a.entity_id FROM ' . $this->tableAttachments . ' a' .
+                ' INNER JOIN ' . $this->tableTags . ' t ON t.id = a.tag_id' .
+                ' WHERE t.name = :name';
+
+        if ($entityType !== null) {
+            $sql .= ' AND a.entity_type = :etype';
+        }
+
+        $sql .= ' ORDER BY a.entity_id ASC';
+
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':name', $tagName, PDO::PARAM_STR);
+        if ($entityType !== null) {
+            $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
+        }
+        $stmt->execute();
+
+        return array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'entity_id');
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    /**
+     * Find a tag by name or create it. Returns the tag ID.
+     */
+    private function findOrCreateTag(string $name, PDO $db, string $ignore): int
+    {
+        $ins = $db->prepare(
+            'INSERT ' . $ignore . ' INTO ' . $this->tableTags . ' (name) VALUES (:name)'
+        );
+        $ins->bindValue(':name', $name, PDO::PARAM_STR);
+        $ins->execute();
+
+        $sel = $db->prepare('SELECT id FROM ' . $this->tableTags . ' WHERE name = :name LIMIT 1');
+        $sel->bindValue(':name', $name, PDO::PARAM_STR);
+        $sel->execute();
+
+        return (int)$sel->fetchColumn();
+    }
+}

--- a/docs/development/tag-manager.md
+++ b/docs/development/tag-manager.md
@@ -1,0 +1,90 @@
+# Tag Manager
+
+`Nene\Xion\TagManager` — generic M:N tag/label system for any entity type.
+
+Tags are reusable and shared across entities. A tag named `'php'` exists once in the `tags` table and can be attached to any number of posts, products, tasks, etc. Entity identity uses `(entity_type, entity_id)` pairs to keep the helper application-agnostic.
+
+## Schema
+
+```sql
+CREATE TABLE tags (
+    id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+    name       VARCHAR(100) NOT NULL UNIQUE,
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE tag_attachments (
+    tag_id      INTEGER      NOT NULL,
+    entity_type VARCHAR(64)  NOT NULL,
+    entity_id   VARCHAR(255) NOT NULL,
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (tag_id, entity_type, entity_id)
+);
+CREATE INDEX idx_tag_attachments_entity ON tag_attachments (entity_type, entity_id);
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `attach(string $entityType, string $entityId, array $tagNames): void` | Attach tags. Creates tags if they don't exist. Idempotent. |
+| `detach(string $entityType, string $entityId, string $tagName): bool` | Remove one tag. Returns true if detached. |
+| `syncTags(string $entityType, string $entityId, array $tagNames): void` | Replace all tags atomically. Empty array removes all. |
+| `tagsFor(string $entityType, string $entityId): array` | Tag names for an entity (alphabetical). |
+| `entitiesWithTag(string $tagName, ?string $entityType = null): array` | Entity IDs with the given tag, optionally filtered by type. |
+
+## Usage
+
+```php
+$tags = new TagManager($pdo);
+
+// Attach (creates tags automatically, idempotent)
+$tags->attach('post', '42', ['php', 'oop', 'design-patterns']);
+
+// Get tags for a post
+$tags->tagsFor('post', '42');
+// ['design-patterns', 'oop', 'php']  ← alphabetical
+
+// Detach one tag
+$tags->detach('post', '42', 'oop');  // true
+
+// Sync (replace all)
+$tags->syncTags('post', '42', ['php', 'solid']);
+// result: ['php', 'solid']
+
+// Find posts with a tag
+$tags->entitiesWithTag('php', 'post');
+// ['42', '99', ...]
+
+// Cross-type (all entity types with this tag)
+$tags->entitiesWithTag('php');
+// ['42', '99', 'product:7', ...]
+```
+
+## Key design points
+
+- **Tag reuse**: a tag name exists once in `tags`; `attach()` uses `INSERT OR IGNORE` for the tag row.
+- **Idempotent attach**: duplicate `(tag_id, entity_type, entity_id)` rows are silently ignored.
+- **`syncTags()` atomicity**: DELETE all existing + INSERT new in a transaction.
+- **Type isolation**: `tagsFor('post', '1')` and `tagsFor('product', '1')` are independent.
+- **`entitiesWithTag()` type filter**: pass `$entityType = null` to query across all types.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE tags (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name VARCHAR(100) NOT NULL UNIQUE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+)');
+$db->exec('CREATE TABLE tag_attachments (
+    tag_id INTEGER NOT NULL,
+    entity_type VARCHAR(64) NOT NULL,
+    entity_id VARCHAR(255) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (tag_id, entity_type, entity_id)
+)');
+$tags = new TagManager($db);
+```

--- a/docs/field-trials/2026-05-field-trial-68.md
+++ b/docs/field-trials/2026-05-field-trial-68.md
@@ -1,0 +1,67 @@
+# Field Trial 68 — Tag / Label System
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft68-tag-manager`
+**Baseline**: post FT67 merge
+
+## Goal
+
+Establish a generic M:N tag/label pattern for NeNe applications. Provide an entity-type-agnostic helper for attaching, detaching, and querying tags across any entity type.
+
+## What was built
+
+### `Nene\Xion\TagManager` (`class/xion/TagManager.php`)
+
+Two-table M:N tag helper providing:
+
+| Method | Description |
+| --- | --- |
+| `attach(string $entityType, string $entityId, array $tagNames): void` | Attach tags; creates if absent; idempotent. |
+| `detach(string $entityType, string $entityId, string $tagName): bool` | Remove one tag attachment. |
+| `syncTags(string $entityType, string $entityId, array $tagNames): void` | Atomically replace all tags. |
+| `tagsFor(string $entityType, string $entityId): array` | Tag names (alphabetical). |
+| `entitiesWithTag(string $tagName, ?string $entityType = null): array` | Entity IDs with a given tag. |
+
+Key design points:
+
+- **Tag reuse**: single `tags` row per name shared across entity types.
+- **Idempotent attach**: `INSERT OR IGNORE` / `INSERT IGNORE` on both tables.
+- **`syncTags()` atomicity**: DELETE all + INSERT new in a transaction.
+- **`(entity_type, entity_id)`**: entity-agnostic design — one helper for any model.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/TagManagerTest.php`)
+
+17 unit tests covering:
+
+- attach creates tags and returns them for entity
+- attach is idempotent
+- attach reuses existing tag row
+- attach empty array does nothing
+- detach returns true when tag was attached
+- detach returns false when tag was not attached
+- detach removes tag
+- syncTags replaces existing tags
+- syncTags with empty array removes all tags
+- syncTags only affects target entity
+- tagsFor returns alphabetically sorted
+- tagsFor returns empty for untagged entity
+- tagsFor is entity-type-isolated
+- entitiesWithTag returns entity IDs
+- entitiesWithTag filters by entity type
+- entitiesWithTag without type filter returns all
+- entitiesWithTag returns empty for unused tag
+
+### Howto (`docs/development/tag-manager.md`)
+
+Covers: schema, API table, usage examples, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`TagManager` is a clean `Nene\Xion` helper. 17 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/TagManagerTest.php
+++ b/tests/Unit/Xion/TagManagerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\TagManager;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for TagManager using an in-memory SQLite database.
+ */
+final class TagManagerTest extends TestCase
+{
+    private PDO $db;
+    private TagManager $tags;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE tags (
+                id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+                name       VARCHAR(100) NOT NULL UNIQUE,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->db->exec(
+            'CREATE TABLE tag_attachments (
+                tag_id      INTEGER      NOT NULL,
+                entity_type VARCHAR(64)  NOT NULL,
+                entity_id   VARCHAR(255) NOT NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (tag_id, entity_type, entity_id)
+            )'
+        );
+        $this->tags = new TagManager($this->db);
+    }
+
+    // ── attach ────────────────────────────────────────────────────────────────
+
+    public function testAttachCreatesTagsAndReturnsThemForEntity(): void
+    {
+        $this->tags->attach('post', '1', ['php', 'oop']);
+        $this->assertSame(['oop', 'php'], $this->tags->tagsFor('post', '1'));
+    }
+
+    public function testAttachIsIdempotent(): void
+    {
+        $this->tags->attach('post', '1', ['php']);
+        $this->tags->attach('post', '1', ['php']);
+        $this->assertCount(1, $this->tags->tagsFor('post', '1'));
+    }
+
+    public function testAttachReusesExistingTag(): void
+    {
+        $this->tags->attach('post', '1', ['php']);
+        $this->tags->attach('post', '2', ['php']);
+        // Both posts share the same tag row
+        $stmt = $this->db->query('SELECT COUNT(*) FROM tags WHERE name = \'php\'');
+        $this->assertSame(1, (int)$stmt->fetchColumn());
+    }
+
+    public function testAttachEmptyArrayDoesNothing(): void
+    {
+        $this->tags->attach('post', '1', []);
+        $this->assertEmpty($this->tags->tagsFor('post', '1'));
+    }
+
+    // ── detach ────────────────────────────────────────────────────────────────
+
+    public function testDetachReturnsTrueWhenTagWasAttached(): void
+    {
+        $this->tags->attach('post', '1', ['php']);
+        $this->assertTrue($this->tags->detach('post', '1', 'php'));
+    }
+
+    public function testDetachReturnsFalseWhenTagWasNotAttached(): void
+    {
+        $this->assertFalse($this->tags->detach('post', '1', 'php'));
+    }
+
+    public function testDetachRemovesTag(): void
+    {
+        $this->tags->attach('post', '1', ['php', 'oop']);
+        $this->tags->detach('post', '1', 'oop');
+        $this->assertSame(['php'], $this->tags->tagsFor('post', '1'));
+    }
+
+    // ── syncTags ──────────────────────────────────────────────────────────────
+
+    public function testSyncTagsReplacesExistingTags(): void
+    {
+        $this->tags->attach('post', '1', ['php', 'oop']);
+        $this->tags->syncTags('post', '1', ['solid', 'tdd']);
+        $this->assertSame(['solid', 'tdd'], $this->tags->tagsFor('post', '1'));
+    }
+
+    public function testSyncTagsWithEmptyArrayRemovesAllTags(): void
+    {
+        $this->tags->attach('post', '1', ['php']);
+        $this->tags->syncTags('post', '1', []);
+        $this->assertEmpty($this->tags->tagsFor('post', '1'));
+    }
+
+    public function testSyncTagsOnlyAffectsTargetEntity(): void
+    {
+        $this->tags->attach('post', '1', ['php']);
+        $this->tags->attach('post', '2', ['php']);
+        $this->tags->syncTags('post', '1', ['solid']);
+        // post:2 should be unchanged
+        $this->assertSame(['php'], $this->tags->tagsFor('post', '2'));
+    }
+
+    // ── tagsFor ───────────────────────────────────────────────────────────────
+
+    public function testTagsForReturnsAlphabeticallySorted(): void
+    {
+        $this->tags->attach('post', '1', ['zzz', 'aaa', 'mmm']);
+        $this->assertSame(['aaa', 'mmm', 'zzz'], $this->tags->tagsFor('post', '1'));
+    }
+
+    public function testTagsForReturnsEmptyForUntaggedEntity(): void
+    {
+        $this->assertEmpty($this->tags->tagsFor('post', '1'));
+    }
+
+    public function testTagsForIsEntityTypeIsolated(): void
+    {
+        $this->tags->attach('post', '1', ['php']);
+        $this->assertEmpty($this->tags->tagsFor('product', '1'));
+    }
+
+    // ── entitiesWithTag ───────────────────────────────────────────────────────
+
+    public function testEntitiesWithTagReturnsEntityIds(): void
+    {
+        $this->tags->attach('post', '1', ['php']);
+        $this->tags->attach('post', '2', ['php']);
+        $this->assertSame(['1', '2'], $this->tags->entitiesWithTag('php', 'post'));
+    }
+
+    public function testEntitiesWithTagFiltersByEntityType(): void
+    {
+        $this->tags->attach('post', '1', ['php']);
+        $this->tags->attach('product', '99', ['php']);
+        $this->assertSame(['1'], $this->tags->entitiesWithTag('php', 'post'));
+    }
+
+    public function testEntitiesWithTagWithoutTypeFilterReturnsAll(): void
+    {
+        $this->tags->attach('post', '1', ['php']);
+        $this->tags->attach('product', '99', ['php']);
+        $entities = $this->tags->entitiesWithTag('php');
+        $this->assertCount(2, $entities);
+    }
+
+    public function testEntitiesWithTagReturnsEmptyForUnusedTag(): void
+    {
+        $this->assertEmpty($this->tags->entitiesWithTag('nonexistent', 'post'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT68 — Tag / Label System.

### `Nene\Xion\TagManager`

Entity-agnostic M:N tag helper:

- `attach/detach/syncTags` — lifecycle
- `tagsFor/entitiesWithTag` — queries
- Tag reuse across entity types; idempotent attach
- `syncTags()` atomic via transaction
- `(entity_type, entity_id)` design — reusable for any model

### Tests

17 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)