### PR TITLE
feat(xion): ActivityFeed — append-only user event timeline with cursor pagination (FT86)

### DIFF
--- a/class/xion/ActivityFeed.php
+++ b/class/xion/ActivityFeed.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * User-facing activity feed — append-only event timeline.
+ *
+ * Records structured events for a user (e.g. "liked a post", "earned a badge").
+ * Each event has a `type`, optional `subject_type`/`subject_id` target, and a
+ * JSON-serialisable `data` payload. Events are never updated or deleted by design
+ * (append-only audit pattern); only an explicit purge clears old entries.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $feed = new ActivityFeed($pdo);
+ *
+ * // Record an event
+ * $feed->record('user-1', 'liked_post', 'post', '42', ['title' => 'Hello World']);
+ *
+ * // Fetch latest events
+ * $events = $feed->fetch('user-1', limit: 20);
+ *
+ * // Count
+ * $feed->count('user-1');
+ *
+ * // Purge old entries (e.g. keep last 90 days)
+ * $feed->purgeOlderThan('user-1', days: 90);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE activity_feed (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id      VARCHAR(255) NOT NULL,
+ *     type         VARCHAR(100) NOT NULL,
+ *     subject_type VARCHAR(100) NOT NULL DEFAULT '',
+ *     subject_id   VARCHAR(255) NOT NULL DEFAULT '',
+ *     data         TEXT         NOT NULL DEFAULT '{}',
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ActivityFeed
+{
+    private const MAX_LIMIT = 100;
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record an activity event for a user.
+     *
+     * @param string               $userId      Actor / owner of the event.
+     * @param string               $type        Event type slug (e.g. 'liked_post', 'earned_badge').
+     * @param string               $subjectType Optional subject entity type.
+     * @param string               $subjectId   Optional subject entity ID.
+     * @param array<string, mixed> $data        Optional JSON payload.
+     * @return int                 New event ID.
+     * @throws \InvalidArgumentException if type is empty.
+     */
+    public function record(
+        string $userId,
+        string $type,
+        string $subjectType = '',
+        string $subjectId = '',
+        array $data = []
+    ): int {
+        $type = trim($type);
+        if ($type === '') {
+            throw new \InvalidArgumentException('Activity type must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO activity_feed (user_id, type, subject_type, subject_id, data)
+             VALUES (:user, :type, :subject_type, :subject_id, :data)'
+        );
+        $stmt->execute([
+            ':user'         => $userId,
+            ':type'         => $type,
+            ':subject_type' => trim($subjectType),
+            ':subject_id'   => trim($subjectId),
+            ':data'         => json_encode($data, JSON_UNESCAPED_UNICODE),
+        ]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Fetch recent activity events for a user (newest first).
+     *
+     * @param  int         $limit      Max events to return (1–100; default 20).
+     * @param  string|null $type       Optional filter by event type.
+     * @param  int|null    $beforeId   Optional cursor — fetch events with id < beforeId.
+     * @return list<array<string, mixed>>
+     */
+    public function fetch(string $userId, int $limit = 20, ?string $type = null, ?int $beforeId = null): array
+    {
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        $clauses = ['user_id = :user'];
+        $params  = [':user' => $userId];
+
+        if ($type !== null) {
+            $clauses[] = 'type = :type';
+            $params[':type'] = $type;
+        }
+
+        if ($beforeId !== null) {
+            $clauses[] = 'id < :before';
+            $params[':before'] = $beforeId;
+        }
+
+        $where = implode(' AND ', $clauses);
+        $stmt  = $this->db()->prepare(
+            "SELECT * FROM activity_feed WHERE {$where} ORDER BY id DESC LIMIT {$limit}"
+        );
+        $stmt->execute($params);
+
+        return array_map(
+            static function (array $row): array {
+                $row['data'] = json_decode($row['data'], true) ?? [];
+                return $row;
+            },
+            $stmt->fetchAll(PDO::FETCH_ASSOC)
+        );
+    }
+
+    /**
+     * Count all events for a user (or filtered by type).
+     */
+    public function count(string $userId, ?string $type = null): int
+    {
+        if ($type !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM activity_feed WHERE user_id = :user AND type = :type'
+            );
+            $stmt->execute([':user' => $userId, ':type' => $type]);
+        } else {
+            $stmt = $this->db()->prepare('SELECT COUNT(*) FROM activity_feed WHERE user_id = :user');
+            $stmt->execute([':user' => $userId]);
+        }
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Purge events older than `$days` days for a user.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $userId, int $days): int
+    {
+        if ($days <= 0) {
+            throw new \InvalidArgumentException("Days must be positive, got {$days}.");
+        }
+
+        $cutoff = date('Y-m-d H:i:s', time() - $days * 86400);
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM activity_feed WHERE user_id = :user AND created_at < :cutoff'
+        );
+        $stmt->execute([':user' => $userId, ':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/ActivityFeedTest.php
+++ b/tests/Unit/Xion/ActivityFeedTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ActivityFeed;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ActivityFeed.
+ */
+final class ActivityFeedTest extends TestCase
+{
+    private PDO $db;
+    private ActivityFeed $feed;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE activity_feed (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id      VARCHAR(255) NOT NULL,
+                type         VARCHAR(100) NOT NULL,
+                subject_type VARCHAR(100) NOT NULL DEFAULT \'\',
+                subject_id   VARCHAR(255) NOT NULL DEFAULT \'\',
+                data         TEXT         NOT NULL DEFAULT \'{}\',
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->feed = new ActivityFeed($this->db);
+    }
+
+    // ── record ────────────────────────────────────────────────────────────────
+
+    public function testRecordReturnsIntId(): void
+    {
+        $id = $this->feed->record('user-1', 'liked_post');
+        $this->assertIsInt($id);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testRecordThrowsOnEmptyType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->feed->record('user-1', '');
+    }
+
+    public function testRecordStoresSubjectFields(): void
+    {
+        $this->feed->record('user-1', 'liked_post', 'post', '42');
+        $events = $this->feed->fetch('user-1');
+        $this->assertSame('post', $events[0]['subject_type']);
+        $this->assertSame('42', $events[0]['subject_id']);
+    }
+
+    public function testRecordStoresJsonData(): void
+    {
+        $this->feed->record('user-1', 'liked_post', data: ['title' => 'Hello']);
+        $events = $this->feed->fetch('user-1');
+        $this->assertSame(['title' => 'Hello'], $events[0]['data']);
+    }
+
+    // ── fetch ─────────────────────────────────────────────────────────────────
+
+    public function testFetchReturnsEventsNewestFirst(): void
+    {
+        $id1 = $this->feed->record('user-1', 'a');
+        $id2 = $this->feed->record('user-1', 'b');
+        $events = $this->feed->fetch('user-1');
+        $this->assertSame((string)$id2, (string)$events[0]['id']);
+        $this->assertSame((string)$id1, (string)$events[1]['id']);
+    }
+
+    public function testFetchRespectsLimit(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->feed->record('user-1', 'evt');
+        }
+        $this->assertCount(3, $this->feed->fetch('user-1', limit: 3));
+    }
+
+    public function testFetchClampsLimitAt100(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->feed->record('user-1', 'evt');
+        }
+        $this->assertCount(5, $this->feed->fetch('user-1', limit: 200));
+    }
+
+    public function testFetchFilterByType(): void
+    {
+        $this->feed->record('user-1', 'liked_post');
+        $this->feed->record('user-1', 'earned_badge');
+        $this->feed->record('user-1', 'liked_post');
+
+        $events = $this->feed->fetch('user-1', type: 'liked_post');
+        $this->assertCount(2, $events);
+    }
+
+    public function testFetchBeforeIdCursor(): void
+    {
+        $id1 = $this->feed->record('user-1', 'a');
+        $id2 = $this->feed->record('user-1', 'b');
+        $id3 = $this->feed->record('user-1', 'c');
+
+        $events = $this->feed->fetch('user-1', beforeId: $id3);
+        $this->assertCount(2, $events);
+        $this->assertSame((string)$id2, (string)$events[0]['id']);
+        $this->assertSame((string)$id1, (string)$events[1]['id']);
+    }
+
+    public function testFetchIsUserScoped(): void
+    {
+        $this->feed->record('user-1', 'a');
+        $this->feed->record('user-2', 'b');
+        $this->assertCount(1, $this->feed->fetch('user-1'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountReturnsZeroForNewUser(): void
+    {
+        $this->assertSame(0, $this->feed->count('user-1'));
+    }
+
+    public function testCountReturnsCorrectTotal(): void
+    {
+        $this->feed->record('user-1', 'a');
+        $this->feed->record('user-1', 'b');
+        $this->assertSame(2, $this->feed->count('user-1'));
+    }
+
+    public function testCountFilterByType(): void
+    {
+        $this->feed->record('user-1', 'liked');
+        $this->feed->record('user-1', 'liked');
+        $this->feed->record('user-1', 'badge');
+        $this->assertSame(2, $this->feed->count('user-1', type: 'liked'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanThrowsOnNonPositiveDays(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->feed->purgeOlderThan('user-1', 0);
+    }
+
+    public function testPurgeOlderThanDeletesOldRows(): void
+    {
+        // Insert a fake old event
+        $this->db->exec(
+            "INSERT INTO activity_feed (user_id, type, created_at)
+             VALUES ('user-1', 'old_event', '2000-01-01 00:00:00')"
+        );
+        $this->feed->record('user-1', 'new_event');
+
+        $purged = $this->feed->purgeOlderThan('user-1', days: 1);
+        $this->assertSame(1, $purged);
+        $this->assertSame(1, $this->feed->count('user-1'));
+    }
+}


### PR DESCRIPTION
## FT86 — ActivityFeed

Append-only user activity event timeline with type filtering and cursor pagination.

### Features
- `record(userId, type, subjectType?, subjectId?, data?)` — insert event with JSON payload
- `fetch(userId, limit?, type?, beforeId?)` — newest-first; cursor via `beforeId`; limit clamped 1–100
- `count(userId, type?)` — total event count with optional type filter
- `purgeOlderThan(userId, days)` — delete old events (positive days required)

### Implementation notes
- Append-only: no UPDATE/DELETE on events (audit trail)
- `data` stored as JSON text; decoded to array on read
- Schema: `activity_feed (user_id, type, subject_type, subject_id, data, created_at)`
- `beforeId` cursor for keyset-style pagination (pairs well with FT25 CursorPage pattern)

### Tests
15 tests, 21 assertions — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)