### PR TITLE
feat(xion): NotificationPreference — channel×type opt-in/out with default opt-in (FT82)

### DIFF
--- a/class/xion/NotificationPreference.php
+++ b/class/xion/NotificationPreference.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Notification preference manager — per-user channel × type opt-in/opt-out.
+ *
+ * Each preference is keyed by `(user_id, channel, type)`:
+ *  - `channel` — delivery channel (e.g. `'email'`, `'push'`, `'sms'`)
+ *  - `type`    — notification category (e.g. `'marketing'`, `'order_update'`)
+ *
+ * Preferences not yet stored default to `true` (opted-in).
+ * Call `setEnabled(…, false)` to opt out; `reset()` to revert to default.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $prefs = new NotificationPreference($pdo);
+ *
+ * // Opt out of marketing emails
+ * $prefs->setEnabled('user-1', 'email', 'marketing', false);
+ *
+ * // Check
+ * $prefs->isEnabled('user-1', 'email', 'marketing'); // false
+ * $prefs->isEnabled('user-1', 'email', 'order');     // true (default)
+ *
+ * // List all stored prefs for a user
+ * $prefs->all('user-1');
+ *
+ * // Reset a specific preference to default
+ * $prefs->reset('user-1', 'email', 'marketing');
+ *
+ * // Reset all preferences for a user
+ * $prefs->resetAll('user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE notification_preferences (
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     channel    VARCHAR(50)  NOT NULL,
+ *     type       VARCHAR(100) NOT NULL,
+ *     enabled    TINYINT(1)   NOT NULL DEFAULT 1,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     PRIMARY KEY (user_id, channel, type)
+ * );
+ * ```
+ */
+final class NotificationPreference
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set whether a user has opted in or out of a notification channel+type.
+     *
+     * Upserts the row: creates if absent, updates if present.
+     *
+     * @throws \InvalidArgumentException if channel or type is empty.
+     */
+    public function setEnabled(string $userId, string $channel, string $type, bool $enabled): void
+    {
+        [$channel, $type] = $this->normalise($channel, $type);
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $stmt = $db->prepare(
+                'INSERT OR REPLACE INTO notification_preferences (user_id, channel, type, enabled, updated_at)
+                 VALUES (:user, :channel, :type, :enabled, CURRENT_TIMESTAMP)'
+            );
+        } else {
+            $stmt = $db->prepare(
+                'INSERT INTO notification_preferences (user_id, channel, type, enabled, updated_at)
+                 VALUES (:user, :channel, :type, :enabled, CURRENT_TIMESTAMP)
+                 ON DUPLICATE KEY UPDATE enabled = VALUES(enabled), updated_at = CURRENT_TIMESTAMP'
+            );
+        }
+
+        $stmt->execute([
+            ':user'    => $userId,
+            ':channel' => $channel,
+            ':type'    => $type,
+            ':enabled' => $enabled ? 1 : 0,
+        ]);
+    }
+
+    /**
+     * Check whether a user has opted in to a notification channel+type.
+     *
+     * Defaults to `true` if no preference record exists.
+     */
+    public function isEnabled(string $userId, string $channel, string $type): bool
+    {
+        [$channel, $type] = $this->normalise($channel, $type);
+        $stmt = $this->db()->prepare(
+            'SELECT enabled FROM notification_preferences
+             WHERE user_id = :user AND channel = :channel AND type = :type
+             LIMIT 1'
+        );
+        $stmt->execute([':user' => $userId, ':channel' => $channel, ':type' => $type]);
+        $row = $stmt->fetchColumn();
+        return $row === false ? true : (bool)(int)$row; // default opt-in
+    }
+
+    /**
+     * Return all stored preferences for a user.
+     *
+     * @return list<array{channel: string, type: string, enabled: bool}>
+     */
+    public function all(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT channel, type, enabled
+             FROM notification_preferences
+             WHERE user_id = :user
+             ORDER BY channel ASC, type ASC'
+        );
+        $stmt->execute([':user' => $userId]);
+        return array_map(
+            static fn (array $r): array => [
+                'channel' => $r['channel'],
+                'type'    => $r['type'],
+                'enabled' => (bool)(int)$r['enabled'],
+            ],
+            $stmt->fetchAll(PDO::FETCH_ASSOC)
+        );
+    }
+
+    /**
+     * Delete a specific preference row (resets to default opt-in behaviour).
+     *
+     * @return bool True if a row was deleted.
+     */
+    public function reset(string $userId, string $channel, string $type): bool
+    {
+        [$channel, $type] = $this->normalise($channel, $type);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM notification_preferences WHERE user_id = :user AND channel = :channel AND type = :type'
+        );
+        $stmt->execute([':user' => $userId, ':channel' => $channel, ':type' => $type]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete all preference rows for a user (reverts everything to default opt-in).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function resetAll(string $userId): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM notification_preferences WHERE user_id = :user');
+        $stmt->execute([':user' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function normalise(string $channel, string $type): array
+    {
+        $channel = trim($channel);
+        $type    = trim($type);
+        if ($channel === '') {
+            throw new \InvalidArgumentException('Channel must not be empty.');
+        }
+        if ($type === '') {
+            throw new \InvalidArgumentException('Type must not be empty.');
+        }
+        return [$channel, $type];
+    }
+}

--- a/tests/Unit/Xion/NotificationPreferenceTest.php
+++ b/tests/Unit/Xion/NotificationPreferenceTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\NotificationPreference;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for NotificationPreference.
+ */
+final class NotificationPreferenceTest extends TestCase
+{
+    private PDO $db;
+    private NotificationPreference $prefs;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE notification_preferences (
+                user_id    VARCHAR(255) NOT NULL,
+                channel    VARCHAR(50)  NOT NULL,
+                type       VARCHAR(100) NOT NULL,
+                enabled    TINYINT(1)   NOT NULL DEFAULT 1,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (user_id, channel, type)
+            )
+        ');
+        $this->prefs = new NotificationPreference($this->db);
+    }
+
+    // ── isEnabled default ─────────────────────────────────────────────────────
+
+    public function testIsEnabledDefaultsToTrue(): void
+    {
+        // No record stored — should default to opted-in
+        $this->assertTrue($this->prefs->isEnabled('user-1', 'email', 'marketing'));
+    }
+
+    // ── setEnabled + isEnabled ────────────────────────────────────────────────
+
+    public function testSetEnabledFalseOptsOut(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->assertFalse($this->prefs->isEnabled('user-1', 'email', 'marketing'));
+    }
+
+    public function testSetEnabledTrueOptsIn(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', true);
+        $this->assertTrue($this->prefs->isEnabled('user-1', 'email', 'marketing'));
+    }
+
+    public function testSetEnabledIsUpsert(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false); // second call should not throw
+        $this->assertFalse($this->prefs->isEnabled('user-1', 'email', 'marketing'));
+    }
+
+    public function testPreferencesAreUserScoped(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->assertTrue($this->prefs->isEnabled('user-2', 'email', 'marketing'));
+    }
+
+    public function testPreferencesAreChannelScoped(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->assertTrue($this->prefs->isEnabled('user-1', 'push', 'marketing'));
+    }
+
+    public function testPreferencesAreTypeScoped(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->assertTrue($this->prefs->isEnabled('user-1', 'email', 'order_update'));
+    }
+
+    public function testSetEnabledThrowsOnEmptyChannel(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->prefs->setEnabled('user-1', '', 'marketing', true);
+    }
+
+    public function testSetEnabledThrowsOnEmptyType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->prefs->setEnabled('user-1', 'email', '', true);
+    }
+
+    // ── all ───────────────────────────────────────────────────────────────────
+
+    public function testAllReturnsStoredPreferences(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->prefs->setEnabled('user-1', 'push', 'order', true);
+
+        $all = $this->prefs->all('user-1');
+        $this->assertCount(2, $all);
+    }
+
+    public function testAllReturnsCorrectShape(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $all = $this->prefs->all('user-1');
+        $this->assertArrayHasKey('channel', $all[0]);
+        $this->assertArrayHasKey('type', $all[0]);
+        $this->assertArrayHasKey('enabled', $all[0]);
+        $this->assertFalse($all[0]['enabled']);
+    }
+
+    public function testAllReturnsEmptyForUserWithNoPrefs(): void
+    {
+        $this->assertSame([], $this->prefs->all('nobody'));
+    }
+
+    public function testAllIsUserScoped(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->prefs->setEnabled('user-2', 'push', 'alerts', false);
+        $this->assertCount(1, $this->prefs->all('user-1'));
+    }
+
+    // ── reset ─────────────────────────────────────────────────────────────────
+
+    public function testResetDeletesRow(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->assertTrue($this->prefs->reset('user-1', 'email', 'marketing'));
+        // After reset, defaults to opted-in
+        $this->assertTrue($this->prefs->isEnabled('user-1', 'email', 'marketing'));
+    }
+
+    public function testResetReturnsFalseIfRowNotPresent(): void
+    {
+        $this->assertFalse($this->prefs->reset('user-1', 'email', 'marketing'));
+    }
+
+    // ── resetAll ──────────────────────────────────────────────────────────────
+
+    public function testResetAllDeletesAllRows(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->prefs->setEnabled('user-1', 'push', 'alerts', false);
+        $this->assertSame(2, $this->prefs->resetAll('user-1'));
+        $this->assertSame([], $this->prefs->all('user-1'));
+    }
+
+    public function testResetAllDoesNotAffectOtherUsers(): void
+    {
+        $this->prefs->setEnabled('user-1', 'email', 'marketing', false);
+        $this->prefs->setEnabled('user-2', 'email', 'marketing', false);
+        $this->prefs->resetAll('user-1');
+        $this->assertCount(1, $this->prefs->all('user-2'));
+    }
+}


### PR DESCRIPTION
## FT82 — NotificationPreference

Per-user notification preference manager using a channel × type matrix.

### Features
- `setEnabled(userId, channel, type, bool)` — upsert preference
- `isEnabled(userId, channel, type)` — returns `true` by default (no record = opted in)
- `all(userId)` — list all stored preferences as `{channel, type, enabled}` structs
- `reset(userId, channel, type)` — delete one row (reverts to default opt-in)
- `resetAll(userId)` — delete all rows for a user

### Implementation notes
- Schema: `notification_preferences (PRIMARY KEY user_id, channel, type)`
- Missing rows treated as opted-in (safe default)
- Upsert: `INSERT OR REPLACE` (SQLite) / `INSERT … ON DUPLICATE KEY UPDATE` (MySQL)
- Validation: empty channel or type throws `InvalidArgumentException`

### Tests
17 tests, 22 assertions — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)