### PR TITLE
feat(xion): FileMetadata — file storage metadata with MIME filter and soft delete (FT75)

### DIFF
--- a/class/xion/FileMetadata.php
+++ b/class/xion/FileMetadata.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * File storage metadata management.
+ *
+ * Records file metadata (path, size, MIME type, owner) in the database
+ * without managing the actual file storage. The physical file lifecycle
+ * (upload, delete from disk/S3/etc.) is handled by the application.
+ *
+ * Supports soft delete: files are marked deleted_at but the row is retained
+ * for audit purposes.
+ *
+ * ## Schema
+ *
+ * ```sql
+ * CREATE TABLE file_metadata (
+ *     id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+ *     owner_id     VARCHAR(255) NOT NULL,
+ *     path         VARCHAR(1024) NOT NULL,
+ *     filename     VARCHAR(255) NOT NULL,
+ *     mime_type    VARCHAR(127) NOT NULL,
+ *     size_bytes   INTEGER      NOT NULL DEFAULT 0,
+ *     storage      VARCHAR(64)  NOT NULL DEFAULT 'local',
+ *     deleted_at   DATETIME     DEFAULT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE INDEX idx_file_metadata_owner ON file_metadata (owner_id, deleted_at);
+ * ```
+ *
+ * ## Usage
+ *
+ * ```php
+ * $fm = new FileMetadata($pdo);
+ *
+ * // Register after upload
+ * $id = $fm->register('user:1', '/uploads/abc123.jpg', 'photo.jpg', 'image/jpeg', 204800);
+ *
+ * // Find
+ * $file = $fm->find($id);
+ *
+ * // List active files for owner
+ * $fm->findByOwner('user:1');
+ *
+ * // Soft delete (mark deleted, retain row)
+ * $fm->delete($id, 'user:1');
+ * ```
+ */
+final class FileMetadata
+{
+    private const TABLE = 'file_metadata';
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly string $table = self::TABLE,
+    ) {
+    }
+
+    /**
+     * Register file metadata after an upload.
+     *
+     * @param  string $ownerId    Application-level owner identifier.
+     * @param  string $path       Storage path or URL (e.g. '/uploads/abc123.jpg', 's3://bucket/key').
+     * @param  string $filename   Original filename as uploaded by the user.
+     * @param  string $mimeType   MIME type (e.g. 'image/jpeg').
+     * @param  int    $sizeBytes  File size in bytes.
+     * @param  string $storage    Storage backend identifier (e.g. 'local', 's3', 'gcs').
+     * @return int New metadata row ID.
+     */
+    public function register(
+        string $ownerId,
+        string $path,
+        string $filename,
+        string $mimeType,
+        int $sizeBytes = 0,
+        string $storage = 'local',
+    ): int {
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $createdAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'INSERT INTO ' . $this->table .
+            ' (owner_id, path, filename, mime_type, size_bytes, storage, created_at)' .
+            ' VALUES (:owner, :path, :filename, :mime, :size, :storage, :t)'
+        );
+        $stmt->bindValue(':owner', $ownerId, PDO::PARAM_STR);
+        $stmt->bindValue(':path', $path, PDO::PARAM_STR);
+        $stmt->bindValue(':filename', $filename, PDO::PARAM_STR);
+        $stmt->bindValue(':mime', $mimeType, PDO::PARAM_STR);
+        $stmt->bindValue(':size', $sizeBytes, PDO::PARAM_INT);
+        $stmt->bindValue(':storage', $storage, PDO::PARAM_STR);
+        $stmt->bindValue(':t', $createdAt, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Find a file by ID. Returns null if not found.
+     *
+     * @param  int $id Row ID.
+     * @return array{id:int,owner_id:string,path:string,filename:string,mime_type:string,size_bytes:int,storage:string,deleted_at:string|null,created_at:string}|null
+     */
+    public function find(int $id): ?array
+    {
+        $db   = $this->db ?? PdoConnection::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id, owner_id, path, filename, mime_type, size_bytes, storage, deleted_at, created_at' .
+            ' FROM ' . $this->table . ' WHERE id = :id LIMIT 1'
+        );
+        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        return $this->mapRow($row);
+    }
+
+    /**
+     * List active (non-deleted) files for an owner.
+     *
+     * @param  string      $ownerId   Owner identifier.
+     * @param  string|null $mimeType  Filter by MIME type prefix (e.g. 'image/'). Null = all.
+     * @return list<array{id:int,owner_id:string,path:string,filename:string,mime_type:string,size_bytes:int,storage:string,deleted_at:null,created_at:string}>
+     */
+    public function findByOwner(string $ownerId, ?string $mimeType = null): array
+    {
+        $db  = $this->db ?? PdoConnection::getInstance();
+        $sql = 'SELECT id, owner_id, path, filename, mime_type, size_bytes, storage, deleted_at, created_at' .
+               ' FROM ' . $this->table .
+               ' WHERE owner_id = :owner AND deleted_at IS NULL';
+
+        if ($mimeType !== null) {
+            $sql .= ' AND mime_type LIKE :mime';
+        }
+
+        $sql .= ' ORDER BY id DESC';
+
+        $stmt = $db->prepare($sql);
+        $stmt->bindValue(':owner', $ownerId, PDO::PARAM_STR);
+        if ($mimeType !== null) {
+            $prefix = rtrim($mimeType, '%') . '%';
+            $stmt->bindValue(':mime', $prefix, PDO::PARAM_STR);
+        }
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn (array $r) => $this->mapRow($r), $rows);
+    }
+
+    /**
+     * Soft-delete a file. Only the owner can delete their own file.
+     *
+     * Returns true if deleted, false if not found or wrong owner.
+     *
+     * @param int    $id      Row ID.
+     * @param string $ownerId Must match the owner_id used in register().
+     */
+    public function delete(int $id, string $ownerId): bool
+    {
+        $db        = $this->db ?? PdoConnection::getInstance();
+        $deletedAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            'UPDATE ' . $this->table .
+            ' SET deleted_at = :t WHERE id = :id AND owner_id = :owner AND deleted_at IS NULL'
+        );
+        $stmt->bindValue(':t', $deletedAt, PDO::PARAM_STR);
+        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $stmt->bindValue(':owner', $ownerId, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    /**
+     * @param  array<string, mixed> $row
+     * @return array{id:int,owner_id:string,path:string,filename:string,mime_type:string,size_bytes:int,storage:string,deleted_at:string|null,created_at:string}
+     */
+    private function mapRow(array $row): array
+    {
+        return [
+            'id'         => (int)$row['id'],
+            'owner_id'   => (string)$row['owner_id'],
+            'path'       => (string)$row['path'],
+            'filename'   => (string)$row['filename'],
+            'mime_type'  => (string)$row['mime_type'],
+            'size_bytes' => (int)$row['size_bytes'],
+            'storage'    => (string)$row['storage'],
+            'deleted_at' => $row['deleted_at'] !== null ? (string)$row['deleted_at'] : null,
+            'created_at' => (string)$row['created_at'],
+        ];
+    }
+}

