### PR TITLE
feat(xion): JobQueue — DB-backed job queue with retry, delay, and multi-queue support (FT73)

### DIFF
--- a/class/xion/JobQueue.php
+++ b/class/xion/JobQueue.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Simple DB-backed job queue for lightweight background task processing.
+ *
+ * Jobs are stored as serialized payloads with status tracking.
+ * A worker calls `dequeue()` to claim the next available job (atomic),
+ * then processes it, then calls `complete()` or `fail()`.
+ * Failed jobs can be retried up to a configurable limit.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE job_queue (
+ *     id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     queue        VARCHAR(64)  NOT NULL DEFAULT 'default',
+ *     payload      TEXT         NOT NULL,
+ *     status       VARCHAR(16)  NOT NULL DEFAULT 'pending',
+ *     attempts     INTEGER      NOT NULL DEFAULT 0,
+ *     max_attempts INTEGER      NOT NULL DEFAULT 3,
+ *     error        TEXT         DEFAULT NULL,
+ *     available_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE INDEX idx_job_queue_dequeue ON job_queue (queue, status, available_at);
+ * ```
+ *
+ * ## Status values
+ *
+ * - `pending`    — waiting to be picked up.
+ * - `processing` — claimed by a worker; being executed.
+ * - `completed`  — finished successfully.
+ * - `failed`     — all attempts exhausted.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $q = new JobQueue($pdo);
+ *
+ * // Enqueue
+ * $id = $q->enqueue(['type' => 'send_email', 'to' => 'user@example.com']);
+ *
+ * // Worker loop
+ * while ($job = $q->dequeue()) {
+ *     try {
+ *         $payload = $job['payload']; // decoded array
+ *         // ... process ...
+ *         $q->complete($job['id']);
+ *     } catch (\Throwable $e) {
+ *         $q->fail($job['id'], $e->getMessage());
+ *     }
+ * }
+ * ```
+ */
+final class JobQueue
+{
+    private const TABLE           = 'job_queue';
+    private const DEFAULT_QUEUE   = 'default';
+    private const STATUS_PENDING  = 'pending';
+    private const STATUS_PROCESS  = 'processing';
+    private const STATUS_COMPLETE = 'completed';
+    private const STATUS_FAILED   = 'failed';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Add a job to the queue.
+     *
+     * @param  array<mixed> $payload     Job data (will be JSON-encoded).
+     * @param  string       $queue       Queue name (default: 'default').
+     * @param  int          $maxAttempts Maximum number of delivery attempts.
+     * @param  int          $delaySeconds Seconds before job becomes available.
+     * @return int New job ID.
+     */
+    public function enqueue(
+        array $payload,
+        string $queue = self::DEFAULT_QUEUE,
+        int $maxAttempts = 3,
+        int $delaySeconds = 0,
+    ): int {
+        $db          = $this->db ?? PdoConnection::getInstance();
+        $now         = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        $availableAt = $delaySeconds > 0
+            ? (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+                ->modify('+' . $delaySeconds . ' seconds')
+                ->format('Y-m-d H:i:s')
+            : $now;
+
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->table .
+            ' (queue, payload, status, max_attempts, available_at, created_at, updated_at)' .
+            ' VALUES (:q, :payload, :status, :max, :avail, :now, :now)'
+        );
+        $stmt->bindValue(':q', $queue, PDO::PARAM_STR);
+        $stmt->bindValue(':payload', json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE), PDO::PARAM_STR);
+        $stmt->bindValue(':status', self::STATUS_PENDING, PDO::PARAM_STR);
+        $stmt->bindValue(':max', $maxAttempts, PDO::PARAM_INT);
+        $stmt->bindValue(':avail', $availableAt, PDO::PARAM_STR);
+        $stmt->bindValue(':now', $now, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Claim the next available job from a queue (atomic).
+     *
+     * Returns null when the queue is empty.
+     * The returned payload is decoded from JSON.
+     *
+     * @param  string $queue Queue name.
+     * @return array{id:int,queue:string,payload:array<mixed>,attempts:int,max_attempts:int,created_at:string}|null
+     */
+    public function dequeue(string $queue = self::DEFAULT_QUEUE): ?array
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $db->beginTransaction();
+        try {
+            $stmt = $db->prepare(
+                'SELECT id, queue, payload, attempts, max_attempts, created_at' .
+                ' FROM ' . $this->table .
+                ' WHERE queue = :q AND status = :status AND available_at <= :now' .
+                ' ORDER BY id ASC LIMIT 1'
+            );
+            $stmt->bindValue(':q', $queue, PDO::PARAM_STR);
+            $stmt->bindValue(':status', self::STATUS_PENDING, PDO::PARAM_STR);
+            $stmt->bindValue(':now', $now, PDO::PARAM_STR);
+            $stmt->execute();
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+            if (!is_array($row)) {
+                $db->rollBack();
+                return null;
+            }
+
+            $upd = $db->prepare(
+                'UPDATE ' . $this->table .
+                ' SET status = :status, attempts = attempts + 1, updated_at = :now' .
+                ' WHERE id = :id'
+            );
+            $upd->bindValue(':status', self::STATUS_PROCESS, PDO::PARAM_STR);
+            $upd->bindValue(':now', $now, PDO::PARAM_STR);
+            $upd->bindValue(':id', (int)$row['id'], PDO::PARAM_INT);
+            $upd->execute();
+
+            $db->commit();
+
+            return [
+                'id'           => (int)$row['id'],
+                'queue'        => (string)$row['queue'],
+                'payload'      => json_decode((string)$row['payload'], true, 512, JSON_THROW_ON_ERROR),
+                'attempts'     => (int)$row['attempts'] + 1,
+                'max_attempts' => (int)$row['max_attempts'],
+                'created_at'   => (string)$row['created_at'],
+            ];
+        } catch (\Throwable $e) {
+            $db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Mark a job as successfully completed.
+     *
+     * @param int $jobId Job ID returned by dequeue().
+     */
+    public function complete(int $jobId): void
+    {
+        $this->updateStatus($jobId, self::STATUS_COMPLETE);
+    }
+
+    /**
+     * Mark a job as failed. If attempts < max_attempts, re-queues it as pending.
+     *
+     * @param int    $jobId   Job ID returned by dequeue().
+     * @param string $error   Error message to record.
+     */
+    public function fail(int $jobId, string $error = ''): void
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        // Check if retries remain
+        $stmt = $db->prepare(
+            'SELECT attempts, max_attempts FROM ' . $this->table . ' WHERE id = :id LIMIT 1'
+        );
+        $stmt->bindValue(':id', $jobId, PDO::PARAM_INT);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return;
+        }
+
+        $newStatus = (int)$row['attempts'] >= (int)$row['max_attempts']
+            ? self::STATUS_FAILED
+            : self::STATUS_PENDING;
+
+        $upd = $db->prepare(
+            'UPDATE ' . $this->table .
+            ' SET status = :status, error = :error, updated_at = :now WHERE id = :id'
+        );
+        $upd->bindValue(':status', $newStatus, PDO::PARAM_STR);
+        $upd->bindValue(':error', $error !== '' ? $error : null, $error !== '' ? PDO::PARAM_STR : PDO::PARAM_NULL);
+        $upd->bindValue(':now', $now, PDO::PARAM_STR);
+        $upd->bindValue(':id', $jobId, PDO::PARAM_INT);
+        $upd->execute();
+    }
+
+    /**
+     * Get the number of jobs by status in a queue.
+     *
+     * @param  string      $queue  Queue name.
+     * @param  string|null $status Filter by status. Null = all statuses.
+     * @return int
+     */
+    public function count(string $queue = self::DEFAULT_QUEUE, ?string $status = null): int
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $sql = 'SELECT COUNT(*) FROM ' . $this->table . ' WHERE queue = :q';
+        if ($status !== null) {
+            $sql .= ' AND status = :status';
+        }
+
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':q', $queue, PDO::PARAM_STR);
+        if ($status !== null) {
+            $stmt->bindValue(':status', $status, PDO::PARAM_STR);
+        }
+        $stmt->execute();
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function updateStatus(int $jobId, string $status): void
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->table . ' SET status = :status, updated_at = :now WHERE id = :id'
+        );
+        $stmt->bindValue(':status', $status, PDO::PARAM_STR);
+        $stmt->bindValue(':now', $now, PDO::PARAM_STR);
+        $stmt->bindValue(':id', $jobId, PDO::PARAM_INT);
+        $stmt->execute();
+    }
+}

