### PR TITLE
feat(xion): SearchHistory — per-user search history with deduplication and auto-trim (FT71)

### DIFF
--- a/class/xion/SearchHistory.php
+++ b/class/xion/SearchHistory.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Per-user search history with deduplication and auto-trimming.
+ *
+ * Each push upserts: if the query already exists for the user, its
+ * `searched_at` is updated (moved to top). The history is trimmed to at
+ * most $maxEntries per user after each push.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE search_history (
+ *     id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     query       VARCHAR(255) NOT NULL,
+ *     searched_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (user_id, query)
+ * );
+ * CREATE INDEX idx_search_history_user ON search_history (user_id, searched_at DESC);
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $sh = new SearchHistory($pdo);
+ *
+ * $sh->push('user:1', 'php arrays');
+ * $sh->push('user:1', 'oop patterns');
+ * $sh->push('user:1', 'php arrays');  // moves to top, no duplicate
+ *
+ * $sh->recent('user:1');   // ['php arrays', 'oop patterns']
+ * $sh->clear('user:1');    // removes all
+ * ```
+ */
+final class SearchHistory
+{
+    private const TABLE       = 'search_history';
+    private const MAX_ENTRIES = 20;
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table      = self::TABLE,
+        private readonly int $maxEntries    = self::MAX_ENTRIES,
+    ) {
+    }
+
+    /**
+     * Push a query to the top of the user's search history.
+     *
+     * If the query already exists, its timestamp is updated (upsert).
+     * After inserting, entries beyond $maxEntries are pruned (oldest first).
+     *
+     * @param string $userId Application-level user identifier.
+     * @param string $query  Search query string.
+     * @throws \InvalidArgumentException if $query is empty after trim.
+     */
+    public function push(string $userId, string $query): void
+    {
+        $query = trim($query);
+        if ($query === '') {
+            throw new \InvalidArgumentException('Search query must not be empty.');
+        }
+
+        $db         = $this->db ?? PdoConnection::getInstance();
+        $driver     = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $searchedAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        if ($driver === 'sqlite') {
+            $sql = 'INSERT OR REPLACE INTO ' . $this->table .
+                   ' (user_id, query, searched_at) VALUES (:u, :q, :t)';
+        } else {
+            $sql = 'INSERT INTO ' . $this->table .
+                   ' (user_id, query, searched_at) VALUES (:u, :q, :t)' .
+                   ' ON DUPLICATE KEY UPDATE searched_at = VALUES(searched_at)';
+        }
+
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':q', $query, PDO::PARAM_STR);
+        $stmt->bindValue(':t', $searchedAt, PDO::PARAM_STR);
+        $stmt->execute();
+
+        $this->trim($userId, $db);
+    }
+
+    /**
+     * Get recent search queries for a user, newest first.
+     *
+     * @param  string $userId Application-level user identifier.
+     * @param  int    $limit  Maximum entries to return (1–$maxEntries).
+     * @return list<string>
+     */
+    public function recent(string $userId, int $limit = 10): array
+    {
+        $limit = max(1, min($this->maxEntries, $limit));
+
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT query FROM ' . $this->table .
+            ' WHERE user_id = :u' .
+            ' ORDER BY searched_at DESC, id DESC' .
+            ' LIMIT :lim'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        return array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'query');
+    }
+
+    /**
+     * Clear all search history for a user.
+     *
+     * Returns the number of entries removed.
+     *
+     * @param string $userId Application-level user identifier.
+     */
+    public function clear(string $userId): int
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'DELETE FROM ' . $this->table . ' WHERE user_id = :u'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    /**
+     * Trim entries beyond $maxEntries for a user, keeping the most recent.
+     */
+    private function trim(string $userId, PDO $db): void
+    {
+        // Count current entries
+        $count = $db->prepare(
+            'SELECT COUNT(*) FROM ' . $this->table . ' WHERE user_id = :u'
+        );
+        $count->bindValue(':u', $userId, PDO::PARAM_STR);
+        $count->execute();
+
+        $total = (int)$count->fetchColumn();
+        if ($total <= $this->maxEntries) {
+            return;
+        }
+
+        // Delete oldest (lowest searched_at, then lowest id) beyond limit
+        $excess = $total - $this->maxEntries;
+        $del    = $db->prepare(
+            'DELETE FROM ' . $this->table .
+            ' WHERE user_id = :u' .
+            ' AND id IN (' .
+            '   SELECT id FROM ' . $this->table .
+            '   WHERE user_id = :u2' .
+            '   ORDER BY searched_at ASC, id ASC' .
+            '   LIMIT :excess' .
+            ' )'
+        );
+        $del->bindValue(':u', $userId, PDO::PARAM_STR);
+        $del->bindValue(':u2', $userId, PDO::PARAM_STR);
+        $del->bindValue(':excess', $excess, PDO::PARAM_INT);
+        $del->execute();
+    }
+}

--- a/docs/development/search-history.md
+++ b/docs/development/search-history.md
@@ -1,0 +1,84 @@
+# Search History
+
+`Nene\Xion\SearchHistory` — per-user search history with deduplication, auto-trimming, and limit control.
+
+## Schema
+
+```sql
+CREATE TABLE search_history (
+    id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+    user_id     VARCHAR(255) NOT NULL,
+    query       VARCHAR(255) NOT NULL,
+    searched_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, query)
+);
+CREATE INDEX idx_search_history_user ON search_history (user_id, searched_at DESC);
+```
+
+The `UNIQUE (user_id, query)` constraint enables upsert — pushing an existing query updates its timestamp instead of creating a duplicate.
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `push(string $userId, string $query): void` | Add/refresh a query. Trims oldest entries beyond max. |
+| `recent(string $userId, int $limit = 10): array` | Recent queries, newest first. |
+| `clear(string $userId): int` | Remove all entries. Returns count deleted. |
+
+## Usage
+
+```php
+$sh = new SearchHistory($pdo);
+
+$sh->push('user:1', 'php arrays');
+$sh->push('user:1', 'oop patterns');
+$sh->push('user:1', 'php arrays');  // moves to top, no duplicate
+
+$sh->recent('user:1');
+// ['php arrays', 'oop patterns']
+
+$sh->recent('user:1', 1);
+// ['php arrays']
+
+$sh->clear('user:1');  // returns 2
+$sh->recent('user:1'); // []
+```
+
+## Deduplication
+
+When a query is pushed that already exists for the user:
+- The `searched_at` timestamp is updated (upsert via `INSERT OR REPLACE`)
+- The query moves to the top of `recent()`
+- No duplicate row is created
+
+## Auto-trim
+
+After each push, entries beyond `$maxEntries` (default 20) are deleted, oldest first. The trim is based on `searched_at ASC` so the most recently searched queries are retained.
+
+Override `maxEntries` via constructor:
+
+```php
+$sh = new SearchHistory($pdo, maxEntries: 10);
+```
+
+## Key design points
+
+- **UNIQUE constraint**: `(user_id, query)` — guarantees one row per user per query.
+- **Upsert**: `INSERT OR REPLACE` (SQLite) / `INSERT … ON DUPLICATE KEY UPDATE` (MySQL).
+- **Whitespace trim**: `push()` strips leading/trailing whitespace from the query.
+- **Empty guard**: throws `InvalidArgumentException` for empty/whitespace-only queries.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE search_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id VARCHAR(255) NOT NULL,
+    query VARCHAR(255) NOT NULL,
+    searched_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, query)
+)');
+$sh = new SearchHistory($db);
+```

