### PR TITLE
feat(xion): Subscription — user plan management with subscribe/change/cancel/renew lifecycle (FT70)

### DIFF
--- a/class/xion/Subscription.php
+++ b/class/xion/Subscription.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * User subscription / plan management.
+ *
+ * Tracks which plan a user is on, when it expires, and provides an
+ * upgrade/downgrade/cancel/renew lifecycle. A history table records
+ * all plan changes for audit purposes.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE subscriptions (
+ *     id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     user_id    VARCHAR(255) NOT NULL UNIQUE,
+ *     plan       VARCHAR(64)  NOT NULL,
+ *     status     VARCHAR(16)  NOT NULL DEFAULT 'active',
+ *     expires_at DATETIME     DEFAULT NULL,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE subscription_history (
+ *     id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     plan       VARCHAR(64)  NOT NULL,
+ *     action     VARCHAR(32)  NOT NULL,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE INDEX idx_subscription_history_user ON subscription_history (user_id);
+ * ```
+ *
+ * ## Status values
+ *
+ * - `active`    — subscription is running; may have an expiry date.
+ * - `cancelled` — user has cancelled; may still be active until expires_at.
+ * - `expired`   — past expires_at; isActive() returns false.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $sub = new Subscription($pdo);
+ *
+ * $sub->subscribe('user:1', 'pro', expiresIn: 86400 * 30);
+ * $sub->isActive('user:1');         // true
+ * $sub->currentPlan('user:1');      // 'pro'
+ *
+ * $sub->changePlan('user:1', 'enterprise');
+ * $sub->cancel('user:1');
+ * $sub->renew('user:1', 86400 * 30);
+ *
+ * $sub->history('user:1');          // plan change log
+ * ```
+ */
+final class Subscription
+{
+    private const TABLE_SUBS    = 'subscriptions';
+    private const TABLE_HISTORY = 'subscription_history';
+
+    private const STATUS_ACTIVE    = 'active';
+    private const STATUS_CANCELLED = 'cancelled';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $tableSubs    = self::TABLE_SUBS,
+        private readonly string $tableHistory = self::TABLE_HISTORY,
+    ) {
+    }
+
+    /**
+     * Subscribe a user to a plan. Replaces any existing subscription.
+     *
+     * @param string   $userId    Application-level user identifier.
+     * @param string   $plan      Plan name (e.g. 'free', 'pro', 'enterprise').
+     * @param int|null $expiresIn Seconds until expiry. Null = no expiry.
+     */
+    public function subscribe(string $userId, string $plan, ?int $expiresIn = null): void
+    {
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $driver    = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $now       = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        $expiresAt = $expiresIn !== null
+            ? (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+                ->modify('+' . $expiresIn . ' seconds')
+                ->format('Y-m-d H:i:s')
+            : null;
+
+        if ($driver === 'sqlite') {
+            $sql = 'INSERT OR REPLACE INTO ' . $this->tableSubs .
+                   ' (user_id, plan, status, expires_at, created_at, updated_at)' .
+                   ' VALUES (:u, :plan, :status, :exp, :now, :now)';
+        } else {
+            $sql = 'INSERT INTO ' . $this->tableSubs .
+                   ' (user_id, plan, status, expires_at, created_at, updated_at)' .
+                   ' VALUES (:u, :plan, :status, :exp, :now, :now)' .
+                   ' ON DUPLICATE KEY UPDATE plan = VALUES(plan), status = VALUES(status),' .
+                   ' expires_at = VALUES(expires_at), updated_at = VALUES(updated_at)';
+        }
+
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':plan', $plan, PDO::PARAM_STR);
+        $stmt->bindValue(':status', self::STATUS_ACTIVE, PDO::PARAM_STR);
+        $stmt->bindValue(':exp', $expiresAt, $expiresAt !== null ? PDO::PARAM_STR : PDO::PARAM_NULL);
+        $stmt->bindValue(':now', $now, PDO::PARAM_STR);
+        $stmt->execute();
+
+        $this->recordHistory($userId, $plan, 'subscribe', $db);
+    }
+
+    /**
+     * Change a user's plan without altering status or expiry.
+     *
+     * Returns false if the user has no subscription.
+     *
+     * @param string $userId Application-level user identifier.
+     * @param string $plan   New plan name.
+     */
+    public function changePlan(string $userId, string $plan): bool
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->tableSubs .
+            ' SET plan = :plan, updated_at = :now WHERE user_id = :u'
+        );
+        $stmt->bindValue(':plan', $plan, PDO::PARAM_STR);
+        $stmt->bindValue(':now', $now, PDO::PARAM_STR);
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        if ($stmt->rowCount() === 0) {
+            return false;
+        }
+
+        $this->recordHistory($userId, $plan, 'change', $db);
+        return true;
+    }
+
+    /**
+     * Cancel a subscription. Sets status to 'cancelled' but keeps the row.
+     *
+     * Returns false if no subscription found.
+     *
+     * @param string $userId Application-level user identifier.
+     */
+    public function cancel(string $userId): bool
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->tableSubs .
+            ' SET status = :status, updated_at = :now WHERE user_id = :u AND status != :status'
+        );
+        $stmt->bindValue(':status', self::STATUS_CANCELLED, PDO::PARAM_STR);
+        $stmt->bindValue(':now', $now, PDO::PARAM_STR);
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        if ($stmt->rowCount() === 0) {
+            return false;
+        }
+
+        $plan = $this->currentPlan($userId) ?? '';
+        $this->recordHistory($userId, $plan, 'cancel', $db);
+        return true;
+    }
+
+    /**
+     * Renew a subscription: sets status to 'active' and extends expiry.
+     *
+     * Returns false if no subscription found.
+     *
+     * @param string   $userId    Application-level user identifier.
+     * @param int|null $expiresIn Seconds from now until new expiry. Null = no expiry.
+     */
+    public function renew(string $userId, ?int $expiresIn = null): bool
+    {
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $now       = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        $expiresAt = $expiresIn !== null
+            ? (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+                ->modify('+' . $expiresIn . ' seconds')
+                ->format('Y-m-d H:i:s')
+            : null;
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->tableSubs .
+            ' SET status = :status, expires_at = :exp, updated_at = :now WHERE user_id = :u'
+        );
+        $stmt->bindValue(':status', self::STATUS_ACTIVE, PDO::PARAM_STR);
+        $stmt->bindValue(':exp', $expiresAt, $expiresAt !== null ? PDO::PARAM_STR : PDO::PARAM_NULL);
+        $stmt->bindValue(':now', $now, PDO::PARAM_STR);
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        if ($stmt->rowCount() === 0) {
+            return false;
+        }
+
+        $plan = $this->currentPlan($userId) ?? '';
+        $this->recordHistory($userId, $plan, 'renew', $db);
+        return true;
+    }
+
+    /**
+     * Check whether a user has an active, non-expired subscription.
+     *
+     * @param string $userId Application-level user identifier.
+     */
+    public function isActive(string $userId): bool
+    {
+        $row = $this->findRow($userId);
+        if ($row === null || $row['status'] !== self::STATUS_ACTIVE) {
+            return false;
+        }
+
+        if ($row['expires_at'] !== null) {
+            $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+            if ((string)$row['expires_at'] <= $now) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the current plan name for a user, or null if no subscription.
+     *
+     * @param string $userId Application-level user identifier.
+     */
+    public function currentPlan(string $userId): ?string
+    {
+        $row = $this->findRow($userId);
+        return $row !== null ? (string)$row['plan'] : null;
+    }
+
+    /**
+     * Get subscription history for a user, newest first.
+     *
+     * @param  string $userId Application-level user identifier.
+     * @return list<array{id:int,plan:string,action:string,created_at:string}>
+     */
+    public function history(string $userId): array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, plan, action, created_at FROM ' . $this->tableHistory .
+            ' WHERE user_id = :u ORDER BY id DESC'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => [
+            'id'         => (int)$r['id'],
+            'plan'       => (string)$r['plan'],
+            'action'     => (string)$r['action'],
+            'created_at' => (string)$r['created_at'],
+        ], $rows);
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    /**
+     * @return array{plan:string,status:string,expires_at:string|null}|null
+     */
+    private function findRow(string $userId): ?array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT plan, status, expires_at FROM ' . $this->tableSubs .
+            ' WHERE user_id = :u LIMIT 1'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        return [
+            'plan'       => (string)$row['plan'],
+            'status'     => (string)$row['status'],
+            'expires_at' => $row['expires_at'] !== null ? (string)$row['expires_at'] : null,
+        ];
+    }
+
+    private function recordHistory(string $userId, string $plan, string $action, PDO $db): void
+    {
+        $now  = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->tableHistory .
+            ' (user_id, plan, action, created_at) VALUES (:u, :plan, :action, :now)'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':plan', $plan, PDO::PARAM_STR);
+        $stmt->bindValue(':action', $action, PDO::PARAM_STR);
+        $stmt->bindValue(':now', $now, PDO::PARAM_STR);
+        $stmt->execute();
+    }
+}

