### PR TITLE
feat(xion): Poll — single-choice poll with vote tally and per-user state (FT80)

### DIFF
--- a/class/xion/Poll.php
+++ b/class/xion/Poll.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Polls and surveys — create questions, vote, and tally results.
+ *
+ * Supports single-choice polls. Each user may cast at most one vote per poll
+ * (INSERT OR IGNORE / INSERT IGNORE enforces the constraint).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $poll = new Poll($pdo);
+ *
+ * // Create poll with options
+ * $pollId  = $poll->create('Which framework?', ['NeNe', 'Laravel', 'Symfony']);
+ * $options = $poll->options($pollId);
+ *
+ * // Vote
+ * $optionId = $options[0]['id'];
+ * $poll->vote($pollId, $optionId, 'user-1');
+ *
+ * // Results
+ * $results = $poll->results($pollId);
+ * // [['option_id' => ..., 'label' => 'NeNe', 'votes' => 1, 'percent' => 100.0], ...]
+ *
+ * // Check if voted
+ * $poll->hasVoted($pollId, 'user-1'); // true
+ * $poll->userVote($pollId, 'user-1'); // ['option_id' => ..., 'label' => 'NeNe']
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE polls (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     question   TEXT        NOT NULL,
+ *     created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE poll_options (
+ *     id      INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     poll_id INTEGER     NOT NULL,
+ *     label   VARCHAR(255) NOT NULL,
+ *     sort    INTEGER     NOT NULL DEFAULT 0
+ * );
+ *
+ * CREATE TABLE poll_votes (
+ *     poll_id   INTEGER      NOT NULL,
+ *     option_id INTEGER      NOT NULL,
+ *     user_id   VARCHAR(255) NOT NULL,
+ *     voted_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     PRIMARY KEY (poll_id, user_id)
+ * );
+ * ```
+ */
+final class Poll
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create a poll with a question and a list of option labels.
+     *
+     * @param  string        $question Non-empty question text.
+     * @param  list<string>  $options  Two or more non-empty option labels.
+     * @return int           New poll ID.
+     * @throws \InvalidArgumentException if question is empty or fewer than 2 options are given.
+     */
+    public function create(string $question, array $options): int
+    {
+        $question = trim($question);
+        if ($question === '') {
+            throw new \InvalidArgumentException('Poll question must not be empty.');
+        }
+
+        $options = array_values(array_filter(array_map('trim', $options), static fn (string $o): bool => $o !== ''));
+        if (count($options) < 2) {
+            throw new \InvalidArgumentException('A poll requires at least 2 options.');
+        }
+
+        $db = $this->db();
+        $db->beginTransaction();
+        try {
+            $stmt = $db->prepare('INSERT INTO polls (question) VALUES (:q)');
+            $stmt->execute([':q' => $question]);
+            $pollId = (int)$db->lastInsertId();
+
+            $optStmt = $db->prepare('INSERT INTO poll_options (poll_id, label, sort) VALUES (:poll, :label, :sort)');
+            foreach ($options as $i => $label) {
+                $optStmt->execute([':poll' => $pollId, ':label' => $label, ':sort' => $i]);
+            }
+
+            $db->commit();
+            return $pollId;
+        } catch (\Throwable $e) {
+            $db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Return the options for a poll, ordered by sort index.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function options(int $pollId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM poll_options WHERE poll_id = :poll ORDER BY sort ASC, id ASC'
+        );
+        $stmt->execute([':poll' => $pollId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Cast a vote for an option in a poll.
+     *
+     * Idempotent for the same (pollId, userId) pair — a second call for the same
+     * user is silently ignored (INSERT OR IGNORE).
+     *
+     * @throws \InvalidArgumentException if the option does not belong to the poll.
+     */
+    public function vote(int $pollId, int $optionId, string $userId): bool
+    {
+        // Verify the option belongs to this poll
+        $check = $this->db()->prepare(
+            'SELECT 1 FROM poll_options WHERE id = :opt AND poll_id = :poll LIMIT 1'
+        );
+        $check->execute([':opt' => $optionId, ':poll' => $pollId]);
+        if ($check->fetchColumn() === false) {
+            throw new \InvalidArgumentException("Option #{$optionId} does not belong to poll #{$pollId}.");
+        }
+
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $sql    = $driver === 'sqlite'
+            ? 'INSERT OR IGNORE INTO poll_votes (poll_id, option_id, user_id) VALUES (:poll, :opt, :user)'
+            : 'INSERT IGNORE INTO poll_votes (poll_id, option_id, user_id) VALUES (:poll, :opt, :user)';
+
+        $stmt = $db->prepare($sql);
+        $stmt->execute([':poll' => $pollId, ':opt' => $optionId, ':user' => $userId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Return vote tallies for all options in a poll.
+     *
+     * @return list<array{option_id: int, label: string, votes: int, percent: float}>
+     */
+    public function results(int $pollId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT o.id AS option_id, o.label,
+                    COUNT(v.user_id) AS votes
+             FROM poll_options o
+             LEFT JOIN poll_votes v ON v.option_id = o.id AND v.poll_id = o.poll_id
+             WHERE o.poll_id = :poll
+             GROUP BY o.id, o.label
+             ORDER BY o.sort ASC, o.id ASC'
+        );
+        $stmt->execute([':poll' => $pollId]);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $total = array_sum(array_column($rows, 'votes'));
+
+        return array_map(
+            static function (array $r) use ($total): array {
+                $votes = (int)$r['votes'];
+                return [
+                    'option_id' => (int)$r['option_id'],
+                    'label'     => $r['label'],
+                    'votes'     => $votes,
+                    'percent'   => $total > 0 ? round($votes / $total * 100, 1) : 0.0,
+                ];
+            },
+            $rows
+        );
+    }
+
+    /**
+     * Check whether a user has already voted in a poll.
+     */
+    public function hasVoted(int $pollId, string $userId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM poll_votes WHERE poll_id = :poll AND user_id = :user LIMIT 1'
+        );
+        $stmt->execute([':poll' => $pollId, ':user' => $userId]);
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Return the option a user voted for, or null if they haven't voted.
+     *
+     * @return array{option_id: int, label: string}|null
+     */
+    public function userVote(int $pollId, string $userId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT o.id AS option_id, o.label
+             FROM poll_votes v
+             JOIN poll_options o ON o.id = v.option_id
+             WHERE v.poll_id = :poll AND v.user_id = :user
+             LIMIT 1'
+        );
+        $stmt->execute([':poll' => $pollId, ':user' => $userId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? ['option_id' => (int)$row['option_id'], 'label' => $row['label']] : null;
+    }
+
+    /**
+     * Get a poll record by ID, or null if not found.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function get(int $pollId): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM polls WHERE id = :id LIMIT 1');
+        $stmt->execute([':id' => $pollId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/PollTest.php
+++ b/tests/Unit/Xion/PollTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\Poll;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Poll.
+ */
+final class PollTest extends TestCase
+{
+    private PDO $db;
+    private Poll $poll;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE polls (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                question   TEXT        NOT NULL,
+                created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE poll_options (
+                id      INTEGER PRIMARY KEY AUTOINCREMENT,
+                poll_id INTEGER     NOT NULL,
+                label   VARCHAR(255) NOT NULL,
+                sort    INTEGER     NOT NULL DEFAULT 0
+            );
+            CREATE TABLE poll_votes (
+                poll_id   INTEGER      NOT NULL,
+                option_id INTEGER      NOT NULL,
+                user_id   VARCHAR(255) NOT NULL,
+                voted_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (poll_id, user_id)
+            );
+        ');
+        $this->poll = new Poll($this->db);
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsIntId(): void
+    {
+        $id = $this->poll->create('Favourite colour?', ['Red', 'Blue', 'Green']);
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testCreateThrowsOnEmptyQuestion(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->poll->create('', ['A', 'B']);
+    }
+
+    public function testCreateThrowsWithFewerThanTwoOptions(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->poll->create('Q?', ['Only one']);
+    }
+
+    public function testCreateStoresQuestion(): void
+    {
+        $id  = $this->poll->create('Best PHP framework?', ['NeNe', 'Laravel']);
+        $row = $this->poll->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('Best PHP framework?', $row['question']);
+    }
+
+    // ── options ───────────────────────────────────────────────────────────────
+
+    public function testOptionsReturnsAllOptionsInOrder(): void
+    {
+        $id      = $this->poll->create('Q?', ['Alpha', 'Beta', 'Gamma']);
+        $options = $this->poll->options($id);
+        $this->assertCount(3, $options);
+        $this->assertSame('Alpha', $options[0]['label']);
+        $this->assertSame('Beta', $options[1]['label']);
+        $this->assertSame('Gamma', $options[2]['label']);
+    }
+
+    public function testOptionsReturnsEmptyForUnknownPoll(): void
+    {
+        $this->assertSame([], $this->poll->options(9999));
+    }
+
+    // ── vote ──────────────────────────────────────────────────────────────────
+
+    public function testVoteReturnsTrueOnSuccess(): void
+    {
+        $pollId   = $this->poll->create('Q?', ['Yes', 'No']);
+        $options  = $this->poll->options($pollId);
+        $optionId = (int)$options[0]['id'];
+        $this->assertTrue($this->poll->vote($pollId, $optionId, 'user-1'));
+    }
+
+    public function testVoteIsIdempotentForSameUser(): void
+    {
+        $pollId   = $this->poll->create('Q?', ['Yes', 'No']);
+        $options  = $this->poll->options($pollId);
+        $optionId = (int)$options[0]['id'];
+        $this->poll->vote($pollId, $optionId, 'user-1');
+        $this->assertFalse($this->poll->vote($pollId, $optionId, 'user-1')); // already voted
+    }
+
+    public function testVoteThrowsForWrongPoll(): void
+    {
+        $pollId  = $this->poll->create('Q?', ['A', 'B']);
+        $pollId2 = $this->poll->create('R?', ['C', 'D']);
+        $options2 = $this->poll->options($pollId2);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->poll->vote($pollId, (int)$options2[0]['id'], 'user-1');
+    }
+
+    // ── results ───────────────────────────────────────────────────────────────
+
+    public function testResultsReturnsZeroVotesInitially(): void
+    {
+        $id      = $this->poll->create('Q?', ['Yes', 'No']);
+        $results = $this->poll->results($id);
+        $this->assertCount(2, $results);
+        $this->assertSame(0, $results[0]['votes']);
+        $this->assertSame(0.0, $results[0]['percent']);
+    }
+
+    public function testResultsTallyCorrectly(): void
+    {
+        $pollId  = $this->poll->create('Q?', ['Yes', 'No']);
+        $options = $this->poll->options($pollId);
+        $yesId   = (int)$options[0]['id'];
+        $noId    = (int)$options[1]['id'];
+
+        $this->poll->vote($pollId, $yesId, 'user-1');
+        $this->poll->vote($pollId, $yesId, 'user-2');
+        $this->poll->vote($pollId, $noId, 'user-3');
+
+        $results = $this->poll->results($pollId);
+        $yes = $results[0];
+        $no  = $results[1];
+
+        $this->assertSame(2, $yes['votes']);
+        $this->assertSame(1, $no['votes']);
+        $this->assertEqualsWithDelta(66.7, $yes['percent'], 0.1);
+        $this->assertEqualsWithDelta(33.3, $no['percent'], 0.1);
+    }
+
+    // ── hasVoted / userVote ───────────────────────────────────────────────────
+
+    public function testHasVotedReturnsFalseBeforeVoting(): void
+    {
+        $id = $this->poll->create('Q?', ['A', 'B']);
+        $this->assertFalse($this->poll->hasVoted($id, 'user-1'));
+    }
+
+    public function testHasVotedReturnsTrueAfterVoting(): void
+    {
+        $pollId  = $this->poll->create('Q?', ['A', 'B']);
+        $options = $this->poll->options($pollId);
+        $this->poll->vote($pollId, (int)$options[0]['id'], 'user-1');
+        $this->assertTrue($this->poll->hasVoted($pollId, 'user-1'));
+    }
+
+    public function testUserVoteReturnsNullBeforeVoting(): void
+    {
+        $id = $this->poll->create('Q?', ['A', 'B']);
+        $this->assertNull($this->poll->userVote($id, 'user-1'));
+    }
+
+    public function testUserVoteReturnsChosenOption(): void
+    {
+        $pollId  = $this->poll->create('Q?', ['A', 'B']);
+        $options = $this->poll->options($pollId);
+        $this->poll->vote($pollId, (int)$options[1]['id'], 'user-1');
+        $vote = $this->poll->userVote($pollId, 'user-1');
+        $this->assertNotNull($vote);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('B', $vote['label']);
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingPoll(): void
+    {
+        $this->assertNull($this->poll->get(9999));
+    }
+}

--- a/tests/Unit/Xion/PollTest.php
+++ b/tests/Unit/Xion/PollTest.php
@@ -69,7 +69,7 @@ final class PollTest extends TestCase
         $id  = $this->poll->create('Best PHP framework?', ['NeNe', 'Laravel']);
         $row = $this->poll->get($id);
         $this->assertNotNull($row);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Best PHP framework?', $row['question']);
     }
 
@@ -179,7 +179,7 @@ final class PollTest extends TestCase
         $this->poll->vote($pollId, (int)$options[1]['id'], 'user-1');
         $vote = $this->poll->userVote($pollId, 'user-1');
         $this->assertNotNull($vote);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('B', $vote['label']);
     }
 


### PR DESCRIPTION
## FT80 — Poll

Single-choice poll with per-user vote tracking and percentage tallies.

### Features
- `create(question, options)` — creates poll with 2+ options; returns poll ID
- `options(pollId)` — returns options in sort order
- `vote(pollId, optionId, userId)` — idempotent (INSERT OR IGNORE); validates option belongs to poll
- `results(pollId)` — per-option vote count and percentage (0.0 when no votes)
- `hasVoted(pollId, userId)` — check if user has voted
- `userVote(pollId, userId)` — returns the option chosen, or null
- `get(pollId)` — fetch poll record

### Implementation notes
- Schema: 3 tables — `polls`, `poll_options`, `poll_votes (PRIMARY KEY poll_id, user_id)`
- `INSERT OR IGNORE` (SQLite) / `INSERT IGNORE` (MySQL) for idempotent votes
- `results()` uses LEFT JOIN so options with 0 votes still appear
- Percentages rounded to 1 decimal place

### Tests
16 tests, 27 assertions — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)