### PR TITLE
feat(xion): BlockList — directional user block with bidirectional query (FT79)

### DIFF
--- a/class/xion/BlockList.php
+++ b/class/xion/BlockList.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * User block list — prevent harassment and unwanted interactions.
+ *
+ * A block is a one-way relationship: blocker → blocked.
+ * Both sides can be queried so callers can implement bidirectional hiding.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $bl = new BlockList($pdo);
+ *
+ * // Block
+ * $bl->block('alice', 'bob');
+ *
+ * // Check
+ * $bl->isBlocked('alice', 'bob');  // true (alice blocked bob)
+ * $bl->isBlockedBy('bob', 'alice'); // true (bob is blocked by alice)
+ * $bl->isEitherBlocked('alice', 'bob'); // true (either direction)
+ *
+ * // Unblock
+ * $bl->unblock('alice', 'bob');
+ *
+ * // List
+ * $bl->blockedBy('alice');  // IDs alice blocked
+ * $bl->blockers('bob');     // IDs who blocked bob
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE block_list (
+ *     blocker_id  VARCHAR(255) NOT NULL,
+ *     blocked_id  VARCHAR(255) NOT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     PRIMARY KEY (blocker_id, blocked_id)
+ * );
+ * ```
+ */
+final class BlockList
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Block a user.
+     *
+     * Idempotent: blocking an already-blocked user is a no-op.
+     *
+     * @throws \InvalidArgumentException if blocker and blocked are the same user.
+     */
+    public function block(string $blockerId, string $blockedId): void
+    {
+        if ($blockerId === $blockedId) {
+            throw new \InvalidArgumentException('A user cannot block themselves.');
+        }
+
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $sql    = $driver === 'sqlite'
+            ? 'INSERT OR IGNORE INTO block_list (blocker_id, blocked_id) VALUES (:blocker, :blocked)'
+            : 'INSERT IGNORE INTO block_list (blocker_id, blocked_id) VALUES (:blocker, :blocked)';
+
+        $stmt = $db->prepare($sql);
+        $stmt->execute([':blocker' => $blockerId, ':blocked' => $blockedId]);
+    }
+
+    /**
+     * Unblock a user.
+     *
+     * @return bool True if the block existed and was removed.
+     */
+    public function unblock(string $blockerId, string $blockedId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM block_list WHERE blocker_id = :blocker AND blocked_id = :blocked'
+        );
+        $stmt->execute([':blocker' => $blockerId, ':blocked' => $blockedId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Check if `$blockerId` has blocked `$blockedId`.
+     */
+    public function isBlocked(string $blockerId, string $blockedId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM block_list WHERE blocker_id = :blocker AND blocked_id = :blocked LIMIT 1'
+        );
+        $stmt->execute([':blocker' => $blockerId, ':blocked' => $blockedId]);
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Check if `$userId` has been blocked by `$byUserId` (reverse direction).
+     */
+    public function isBlockedBy(string $userId, string $byUserId): bool
+    {
+        return $this->isBlocked($byUserId, $userId);
+    }
+
+    /**
+     * Check if either user has blocked the other.
+     *
+     * Useful for hiding content in both directions without two calls.
+     */
+    public function isEitherBlocked(string $userA, string $userB): bool
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM block_list
+             WHERE (blocker_id = :a AND blocked_id = :b)
+                OR (blocker_id = :b2 AND blocked_id = :a2)
+             LIMIT 1'
+        );
+        $stmt->execute([':a' => $userA, ':b' => $userB, ':a2' => $userA, ':b2' => $userB]);
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Return the list of user IDs that `$blockerId` has blocked.
+     *
+     * @return list<string>
+     */
+    public function blockedBy(string $blockerId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT blocked_id FROM block_list WHERE blocker_id = :blocker ORDER BY created_at ASC'
+        );
+        $stmt->execute([':blocker' => $blockerId]);
+        return array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'blocked_id');
+    }
+
+    /**
+     * Return the list of user IDs who have blocked `$userId`.
+     *
+     * @return list<string>
+     */
+    public function blockers(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT blocker_id FROM block_list WHERE blocked_id = :blocked ORDER BY created_at ASC'
+        );
+        $stmt->execute([':blocked' => $userId]);
+        return array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'blocker_id');
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/BlockListTest.php
+++ b/tests/Unit/Xion/BlockListTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\BlockList;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for BlockList.
+ */
+final class BlockListTest extends TestCase
+{
+    private PDO $db;
+    private BlockList $bl;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE block_list (
+                blocker_id  VARCHAR(255) NOT NULL,
+                blocked_id  VARCHAR(255) NOT NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (blocker_id, blocked_id)
+            )
+        ');
+        $this->bl = new BlockList($this->db);
+    }
+
+    // ── block ─────────────────────────────────────────────────────────────────
+
+    public function testBlockCreateRelation(): void
+    {
+        $this->bl->block('alice', 'bob');
+        $this->assertTrue($this->bl->isBlocked('alice', 'bob'));
+    }
+
+    public function testBlockIsIdempotent(): void
+    {
+        $this->bl->block('alice', 'bob');
+        $this->bl->block('alice', 'bob'); // should not throw
+        $this->assertTrue($this->bl->isBlocked('alice', 'bob'));
+    }
+
+    public function testBlockSelfThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->bl->block('alice', 'alice');
+    }
+
+    public function testBlockIsDirectional(): void
+    {
+        $this->bl->block('alice', 'bob');
+        $this->assertFalse($this->bl->isBlocked('bob', 'alice'));
+    }
+
+    // ── unblock ───────────────────────────────────────────────────────────────
+
+    public function testUnblockRemovesRelation(): void
+    {
+        $this->bl->block('alice', 'bob');
+        $this->assertTrue($this->bl->unblock('alice', 'bob'));
+        $this->assertFalse($this->bl->isBlocked('alice', 'bob'));
+    }
+
+    public function testUnblockReturnsFalseIfNotBlocked(): void
+    {
+        $this->assertFalse($this->bl->unblock('alice', 'bob'));
+    }
+
+    public function testUnblockOnlyRemovesCorrectDirection(): void
+    {
+        $this->bl->block('alice', 'bob');
+        $this->bl->block('bob', 'alice');
+
+        $this->bl->unblock('alice', 'bob');
+        $this->assertFalse($this->bl->isBlocked('alice', 'bob'));
+        $this->assertTrue($this->bl->isBlocked('bob', 'alice'));
+    }
+
+    // ── isBlockedBy ───────────────────────────────────────────────────────────
+
+    public function testIsBlockedByReturnsTrue(): void
+    {
+        $this->bl->block('alice', 'bob');
+        $this->assertTrue($this->bl->isBlockedBy('bob', 'alice'));
+    }
+
+    public function testIsBlockedByReturnsFalse(): void
+    {
+        $this->assertFalse($this->bl->isBlockedBy('bob', 'alice'));
+    }
+
+    // ── isEitherBlocked ───────────────────────────────────────────────────────
+
+    public function testIsEitherBlockedTrueWhenAliceBlocksBob(): void
+    {
+        $this->bl->block('alice', 'bob');
+        $this->assertTrue($this->bl->isEitherBlocked('alice', 'bob'));
+        $this->assertTrue($this->bl->isEitherBlocked('bob', 'alice')); // symmetric query
+    }
+
+    public function testIsEitherBlockedFalseWhenNoBlock(): void
+    {
+        $this->assertFalse($this->bl->isEitherBlocked('alice', 'bob'));
+    }
+
+    public function testIsEitherBlockedTrueWhenBothBlock(): void
+    {
+        $this->bl->block('alice', 'bob');
+        $this->bl->block('bob', 'alice');
+        $this->assertTrue($this->bl->isEitherBlocked('alice', 'bob'));
+    }
+
+    // ── blockedBy ─────────────────────────────────────────────────────────────
+
+    public function testBlockedByReturnsBlockedIds(): void
+    {
+        $this->bl->block('alice', 'bob');
+        $this->bl->block('alice', 'carol');
+        $list = $this->bl->blockedBy('alice');
+        $this->assertContains('bob', $list);
+        $this->assertContains('carol', $list);
+        $this->assertCount(2, $list);
+    }
+
+    public function testBlockedByReturnsEmptyForNoBlocks(): void
+    {
+        $this->assertSame([], $this->bl->blockedBy('alice'));
+    }
+
+    public function testBlockedByIsUserScoped(): void
+    {
+        $this->bl->block('alice', 'bob');
+        $this->assertSame([], $this->bl->blockedBy('bob'));
+    }
+
+    // ── blockers ──────────────────────────────────────────────────────────────
+
+    public function testBlockersReturnsWhoBlockedUser(): void
+    {
+        $this->bl->block('alice', 'dave');
+        $this->bl->block('bob', 'dave');
+        $list = $this->bl->blockers('dave');
+        $this->assertContains('alice', $list);
+        $this->assertContains('bob', $list);
+        $this->assertCount(2, $list);
+    }
+
+    public function testBlockersReturnsEmptyIfNobodyBlocked(): void
+    {
+        $this->assertSame([], $this->bl->blockers('dave'));
+    }
+}


### PR DESCRIPTION
## FT79 — BlockList

One-way user block relationship with bidirectional query support.

### Features
- `block()` — idempotent block; throws on self-block
- `unblock()` — remove block; returns false if not blocked
- `isBlocked(blocker, blocked)` — direct direction check
- `isBlockedBy(user, byUser)` — reverse direction check
- `isEitherBlocked(a, b)` — true if either party has blocked the other (single query)
- `blockedBy(blockerId)` — list of IDs the user has blocked
- `blockers(userId)` — list of IDs who have blocked this user

### Implementation notes
- Schema: `block_list (blocker_id, blocked_id, created_at, PRIMARY KEY(blocker_id, blocked_id))`
- `INSERT OR IGNORE` (SQLite) / `INSERT IGNORE` (MySQL) for idempotency
- Self-block throws `InvalidArgumentException`
- `isEitherBlocked()` uses a single SQL OR query for efficiency

### Tests
17 tests, 24 assertions — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)