### PR TITLE
feat(xion): AddressBook — multi-address per-user book with default (FT77)

### DIFF
--- a/class/xion/AddressBook.php
+++ b/class/xion/AddressBook.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Per-user address book with multiple addresses and a default flag.
+ *
+ * Stores named postal/shipping addresses for a user.
+ * Each user may have many addresses; at most one is the default.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $book = new AddressBook($pdo);
+ *
+ * // Add
+ * $id = $book->add('user-1', [
+ *     'label'      => 'Home',
+ *     'name'       => 'Taro Yamada',
+ *     'line1'      => '1-2-3 Shinjuku',
+ *     'line2'      => '',
+ *     'city'       => 'Shinjuku-ku',
+ *     'state'      => 'Tokyo',
+ *     'postal'     => '160-0022',
+ *     'country'    => 'JP',
+ *     'phone'      => '+81-90-0000-0000',
+ *     'is_default' => true,
+ * ]);
+ *
+ * // List
+ * $addresses = $book->list('user-1');
+ *
+ * // Set default
+ * $book->setDefault('user-1', $id);
+ *
+ * // Update
+ * $book->update('user-1', $id, ['label' => 'Work']);
+ *
+ * // Remove
+ * $book->remove('user-1', $id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE addresses (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     label      VARCHAR(100) NOT NULL DEFAULT '',
+ *     name       VARCHAR(255) NOT NULL DEFAULT '',
+ *     line1      VARCHAR(255) NOT NULL DEFAULT '',
+ *     line2      VARCHAR(255) NOT NULL DEFAULT '',
+ *     city       VARCHAR(100) NOT NULL DEFAULT '',
+ *     state      VARCHAR(100) NOT NULL DEFAULT '',
+ *     postal     VARCHAR(20)  NOT NULL DEFAULT '',
+ *     country    VARCHAR(2)   NOT NULL DEFAULT '',
+ *     phone      VARCHAR(50)  NOT NULL DEFAULT '',
+ *     is_default TINYINT(1)   NOT NULL DEFAULT 0,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class AddressBook
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add a new address for a user.
+     *
+     * If `is_default` is true the previous default (if any) is cleared atomically.
+     *
+     * @param  string                $userId  User identifier.
+     * @param  array<string, mixed>  $data    Address fields (see schema above).
+     * @return int                   New address ID.
+     * @throws \InvalidArgumentException if required fields are empty.
+     */
+    public function add(string $userId, array $data): int
+    {
+        $db = $this->db();
+
+        $label   = trim((string)($data['label']   ?? ''));
+        $name    = trim((string)($data['name']    ?? ''));
+        $line1   = trim((string)($data['line1']   ?? ''));
+        $city    = trim((string)($data['city']    ?? ''));
+        $country = trim((string)($data['country'] ?? ''));
+
+        if ($line1 === '') {
+            throw new \InvalidArgumentException('Address line1 must not be empty.');
+        }
+        if ($country === '') {
+            throw new \InvalidArgumentException('Country must not be empty.');
+        }
+
+        $isDefault = !empty($data['is_default']);
+
+        $db->beginTransaction();
+        try {
+            if ($isDefault) {
+                $this->clearDefault($db, $userId);
+            }
+
+            $stmt = $db->prepare(
+                'INSERT INTO addresses
+                    (user_id, label, name, line1, line2, city, state, postal, country, phone, is_default, updated_at)
+                 VALUES
+                    (:user_id, :label, :name, :line1, :line2, :city, :state, :postal, :country, :phone, :is_default, CURRENT_TIMESTAMP)'
+            );
+            $stmt->execute([
+                ':user_id'    => $userId,
+                ':label'      => $label,
+                ':name'       => $name,
+                ':line1'      => $line1,
+                ':line2'      => trim((string)($data['line2'] ?? '')),
+                ':city'       => $city,
+                ':state'      => trim((string)($data['state'] ?? '')),
+                ':postal'     => trim((string)($data['postal'] ?? '')),
+                ':country'    => $country,
+                ':phone'      => trim((string)($data['phone'] ?? '')),
+                ':is_default' => $isDefault ? 1 : 0,
+            ]);
+
+            $id = (int)$db->lastInsertId();
+            $db->commit();
+            return $id;
+        } catch (\Throwable $e) {
+            $db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Update fields of an existing address.
+     *
+     * Only the keys present in `$data` are updated.
+     * If `is_default` is set to true the previous default is cleared.
+     *
+     * @param string               $userId    Owner user ID.
+     * @param int                  $addressId Address to update.
+     * @param array<string, mixed> $data      Fields to change.
+     * @return bool                True if a row was updated.
+     * @throws \InvalidArgumentException if line1/country would be set to empty.
+     */
+    public function update(string $userId, int $addressId, array $data): bool
+    {
+        $db = $this->db();
+
+        $allowed = ['label', 'name', 'line1', 'line2', 'city', 'state', 'postal', 'country', 'phone', 'is_default'];
+        $sets    = [];
+        $params  = [':user_id' => $userId, ':id' => $addressId];
+
+        foreach ($allowed as $col) {
+            if (!array_key_exists($col, $data)) {
+                continue;
+            }
+            if ($col === 'is_default') {
+                continue; // handled separately
+            }
+            $value = trim((string)$data[$col]);
+            if ($col === 'line1' && $value === '') {
+                throw new \InvalidArgumentException('Address line1 must not be empty.');
+            }
+            if ($col === 'country' && $value === '') {
+                throw new \InvalidArgumentException('Country must not be empty.');
+            }
+            $sets[":$col"] = $value;
+        }
+
+        $isDefaultSet = array_key_exists('is_default', $data);
+        $isDefault    = $isDefaultSet && !empty($data['is_default']);
+
+        if (empty($sets) && !$isDefaultSet) {
+            return false;
+        }
+
+        $db->beginTransaction();
+        try {
+            if ($isDefault) {
+                $this->clearDefault($db, $userId);
+                $sets[':is_default'] = 1;
+            } elseif ($isDefaultSet) {
+                $sets[':is_default'] = 0;
+            }
+
+            $setClauses = implode(
+                ', ',
+                array_map(
+                    static fn (string $k): string => ltrim($k, ':') . ' = ' . $k,
+                    array_keys($sets)
+                )
+            );
+
+            $sql = "UPDATE addresses SET {$setClauses}, updated_at = CURRENT_TIMESTAMP
+                    WHERE user_id = :user_id AND id = :id";
+
+            $stmt = $db->prepare($sql);
+            $stmt->execute(array_merge($sets, $params));
+
+            $affected = $stmt->rowCount();
+            $db->commit();
+            return $affected > 0;
+        } catch (\Throwable $e) {
+            $db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Remove an address (hard delete).
+     *
+     * If the deleted address was the default, no other address is auto-promoted.
+     *
+     * @return bool True if a row was deleted.
+     */
+    public function remove(string $userId, int $addressId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM addresses WHERE user_id = :user_id AND id = :id'
+        );
+        $stmt->execute([':user_id' => $userId, ':id' => $addressId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Get a single address by ID (must belong to the user).
+     *
+     * @return array<string, mixed>|null
+     */
+    public function get(string $userId, int $addressId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM addresses WHERE user_id = :user_id AND id = :id LIMIT 1'
+        );
+        $stmt->execute([':user_id' => $userId, ':id' => $addressId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * List all addresses for a user, default first then by id ASC.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function list(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM addresses WHERE user_id = :user_id ORDER BY is_default DESC, id ASC'
+        );
+        $stmt->execute([':user_id' => $userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Set one address as the default for a user.
+     *
+     * Clears any existing default within a transaction.
+     *
+     * @return bool True if the address exists and was updated.
+     */
+    public function setDefault(string $userId, int $addressId): bool
+    {
+        $db = $this->db();
+        $db->beginTransaction();
+        try {
+            $this->clearDefault($db, $userId);
+
+            $stmt = $db->prepare(
+                'UPDATE addresses SET is_default = 1, updated_at = CURRENT_TIMESTAMP
+                 WHERE user_id = :user_id AND id = :id'
+            );
+            $stmt->execute([':user_id' => $userId, ':id' => $addressId]);
+            $affected = $stmt->rowCount();
+            $db->commit();
+            return $affected > 0;
+        } catch (\Throwable $e) {
+            $db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Return the default address for a user, or null if none set.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getDefault(string $userId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM addresses WHERE user_id = :user_id AND is_default = 1 LIMIT 1'
+        );
+        $stmt->execute([':user_id' => $userId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function clearDefault(PDO $db, string $userId): void
+    {
+        $stmt = $db->prepare(
+            'UPDATE addresses SET is_default = 0, updated_at = CURRENT_TIMESTAMP
+             WHERE user_id = :user_id AND is_default = 1'
+        );
+        $stmt->execute([':user_id' => $userId]);
+    }
+}

--- a/tests/Unit/Xion/AddressBookTest.php
+++ b/tests/Unit/Xion/AddressBookTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\AddressBook;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for AddressBook.
+ */
+final class AddressBookTest extends TestCase
+{
+    private PDO $db;
+    private AddressBook $book;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE addresses (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL,
+                label      VARCHAR(100) NOT NULL DEFAULT \'\',
+                name       VARCHAR(255) NOT NULL DEFAULT \'\',
+                line1      VARCHAR(255) NOT NULL DEFAULT \'\',
+                line2      VARCHAR(255) NOT NULL DEFAULT \'\',
+                city       VARCHAR(100) NOT NULL DEFAULT \'\',
+                state      VARCHAR(100) NOT NULL DEFAULT \'\',
+                postal     VARCHAR(20)  NOT NULL DEFAULT \'\',
+                country    VARCHAR(2)   NOT NULL DEFAULT \'\',
+                phone      VARCHAR(50)  NOT NULL DEFAULT \'\',
+                is_default TINYINT(1)   NOT NULL DEFAULT 0,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->book = new AddressBook($this->db);
+    }
+
+    private function sampleData(array $overrides = []): array
+    {
+        return array_merge([
+            'label'      => 'Home',
+            'name'       => 'Taro Yamada',
+            'line1'      => '1-2-3 Shinjuku',
+            'line2'      => '',
+            'city'       => 'Shinjuku-ku',
+            'state'      => 'Tokyo',
+            'postal'     => '160-0022',
+            'country'    => 'JP',
+            'phone'      => '+81-90-0000-0000',
+            'is_default' => false,
+        ], $overrides);
+    }
+
+    // ── add ───────────────────────────────────────────────────────────────────
+
+    public function testAddReturnsIntId(): void
+    {
+        $id = $this->book->add('user-1', $this->sampleData());
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testAddStoresAllFields(): void
+    {
+        $id  = $this->book->add('user-1', $this->sampleData());
+        $row = $this->book->get('user-1', $id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('Home', $row['label']);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('Taro Yamada', $row['name']);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('1-2-3 Shinjuku', $row['line1']);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('JP', $row['country']);
+    }
+
+    public function testAddThrowsIfLine1Empty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->book->add('user-1', $this->sampleData(['line1' => '']));
+    }
+
+    public function testAddThrowsIfCountryEmpty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->book->add('user-1', $this->sampleData(['country' => '']));
+    }
+
+    public function testAddWithIsDefaultSetsDefaultFlag(): void
+    {
+        $id  = $this->book->add('user-1', $this->sampleData(['is_default' => true]));
+        $row = $this->book->get('user-1', $id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(1, (int)$row['is_default']);
+    }
+
+    public function testAddSecondDefaultClearsPreviousDefault(): void
+    {
+        $id1 = $this->book->add('user-1', $this->sampleData(['is_default' => true]));
+        $id2 = $this->book->add('user-1', $this->sampleData(['label' => 'Work', 'is_default' => true]));
+
+        $row1 = $this->book->get('user-1', $id1);
+        $row2 = $this->book->get('user-1', $id2);
+        $this->assertNotNull($row1);
+        $this->assertNotNull($row2);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(0, (int)$row1['is_default'], 'old default should be cleared');
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(1, (int)$row2['is_default'], 'new default should be set');
+    }
+
+    // ── list ──────────────────────────────────────────────────────────────────
+
+    public function testListReturnsAllAddresses(): void
+    {
+        $this->book->add('user-1', $this->sampleData(['label' => 'A']));
+        $this->book->add('user-1', $this->sampleData(['label' => 'B']));
+        $this->book->add('user-1', $this->sampleData(['label' => 'C']));
+
+        $list = $this->book->list('user-1');
+        $this->assertCount(3, $list);
+    }
+
+    public function testListReturnsEmptyForUnknownUser(): void
+    {
+        $list = $this->book->list('no-such-user');
+        $this->assertSame([], $list);
+    }
+
+    public function testListDefaultAddressComesFirst(): void
+    {
+        $this->book->add('user-1', $this->sampleData(['label' => 'A']));
+        $id2 = $this->book->add('user-1', $this->sampleData(['label' => 'B', 'is_default' => true]));
+        $this->book->add('user-1', $this->sampleData(['label' => 'C']));
+
+        $list = $this->book->list('user-1');
+        $this->assertSame((string)$id2, (string)$list[0]['id']);
+    }
+
+    public function testListIsolatedBetweenUsers(): void
+    {
+        $this->book->add('user-1', $this->sampleData());
+        $this->book->add('user-2', $this->sampleData(['label' => 'Work']));
+
+        $this->assertCount(1, $this->book->list('user-1'));
+        $this->assertCount(1, $this->book->list('user-2'));
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $result = $this->book->get('user-1', 9999);
+        $this->assertNull($result);
+    }
+
+    public function testGetDoesNotCrossUserBoundary(): void
+    {
+        $id = $this->book->add('user-1', $this->sampleData());
+        $result = $this->book->get('user-2', $id);
+        $this->assertNull($result);
+    }
+
+    // ── update ────────────────────────────────────────────────────────────────
+
+    public function testUpdateChangesFields(): void
+    {
+        $id = $this->book->add('user-1', $this->sampleData());
+        $this->book->update('user-1', $id, ['label' => 'Office', 'city' => 'Osaka']);
+
+        $row = $this->book->get('user-1', $id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('Office', $row['label']);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('Osaka', $row['city']);
+    }
+
+    public function testUpdateReturnsFalseForUnknownId(): void
+    {
+        $result = $this->book->update('user-1', 9999, ['label' => 'X']);
+        $this->assertFalse($result);
+    }
+
+    public function testUpdateThrowsIfLine1SetToEmpty(): void
+    {
+        $id = $this->book->add('user-1', $this->sampleData());
+        $this->expectException(\InvalidArgumentException::class);
+        $this->book->update('user-1', $id, ['line1' => '']);
+    }
+
+    public function testUpdateIsDefaultClearsPreviousDefault(): void
+    {
+        $id1 = $this->book->add('user-1', $this->sampleData(['is_default' => true]));
+        $id2 = $this->book->add('user-1', $this->sampleData(['label' => 'Work']));
+
+        $this->book->update('user-1', $id2, ['is_default' => true]);
+
+        $row1 = $this->book->get('user-1', $id1);
+        $row2 = $this->book->get('user-1', $id2);
+        $this->assertNotNull($row1);
+        $this->assertNotNull($row2);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(0, (int)$row1['is_default']);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(1, (int)$row2['is_default']);
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesAddress(): void
+    {
+        $id = $this->book->add('user-1', $this->sampleData());
+        $this->assertTrue($this->book->remove('user-1', $id));
+        $this->assertNull($this->book->get('user-1', $id));
+    }
+
+    public function testRemoveReturnsFalseForUnknownId(): void
+    {
+        $this->assertFalse($this->book->remove('user-1', 9999));
+    }
+
+    public function testRemoveDoesNotCrossUserBoundary(): void
+    {
+        $id = $this->book->add('user-1', $this->sampleData());
+        $this->assertFalse($this->book->remove('user-2', $id));
+        $this->assertNotNull($this->book->get('user-1', $id));
+    }
+
+    // ── setDefault / getDefault ───────────────────────────────────────────────
+
+    public function testSetDefaultMarksAddress(): void
+    {
+        $id = $this->book->add('user-1', $this->sampleData());
+        $this->assertTrue($this->book->setDefault('user-1', $id));
+
+        $row = $this->book->get('user-1', $id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(1, (int)$row['is_default']);
+    }
+
+    public function testSetDefaultClearsPreviousDefault(): void
+    {
+        $id1 = $this->book->add('user-1', $this->sampleData(['is_default' => true]));
+        $id2 = $this->book->add('user-1', $this->sampleData(['label' => 'Work']));
+
+        $this->book->setDefault('user-1', $id2);
+
+        $row1 = $this->book->get('user-1', $id1);
+        $this->assertNotNull($row1);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(0, (int)$row1['is_default']);
+    }
+
+    public function testGetDefaultReturnsNullWhenNoneSet(): void
+    {
+        $this->book->add('user-1', $this->sampleData());
+        $this->assertNull($this->book->getDefault('user-1'));
+    }
+
+    public function testGetDefaultReturnsDefaultAddress(): void
+    {
+        $id = $this->book->add('user-1', $this->sampleData(['is_default' => true]));
+        $def = $this->book->getDefault('user-1');
+        $this->assertNotNull($def);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame((string)$id, (string)$def['id']);
+    }
+
+    public function testSetDefaultReturnsFalseForUnknownId(): void
+    {
+        $this->assertFalse($this->book->setDefault('user-1', 9999));
+    }
+}

--- a/tests/Unit/Xion/AddressBookTest.php
+++ b/tests/Unit/Xion/AddressBookTest.php
@@ -71,13 +71,13 @@ final class AddressBookTest extends TestCase
         $id  = $this->book->add('user-1', $this->sampleData());
         $row = $this->book->get('user-1', $id);
         $this->assertNotNull($row);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Home', $row['label']);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Taro Yamada', $row['name']);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('1-2-3 Shinjuku', $row['line1']);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('JP', $row['country']);
     }
 
@@ -98,7 +98,7 @@ final class AddressBookTest extends TestCase
         $id  = $this->book->add('user-1', $this->sampleData(['is_default' => true]));
         $row = $this->book->get('user-1', $id);
         $this->assertNotNull($row);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(1, (int)$row['is_default']);
     }
 
@@ -111,9 +111,9 @@ final class AddressBookTest extends TestCase
         $row2 = $this->book->get('user-1', $id2);
         $this->assertNotNull($row1);
         $this->assertNotNull($row2);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(0, (int)$row1['is_default'], 'old default should be cleared');
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(1, (int)$row2['is_default'], 'new default should be set');
     }
 
@@ -178,9 +178,9 @@ final class AddressBookTest extends TestCase
 
         $row = $this->book->get('user-1', $id);
         $this->assertNotNull($row);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Office', $row['label']);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Osaka', $row['city']);
     }
 
@@ -208,9 +208,9 @@ final class AddressBookTest extends TestCase
         $row2 = $this->book->get('user-1', $id2);
         $this->assertNotNull($row1);
         $this->assertNotNull($row2);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(0, (int)$row1['is_default']);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(1, (int)$row2['is_default']);
     }
 
@@ -244,7 +244,7 @@ final class AddressBookTest extends TestCase
 
         $row = $this->book->get('user-1', $id);
         $this->assertNotNull($row);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(1, (int)$row['is_default']);
     }
 
@@ -257,7 +257,7 @@ final class AddressBookTest extends TestCase
 
         $row1 = $this->book->get('user-1', $id1);
         $this->assertNotNull($row1);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(0, (int)$row1['is_default']);
     }
 
@@ -272,7 +272,7 @@ final class AddressBookTest extends TestCase
         $id = $this->book->add('user-1', $this->sampleData(['is_default' => true]));
         $def = $this->book->getDefault('user-1');
         $this->assertNotNull($def);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame((string)$id, (string)$def['id']);
     }
 


### PR DESCRIPTION
## FT77 — AddressBook

Per-user address book supporting multiple addresses with a default flag.

### Features
- `add()` — add address; sets default atomically if `is_default: true`
- `update()` — partial update; promotes to default when `is_default: true`
- `remove()` — hard delete (user-scoped)
- `get()` — single address by ID (user-scoped)
- `list()` — all user addresses, default first then by ID
- `setDefault()` — atomic default swap
- `getDefault()` — retrieve current default address

### Implementation notes
- All writes are user-scoped (no cross-user access)
- Default-switching is atomic (transaction: clear old → set new)
- Validation guards: `line1` and `country` must not be empty
- `update()` only touches provided keys (partial update)

### Tests
24 tests, 45 assertions — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)