### PR TITLE
feat(xion): NewsletterSubscription — double opt-in mailing list (FT78)

### DIFF
--- a/class/xion/NewsletterSubscription.php
+++ b/class/xion/NewsletterSubscription.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Newsletter / mailing-list subscription manager with double opt-in support.
+ *
+ * Each subscription tracks an email address, a list name, and a status:
+ *  - `pending`     — subscribed but confirmation not yet clicked (double opt-in)
+ *  - `confirmed`   — active subscriber
+ *  - `unsubscribed`— opted out (row kept for audit)
+ *
+ * Confirmation tokens are 64 hex chars (256-bit random, SHA-256 stored).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $nl = new NewsletterSubscription($pdo);
+ *
+ * // Subscribe (double opt-in)
+ * $rawToken = $nl->subscribe('user@example.com', 'weekly');
+ * // … email $rawToken in the confirmation link …
+ *
+ * // Confirm
+ * $ok = $nl->confirm($rawToken);
+ *
+ * // Direct confirm (no double opt-in required)
+ * $nl->subscribe('user@example.com', 'weekly', confirm: true);
+ *
+ * // Unsubscribe
+ * $nl->unsubscribe('user@example.com', 'weekly');
+ *
+ * // Status
+ * $status = $nl->status('user@example.com', 'weekly'); // 'confirmed'|'pending'|'unsubscribed'|null
+ *
+ * // List confirmed subscribers for a list
+ * $emails = $nl->listConfirmed('weekly');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE newsletter_subscriptions (
+ *     id              INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     email           VARCHAR(255) NOT NULL,
+ *     list_name       VARCHAR(100) NOT NULL,
+ *     status          VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     confirm_hash    VARCHAR(64)  DEFAULT NULL,
+ *     confirmed_at    DATETIME     DEFAULT NULL,
+ *     unsubscribed_at DATETIME     DEFAULT NULL,
+ *     created_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (email, list_name)
+ * );
+ * ```
+ */
+final class NewsletterSubscription
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Subscribe an email address to a list.
+     *
+     * If the email is already confirmed, this is a no-op and returns null.
+     * If previously unsubscribed, the subscription is reset to pending.
+     * If `$confirm` is true, the status is immediately set to `confirmed`.
+     *
+     * @param  string $email     Email address (case-insensitive).
+     * @param  string $listName  List identifier.
+     * @param  bool   $confirm   If true, bypass double opt-in and confirm immediately.
+     * @return string|null       Raw confirmation token (null when already confirmed or $confirm = true).
+     * @throws \InvalidArgumentException if email is invalid or list name is empty.
+     */
+    public function subscribe(string $email, string $listName, bool $confirm = false): ?string
+    {
+        $email    = $this->normaliseEmail($email);
+        $listName = $this->normaliseList($listName);
+        $db       = $this->db();
+
+        $existing = $this->fetchRow($email, $listName);
+
+        if ($existing !== null && $existing['status'] === 'confirmed') {
+            return null; // already confirmed — no change
+        }
+
+        if ($confirm) {
+            // Upsert directly to confirmed
+            $this->upsert($db, $email, $listName, 'confirmed', null, 'CURRENT_TIMESTAMP', null);
+            return null;
+        }
+
+        // Generate confirmation token
+        $rawToken = bin2hex(random_bytes(32)); // 64 hex chars
+        $hash     = hash('sha256', $rawToken);
+
+        $this->upsert($db, $email, $listName, 'pending', $hash, null, null);
+        return $rawToken;
+    }
+
+    /**
+     * Confirm a subscription using the raw token from the confirmation email.
+     *
+     * @param  string $rawToken Raw token (as returned by subscribe()).
+     * @return bool   True if confirmed successfully; false if token not found / already used.
+     */
+    public function confirm(string $rawToken): bool
+    {
+        $hash = hash('sha256', $rawToken);
+        $stmt = $this->db()->prepare(
+            "UPDATE newsletter_subscriptions
+             SET status = 'confirmed', confirmed_at = CURRENT_TIMESTAMP,
+                 confirm_hash = NULL, updated_at = CURRENT_TIMESTAMP
+             WHERE confirm_hash = :hash AND status = 'pending'"
+        );
+        $stmt->execute([':hash' => $hash]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Unsubscribe an email from a list.
+     *
+     * @return bool True if the subscription existed (regardless of previous status).
+     */
+    public function unsubscribe(string $email, string $listName): bool
+    {
+        $email    = $this->normaliseEmail($email);
+        $listName = $this->normaliseList($listName);
+
+        $stmt = $this->db()->prepare(
+            "UPDATE newsletter_subscriptions
+             SET status = 'unsubscribed', unsubscribed_at = CURRENT_TIMESTAMP,
+                 confirm_hash = NULL, updated_at = CURRENT_TIMESTAMP
+             WHERE email = :email AND list_name = :list_name AND status != 'unsubscribed'"
+        );
+        $stmt->execute([':email' => $email, ':list_name' => $listName]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Get the current subscription status for an email+list pair.
+     *
+     * @return 'pending'|'confirmed'|'unsubscribed'|null
+     */
+    public function status(string $email, string $listName): ?string
+    {
+        $email    = $this->normaliseEmail($email);
+        $listName = $this->normaliseList($listName);
+        $row      = $this->fetchRow($email, $listName);
+        return $row !== null ? $row['status'] : null;
+    }
+
+    /**
+     * List confirmed subscriber emails for a given list.
+     *
+     * @return list<string>
+     */
+    public function listConfirmed(string $listName): array
+    {
+        $listName = $this->normaliseList($listName);
+        $stmt     = $this->db()->prepare(
+            "SELECT email FROM newsletter_subscriptions
+             WHERE list_name = :list_name AND status = 'confirmed'
+             ORDER BY confirmed_at ASC"
+        );
+        $stmt->execute([':list_name' => $listName]);
+        return array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'email');
+    }
+
+    /**
+     * Re-subscribe an unsubscribed email (resets to pending; returns new token).
+     *
+     * Convenience wrapper — identical to subscribe() since subscribe() resets unsubscribed rows.
+     */
+    public function resubscribe(string $email, string $listName): ?string
+    {
+        return $this->subscribe($email, $listName);
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function fetchRow(string $email, string $listName): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM newsletter_subscriptions WHERE email = :email AND list_name = :list_name LIMIT 1'
+        );
+        $stmt->execute([':email' => $email, ':list_name' => $listName]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    private function upsert(
+        PDO $db,
+        string $email,
+        string $listName,
+        string $status,
+        ?string $confirmHash,
+        ?string $confirmedAt,
+        ?string $unsubscribedAt
+    ): void {
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $stmt = $db->prepare(
+                'INSERT OR REPLACE INTO newsletter_subscriptions
+                    (email, list_name, status, confirm_hash, confirmed_at, unsubscribed_at, updated_at)
+                 VALUES (:email, :list_name, :status, :confirm_hash, :confirmed_at, :unsubscribed_at, CURRENT_TIMESTAMP)'
+            );
+        } else {
+            $stmt = $db->prepare(
+                'INSERT INTO newsletter_subscriptions
+                    (email, list_name, status, confirm_hash, confirmed_at, unsubscribed_at, updated_at)
+                 VALUES (:email, :list_name, :status, :confirm_hash, :confirmed_at, :unsubscribed_at, CURRENT_TIMESTAMP)
+                 ON DUPLICATE KEY UPDATE
+                    status = VALUES(status),
+                    confirm_hash = VALUES(confirm_hash),
+                    confirmed_at = VALUES(confirmed_at),
+                    unsubscribed_at = VALUES(unsubscribed_at),
+                    updated_at = CURRENT_TIMESTAMP'
+            );
+        }
+
+        $stmt->execute([
+            ':email'           => $email,
+            ':list_name'       => $listName,
+            ':status'          => $status,
+            ':confirm_hash'    => $confirmHash,
+            ':confirmed_at'    => $confirmedAt,
+            ':unsubscribed_at' => $unsubscribedAt,
+        ]);
+    }
+
+    private function normaliseEmail(string $email): string
+    {
+        $email = strtolower(trim($email));
+        if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new \InvalidArgumentException("Invalid email address: '{$email}'.");
+        }
+        return $email;
+    }
+
+    private function normaliseList(string $listName): string
+    {
+        $listName = trim($listName);
+        if ($listName === '') {
+            throw new \InvalidArgumentException('List name must not be empty.');
+        }
+        return $listName;
+    }
+}

--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -12,37 +12,37 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ---
 
-## Active candidates (FT73+)
+## Active candidates (FT78+)
 
-### FT73 — Rate-limited Queue (Simple Job Queue)
+### FT78 — Newsletter Subscription
 
-**Why**: DB-backed lightweight job queue。バックグラウンド処理の最小実装。FT36 (大型) より前の軽量版。
-**Scope**: `Nene\Xion\JobQueue` — enqueue/dequeue/complete/fail/retry、ステータス管理。
+**Why**: メーリングリスト購読管理。ダブルオプトイン・購読解除・ステータス管理。
+**Scope**: `Nene\Xion\NewsletterSubscription` — subscribe/confirm/unsubscribe/status/list、確認トークン管理。
 **Size**: small–medium.
 
-### FT74 — Geo / Location Helper
+### FT79 — User Block List
 
-**Why**: 緯度経度ベースの距離計算・バウンディングボックス。近隣スポット検索等に使用。
-**Scope**: `Nene\Func\GeoHelper` — distanceKm/distanceMi/boundingBox、Haversine 公式。
+**Why**: ユーザー間のブロック機能。コンテンツ非表示・フォロー防止等の基盤。
+**Scope**: `Nene\Xion\BlockList` — block/unblock/isBlocked/blockedBy/list、双方向チェック。
 **Size**: small.
 
-### FT75 — File Storage Metadata
+### FT80 — Poll / Survey
 
-**Why**: アップロードファイルのメタデータ管理（実ストレージは外部）。パス・サイズ・MIME・所有者。
-**Scope**: `Nene\Xion\FileMetadata` — register/find/findByOwner/delete、soft-delete。
-**Size**: small.
-
-### FT76 — Two-Factor Authentication (TOTP)
-
-**Why**: TOTP ベースの 2FA。Google Authenticator 互換。Secret 生成・コード検証・バックアップコード。
-**Scope**: `Nene\Xion\TotpAuthenticator` — generateSecret/verifyCode/generateBackupCodes、RFC 6238。
+**Why**: 選択式投票。単一/複数選択・集計・ユーザー投票履歴。
+**Scope**: `Nene\Xion\Poll` — createPoll/addOption/vote/results/hasVoted、設問+選択肢+集計。
 **Size**: medium.
 
-### FT77 — Address Book
+### FT81 — Wishlist
 
-**Why**: ユーザーの配送先・請求先住所管理。複数住所・デフォルト設定。
-**Scope**: `Nene\Xion\AddressBook` — add/update/remove/list/setDefault、複数住所対応。
-**Size**: small–medium.
+**Why**: ユーザーの「お気に入り商品」管理。entity-agnostic設計でどんなコンテンツにも対応。
+**Scope**: `Nene\Xion\Wishlist` — add/remove/contains/list、entity_type+entity_idペア。
+**Size**: small.
+
+### FT82 — Notification Preferences
+
+**Why**: 通知チャンネル・種別ごとの受信設定。メール/Push/SMS等の配信制御基盤。
+**Scope**: `Nene\Xion\NotificationPreference` — setEnabled/isEnabled/all/reset、チャンネル×種別マトリクス。
+**Size**: small.
 
 ---
 
@@ -82,6 +82,11 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT77 — Address Book** (2026-05-27): `Nene\Xion\AddressBook` — add/update/remove/list/setDefault; default swap transaction; partial update. PR #511.
+- **FT76 — Two-Factor Authentication (TOTP)** (2026-05-27): `Nene\Xion\TotpAuthenticator` — RFC 6238; generateSecret/verifyCode/otpauthUri/generateBackupCodes; HMAC-SHA1 HOTP. PR #510.
+- **FT75 — File Storage Metadata** (2026-05-27): `Nene\Xion\FileMetadata` — register/find/findByOwner/delete; MIME prefix filter; soft delete; storage field. PR #509.
+- **FT74 — Geo / Location Helper** (2026-05-27): `Nene\Func\GeoHelper` — distanceKm/distanceMi/boundingBox; Haversine formula; pole-safe lonDelta. PR #508.
+- **FT73 — Rate-limited Queue (Simple Job Queue)** (2026-05-27): `Nene\Xion\JobQueue` — enqueue/dequeue/complete/fail; atomic dequeue; delayed jobs. PR #507.
 - **FT72 — Bookmark** (2026-05-27): `Nene\Xion\Bookmark` — save/remove/isSaved/list; collection grouping; UNIQUE constraint. PR #506.
 - **FT71 — Search History** (2026-05-27): `Nene\Xion\SearchHistory` — upsert dedup, auto-trim, push/recent/clear. PR #505.
 - **FT70 — Subscription** (2026-05-27): `Nene\Xion\Subscription` — subscribe/changePlan/cancel/renew; history table. PR #504.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,17 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT72 are complete (FT36 deferred as ADR-class); ADR-0001–0013 are in place. Next work is FT73+ — see **Field Trials** and **Backlog Candidates** below.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT77 are complete (FT36 deferred as ADR-class); ADR-0001–0013 are in place. Next work is FT78+ — see **Field Trials** and **Backlog Candidates** below.
 
 ## Recently Completed
+
+### 2026-05-27 — FT73–FT77: Infrastructure + auth + geo + identity wave (5 trials)
+
+**FT73 — Job Queue**: `JobQueue` enqueue/dequeue/complete/fail; atomic dequeue; delayed jobs. PR #507.
+**FT74 — Geo Helper**: `GeoHelper` distanceKm/distanceMi/boundingBox; Haversine formula. PR #508.
+**FT75 — File Metadata**: `FileMetadata` register/find/findByOwner/delete; soft delete; MIME filter. PR #509.
+**FT76 — TOTP Authenticator**: `TotpAuthenticator` RFC 6238; generateSecret/verifyCode/otpauthUri/backup codes. PR #510.
+**FT77 — Address Book**: `AddressBook` add/update/remove/list/setDefault; atomic default swap. PR #511.
 
 ### 2026-05-27 — FT68–FT72: Extended social patterns wave (5 trials)
 

--- a/tests/Unit/Xion/NewsletterSubscriptionTest.php
+++ b/tests/Unit/Xion/NewsletterSubscriptionTest.php
@@ -43,6 +43,7 @@ final class NewsletterSubscriptionTest extends TestCase
     {
         $token = $this->nl->subscribe('user@example.com', 'weekly');
         $this->assertIsString($token);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullableInternal
         $this->assertSame(64, strlen($token)); // 32 bytes = 64 hex chars
     }
 

--- a/tests/Unit/Xion/NewsletterSubscriptionTest.php
+++ b/tests/Unit/Xion/NewsletterSubscriptionTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\NewsletterSubscription;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for NewsletterSubscription.
+ */
+final class NewsletterSubscriptionTest extends TestCase
+{
+    private PDO $db;
+    private NewsletterSubscription $nl;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE newsletter_subscriptions (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                email           VARCHAR(255) NOT NULL,
+                list_name       VARCHAR(100) NOT NULL,
+                status          VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                confirm_hash    VARCHAR(64)  DEFAULT NULL,
+                confirmed_at    DATETIME     DEFAULT NULL,
+                unsubscribed_at DATETIME     DEFAULT NULL,
+                created_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (email, list_name)
+            )
+        ');
+        $this->nl = new NewsletterSubscription($this->db);
+    }
+
+    // ── subscribe ─────────────────────────────────────────────────────────────
+
+    public function testSubscribeReturnsToken(): void
+    {
+        $token = $this->nl->subscribe('user@example.com', 'weekly');
+        $this->assertIsString($token);
+        $this->assertSame(64, strlen($token)); // 32 bytes = 64 hex chars
+    }
+
+    public function testSubscribeStatusIsPending(): void
+    {
+        $this->nl->subscribe('user@example.com', 'weekly');
+        $this->assertSame('pending', $this->nl->status('user@example.com', 'weekly'));
+    }
+
+    public function testSubscribeWithConfirmTrueIsConfirmedImmediately(): void
+    {
+        $token = $this->nl->subscribe('user@example.com', 'weekly', confirm: true);
+        $this->assertNull($token);
+        $this->assertSame('confirmed', $this->nl->status('user@example.com', 'weekly'));
+    }
+
+    public function testSubscribeAlreadyConfirmedIsNoOp(): void
+    {
+        $this->nl->subscribe('user@example.com', 'weekly', confirm: true);
+        $token = $this->nl->subscribe('user@example.com', 'weekly');
+        $this->assertNull($token); // already confirmed — not re-queued
+        $this->assertSame('confirmed', $this->nl->status('user@example.com', 'weekly'));
+    }
+
+    public function testSubscribeResetsUnsubscribed(): void
+    {
+        $this->nl->subscribe('user@example.com', 'weekly', confirm: true);
+        $this->nl->unsubscribe('user@example.com', 'weekly');
+        $token = $this->nl->subscribe('user@example.com', 'weekly');
+        $this->assertIsString($token);
+        $this->assertSame('pending', $this->nl->status('user@example.com', 'weekly'));
+    }
+
+    public function testSubscribeNormalisesEmailCase(): void
+    {
+        $this->nl->subscribe('USER@EXAMPLE.COM', 'weekly');
+        $this->assertSame('pending', $this->nl->status('user@example.com', 'weekly'));
+    }
+
+    public function testSubscribeThrowsOnInvalidEmail(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->nl->subscribe('not-an-email', 'weekly');
+    }
+
+    public function testSubscribeThrowsOnEmptyListName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->nl->subscribe('user@example.com', '');
+    }
+
+    // ── confirm ───────────────────────────────────────────────────────────────
+
+    public function testConfirmWithValidTokenReturnsTrue(): void
+    {
+        $token = $this->nl->subscribe('user@example.com', 'weekly');
+        $this->assertNotNull($token);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertTrue($this->nl->confirm($token));
+        $this->assertSame('confirmed', $this->nl->status('user@example.com', 'weekly'));
+    }
+
+    public function testConfirmWithInvalidTokenReturnsFalse(): void
+    {
+        $this->nl->subscribe('user@example.com', 'weekly');
+        $this->assertFalse($this->nl->confirm('0000000000000000000000000000000000000000000000000000000000000000'));
+    }
+
+    public function testConfirmTokenIsOneTime(): void
+    {
+        $token = $this->nl->subscribe('user@example.com', 'weekly');
+        $this->assertNotNull($token);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->nl->confirm($token);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertFalse($this->nl->confirm($token)); // already confirmed → not pending
+    }
+
+    // ── unsubscribe ───────────────────────────────────────────────────────────
+
+    public function testUnsubscribeConfirmedSubscriber(): void
+    {
+        $this->nl->subscribe('user@example.com', 'weekly', confirm: true);
+        $this->assertTrue($this->nl->unsubscribe('user@example.com', 'weekly'));
+        $this->assertSame('unsubscribed', $this->nl->status('user@example.com', 'weekly'));
+    }
+
+    public function testUnsubscribePendingSubscriber(): void
+    {
+        $this->nl->subscribe('user@example.com', 'weekly');
+        $this->assertTrue($this->nl->unsubscribe('user@example.com', 'weekly'));
+        $this->assertSame('unsubscribed', $this->nl->status('user@example.com', 'weekly'));
+    }
+
+    public function testUnsubscribeAlreadyUnsubscribedReturnsFalse(): void
+    {
+        $this->nl->subscribe('user@example.com', 'weekly', confirm: true);
+        $this->nl->unsubscribe('user@example.com', 'weekly');
+        $this->assertFalse($this->nl->unsubscribe('user@example.com', 'weekly'));
+    }
+
+    public function testUnsubscribeNonExistentReturnsFalse(): void
+    {
+        $this->assertFalse($this->nl->unsubscribe('unknown@example.com', 'weekly'));
+    }
+
+    // ── status ────────────────────────────────────────────────────────────────
+
+    public function testStatusReturnsNullForUnknown(): void
+    {
+        $this->assertNull($this->nl->status('nobody@example.com', 'weekly'));
+    }
+
+    // ── listConfirmed ─────────────────────────────────────────────────────────
+
+    public function testListConfirmedReturnsOnlyConfirmedEmails(): void
+    {
+        $this->nl->subscribe('a@example.com', 'weekly', confirm: true);
+        $this->nl->subscribe('b@example.com', 'weekly'); // pending
+        $this->nl->subscribe('c@example.com', 'weekly', confirm: true);
+        $this->nl->unsubscribe('c@example.com', 'weekly');
+
+        $list = $this->nl->listConfirmed('weekly');
+        $this->assertSame(['a@example.com'], $list);
+    }
+
+    public function testListConfirmedIsListIsolated(): void
+    {
+        $this->nl->subscribe('a@example.com', 'weekly', confirm: true);
+        $this->nl->subscribe('b@example.com', 'monthly', confirm: true);
+
+        $this->assertSame(['a@example.com'], $this->nl->listConfirmed('weekly'));
+        $this->assertSame(['b@example.com'], $this->nl->listConfirmed('monthly'));
+    }
+
+    // ── resubscribe ───────────────────────────────────────────────────────────
+
+    public function testResubscribeAfterUnsubscribeReturnsPending(): void
+    {
+        $this->nl->subscribe('user@example.com', 'weekly', confirm: true);
+        $this->nl->unsubscribe('user@example.com', 'weekly');
+        $token = $this->nl->resubscribe('user@example.com', 'weekly');
+        $this->assertIsString($token);
+        $this->assertSame('pending', $this->nl->status('user@example.com', 'weekly'));
+    }
+}


### PR DESCRIPTION
## FT78 — NewsletterSubscription

Newsletter / mailing-list subscription manager with double opt-in support.

### Features
- `subscribe()` — subscribe email; returns 64-char raw confirmation token (or null if already confirmed)
- `confirm()` — validate token and activate subscription
- `unsubscribe()` — mark as unsubscribed (row retained for audit)
- `status()` — `'pending'|'confirmed'|'unsubscribed'|null`
- `listConfirmed()` — list active subscribers for a list
- `resubscribe()` — convenience wrapper to re-subscribe an unsubscribed email

### Implementation notes
- Status lifecycle: `pending → confirmed` (via token) or `* → unsubscribed`
- Confirmation token: 256-bit random, SHA-256 stored; one-time use (hash cleared on confirm)
- Upsert: `INSERT OR REPLACE` (SQLite) / `INSERT … ON DUPLICATE KEY UPDATE` (MySQL)
- Email normalized to lowercase; invalid emails / empty list names throw `InvalidArgumentException`

### Tests
19 tests, 30 assertions — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)