--- a/docs/development/subscription.md
+++ b/docs/development/subscription.md
@@ -1,0 +1,94 @@
+# Subscription
+
+`Nene\Xion\Subscription` — user subscription / plan management with history tracking.
+
+## Schema
+
+```sql
+CREATE TABLE subscriptions (
+    id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+    user_id    VARCHAR(255) NOT NULL UNIQUE,
+    plan       VARCHAR(64)  NOT NULL,
+    status     VARCHAR(16)  NOT NULL DEFAULT 'active',
+    expires_at DATETIME     DEFAULT NULL,
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE subscription_history (
+    id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+    user_id    VARCHAR(255) NOT NULL,
+    plan       VARCHAR(64)  NOT NULL,
+    action     VARCHAR(32)  NOT NULL,
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_subscription_history_user ON subscription_history (user_id);
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `subscribe(string $userId, string $plan, ?int $expiresIn = null): void` | Create or replace a subscription. |
+| `changePlan(string $userId, string $plan): bool` | Change plan without touching status/expiry. |
+| `cancel(string $userId): bool` | Set status to `'cancelled'`. |
+| `renew(string $userId, ?int $expiresIn = null): bool` | Restore to `'active'` with new expiry. |
+| `isActive(string $userId): bool` | True if status is `'active'` and not past expires_at. |
+| `currentPlan(string $userId): ?string` | Current plan name, or null if no subscription. |
+| `history(string $userId): array` | Plan change log, newest first. |
+
+## Usage
+
+```php
+$sub = new Subscription($pdo);
+
+// Subscribe
+$sub->subscribe('user:1', 'pro', expiresIn: 86400 * 30);
+$sub->isActive('user:1');     // true
+$sub->currentPlan('user:1');  // 'pro'
+
+// Upgrade
+$sub->changePlan('user:1', 'enterprise');
+
+// Cancel
+$sub->cancel('user:1');
+$sub->isActive('user:1');  // false
+
+// Renew after cancellation
+$sub->renew('user:1', 86400 * 30);
+$sub->isActive('user:1');  // true
+
+// History (newest first)
+$sub->history('user:1');
+// [
+//   ['id' => 4, 'plan' => 'enterprise', 'action' => 'renew',     'created_at' => '...'],
+//   ['id' => 3, 'plan' => 'enterprise', 'action' => 'cancel',    'created_at' => '...'],
+//   ['id' => 2, 'plan' => 'enterprise', 'action' => 'change',    'created_at' => '...'],
+//   ['id' => 1, 'plan' => 'pro',        'action' => 'subscribe', 'created_at' => '...'],
+// ]
+```
+
+## Status values
+
+| Status | Meaning |
+| --- | --- |
+| `active` | Subscription is running. |
+| `cancelled` | User cancelled; may still be valid if expires_at is in the future. |
+
+`isActive()` returns `false` when: no subscription, `status = 'cancelled'`, or `expires_at` is in the past.
+
+## Key design points
+
+- **One row per user**: `UNIQUE (user_id)` in `subscriptions`. `subscribe()` upserts.
+- **History table**: every plan/status change writes a history row with `action` and `plan`.
+- **`cancel()`**: idempotent guard — won't double-cancel (checks `status != 'cancelled'`).
+- **`renew()`**: works from any status — restores `active` and sets new expiry.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+// Create subscriptions + subscription_history tables (see schema above)
+$sub = new Subscription($db);
+```