--- a/docs/development/file-metadata.md
+++ b/docs/development/file-metadata.md
@@ -1,0 +1,100 @@
+# File Metadata
+
+`Nene\Xion\FileMetadata` — file storage metadata management with soft delete.
+
+Records file metadata (path, MIME type, size, owner, storage backend) in the database. Does **not** manage the physical file — upload and deletion of the actual bytes is the application's responsibility.
+
+## Schema
+
+```sql
+CREATE TABLE file_metadata (
+    id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+    owner_id     VARCHAR(255) NOT NULL,
+    path         VARCHAR(1024) NOT NULL,
+    filename     VARCHAR(255) NOT NULL,
+    mime_type    VARCHAR(127) NOT NULL,
+    size_bytes   INTEGER      NOT NULL DEFAULT 0,
+    storage      VARCHAR(64)  NOT NULL DEFAULT 'local',
+    deleted_at   DATETIME     DEFAULT NULL,
+    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_file_metadata_owner ON file_metadata (owner_id, deleted_at);
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `register(string $ownerId, string $path, string $filename, string $mimeType, int $sizeBytes = 0, string $storage = 'local'): int` | Register file metadata. Returns ID. |
+| `find(int $id): ?array` | Get file by ID (including soft-deleted). Returns null if not found. |
+| `findByOwner(string $ownerId, ?string $mimeType = null): array` | Active (non-deleted) files for owner, optionally filtered by MIME. |
+| `delete(int $id, string $ownerId): bool` | Soft-delete. Owner-enforced. Returns true if deleted. |
+
+## Usage
+
+```php
+$fm = new FileMetadata($pdo);
+
+// After upload — register metadata
+$id = $fm->register(
+    'user:1',
+    '/uploads/2026/05/abc123.jpg',    // storage path
+    'photo.jpg',                       // original filename
+    'image/jpeg',
+    204800,                            // 200 KB
+    'local',                           // or 's3', 'gcs', etc.
+);
+
+// Find by ID
+$file = $fm->find($id);
+// ['id' => 1, 'owner_id' => 'user:1', 'path' => '/uploads/...', 'mime_type' => 'image/jpeg', ...]
+
+// List active files
+$fm->findByOwner('user:1');               // all types
+$fm->findByOwner('user:1', 'image/');     // images only (LIKE 'image/%')
+$fm->findByOwner('user:1', 'application/pdf');  // exact MIME
+
+// Soft delete (row retained, deleted_at set)
+$fm->delete($id, 'user:1');   // true
+$fm->delete($id, 'user:2');   // false — wrong owner
+$fm->delete($id, 'user:1');   // false — already deleted
+```
+
+## Soft delete
+
+`delete()` sets `deleted_at` but keeps the row. `findByOwner()` excludes deleted files. `find()` returns deleted files (for admin/audit use). The physical file deletion is the application's responsibility.
+
+## MIME type filter
+
+`findByOwner($userId, 'image/')` matches any MIME starting with `image/` (JPEG, PNG, WebP, etc.) using `LIKE 'image/%'`. Pass a full MIME type for exact match:
+
+```php
+$fm->findByOwner('user:1', 'image/jpeg');        // exact
+$fm->findByOwner('user:1', 'image/');            // all images
+$fm->findByOwner('user:1', 'application/pdf');   // exact
+```
+
+## Key design points
+
+- **Metadata only**: no file I/O — decoupled from storage layer.
+- **`storage` field**: identifies the backend (`'local'`, `'s3'`, `'gcs'`); app uses it to route deletion.
+- **Soft delete**: owner-enforced; `deleted_at IS NULL` filter in `findByOwner()`.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+## Test patterns
+
+```php
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE file_metadata (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_id VARCHAR(255) NOT NULL,
+    path VARCHAR(1024) NOT NULL,
+    filename VARCHAR(255) NOT NULL,
+    mime_type VARCHAR(127) NOT NULL,
+    size_bytes INTEGER NOT NULL DEFAULT 0,
+    storage VARCHAR(64) NOT NULL DEFAULT \'local\',
+    deleted_at DATETIME DEFAULT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+)');
+$fm = new FileMetadata($db);
+```

--- a/docs/field-trials/2026-05-field-trial-75.md
+++ b/docs/field-trials/2026-05-field-trial-75.md
@@ -1,0 +1,62 @@
+# Field Trial 75 — File Storage Metadata
+
+**Date**: 2026-05-27
+**Branch**: `feat/ft75-file-metadata`
+**Baseline**: post FT74 merge
+
+## Goal
+
+Establish a file storage metadata pattern for NeNe applications. Track uploaded file metadata in the DB while keeping the actual storage layer decoupled — the helper records what exists, not where.
+
+## What was built
+
+### `Nene\Xion\FileMetadata` (`class/xion/FileMetadata.php`)
+
+DB-backed file metadata manager providing:
+
+| Method | Description |
+| --- | --- |
+| `register(string $ownerId, string $path, string $filename, string $mimeType, int $sizeBytes, string $storage): int` | Register file. Returns ID. |
+| `find(int $id): ?array` | Get by ID (includes deleted). |
+| `findByOwner(string $ownerId, ?string $mimeType = null): array` | Active files; optional MIME filter. |
+| `delete(int $id, string $ownerId): bool` | Owner-enforced soft delete. |
+
+Key design points:
+
+- **Metadata only**: no file I/O — decoupled from storage backend.
+- **`storage` field**: `'local'`, `'s3'`, `'gcs'` etc. — app routes actual deletion.
+- **MIME filter**: `findByOwner($u, 'image/')` → `LIKE 'image/%'` for prefix match.
+- **Soft delete**: `deleted_at` set; `findByOwner()` excludes; `find()` includes.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/FileMetadataTest.php`)
+
+13 unit tests covering:
+
+- register returns id
+- register stores metadata (path, filename, mime, size, storage)
+- find returns null for unknown id
+- find returns row for known id
+- find returns soft-deleted file
+- findByOwner returns active files
+- findByOwner excludes soft-deleted
+- findByOwner is owner-isolated
+- findByOwner filters by MIME type
+- delete returns true by owner
+- delete returns false by wrong owner
+- delete sets deleted_at
+- delete already deleted returns false
+
+### Howto (`docs/development/file-metadata.md`)
+
+Covers: schema, API table, usage, soft delete, MIME filter, key design points, test patterns.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`FileMetadata` is a clean `Nene\Xion` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/FileMetadataTest.php
+++ b/tests/Unit/Xion/FileMetadataTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\FileMetadata;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for FileMetadata using an in-memory SQLite database.
+ */
+final class FileMetadataTest extends TestCase
+{
+    private PDO $db;
+    private FileMetadata $fm;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec(
+            'CREATE TABLE file_metadata (
+                id           INTEGER      PRIMARY KEY AUTOINCREMENT,
+                owner_id     VARCHAR(255) NOT NULL,
+                path         VARCHAR(1024) NOT NULL,
+                filename     VARCHAR(255) NOT NULL,
+                mime_type    VARCHAR(127) NOT NULL,
+                size_bytes   INTEGER      NOT NULL DEFAULT 0,
+                storage      VARCHAR(64)  NOT NULL DEFAULT \'local\',
+                deleted_at   DATETIME     DEFAULT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )'
+        );
+        $this->fm = new FileMetadata($this->db);
+    }
+
+    // ── register ──────────────────────────────────────────────────────────────
+
+    public function testRegisterReturnsId(): void
+    {
+        $id = $this->fm->register('user:1', '/uploads/a.jpg', 'photo.jpg', 'image/jpeg', 1024);
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testRegisterStoresMetadata(): void
+    {
+        $id   = $this->fm->register('user:1', '/uploads/a.jpg', 'photo.jpg', 'image/jpeg', 2048, 's3');
+        $file = $this->fm->find($id);
+        $this->assertNotNull($file);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('/uploads/a.jpg', $file['path']);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('photo.jpg', $file['filename']);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('image/jpeg', $file['mime_type']);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(2048, $file['size_bytes']);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('s3', $file['storage']);
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsNullForUnknownId(): void
+    {
+        $this->assertNull($this->fm->find(9999));
+    }
+
+    public function testFindReturnsRowForKnownId(): void
+    {
+        $id = $this->fm->register('user:1', '/uploads/b.pdf', 'doc.pdf', 'application/pdf');
+        $this->assertNotNull($this->fm->find($id));
+    }
+
+    public function testFindReturnsSoftDeletedFile(): void
+    {
+        $id = $this->fm->register('user:1', '/uploads/c.jpg', 'img.jpg', 'image/jpeg');
+        $this->fm->delete($id, 'user:1');
+        $file = $this->fm->find($id);
+        $this->assertNotNull($file);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertNotNull($file['deleted_at']);
+    }
+
+    // ── findByOwner ───────────────────────────────────────────────────────────
+
+    public function testFindByOwnerReturnsActiveFiles(): void
+    {
+        $this->fm->register('user:1', '/uploads/a.jpg', 'a.jpg', 'image/jpeg');
+        $this->fm->register('user:1', '/uploads/b.jpg', 'b.jpg', 'image/jpeg');
+        $this->assertCount(2, $this->fm->findByOwner('user:1'));
+    }
+
+    public function testFindByOwnerExcludesSoftDeleted(): void
+    {
+        $id = $this->fm->register('user:1', '/uploads/a.jpg', 'a.jpg', 'image/jpeg');
+        $this->fm->delete($id, 'user:1');
+        $this->assertEmpty($this->fm->findByOwner('user:1'));
+    }
+
+    public function testFindByOwnerIsOwnerIsolated(): void
+    {
+        $this->fm->register('user:1', '/uploads/a.jpg', 'a.jpg', 'image/jpeg');
+        $this->assertEmpty($this->fm->findByOwner('user:2'));
+    }
+
+    public function testFindByOwnerFiltersByMimeType(): void
+    {
+        $this->fm->register('user:1', '/uploads/a.jpg', 'a.jpg', 'image/jpeg');
+        $this->fm->register('user:1', '/uploads/b.pdf', 'b.pdf', 'application/pdf');
+        $images = $this->fm->findByOwner('user:1', 'image/');
+        $this->assertCount(1, $images);
+        $this->assertSame('image/jpeg', $images[0]['mime_type']);
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteReturnsTrueByOwner(): void
+    {
+        $id = $this->fm->register('user:1', '/uploads/a.jpg', 'a.jpg', 'image/jpeg');
+        $this->assertTrue($this->fm->delete($id, 'user:1'));
+    }
+
+    public function testDeleteReturnsFalseByWrongOwner(): void
+    {
+        $id = $this->fm->register('user:1', '/uploads/a.jpg', 'a.jpg', 'image/jpeg');
+        $this->assertFalse($this->fm->delete($id, 'user:2'));
+    }
+
+    public function testDeleteSetsDeletedAt(): void
+    {
+        $id   = $this->fm->register('user:1', '/uploads/a.jpg', 'a.jpg', 'image/jpeg');
+        $this->fm->delete($id, 'user:1');
+        $file = $this->fm->find($id);
+        $this->assertNotNull($file);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertNotNull($file['deleted_at']);
+    }
+
+    public function testDeleteAlreadyDeletedReturnsFalse(): void
+    {
+        $id = $this->fm->register('user:1', '/uploads/a.jpg', 'a.jpg', 'image/jpeg');
+        $this->fm->delete($id, 'user:1');
+        $this->assertFalse($this->fm->delete($id, 'user:1'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements FT75 — File Storage Metadata.

### `Nene\Xion\FileMetadata`

DB-only file metadata manager (no file I/O):

- `register/find/findByOwner/delete`
- MIME type prefix filter (`image/` → `LIKE 'image/%'`)
- Soft delete: owner-enforced; findByOwner excludes; find includes
- `storage` field for multi-backend routing

### Tests

13 unit tests; all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)