--- a/docs/field-trials/2026-05-field-trial-71.md
+++ b/docs/field-trials/2026-05-field-trial-71.md
@@ -1,0 +1,62 @@
+# Field Trial 71 — Search History
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft71-search-history`
+**Baseline**: post FT70 merge
+
+## Goal
+
+Establish a per-user search history pattern for NeNe applications. Provide deduplication (upsert on re-push), auto-trimming to a configurable limit, and a simple recent-queries API.
+
+## What was built
+
+### `Nene\Xion\SearchHistory` (`class/xion/SearchHistory.php`)
+
+DB-backed search history providing:
+
+| Method | Description |
+| --- | --- |
+| `push(string $userId, string $query): void` | Upsert query, trim to max limit. |
+| `recent(string $userId, int $limit = 10): array` | Recent queries, newest first. |
+| `clear(string $userId): int` | Delete all entries; returns count. |
+
+Key design points:
+
+- **UNIQUE (user_id, query)**: deduplication at DB layer.
+- **Upsert**: `INSERT OR REPLACE` (SQLite) / `ON DUPLICATE KEY UPDATE` (MySQL) — re-push moves query to top.
+- **Auto-trim**: after each push, oldest entries beyond `$maxEntries` are deleted.
+- **Whitespace trim + empty guard**: query is trimmed; empty throws `InvalidArgumentException`.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/SearchHistoryTest.php`)
+
+14 unit tests covering:
+
+- push adds query
+- push deduplicates
+- push duplicate moves to top
+- push trims older than max entries
+- push empty query throws
+- push whitespace-only query throws
+- push trims query whitespace
+- recent returns newest first
+- recent returns empty for new user
+- recent is user-isolated
+- recent limit is applied
+- clear removes all entries
+- clear returns count of removed entries
+- clear is user-isolated
+
+### Howto (`docs/development/search-history.md`)
+
+Covers: schema, API table, usage, deduplication behavior, auto-trim, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`SearchHistory` is a clean `Nene\Xion` helper. 14 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/SearchHistoryTest.php
+++ b/tests/Unit/Xion/SearchHistoryTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\SearchHistory;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for SearchHistory using an in-memory SQLite database.
+ */
+final class SearchHistoryTest extends TestCase
+{
+    private PDO $db;
+    private SearchHistory $sh;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE search_history (
+                id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+                user_id     VARCHAR(255) NOT NULL,
+                query       VARCHAR(255) NOT NULL,
+                searched_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (user_id, query)
+            )'
+        );
+        $this->sh = new SearchHistory($this->db);
+    }
+
+    // ── push ──────────────────────────────────────────────────────────────────
+
+    public function testPushAddsQuery(): void
+    {
+        $this->sh->push('user:1', 'php');
+        $this->assertSame(['php'], $this->sh->recent('user:1'));
+    }
+
+    public function testPushDeduplicate(): void
+    {
+        $this->sh->push('user:1', 'php');
+        $this->sh->push('user:1', 'php');
+        $this->assertCount(1, $this->sh->recent('user:1'));
+    }
+
+    public function testPushDuplicateMoveToTop(): void
+    {
+        $this->sh->push('user:1', 'php');
+        $this->sh->push('user:1', 'oop');
+        $this->sh->push('user:1', 'php');
+        $this->assertSame('php', $this->sh->recent('user:1')[0]);
+    }
+
+    public function testPushTrimsOlderThanMaxEntries(): void
+    {
+        $sh = new SearchHistory($this->db, maxEntries: 3);
+        $sh->push('user:1', 'a');
+        $sh->push('user:1', 'b');
+        $sh->push('user:1', 'c');
+        $sh->push('user:1', 'd');  // 'a' should be trimmed
+        $recent = $sh->recent('user:1', 10);
+        $this->assertCount(3, $recent);
+        $this->assertNotContains('a', $recent);
+    }
+
+    public function testPushEmptyQueryThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sh->push('user:1', '');
+    }
+
+    public function testPushWhitespaceOnlyQueryThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sh->push('user:1', '   ');
+    }
+
+    public function testPushTrimsQueryWhitespace(): void
+    {
+        $this->sh->push('user:1', '  php  ');
+        $this->assertSame(['php'], $this->sh->recent('user:1'));
+    }
+
+    // ── recent ────────────────────────────────────────────────────────────────
+
+    public function testRecentReturnsNewestFirst(): void
+    {
+        $this->sh->push('user:1', 'first');
+        $this->sh->push('user:1', 'second');
+        $recent = $this->sh->recent('user:1');
+        $this->assertSame('second', $recent[0]);
+        $this->assertSame('first', $recent[1]);
+    }
+
+    public function testRecentReturnsEmptyForNewUser(): void
+    {
+        $this->assertEmpty($this->sh->recent('user:1'));
+    }
+
+    public function testRecentIsUserIsolated(): void
+    {
+        $this->sh->push('user:1', 'php');
+        $this->assertEmpty($this->sh->recent('user:2'));
+    }
+
+    public function testRecentLimitIsApplied(): void
+    {
+        $this->sh->push('user:1', 'a');
+        $this->sh->push('user:1', 'b');
+        $this->sh->push('user:1', 'c');
+        $this->assertCount(2, $this->sh->recent('user:1', 2));
+    }
+
+    // ── clear ─────────────────────────────────────────────────────────────────
+
+    public function testClearRemovesAllEntries(): void
+    {
+        $this->sh->push('user:1', 'php');
+        $this->sh->push('user:1', 'oop');
+        $this->sh->clear('user:1');
+        $this->assertEmpty($this->sh->recent('user:1'));
+    }
+
+    public function testClearReturnsCountOfRemovedEntries(): void
+    {
+        $this->sh->push('user:1', 'php');
+        $this->sh->push('user:1', 'oop');
+        $this->assertSame(2, $this->sh->clear('user:1'));
+    }
+
+    public function testClearIsUserIsolated(): void
+    {
+        $this->sh->push('user:1', 'php');
+        $this->sh->push('user:2', 'oop');
+        $this->sh->clear('user:1');
+        $this->assertSame(['oop'], $this->sh->recent('user:2'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT71 — Search History.

### `Nene\Xion\SearchHistory`

Per-user search history:

- `push/recent/clear`
- Deduplication via `UNIQUE (user_id, query)`
- Re-push moves existing query to top (upsert)
- Auto-trim to configurable max entries after each push
- Whitespace trim + empty guard

### Tests

14 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)