### PR TITLE
feat(xion): Bookmark — generic per-user bookmark/saved-item manager with collections (FT72)

### DIFF
--- a/class/xion/Bookmark.php
+++ b/class/xion/Bookmark.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Generic per-user bookmark / saved-item manager.
+ *
+ * Users can bookmark any entity identified by (entity_type, entity_id).
+ * The same helper serves wishlists, favourites, "read later" lists, etc.
+ * An optional `collection` field allows grouping within a user's bookmarks.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE bookmarks (
+ *     id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     entity_type VARCHAR(64)  NOT NULL,
+ *     entity_id   VARCHAR(255) NOT NULL,
+ *     collection  VARCHAR(64)  NOT NULL DEFAULT '',
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (user_id, entity_type, entity_id)
+ * );
+ * CREATE INDEX idx_bookmarks_user ON bookmarks (user_id, collection);
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $bm = new Bookmark($pdo);
+ *
+ * $bm->save('user:1', 'article', '42');
+ * $bm->save('user:1', 'article', '99', 'read-later');
+ *
+ * $bm->isSaved('user:1', 'article', '42');  // true
+ * $bm->list('user:1', 'article');            // all article bookmarks
+ * $bm->list('user:1', 'article', 'read-later'); // filtered by collection
+ *
+ * $bm->remove('user:1', 'article', '42');   // true
+ * ```
+ */
+final class Bookmark
+{
+    private const TABLE = 'bookmarks';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Save a bookmark.
+     *
+     * Idempotent: saving an already-bookmarked item is a no-op.
+     *
+     * @param string $userId     Application-level user identifier.
+     * @param string $entityType Entity type (e.g. 'article', 'product').
+     * @param string $entityId   Entity ID.
+     * @param string $collection Optional collection name (e.g. 'read-later', 'wishlist').
+     * @return bool True if newly bookmarked, false if already existed.
+     */
+    public function save(
+        string $userId,
+        string $entityType,
+        string $entityId,
+        string $collection = '',
+    ): bool {
+        $db     = $this->db ?? PdoConnection::getInstance();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $ignore = $driver === 'sqlite' ? 'OR IGNORE' : 'IGNORE';
+
+        $stmt = $db->prepare(
+            'INSERT ' . $ignore . ' INTO ' . $this->table .
+            ' (user_id, entity_type, entity_id, collection)' .
+            ' VALUES (:u, :etype, :eid, :col)'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
+        $stmt->bindValue(':eid', $entityId, PDO::PARAM_STR);
+        $stmt->bindValue(':col', $collection, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Remove a bookmark.
+     *
+     * Returns true if removed, false if not bookmarked.
+     *
+     * @param string $userId     Application-level user identifier.
+     * @param string $entityType Entity type.
+     * @param string $entityId   Entity ID.
+     */
+    public function remove(string $userId, string $entityType, string $entityId): bool
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'DELETE FROM ' . $this->table .
+            ' WHERE user_id = :u AND entity_type = :etype AND entity_id = :eid'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
+        $stmt->bindValue(':eid', $entityId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Check whether an item is bookmarked by a user.
+     *
+     * @param string $userId     Application-level user identifier.
+     * @param string $entityType Entity type.
+     * @param string $entityId   Entity ID.
+     */
+    public function isSaved(string $userId, string $entityType, string $entityId): bool
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT 1 FROM ' . $this->table .
+            ' WHERE user_id = :u AND entity_type = :etype AND entity_id = :eid LIMIT 1'
+        );
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
+        $stmt->bindValue(':eid', $entityId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * List bookmarks for a user, optionally filtered by entity type and collection.
+     *
+     * Ordered by created_at DESC (most recently bookmarked first).
+     *
+     * @param  string      $userId     Application-level user identifier.
+     * @param  string|null $entityType Limit to this entity type. Null = all types.
+     * @param  string|null $collection Limit to this collection. Null = all collections.
+     * @return list<array{id:int,entity_type:string,entity_id:string,collection:string,created_at:string}>
+     */
+    public function list(
+        string $userId,
+        ?string $entityType = null,
+        ?string $collection = null,
+    ): array {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $sql = 'SELECT id, entity_type, entity_id, collection, created_at' .
+               ' FROM ' . $this->table .
+               ' WHERE user_id = :u';
+
+        if ($entityType !== null) {
+            $sql .= ' AND entity_type = :etype';
+        }
+        if ($collection !== null) {
+            $sql .= ' AND collection = :col';
+        }
+
+        $sql .= ' ORDER BY created_at DESC, id DESC';
+
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':u', $userId, PDO::PARAM_STR);
+        if ($entityType !== null) {
+            $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
+        }
+        if ($collection !== null) {
+            $stmt->bindValue(':col', $collection, PDO::PARAM_STR);
+        }
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => [
+            'id'          => (int)$r['id'],
+            'entity_type' => (string)$r['entity_type'],
+            'entity_id'   => (string)$r['entity_id'],
+            'collection'  => (string)$r['collection'],
+            'created_at'  => (string)$r['created_at'],
+        ], $rows);
+    }
+}

--- a/docs/development/bookmark.md
+++ b/docs/development/bookmark.md
@@ -1,0 +1,96 @@
+# Bookmark
+
+`Nene\Xion\Bookmark` — generic per-user bookmark / saved-item manager.
+
+Users can bookmark any entity identified by `(entity_type, entity_id)`. An optional `collection` field groups bookmarks (e.g. `'wishlist'`, `'read-later'`, `'favourites'`).
+
+## Schema
+
+```sql
+CREATE TABLE bookmarks (
+    id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+    user_id     VARCHAR(255) NOT NULL,
+    entity_type VARCHAR(64)  NOT NULL,
+    entity_id   VARCHAR(255) NOT NULL,
+    collection  VARCHAR(64)  NOT NULL DEFAULT '',
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, entity_type, entity_id)
+);
+CREATE INDEX idx_bookmarks_user ON bookmarks (user_id, collection);
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `save(string $userId, string $entityType, string $entityId, string $collection = ''): bool` | Bookmark an entity. Returns true if new, false if already exists. |
+| `remove(string $userId, string $entityType, string $entityId): bool` | Remove bookmark. Returns true if deleted. |
+| `isSaved(string $userId, string $entityType, string $entityId): bool` | Check bookmark status. |
+| `list(string $userId, ?string $entityType = null, ?string $collection = null): array` | List bookmarks; optionally filter by type and/or collection. |
+
+## Usage
+
+```php
+$bm = new Bookmark($pdo);
+
+// Save
+$bm->save('user:1', 'article', '42');                      // true
+$bm->save('user:1', 'article', '99', 'read-later');        // true
+$bm->save('user:1', 'article', '42');                      // false — already saved
+
+// Check
+$bm->isSaved('user:1', 'article', '42');   // true
+$bm->isSaved('user:2', 'article', '42');   // false
+
+// List all
+$bm->list('user:1');
+// [['id' => 2, 'entity_type' => 'article', 'entity_id' => '99', 'collection' => 'read-later', ...],
+//  ['id' => 1, 'entity_type' => 'article', 'entity_id' => '42', 'collection' => '',           ...]]
+
+// Filter by type
+$bm->list('user:1', 'article');
+
+// Filter by type + collection
+$bm->list('user:1', 'article', 'read-later');
+
+// Remove
+$bm->remove('user:1', 'article', '42');  // true
+$bm->remove('user:1', 'article', '42');  // false
+```
+
+## Collections
+
+Collections are plain strings. Use whatever naming convention fits your app:
+
+```php
+$bm->save($userId, 'product', $productId, 'wishlist');
+$bm->save($userId, 'article', $articleId, 'read-later');
+$bm->save($userId, 'post',    $postId,    '');              // uncategorised
+```
+
+Pass `$collection = null` to `list()` to return all collections.
+
+## Key design points
+
+- **UNIQUE (user_id, entity_type, entity_id)**: prevents duplicate bookmarks at DB layer.
+- **`save()` idempotent**: `INSERT OR IGNORE` / `INSERT IGNORE` — duplicate is a no-op returning `false`.
+- **Collection default `''`**: uncategorised bookmarks use an empty string, not NULL.
+- **`(entity_type, entity_id)`**: entity-agnostic — reuse across all content types.
+- **`list()` order**: `created_at DESC, id DESC` — most recently bookmarked first.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE bookmarks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id VARCHAR(255) NOT NULL,
+    entity_type VARCHAR(64) NOT NULL,
+    entity_id VARCHAR(255) NOT NULL,
+    collection VARCHAR(64) NOT NULL DEFAULT \'\',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, entity_type, entity_id)
+)');
+$bm = new Bookmark($db);
+```

--- a/docs/field-trials/2026-05-field-trial-72.md
+++ b/docs/field-trials/2026-05-field-trial-72.md
@@ -1,0 +1,66 @@
+# Field Trial 72 — Bookmark / Saved Items
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft72-bookmark`
+**Baseline**: post FT71 merge
+
+## Goal
+
+Establish a generic bookmark / saved-item pattern for NeNe applications. Provide a user-agnostic, entity-type-agnostic helper for wishlists, favourites, and "read later" lists.
+
+## What was built
+
+### `Nene\Xion\Bookmark` (`class/xion/Bookmark.php`)
+
+DB-backed per-user bookmark manager providing:
+
+| Method | Description |
+| --- | --- |
+| `save(string $userId, string $entityType, string $entityId, string $collection = ''): bool` | Idempotent save; true if new. |
+| `remove(string $userId, string $entityType, string $entityId): bool` | Remove; true if deleted. |
+| `isSaved(string $userId, string $entityType, string $entityId): bool` | Status check. |
+| `list(string $userId, ?string $entityType = null, ?string $collection = null): array` | Filtered list, newest first. |
+
+Key design points:
+
+- **UNIQUE (user_id, entity_type, entity_id)**: DB-enforced deduplication.
+- **`save()` idempotent**: `INSERT OR IGNORE` / `INSERT IGNORE` — duplicate returns `false`.
+- **`collection`**: optional grouping field (default `''`); enables wishlist/favourites/read-later etc.
+- **`(entity_type, entity_id)` agnostic**: reusable across all content types.
+- **`list()` filters**: type and/or collection are optional; all nullable.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/BookmarkTest.php`)
+
+16 unit tests covering:
+
+- save returns true on first bookmark
+- save returns false when already saved
+- save with collection
+- remove returns true when bookmarked
+- remove returns false when not bookmarked
+- remove deletes bookmark
+- isSaved returns true after save
+- isSaved returns false before save
+- isSaved is user-isolated
+- isSaved is entity-type-isolated
+- list returns all bookmarks for user
+- list filters by entity type
+- list filters by collection
+- list is user-isolated
+- list returns empty for new user
+- list result contains expected keys
+
+### Howto (`docs/development/bookmark.md`)
+
+Covers: schema, API table, usage, collections, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`Bookmark` is a clean `Nene\Xion` helper. 16 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/BookmarkTest.php
+++ b/tests/Unit/Xion/BookmarkTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\Bookmark;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Bookmark using an in-memory SQLite database.
+ */
+final class BookmarkTest extends TestCase
+{
+    private PDO $db;
+    private Bookmark $bm;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE bookmarks (
+                id          INTEGER      PRIMARY KEY AUTOINCREMENT,
+                user_id     VARCHAR(255) NOT NULL,
+                entity_type VARCHAR(64)  NOT NULL,
+                entity_id   VARCHAR(255) NOT NULL,
+                collection  VARCHAR(64)  NOT NULL DEFAULT \'\',
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (user_id, entity_type, entity_id)
+            )'
+        );
+        $this->bm = new Bookmark($this->db);
+    }
+
+    // ── save ──────────────────────────────────────────────────────────────────
+
+    public function testSaveReturnsTrueOnFirstBookmark(): void
+    {
+        $this->assertTrue($this->bm->save('user:1', 'article', '42'));
+    }
+
+    public function testSaveReturnsFalseWhenAlreadySaved(): void
+    {
+        $this->bm->save('user:1', 'article', '42');
+        $this->assertFalse($this->bm->save('user:1', 'article', '42'));
+    }
+
+    public function testSaveWithCollection(): void
+    {
+        $this->bm->save('user:1', 'article', '42', 'read-later');
+        $list = $this->bm->list('user:1');
+        $this->assertSame('read-later', $list[0]['collection']);
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveReturnsTrueWhenBookmarked(): void
+    {
+        $this->bm->save('user:1', 'article', '42');
+        $this->assertTrue($this->bm->remove('user:1', 'article', '42'));
+    }
+
+    public function testRemoveReturnsFalseWhenNotBookmarked(): void
+    {
+        $this->assertFalse($this->bm->remove('user:1', 'article', '42'));
+    }
+
+    public function testRemoveDeletesBookmark(): void
+    {
+        $this->bm->save('user:1', 'article', '42');
+        $this->bm->remove('user:1', 'article', '42');
+        $this->assertFalse($this->bm->isSaved('user:1', 'article', '42'));
+    }
+
+    // ── isSaved ───────────────────────────────────────────────────────────────
+
+    public function testIsSavedReturnsTrueAfterSave(): void
+    {
+        $this->bm->save('user:1', 'article', '42');
+        $this->assertTrue($this->bm->isSaved('user:1', 'article', '42'));
+    }
+
+    public function testIsSavedReturnsFalseBeforeSave(): void
+    {
+        $this->assertFalse($this->bm->isSaved('user:1', 'article', '42'));
+    }
+
+    public function testIsSavedIsUserIsolated(): void
+    {
+        $this->bm->save('user:1', 'article', '42');
+        $this->assertFalse($this->bm->isSaved('user:2', 'article', '42'));
+    }
+
+    public function testIsSavedIsEntityTypeIsolated(): void
+    {
+        $this->bm->save('user:1', 'article', '42');
+        $this->assertFalse($this->bm->isSaved('user:1', 'product', '42'));
+    }
+
+    // ── list ──────────────────────────────────────────────────────────────────
+
+    public function testListReturnsAllBookmarksForUser(): void
+    {
+        $this->bm->save('user:1', 'article', '1');
+        $this->bm->save('user:1', 'article', '2');
+        $this->assertCount(2, $this->bm->list('user:1'));
+    }
+
+    public function testListFiltersByEntityType(): void
+    {
+        $this->bm->save('user:1', 'article', '1');
+        $this->bm->save('user:1', 'product', '99');
+        $this->assertCount(1, $this->bm->list('user:1', 'article'));
+    }
+
+    public function testListFiltersByCollection(): void
+    {
+        $this->bm->save('user:1', 'article', '1', 'read-later');
+        $this->bm->save('user:1', 'article', '2', 'favourites');
+        $list = $this->bm->list('user:1', 'article', 'read-later');
+        $this->assertCount(1, $list);
+        $this->assertSame('1', $list[0]['entity_id']);
+    }
+
+    public function testListIsUserIsolated(): void
+    {
+        $this->bm->save('user:1', 'article', '1');
+        $this->assertEmpty($this->bm->list('user:2'));
+    }
+
+    public function testListReturnsEmptyForNewUser(): void
+    {
+        $this->assertEmpty($this->bm->list('user:1'));
+    }
+
+    public function testListResultContainsExpectedKeys(): void
+    {
+        $this->bm->save('user:1', 'article', '42', 'fav');
+        $list = $this->bm->list('user:1');
+        $this->assertArrayHasKey('id', $list[0]);
+        $this->assertArrayHasKey('entity_type', $list[0]);
+        $this->assertArrayHasKey('entity_id', $list[0]);
+        $this->assertArrayHasKey('collection', $list[0]);
+        $this->assertArrayHasKey('created_at', $list[0]);
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT72 — Bookmark / Saved Items.

### `Nene\Xion\Bookmark`

Per-user bookmark manager:

- `save/remove/isSaved/list`
- Idempotent save via `INSERT OR IGNORE`
- Optional `collection` field (wishlist/favourites/read-later)
- `(entity_type, entity_id)` agnostic design
- `list()` with optional type + collection filters

### Tests

16 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)