--- a/docs/development/job-queue.md
+++ b/docs/development/job-queue.md
@@ -1,0 +1,116 @@
+# Job Queue
+
+`Nene\Xion\JobQueue` — simple DB-backed job queue for lightweight background task processing.
+
+## Schema
+
+```sql
+CREATE TABLE job_queue (
+    id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+    queue        VARCHAR(64)  NOT NULL DEFAULT 'default',
+    payload      TEXT         NOT NULL,
+    status       VARCHAR(16)  NOT NULL DEFAULT 'pending',
+    attempts     INTEGER      NOT NULL DEFAULT 0,
+    max_attempts INTEGER      NOT NULL DEFAULT 3,
+    error        TEXT         DEFAULT NULL,
+    available_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_job_queue_dequeue ON job_queue (queue, status, available_at);
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `enqueue(array $payload, string $queue = 'default', int $maxAttempts = 3, int $delaySeconds = 0): int` | Add job. Returns ID. |
+| `dequeue(string $queue = 'default'): ?array` | Claim next job atomically. Returns null when empty. |
+| `complete(int $jobId): void` | Mark as completed. |
+| `fail(int $jobId, string $error = ''): void` | Mark as failed or re-queue if retries remain. |
+| `count(string $queue = 'default', ?string $status = null): int` | Count jobs (all or by status). |
+
+## Status values
+
+| Status | Meaning |
+| --- | --- |
+| `pending` | Waiting to be picked up. |
+| `processing` | Claimed by a worker. |
+| `completed` | Finished successfully. |
+| `failed` | All attempts exhausted. |
+
+## Usage
+
+```php
+$q = new JobQueue($pdo);
+
+// Enqueue
+$id = $q->enqueue(['type' => 'send_email', 'to' => 'user@example.com']);
+$q->enqueue(['type' => 'resize_image', 'path' => '/tmp/img.jpg'], queue: 'images');
+$q->enqueue(['type' => 'reminder'],  delaySeconds: 3600);  // run in 1 hour
+
+// Worker loop
+while ($job = $q->dequeue()) {
+    try {
+        $payload = $job['payload'];  // decoded array
+        match ($payload['type']) {
+            'send_email'    => sendEmail($payload),
+            'resize_image'  => resizeImage($payload),
+        };
+        $q->complete($job['id']);
+    } catch (\Throwable $e) {
+        $q->fail($job['id'], $e->getMessage());
+        // If attempts < max_attempts: status → 'pending' (retry)
+        // If attempts >= max_attempts: status → 'failed' (dead)
+    }
+}
+
+// Stats
+$q->count('default', 'pending');    // waiting
+$q->count('default', 'failed');     // dead-letter
+$q->count('default');               // total
+```
+
+## Atomic dequeue
+
+`dequeue()` uses a transaction to atomically:
+1. `SELECT … LIMIT 1` for the oldest pending, available job
+2. `UPDATE … SET status = 'processing', attempts = attempts + 1`
+
+This prevents two workers from claiming the same job.
+
+## Retry semantics
+
+`fail()` checks `attempts` vs `max_attempts`:
+- If `attempts < max_attempts` → status reverts to `'pending'` (job is re-queued)
+- If `attempts >= max_attempts` → status set to `'failed'` (dead letter)
+
+## Delayed jobs
+
+`delaySeconds > 0` sets `available_at` to a future timestamp. The job is skipped by `dequeue()` until that time arrives.
+
+## Key design points
+
+- **FIFO**: `dequeue()` orders by `id ASC`.
+- **Multi-queue**: jobs are isolated by `queue` name; use separate queues for priority tiers.
+- **JSON payload**: `enqueue()` JSON-encodes; `dequeue()` JSON-decodes.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE job_queue (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    queue VARCHAR(64) NOT NULL DEFAULT \'default\',
+    payload TEXT NOT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT \'pending\',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 3,
+    error TEXT DEFAULT NULL,
+    available_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+)');
+$q = new JobQueue($db);
+```

