### PR TITLE
feat(xion): DeviceToken — remember-me / trusted-device token with expiry (FT84)

### DIFF
--- a/class/xion/DeviceToken.php
+++ b/class/xion/DeviceToken.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Device trust / Remember-Me token manager.
+ *
+ * Issues long-lived opaque tokens that identify a trusted device or browser session.
+ * Raw token is shown once; only its SHA-256 hash is stored.
+ * Tokens expire and can be revoked individually or all at once per user.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $dt = new DeviceToken($pdo);
+ *
+ * // Issue a 30-day remember-me token
+ * $raw = $dt->issue('user-1', ttlDays: 30, label: 'MacBook Chrome');
+ * // Store $raw in a cookie; the class stores only its hash.
+ *
+ * // Validate on next visit
+ * $result = $dt->validate($raw);
+ * if ($result !== null) {
+ *     // $result['user_id'] is the authenticated user
+ * }
+ *
+ * // Revoke one token
+ * $dt->revoke($raw);
+ *
+ * // Revoke all tokens for a user (e.g. on password change)
+ * $dt->revokeAll('user-1');
+ *
+ * // List active tokens for a user (for "logged-in devices" UI)
+ * $dt->list('user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE device_tokens (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     token_hash  VARCHAR(64)  NOT NULL UNIQUE,
+ *     label       VARCHAR(255) NOT NULL DEFAULT '',
+ *     expires_at  DATETIME     NOT NULL,
+ *     last_used_at DATETIME    DEFAULT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class DeviceToken
+{
+    private const DEFAULT_TTL_DAYS = 30;
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Issue a new device/remember-me token.
+     *
+     * @param  string $userId  User to associate the token with.
+     * @param  int    $ttlDays Number of days until the token expires (default 30).
+     * @param  string $label   Human-readable device label (e.g. 'MacBook Chrome').
+     * @return string          Raw token — store in a secure HTTP-only cookie.
+     */
+    public function issue(string $userId, int $ttlDays = self::DEFAULT_TTL_DAYS, string $label = ''): string
+    {
+        $raw       = bin2hex(random_bytes(32)); // 64 hex chars
+        $hash      = hash('sha256', $raw);
+        $expiresAt = date('Y-m-d H:i:s', time() + $ttlDays * 86400);
+
+        $this->db()->prepare(
+            'INSERT INTO device_tokens (user_id, token_hash, label, expires_at)
+             VALUES (:user, :hash, :label, :expires)'
+        )->execute([
+            ':user'    => $userId,
+            ':hash'    => $hash,
+            ':label'   => trim($label),
+            ':expires' => $expiresAt,
+        ]);
+
+        return $raw;
+    }
+
+    /**
+     * Validate a raw token.
+     *
+     * Checks expiry and updates `last_used_at` on success.
+     *
+     * @param  string $rawToken Raw token from the cookie.
+     * @return array<string, mixed>|null Full token row (with user_id), or null if invalid/expired.
+     */
+    public function validate(string $rawToken): ?array
+    {
+        $hash = hash('sha256', $rawToken);
+        $db   = $this->db();
+
+        $stmt = $db->prepare(
+            'SELECT * FROM device_tokens
+             WHERE token_hash = :hash AND expires_at > CURRENT_TIMESTAMP
+             LIMIT 1'
+        );
+        $stmt->execute([':hash' => $hash]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        // Update last_used_at
+        $db->prepare(
+            'UPDATE device_tokens SET last_used_at = CURRENT_TIMESTAMP WHERE token_hash = :hash'
+        )->execute([':hash' => $hash]);
+
+        return $row;
+    }
+
+    /**
+     * Revoke a single token by raw value.
+     *
+     * @return bool True if a token was found and deleted.
+     */
+    public function revoke(string $rawToken): bool
+    {
+        $hash = hash('sha256', $rawToken);
+        $stmt = $this->db()->prepare('DELETE FROM device_tokens WHERE token_hash = :hash');
+        $stmt->execute([':hash' => $hash]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Revoke all tokens for a user (e.g. on password change or account compromise).
+     *
+     * @return int Number of tokens revoked.
+     */
+    public function revokeAll(string $userId): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM device_tokens WHERE user_id = :user');
+        $stmt->execute([':user' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * List all non-expired tokens for a user (for "trusted devices" UI).
+     *
+     * Note: token hashes are NOT included in the returned rows.
+     *
+     * @return list<array{id: int, label: string, expires_at: string, last_used_at: string|null, created_at: string}>
+     */
+    public function list(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, label, expires_at, last_used_at, created_at
+             FROM device_tokens
+             WHERE user_id = :user AND expires_at > CURRENT_TIMESTAMP
+             ORDER BY created_at DESC'
+        );
+        $stmt->execute([':user' => $userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Purge all expired tokens for a user (or all users if userId is empty).
+     *
+     * @return int Number of tokens purged.
+     */
+    public function purgeExpired(string $userId = ''): int
+    {
+        if ($userId !== '') {
+            $stmt = $this->db()->prepare(
+                'DELETE FROM device_tokens WHERE user_id = :user AND expires_at <= CURRENT_TIMESTAMP'
+            );
+            $stmt->execute([':user' => $userId]);
+        } else {
+            $stmt = $this->db()->prepare('DELETE FROM device_tokens WHERE expires_at <= CURRENT_TIMESTAMP');
+            $stmt->execute();
+        }
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/DeviceTokenTest.php
+++ b/tests/Unit/Xion/DeviceTokenTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\DeviceToken;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for DeviceToken.
+ */
+final class DeviceTokenTest extends TestCase
+{
+    private PDO $db;
+    private DeviceToken $dt;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE device_tokens (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id      VARCHAR(255) NOT NULL,
+                token_hash   VARCHAR(64)  NOT NULL UNIQUE,
+                label        VARCHAR(255) NOT NULL DEFAULT \'\',
+                expires_at   DATETIME     NOT NULL,
+                last_used_at DATETIME     DEFAULT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->dt = new DeviceToken($this->db);
+    }
+
+    // ── issue ─────────────────────────────────────────────────────────────────
+
+    public function testIssueReturnsRawToken(): void
+    {
+        $raw = $this->dt->issue('user-1');
+        $this->assertIsString($raw);
+        $this->assertSame(64, strlen($raw)); // 32 bytes = 64 hex chars
+    }
+
+    public function testIssueStoresHashNotRaw(): void
+    {
+        $raw  = $this->dt->issue('user-1');
+        $hash = hash('sha256', $raw);
+        $stmt = $this->db->prepare('SELECT token_hash FROM device_tokens WHERE token_hash = ?');
+        $stmt->execute([$hash]);
+        $this->assertNotFalse($stmt->fetchColumn());
+    }
+
+    public function testIssueStoresLabel(): void
+    {
+        $this->dt->issue('user-1', label: 'My Phone');
+        $list = $this->dt->list('user-1');
+        $this->assertSame('My Phone', $list[0]['label']);
+    }
+
+    public function testIssueMultipleTokensForSameUser(): void
+    {
+        $this->dt->issue('user-1');
+        $this->dt->issue('user-1');
+        $this->assertCount(2, $this->dt->list('user-1'));
+    }
+
+    // ── validate ──────────────────────────────────────────────────────────────
+
+    public function testValidateReturnsRowForValidToken(): void
+    {
+        $raw    = $this->dt->issue('user-1');
+        $result = $this->dt->validate($raw);
+        $this->assertNotNull($result);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('user-1', $result['user_id']);
+    }
+
+    public function testValidateReturnsNullForUnknownToken(): void
+    {
+        $this->assertNull($this->dt->validate(str_repeat('0', 64)));
+    }
+
+    public function testValidateReturnsNullForExpiredToken(): void
+    {
+        // Issue a token that's already expired
+        $raw  = bin2hex(random_bytes(32));
+        $hash = hash('sha256', $raw);
+        $this->db->prepare(
+            'INSERT INTO device_tokens (user_id, token_hash, expires_at)
+             VALUES (\'user-1\', :hash, \'2000-01-01 00:00:00\')'
+        )->execute([':hash' => $hash]);
+
+        $this->assertNull($this->dt->validate($raw));
+    }
+
+    public function testValidateUpdatesLastUsedAt(): void
+    {
+        $raw = $this->dt->issue('user-1');
+        $this->dt->validate($raw);
+        $list = $this->dt->list('user-1');
+        $this->assertNotNull($list[0]['last_used_at']);
+    }
+
+    // ── revoke ────────────────────────────────────────────────────────────────
+
+    public function testRevokeRemovesToken(): void
+    {
+        $raw = $this->dt->issue('user-1');
+        $this->assertTrue($this->dt->revoke($raw));
+        $this->assertNull($this->dt->validate($raw));
+    }
+
+    public function testRevokeReturnsFalseForUnknownToken(): void
+    {
+        $this->assertFalse($this->dt->revoke(str_repeat('0', 64)));
+    }
+
+    // ── revokeAll ─────────────────────────────────────────────────────────────
+
+    public function testRevokeAllRemovesAllUserTokens(): void
+    {
+        $this->dt->issue('user-1');
+        $this->dt->issue('user-1');
+        $this->assertSame(2, $this->dt->revokeAll('user-1'));
+        $this->assertSame([], $this->dt->list('user-1'));
+    }
+
+    public function testRevokeAllDoesNotAffectOtherUsers(): void
+    {
+        $this->dt->issue('user-1');
+        $this->dt->issue('user-2');
+        $this->dt->revokeAll('user-1');
+        $this->assertCount(1, $this->dt->list('user-2'));
+    }
+
+    // ── list ──────────────────────────────────────────────────────────────────
+
+    public function testListReturnsEmptyForUnknownUser(): void
+    {
+        $this->assertSame([], $this->dt->list('nobody'));
+    }
+
+    public function testListExcludesExpiredTokens(): void
+    {
+        $this->dt->issue('user-1'); // valid
+        // Insert expired token manually
+        $this->db->exec(
+            "INSERT INTO device_tokens (user_id, token_hash, expires_at)
+             VALUES ('user-1', 'aaaa', '2000-01-01 00:00:00')"
+        );
+        $this->assertCount(1, $this->dt->list('user-1'));
+    }
+
+    public function testListDoesNotIncludeTokenHash(): void
+    {
+        $this->dt->issue('user-1');
+        $list = $this->dt->list('user-1');
+        $this->assertArrayNotHasKey('token_hash', $list[0]);
+    }
+
+    // ── purgeExpired ──────────────────────────────────────────────────────────
+
+    public function testPurgeExpiredRemovesExpiredTokens(): void
+    {
+        $this->dt->issue('user-1'); // valid
+        $this->db->exec(
+            "INSERT INTO device_tokens (user_id, token_hash, expires_at)
+             VALUES ('user-1', 'bbbb', '2000-01-01 00:00:00')"
+        );
+        $purged = $this->dt->purgeExpired('user-1');
+        $this->assertSame(1, $purged);
+        $this->assertCount(1, $this->dt->list('user-1'));
+    }
+}

--- a/tests/Unit/Xion/DeviceTokenTest.php
+++ b/tests/Unit/Xion/DeviceTokenTest.php
@@ -73,7 +73,7 @@ final class DeviceTokenTest extends TestCase
         $raw    = $this->dt->issue('user-1');
         $result = $this->dt->validate($raw);
         $this->assertNotNull($result);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('user-1', $result['user_id']);
     }
 


### PR DESCRIPTION
## FT84 — DeviceToken

Long-lived opaque remember-me / device trust tokens with SHA-256 hash storage.

### Features
- `issue(userId, ttlDays?, label?)` — generates token; stores only SHA-256 hash; returns raw token
- `validate(rawToken)` — checks expiry, updates `last_used_at`, returns row with `user_id`
- `revoke(rawToken)` — delete a single token by raw value
- `revokeAll(userId)` — revoke all user tokens (password change / compromise response)
- `list(userId)` — non-expired tokens for UI (token_hash excluded from output)
- `purgeExpired(userId?)` — delete expired tokens

### Implementation notes
- Token format: 64 hex chars (32 random bytes)
- Schema: `device_tokens (UNIQUE token_hash, expires_at, last_used_at)`
- `list()` omits `token_hash` from returned rows — safe to render in UI

### Tests
16 tests, 21 assertions — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)