### PR TITLE
feat(xion): CommentThread — threaded comments with depth limit and soft delete (FT69)

### DIFF
--- a/class/xion/CommentThread.php
+++ b/class/xion/CommentThread.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Threaded comment system with nesting depth limit and soft delete.
+ *
+ * Comments belong to an entity identified by (entity_type, entity_id).
+ * Replies are linked via parent_id. Maximum nesting depth is enforced
+ * to prevent runaway tree growth.
+ *
+ * Deleted comments have their body replaced with a placeholder and
+ * their author_id set to null, but the row is retained so reply
+ * threading is preserved.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE comments (
+ *     id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     entity_type VARCHAR(64)  NOT NULL,
+ *     entity_id   VARCHAR(255) NOT NULL,
+ *     parent_id   INTEGER      DEFAULT NULL,
+ *     author_id   VARCHAR(255),
+ *     body        TEXT         NOT NULL,
+ *     depth       INTEGER      NOT NULL DEFAULT 0,
+ *     deleted_at  DATETIME     DEFAULT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE INDEX idx_comments_entity ON comments (entity_type, entity_id, parent_id);
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ct = new CommentThread($pdo);
+ *
+ * // Top-level comment
+ * $id1 = $ct->post('article', '42', 'user:1', 'Great article!');
+ *
+ * // Reply (depth = parent.depth + 1)
+ * $id2 = $ct->reply($id1, 'user:2', 'Thanks!');
+ *
+ * // List (non-deleted, ordered by id ASC)
+ * $ct->list('article', '42');
+ *
+ * // Soft delete (body replaced, author_id nulled)
+ * $ct->softDelete($id1, 'user:1');
+ * ```
+ */
+final class CommentThread
+{
+    private const TABLE     = 'comments';
+    private const MAX_DEPTH = 5;
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table    = self::TABLE,
+        private readonly int $maxDepth    = self::MAX_DEPTH,
+    ) {
+    }
+
+    /**
+     * Post a top-level comment on an entity.
+     *
+     * @param  string $entityType Entity type (e.g. 'article', 'product').
+     * @param  string $entityId   Entity ID.
+     * @param  string $authorId   Author identifier.
+     * @param  string $body       Comment body.
+     * @return int New comment ID.
+     * @throws \InvalidArgumentException if $body is empty.
+     */
+    public function post(string $entityType, string $entityId, string $authorId, string $body): int
+    {
+        $this->assertBody($body);
+
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $createdAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->table .
+            ' (entity_type, entity_id, author_id, body, depth, created_at)' .
+            ' VALUES (:etype, :eid, :author, :body, 0, :t)'
+        );
+        $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
+        $stmt->bindValue(':eid', $entityId, PDO::PARAM_STR);
+        $stmt->bindValue(':author', $authorId, PDO::PARAM_STR);
+        $stmt->bindValue(':body', $body, PDO::PARAM_STR);
+        $stmt->bindValue(':t', $createdAt, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Reply to an existing comment.
+     *
+     * @param  int    $parentId Target comment ID to reply to.
+     * @param  string $authorId Author identifier.
+     * @param  string $body     Reply body.
+     * @return int New comment ID.
+     * @throws \InvalidArgumentException if $body is empty, parent not found, or max depth exceeded.
+     */
+    public function reply(int $parentId, string $authorId, string $body): int
+    {
+        $this->assertBody($body);
+
+        $db     = $this->db ?? PdoConnection::getInstance();
+        $parent = $this->findComment($parentId, $db);
+
+        if ($parent === null) {
+            throw new \InvalidArgumentException("Parent comment {$parentId} not found.");
+        }
+
+        $newDepth = (int)$parent['depth'] + 1;
+        if ($newDepth > $this->maxDepth) {
+            throw new \InvalidArgumentException(
+                "Maximum comment depth ({$this->maxDepth}) reached."
+            );
+        }
+
+        $createdAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->table .
+            ' (entity_type, entity_id, parent_id, author_id, body, depth, created_at)' .
+            ' VALUES (:etype, :eid, :pid, :author, :body, :depth, :t)'
+        );
+        $stmt->bindValue(':etype', $parent['entity_type'], PDO::PARAM_STR);
+        $stmt->bindValue(':eid', $parent['entity_id'], PDO::PARAM_STR);
+        $stmt->bindValue(':pid', $parentId, PDO::PARAM_INT);
+        $stmt->bindValue(':author', $authorId, PDO::PARAM_STR);
+        $stmt->bindValue(':body', $body, PDO::PARAM_STR);
+        $stmt->bindValue(':depth', $newDepth, PDO::PARAM_INT);
+        $stmt->bindValue(':t', $createdAt, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Soft-delete a comment. Only the author can delete their own comment.
+     *
+     * The body is replaced with a placeholder and author_id is nulled.
+     * The row is retained to preserve reply threading.
+     *
+     * Returns true if deleted, false if not found or wrong author.
+     *
+     * @param int    $commentId Comment to delete.
+     * @param string $authorId  Must match the comment's author_id.
+     */
+    public function softDelete(int $commentId, string $authorId): bool
+    {
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $deletedAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->table .
+            ' SET body = \'[deleted]\', author_id = NULL, deleted_at = :t' .
+            ' WHERE id = :id AND author_id = :author AND deleted_at IS NULL'
+        );
+        $stmt->bindValue(':t', $deletedAt, PDO::PARAM_STR);
+        $stmt->bindValue(':id', $commentId, PDO::PARAM_INT);
+        $stmt->bindValue(':author', $authorId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List all comments for an entity, ordered by id ASC (includes soft-deleted).
+     *
+     * @param  string $entityType Entity type.
+     * @param  string $entityId   Entity ID.
+     * @return list<array{id:int,parent_id:int|null,author_id:string|null,body:string,depth:int,deleted_at:string|null,created_at:string}>
+     */
+    public function list(string $entityType, string $entityId): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, parent_id, author_id, body, depth, deleted_at, created_at' .
+            ' FROM ' . $this->table .
+            ' WHERE entity_type = :etype AND entity_id = :eid' .
+            ' ORDER BY id ASC'
+        );
+        $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
+        $stmt->bindValue(':eid', $entityId, PDO::PARAM_STR);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => [
+            'id'         => (int)$r['id'],
+            'parent_id'  => $r['parent_id'] !== null ? (int)$r['parent_id'] : null,
+            'author_id'  => $r['author_id'] !== null ? (string)$r['author_id'] : null,
+            'body'       => (string)$r['body'],
+            'depth'      => (int)$r['depth'],
+            'deleted_at' => $r['deleted_at'] !== null ? (string)$r['deleted_at'] : null,
+            'created_at' => (string)$r['created_at'],
+        ], $rows);
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    /**
+     * @return array{entity_type:string,entity_id:string,depth:int}|null
+     */
+    private function findComment(int $id, PDO $db): ?array
+    {
+        $stmt = $db->prepare(
+            'SELECT entity_type, entity_id, depth FROM ' . $this->table .
+            ' WHERE id = :id LIMIT 1'
+        );
+        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        return [
+            'entity_type' => (string)$row['entity_type'],
+            'entity_id'   => (string)$row['entity_id'],
+            'depth'       => (int)$row['depth'],
+        ];
+    }
+
+    private function assertBody(string $body): void
+    {
+        if (trim($body) === '') {
+            throw new \InvalidArgumentException('Comment body must not be empty.');
+        }
+    }
+}

--- a/docs/development/comment-thread.md
+++ b/docs/development/comment-thread.md
@@ -1,0 +1,99 @@
+# Comment Thread
+
+`Nene\Xion\CommentThread` — threaded comment system with nesting depth limit and soft delete.
+
+## Schema
+
+```sql
+CREATE TABLE comments (
+    id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+    entity_type VARCHAR(64)  NOT NULL,
+    entity_id   VARCHAR(255) NOT NULL,
+    parent_id   INTEGER      DEFAULT NULL,
+    author_id   VARCHAR(255),
+    body        TEXT         NOT NULL,
+    depth       INTEGER      NOT NULL DEFAULT 0,
+    deleted_at  DATETIME     DEFAULT NULL,
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_comments_entity ON comments (entity_type, entity_id, parent_id);
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `post(string $entityType, string $entityId, string $authorId, string $body): int` | Post a top-level comment. Returns new ID. |
+| `reply(int $parentId, string $authorId, string $body): int` | Reply to a comment. Returns new ID. |
+| `softDelete(int $commentId, string $authorId): bool` | Soft-delete (author-enforced). Returns true if deleted. |
+| `list(string $entityType, string $entityId): array` | All comments for an entity (ASC, includes deleted). |
+
+## Usage
+
+```php
+$ct = new CommentThread($pdo);
+
+// Top-level comment
+$id1 = $ct->post('article', '42', 'user:1', 'Great read!');
+
+// Reply (depth = parent.depth + 1)
+$id2 = $ct->reply($id1, 'user:2', 'Agreed!');
+$id3 = $ct->reply($id2, 'user:3', 'Me too!');  // depth 2
+
+// List (newest → oldest via ORDER BY id ASC)
+$comments = $ct->list('article', '42');
+// [
+//   ['id' => 1, 'parent_id' => null, 'author_id' => 'user:1', 'body' => 'Great read!', 'depth' => 0, ...],
+//   ['id' => 2, 'parent_id' => 1,    'author_id' => 'user:2', 'body' => 'Agreed!',     'depth' => 1, ...],
+//   ...
+// ]
+
+// Soft delete (body replaced, author_id nulled, row retained for threading)
+$ct->softDelete($id1, 'user:1');  // true
+$ct->softDelete($id1, 'user:2');  // false — wrong author
+```
+
+## Soft delete behavior
+
+When a comment is soft-deleted:
+- `body` is set to `'[deleted]'`
+- `author_id` is set to `null`
+- `deleted_at` is set to the current UTC timestamp
+- The row is **retained** — replies remain threaded correctly
+
+`list()` includes soft-deleted comments so the thread structure is intact. Applications should render `[deleted]` comments differently based on `deleted_at !== null`.
+
+## Depth limit
+
+The default maximum nesting depth is 5 (depth 0 = top-level, depth 5 = deepest reply). Exceeding it throws `InvalidArgumentException`. Override via constructor:
+
+```php
+$ct = new CommentThread($pdo, maxDepth: 3);
+```
+
+## Key design points
+
+- **`(entity_type, entity_id)`**: entity-agnostic — reusable across any content type.
+- **`depth` column**: stored on insert for fast flat-list rendering without tree traversal.
+- **Soft delete**: row retained; author and body redacted. Reply structure preserved.
+- **Author enforcement**: `softDelete()` requires matching `author_id`.
+- **Empty body guard**: `post()` and `reply()` throw `InvalidArgumentException` for empty/whitespace-only body.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type VARCHAR(64) NOT NULL,
+    entity_id VARCHAR(255) NOT NULL,
+    parent_id INTEGER DEFAULT NULL,
+    author_id VARCHAR(255),
+    body TEXT NOT NULL,
+    depth INTEGER NOT NULL DEFAULT 0,
+    deleted_at DATETIME DEFAULT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+)');
+$ct = new CommentThread($db);
+```

--- a/docs/field-trials/2026-05-field-trial-69.md
+++ b/docs/field-trials/2026-05-field-trial-69.md
@@ -1,0 +1,70 @@
+# Field Trial 69 — Comment Thread
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft69-comment-thread`
+**Baseline**: post FT68 merge
+
+## Goal
+
+Establish a threaded comment pattern for NeNe applications. Support top-level posting, nested replies with depth enforcement, and soft deletion that preserves thread structure.
+
+## What was built
+
+### `Nene\Xion\CommentThread` (`class/xion/CommentThread.php`)
+
+DB-backed threaded comment manager providing:
+
+| Method | Description |
+| --- | --- |
+| `post(string $entityType, string $entityId, string $authorId, string $body): int` | Top-level comment. |
+| `reply(int $parentId, string $authorId, string $body): int` | Nested reply with depth check. |
+| `softDelete(int $commentId, string $authorId): bool` | Author-enforced soft delete. |
+| `list(string $entityType, string $entityId): array` | All comments ordered by id ASC. |
+
+Key design points:
+
+- **`depth` column**: stored on insert (parent.depth + 1); no tree traversal needed for rendering.
+- **Depth limit**: default 5, configurable via constructor. Throws `InvalidArgumentException` when exceeded.
+- **Soft delete semantics**: `body = '[deleted]'`, `author_id = NULL`, row retained for threading.
+- **`(entity_type, entity_id)`** entity-agnostic design.
+- **Empty body guard**: throws for empty/whitespace-only bodies.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/CommentThreadTest.php`)
+
+20 unit tests covering:
+
+- post returns id
+- posted comment appears in list
+- posted comment has depth zero
+- post empty body throws
+- reply returns id
+- reply has depth one more than parent
+- reply has parent_id set
+- reply to nonexistent parent throws
+- reply empty body throws
+- reply max depth enforced
+- softDelete returns true by author
+- softDelete returns false by non-author
+- softDelete replaces body
+- softDelete nulls author_id
+- softDelete sets deleted_at
+- softDelete already deleted returns false
+- list returns all comments including deleted
+- list is entity-type-isolated
+- list is entity-id-isolated
+- list orders by id ascending
+
+### Howto (`docs/development/comment-thread.md`)
+
+Covers: schema, API table, usage, soft delete behavior, depth limit configuration, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`CommentThread` is a clean `Nene\Xion` helper. 20 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/CommentThreadTest.php
+++ b/tests/Unit/Xion/CommentThreadTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\CommentThread;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for CommentThread using an in-memory SQLite database.
+ */
+final class CommentThreadTest extends TestCase
+{
+    private PDO $db;
+    private CommentThread $ct;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE comments (
+                id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+                entity_type VARCHAR(64)  NOT NULL,
+                entity_id   VARCHAR(255) NOT NULL,
+                parent_id   INTEGER      DEFAULT NULL,
+                author_id   VARCHAR(255),
+                body        TEXT         NOT NULL,
+                depth       INTEGER      NOT NULL DEFAULT 0,
+                deleted_at  DATETIME     DEFAULT NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->ct = new CommentThread($this->db);
+    }
+
+    // ── post ──────────────────────────────────────────────────────────────────
+
+    public function testPostReturnsId(): void
+    {
+        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testPostedCommentAppearsInList(): void
+    {
+        $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $list = $this->ct->list('article', '1');
+        $this->assertCount(1, $list);
+        $this->assertSame('Hello!', $list[0]['body']);
+    }
+
+    public function testPostedCommentHasDepthZero(): void
+    {
+        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $list = $this->ct->list('article', '1');
+        $this->assertSame(0, $list[0]['depth']);
+    }
+
+    public function testPostEmptyBodyThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ct->post('article', '1', 'user:1', '');
+    }
+
+    // ── reply ─────────────────────────────────────────────────────────────────
+
+    public function testReplyReturnsId(): void
+    {
+        $parentId = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $replyId  = $this->ct->reply($parentId, 'user:2', 'Thanks!');
+        $this->assertIsInt($replyId);
+        $this->assertNotSame($parentId, $replyId);
+    }
+
+    public function testReplyHasDepthOneMoreThanParent(): void
+    {
+        $parentId = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->ct->reply($parentId, 'user:2', 'Thanks!');
+        $list = $this->ct->list('article', '1');
+        $this->assertSame(1, $list[1]['depth']);
+    }
+
+    public function testReplyHasParentIdSet(): void
+    {
+        $parentId = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $replyId  = $this->ct->reply($parentId, 'user:2', 'Thanks!');
+        $list     = $this->ct->list('article', '1');
+        $reply    = array_values(array_filter($list, fn ($c) => $c['id'] === $replyId))[0];
+        $this->assertSame($parentId, $reply['parent_id']);
+    }
+
+    public function testReplyToNonexistentParentThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ct->reply(9999, 'user:1', 'Hello!');
+    }
+
+    public function testReplyEmptyBodyThrows(): void
+    {
+        $parentId = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ct->reply($parentId, 'user:2', '   ');
+    }
+
+    public function testReplyMaxDepthEnforced(): void
+    {
+        // With maxDepth=2, depth 0→1→2 is allowed, depth 3 is not
+        $ct = new CommentThread($this->db, maxDepth: 2);
+        $d0 = $ct->post('article', '1', 'user:1', 'depth 0');
+        $d1 = $ct->reply($d0, 'user:1', 'depth 1');
+        $d2 = $ct->reply($d1, 'user:1', 'depth 2');
+        $this->expectException(\InvalidArgumentException::class);
+        $ct->reply($d2, 'user:1', 'depth 3 — too deep');
+    }
+
+    // ── softDelete ────────────────────────────────────────────────────────────
+
+    public function testSoftDeleteReturnsTrueByAuthor(): void
+    {
+        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->assertTrue($this->ct->softDelete($id, 'user:1'));
+    }
+
+    public function testSoftDeleteReturnsFalseByNonAuthor(): void
+    {
+        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->assertFalse($this->ct->softDelete($id, 'user:2'));
+    }
+
+    public function testSoftDeleteReplacesBody(): void
+    {
+        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->ct->softDelete($id, 'user:1');
+        $list = $this->ct->list('article', '1');
+        $this->assertSame('[deleted]', $list[0]['body']);
+    }
+
+    public function testSoftDeleteNullsAuthorId(): void
+    {
+        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->ct->softDelete($id, 'user:1');
+        $list = $this->ct->list('article', '1');
+        $this->assertNull($list[0]['author_id']);
+    }
+
+    public function testSoftDeleteSetsDeletedAt(): void
+    {
+        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->ct->softDelete($id, 'user:1');
+        $list = $this->ct->list('article', '1');
+        $this->assertNotNull($list[0]['deleted_at']);
+    }
+
+    public function testSoftDeleteAlreadyDeletedReturnsFalse(): void
+    {
+        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->ct->softDelete($id, 'user:1');
+        $this->assertFalse($this->ct->softDelete($id, 'user:1'));
+    }
+
+    // ── list ──────────────────────────────────────────────────────────────────
+
+    public function testListReturnsAllCommentsIncludingDeleted(): void
+    {
+        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->ct->softDelete($id, 'user:1');
+        $this->assertCount(1, $this->ct->list('article', '1'));
+    }
+
+    public function testListIsEntityTypeIsolated(): void
+    {
+        $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->assertEmpty($this->ct->list('product', '1'));
+    }
+
+    public function testListIsEntityIdIsolated(): void
+    {
+        $this->ct->post('article', '1', 'user:1', 'Hello!');
+        $this->assertEmpty($this->ct->list('article', '2'));
+    }
+
+    public function testListOrdersByIdAscending(): void
+    {
+        $this->ct->post('article', '1', 'user:1', 'first');
+        $this->ct->post('article', '1', 'user:2', 'second');
+        $list = $this->ct->list('article', '1');
+        $this->assertSame('first', $list[0]['body']);
+        $this->assertSame('second', $list[1]['body']);
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT69 — Comment Thread.

### `Nene\Xion\CommentThread`

Threaded comment system:

- `post/reply/softDelete/list`
- `depth` stored on insert (no traversal needed)
- Depth limit (default 5, configurable)
- Soft delete: body redacted, author nulled, row retained for threading
- `(entity_type, entity_id)` agnostic design

### Tests

20 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)