--- a/docs/field-trials/2026-05-field-trial-70.md
+++ b/docs/field-trials/2026-05-field-trial-70.md
@@ -1,0 +1,75 @@
+# Field Trial 70 — Subscription / Plan
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft70-subscription`
+**Baseline**: post FT69 merge
+
+## Goal
+
+Establish a user subscription / plan management pattern for NeNe applications. Provide lifecycle management (subscribe/change/cancel/renew) with history tracking.
+
+## What was built
+
+### `Nene\Xion\Subscription` (`class/xion/Subscription.php`)
+
+Two-table subscription manager providing:
+
+| Method | Description |
+| --- | --- |
+| `subscribe(string $userId, string $plan, ?int $expiresIn = null): void` | Upsert subscription. |
+| `changePlan(string $userId, string $plan): bool` | Change plan; returns false if no subscription. |
+| `cancel(string $userId): bool` | Set cancelled; returns false if already cancelled or missing. |
+| `renew(string $userId, ?int $expiresIn = null): bool` | Restore active; returns false if no subscription. |
+| `isActive(string $userId): bool` | True if active and not expired. |
+| `currentPlan(string $userId): ?string` | Current plan or null. |
+| `history(string $userId): array` | Change log, newest first. |
+
+Key design points:
+
+- **One row per user**: `UNIQUE (user_id)` upsert via `INSERT OR REPLACE` / `ON DUPLICATE KEY UPDATE`.
+- **History table**: every action (subscribe/change/cancel/renew) writes a history row.
+- **`cancel()` idempotent guard**: `WHERE status != 'cancelled'` prevents double-cancel.
+- **`isActive()` compound check**: status = 'active' AND (expires_at IS NULL OR expires_at > now).
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/SubscriptionTest.php`)
+
+23 unit tests covering:
+
+- subscribe creates active subscription
+- subscribe sets current plan
+- subscribe with expiry stores expires_at
+- subscribe replaces existing subscription
+- subscribe records history
+- isActive false for no subscription
+- isActive false for expired subscription
+- isActive false for cancelled subscription
+- currentPlan returns null for no subscription
+- changePlan updates plan
+- changePlan returns true on success
+- changePlan returns false when no subscription
+- changePlan records history
+- cancel returns true on success
+- cancel returns false when no subscription
+- cancel returns false when already cancelled
+- cancel records history
+- renew activates cancelled subscription
+- renew returns true on success
+- renew returns false when no subscription
+- renew records history
+- history returns newest first
+- history is user-isolated
+
+### Howto (`docs/development/subscription.md`)
+
+Covers: schema, API table, usage examples, status values, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`Subscription` is a clean `Nene\Xion` helper. 23 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/SubscriptionTest.php
+++ b/tests/Unit/Xion/SubscriptionTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\Subscription;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Subscription using an in-memory SQLite database.
+ */
+final class SubscriptionTest extends TestCase
+{
+    private PDO $db;
+    private Subscription $sub;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE subscriptions (
+                id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL UNIQUE,
+                plan       VARCHAR(64)  NOT NULL,
+                status     VARCHAR(16)  NOT NULL DEFAULT \'active\',
+                expires_at DATETIME     DEFAULT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->db->exec(
+            'CREATE TABLE subscription_history (
+                id         INTEGER      PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL,
+                plan       VARCHAR(64)  NOT NULL,
+                action     VARCHAR(32)  NOT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->sub = new Subscription($this->db);
+    }
+
+    // ── subscribe ─────────────────────────────────────────────────────────────
+
+    public function testSubscribeCreatesActiveSubscription(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $this->assertTrue($this->sub->isActive('user:1'));
+    }
+
+    public function testSubscribeSetsCurrentPlan(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $this->assertSame('pro', $this->sub->currentPlan('user:1'));
+    }
+
+    public function testSubscribeWithExpiryStoresExpiresAt(): void
+    {
+        $this->sub->subscribe('user:1', 'pro', expiresIn: 3600);
+        $stmt = $this->db->query("SELECT expires_at FROM subscriptions WHERE user_id = 'user:1'");
+        $this->assertNotNull($stmt->fetchColumn());
+    }
+
+    public function testSubscribeReplacesExistingSubscription(): void
+    {
+        $this->sub->subscribe('user:1', 'free');
+        $this->sub->subscribe('user:1', 'pro');
+        $this->assertSame('pro', $this->sub->currentPlan('user:1'));
+    }
+
+    public function testSubscribeRecordsHistory(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $history = $this->sub->history('user:1');
+        $this->assertSame('subscribe', $history[0]['action']);
+    }
+
+    // ── isActive ──────────────────────────────────────────────────────────────
+
+    public function testIsActiveReturnsFalseForNoSubscription(): void
+    {
+        $this->assertFalse($this->sub->isActive('user:1'));
+    }
+
+    public function testIsActiveReturnsFalseForExpiredSubscription(): void
+    {
+        $this->sub->subscribe('user:1', 'pro', expiresIn: 3600);
+        $this->db->exec("UPDATE subscriptions SET expires_at = '2000-01-01 00:00:00' WHERE user_id = 'user:1'");
+        $this->assertFalse($this->sub->isActive('user:1'));
+    }
+
+    public function testIsActiveReturnsFalseForCancelledSubscription(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $this->sub->cancel('user:1');
+        $this->assertFalse($this->sub->isActive('user:1'));
+    }
+
+    // ── currentPlan ───────────────────────────────────────────────────────────
+
+    public function testCurrentPlanReturnsNullForNoSubscription(): void
+    {
+        $this->assertNull($this->sub->currentPlan('user:1'));
+    }
+
+    // ── changePlan ────────────────────────────────────────────────────────────
+
+    public function testChangePlanUpdatesPlan(): void
+    {
+        $this->sub->subscribe('user:1', 'free');
+        $this->sub->changePlan('user:1', 'enterprise');
+        $this->assertSame('enterprise', $this->sub->currentPlan('user:1'));
+    }
+
+    public function testChangePlanReturnsTrueOnSuccess(): void
+    {
+        $this->sub->subscribe('user:1', 'free');
+        $this->assertTrue($this->sub->changePlan('user:1', 'pro'));
+    }
+
+    public function testChangePlanReturnsFalseWhenNoSubscription(): void
+    {
+        $this->assertFalse($this->sub->changePlan('user:1', 'pro'));
+    }
+
+    public function testChangePlanRecordsHistory(): void
+    {
+        $this->sub->subscribe('user:1', 'free');
+        $this->sub->changePlan('user:1', 'pro');
+        $history = $this->sub->history('user:1');
+        $this->assertSame('change', $history[0]['action']);
+    }
+
+    // ── cancel ────────────────────────────────────────────────────────────────
+
+    public function testCancelReturnsTrueOnSuccess(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $this->assertTrue($this->sub->cancel('user:1'));
+    }
+
+    public function testCancelReturnsFalseWhenNoSubscription(): void
+    {
+        $this->assertFalse($this->sub->cancel('user:1'));
+    }
+
+    public function testCancelReturnsFalseWhenAlreadyCancelled(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $this->sub->cancel('user:1');
+        $this->assertFalse($this->sub->cancel('user:1'));
+    }
+
+    public function testCancelRecordsHistory(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $this->sub->cancel('user:1');
+        $history = $this->sub->history('user:1');
+        $this->assertSame('cancel', $history[0]['action']);
+    }
+
+    // ── renew ─────────────────────────────────────────────────────────────────
+
+    public function testRenewActivatesCancelledSubscription(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $this->sub->cancel('user:1');
+        $this->sub->renew('user:1', 86400);
+        $this->assertTrue($this->sub->isActive('user:1'));
+    }
+
+    public function testRenewReturnsTrueOnSuccess(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $this->assertTrue($this->sub->renew('user:1', 86400));
+    }
+
+    public function testRenewReturnsFalseWhenNoSubscription(): void
+    {
+        $this->assertFalse($this->sub->renew('user:1', 86400));
+    }
+
+    public function testRenewRecordsHistory(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $this->sub->renew('user:1', 86400);
+        $history = $this->sub->history('user:1');
+        $this->assertSame('renew', $history[0]['action']);
+    }
+
+    // ── history ───────────────────────────────────────────────────────────────
+
+    public function testHistoryReturnsNewestFirst(): void
+    {
+        $this->sub->subscribe('user:1', 'free');
+        $this->sub->changePlan('user:1', 'pro');
+        $history = $this->sub->history('user:1');
+        $this->assertSame('change', $history[0]['action']);
+        $this->assertSame('subscribe', $history[1]['action']);
+    }
+
+    public function testHistoryIsUserIsolated(): void
+    {
+        $this->sub->subscribe('user:1', 'pro');
+        $this->assertEmpty($this->sub->history('user:2'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT70 — Subscription / Plan.

### `Nene\Xion\Subscription`

Two-table plan management:

- `subscribe/changePlan/cancel/renew` — full lifecycle
- `isActive/currentPlan` — status queries
- `history()` — change log, newest first
- Upsert via INSERT OR REPLACE (SQLite) / ON DUPLICATE KEY UPDATE (MySQL)
- Cancel idempotent guard

### Tests

23 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)