--- a/docs/field-trials/2026-05-field-trial-73.md
+++ b/docs/field-trials/2026-05-field-trial-73.md
@@ -1,0 +1,66 @@
+# Field Trial 73 — Simple Job Queue
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft73-job-queue`
+**Baseline**: post FT72 merge
+
+## Goal
+
+Establish a lightweight DB-backed job queue pattern for NeNe applications. Provide enqueue/dequeue/complete/fail lifecycle with retry support — a simpler alternative to FT36 (ADR-class background jobs).
+
+## What was built
+
+### `Nene\Xion\JobQueue` (`class/xion/JobQueue.php`)
+
+DB-backed job queue providing:
+
+| Method | Description |
+| --- | --- |
+| `enqueue(array $payload, string $queue, int $maxAttempts, int $delaySeconds): int` | Add job; JSON payload. |
+| `dequeue(string $queue): ?array` | Atomically claim next pending job. |
+| `complete(int $jobId): void` | Mark completed. |
+| `fail(int $jobId, string $error): void` | Record failure; retry or mark failed. |
+| `count(string $queue, ?string $status): int` | Job counts. |
+
+Key design points:
+
+- **Atomic dequeue**: transaction + SELECT…LIMIT 1 + UPDATE prevents double-claim.
+- **FIFO**: `ORDER BY id ASC` in dequeue.
+- **Retry semantics**: `fail()` re-queues if `attempts < max_attempts`, else marks `failed`.
+- **Delayed jobs**: `delaySeconds > 0` sets future `available_at`; skipped until available.
+- **Multi-queue**: jobs isolated by `queue` name.
+- **JSON payload**: encode on enqueue, decode on dequeue.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/JobQueueTest.php`)
+
+14 unit tests covering:
+
+- enqueue returns id
+- enqueued job is pending
+- enqueue with custom queue
+- enqueue with delay (not immediately available)
+- dequeue returns job
+- dequeue returns null when empty
+- dequeue changes status to processing
+- dequeue increments attempts
+- dequeue is FIFO
+- complete marks job done
+- fail with remaining attempts re-queues
+- fail with no attempts remaining marks failed
+- count all statuses when null filter
+- count is queue-isolated
+
+### Howto (`docs/development/job-queue.md`)
+
+Covers: schema, API table, status values, usage examples, atomic dequeue, retry semantics, delayed jobs, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`JobQueue` is a clean `Nene\Xion` helper. 14 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/JobQueueTest.php
+++ b/tests/Unit/Xion/JobQueueTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\JobQueue;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for JobQueue using an in-memory SQLite database.
+ */
+final class JobQueueTest extends TestCase
+{
+    private PDO $db;
+    private JobQueue $q;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE job_queue (
+                id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+                queue        VARCHAR(64)  NOT NULL DEFAULT \'default\',
+                payload      TEXT         NOT NULL,
+                status       VARCHAR(16)  NOT NULL DEFAULT \'pending\',
+                attempts     INTEGER      NOT NULL DEFAULT 0,
+                max_attempts INTEGER      NOT NULL DEFAULT 3,
+                error        TEXT         DEFAULT NULL,
+                available_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->q = new JobQueue($this->db);
+    }
+
+    // ── enqueue ───────────────────────────────────────────────────────────────
+
+    public function testEnqueueReturnsId(): void
+    {
+        $id = $this->q->enqueue(['type' => 'email']);
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testEnqueuedJobIsPending(): void
+    {
+        $this->q->enqueue(['type' => 'email']);
+        $this->assertSame(1, $this->q->count('default', 'pending'));
+    }
+
+    public function testEnqueueWithCustomQueue(): void
+    {
+        $this->q->enqueue(['type' => 'email'], queue: 'emails');
+        $this->assertSame(1, $this->q->count('emails', 'pending'));
+        $this->assertSame(0, $this->q->count('default', 'pending'));
+    }
+
+    public function testEnqueueWithDelay(): void
+    {
+        $this->q->enqueue(['type' => 'email'], delaySeconds: 3600);
+        // Job is not yet available
+        $job = $this->q->dequeue();
+        $this->assertNull($job);
+    }
+
+    // ── dequeue ───────────────────────────────────────────────────────────────
+
+    public function testDequeueReturnsJob(): void
+    {
+        $this->q->enqueue(['type' => 'email', 'to' => 'a@b.com']);
+        $job = $this->q->dequeue();
+        $this->assertNotNull($job);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('email', $job['payload']['type']);
+    }
+
+    public function testDequeueReturnsNullWhenEmpty(): void
+    {
+        $this->assertNull($this->q->dequeue());
+    }
+
+    public function testDequeueChangesStatusToProcessing(): void
+    {
+        $this->q->enqueue(['type' => 'email']);
+        $this->q->dequeue();
+        $this->assertSame(0, $this->q->count('default', 'pending'));
+        $this->assertSame(1, $this->q->count('default', 'processing'));
+    }
+
+    public function testDequeueIncrementsAttempts(): void
+    {
+        $this->q->enqueue(['type' => 'email']);
+        $job = $this->q->dequeue();
+        $this->assertIsArray($job);
+        $this->assertSame(1, $job['attempts']);
+    }
+
+    public function testDequeueIsFIFO(): void
+    {
+        $id1 = $this->q->enqueue(['order' => 1]);
+        $id2 = $this->q->enqueue(['order' => 2]);
+        $job = $this->q->dequeue();
+        $this->assertIsArray($job);
+        $this->assertSame($id1, $job['id']);
+    }
+
+    // ── complete ──────────────────────────────────────────────────────────────
+
+    public function testCompleteMarksJobDone(): void
+    {
+        $this->q->enqueue(['type' => 'email']);
+        $job = $this->q->dequeue();
+        $this->assertIsArray($job);
+        $this->q->complete($job['id']);
+        $this->assertSame(1, $this->q->count('default', 'completed'));
+    }
+
+    // ── fail ──────────────────────────────────────────────────────────────────
+
+    public function testFailWithRemainingAttemptsReQueues(): void
+    {
+        $this->q->enqueue(['type' => 'email'], maxAttempts: 3);
+        $job = $this->q->dequeue();
+        $this->assertIsArray($job);
+        $this->q->fail($job['id'], 'connection error');
+        // 1 attempt used, 2 remaining — status should be pending again
+        $this->assertSame(1, $this->q->count('default', 'pending'));
+    }
+
+    public function testFailWithNoAttemptsRemainingMarksFailed(): void
+    {
+        $this->q->enqueue(['type' => 'email'], maxAttempts: 1);
+        $job = $this->q->dequeue();
+        $this->assertIsArray($job);
+        $this->q->fail($job['id'], 'permanent error');
+        $this->assertSame(1, $this->q->count('default', 'failed'));
+        $this->assertSame(0, $this->q->count('default', 'pending'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountAllStatusesWhenNullFilter(): void
+    {
+        $this->q->enqueue(['a' => 1]);
+        $this->q->enqueue(['b' => 2]);
+        $this->assertSame(2, $this->q->count('default'));
+    }
+
+    public function testCountIsQueueIsolated(): void
+    {
+        $this->q->enqueue(['a' => 1], queue: 'q1');
+        $this->q->enqueue(['b' => 2], queue: 'q2');
+        $this->assertSame(1, $this->q->count('q1'));
+        $this->assertSame(1, $this->q->count('q2'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT73 — Simple Job Queue.

### `Nene\Xion\JobQueue`

Lightweight DB-backed job queue:

- `enqueue/dequeue/complete/fail/count`
- Atomic dequeue via transaction
- FIFO ordering by id
- Retry: re-queues if attempts < max, marks failed when exhausted
- Delayed jobs via `delaySeconds`
- Multi-queue isolation

### Tests

14 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)