### PR TITLE
feat(xion): ContentFlag — user content flagging and moderation queue (FT88)

### DIFF
--- a/class/xion/ContentFlag.php
+++ b/class/xion/ContentFlag.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * User content flagging and moderation queue.
+ *
+ * Users can flag content (posts, comments, profiles) for review.
+ * Moderators then take an action: `approve` (keep), `remove` (take down), or `dismiss` (no action).
+ *
+ * Duplicate flags by the same user on the same entity are silently ignored.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cf = new ContentFlag($pdo);
+ *
+ * // User flags a post
+ * $cf->flag('user-1', 'post', '99', reason: 'spam');
+ *
+ * // Moderator queue
+ * $queue = $cf->queue(status: 'pending');
+ *
+ * // Moderate
+ * $cf->moderate('post', '99', action: 'remove', moderatorId: 'mod-1', note: 'Confirmed spam');
+ *
+ * // Check moderation status
+ * $cf->status('post', '99'); // 'pending'|'approved'|'removed'|'dismissed'|null
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE content_flags (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     reporter_id  VARCHAR(255) NOT NULL,
+ *     entity_type  VARCHAR(100) NOT NULL,
+ *     entity_id    VARCHAR(255) NOT NULL,
+ *     reason       VARCHAR(100) NOT NULL DEFAULT '',
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     moderator_id VARCHAR(255) DEFAULT NULL,
+ *     note         TEXT         NOT NULL DEFAULT '',
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     resolved_at  DATETIME     DEFAULT NULL,
+ *     UNIQUE (reporter_id, entity_type, entity_id)
+ * );
+ * ```
+ */
+final class ContentFlag
+{
+    private const VALID_ACTIONS = ['approve', 'remove', 'dismiss'];
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Flag a piece of content for moderation review.
+     *
+     * Idempotent: a user can only flag the same entity once (UNIQUE reporter+entity).
+     *
+     * @return bool True if a new flag was created; false if already flagged.
+     * @throws \InvalidArgumentException if entity_type or entity_id is empty.
+     */
+    public function flag(
+        string $reporterId,
+        string $entityType,
+        string $entityId,
+        string $reason = ''
+    ): bool {
+        $entityType = $this->normaliseStr($entityType, 'entity_type');
+        $entityId   = $this->normaliseStr($entityId, 'entity_id');
+
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $sql    = $driver === 'sqlite'
+            ? 'INSERT OR IGNORE INTO content_flags (reporter_id, entity_type, entity_id, reason)
+               VALUES (:reporter, :type, :entity, :reason)'
+            : 'INSERT IGNORE INTO content_flags (reporter_id, entity_type, entity_id, reason)
+               VALUES (:reporter, :type, :entity, :reason)';
+
+        $stmt = $db->prepare($sql);
+        $stmt->execute([
+            ':reporter' => $reporterId,
+            ':type'     => $entityType,
+            ':entity'   => $entityId,
+            ':reason'   => trim($reason),
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Resolve a flag (or all flags on the same entity) with a moderation action.
+     *
+     * All `pending` flags for the entity are updated atomically.
+     *
+     * @param string $action      'approve' | 'remove' | 'dismiss'
+     * @param string $moderatorId Moderator's user ID.
+     * @param string $note        Optional moderation note.
+     * @return int Number of flag rows updated.
+     * @throws \InvalidArgumentException if action is invalid.
+     */
+    public function moderate(
+        string $entityType,
+        string $entityId,
+        string $action,
+        string $moderatorId,
+        string $note = ''
+    ): int {
+        if (!in_array($action, self::VALID_ACTIONS, true)) {
+            throw new \InvalidArgumentException(
+                "Invalid action '{$action}'. Must be one of: " . implode(', ', self::VALID_ACTIONS) . '.'
+            );
+        }
+
+        $stmt = $this->db()->prepare(
+            "UPDATE content_flags
+             SET status = :action, moderator_id = :mod, note = :note,
+                 resolved_at = CURRENT_TIMESTAMP
+             WHERE entity_type = :type AND entity_id = :entity AND status = 'pending'"
+        );
+        $stmt->execute([
+            ':action' => $action,
+            ':mod'    => $moderatorId,
+            ':note'   => trim($note),
+            ':type'   => $entityType,
+            ':entity' => $entityId,
+        ]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Get the current moderation status for an entity.
+     *
+     * Returns the most recent resolution action, or 'pending' if unresolved, or null if never flagged.
+     *
+     * @return 'pending'|'approve'|'remove'|'dismiss'|null
+     */
+    public function status(string $entityType, string $entityId): ?string
+    {
+        // Prefer resolved status; fall back to pending
+        $stmt = $this->db()->prepare(
+            'SELECT status FROM content_flags
+             WHERE entity_type = :type AND entity_id = :entity
+             ORDER BY CASE status WHEN \'pending\' THEN 1 ELSE 0 END ASC, resolved_at DESC
+             LIMIT 1'
+        );
+        $stmt->execute([':type' => $entityType, ':entity' => $entityId]);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : null;
+    }
+
+    /**
+     * Return the moderation queue filtered by status.
+     *
+     * Groups by entity so each entity appears once even if flagged multiple times.
+     *
+     * @param  string $status 'pending' | 'approve' | 'remove' | 'dismiss'
+     * @param  int    $limit  Max rows (1–100).
+     * @return list<array<string, mixed>>
+     */
+    public function queue(string $status = 'pending', int $limit = 50): array
+    {
+        $limit = max(1, min(100, $limit));
+        $stmt  = $this->db()->prepare(
+            'SELECT entity_type, entity_id, status,
+                    COUNT(*) AS flag_count,
+                    MIN(created_at) AS first_flagged_at
+             FROM content_flags
+             WHERE status = :status
+             GROUP BY entity_type, entity_id, status
+             ORDER BY first_flagged_at ASC
+             LIMIT :limit'
+        );
+        $stmt->bindValue(':status', $status);
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * List all flags submitted by a specific reporter.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function byReporter(string $reporterId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM content_flags WHERE reporter_id = :reporter ORDER BY created_at DESC'
+        );
+        $stmt->execute([':reporter' => $reporterId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function normaliseStr(string $value, string $field): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$field} must not be empty.");
+        }
+        return $value;
+    }
+}

--- a/tests/Unit/Xion/ContentFlagTest.php
+++ b/tests/Unit/Xion/ContentFlagTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ContentFlag;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ContentFlag.
+ */
+final class ContentFlagTest extends TestCase
+{
+    private PDO $db;
+    private ContentFlag $cf;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE content_flags (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                reporter_id  VARCHAR(255) NOT NULL,
+                entity_type  VARCHAR(100) NOT NULL,
+                entity_id    VARCHAR(255) NOT NULL,
+                reason       VARCHAR(100) NOT NULL DEFAULT \'\',
+                status       VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                moderator_id VARCHAR(255) DEFAULT NULL,
+                note         TEXT         NOT NULL DEFAULT \'\',
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                resolved_at  DATETIME     DEFAULT NULL,
+                UNIQUE (reporter_id, entity_type, entity_id)
+            )
+        ');
+        $this->cf = new ContentFlag($this->db);
+    }
+
+    // ── flag ──────────────────────────────────────────────────────────────────
+
+    public function testFlagReturnsTrueOnFirstFlag(): void
+    {
+        $this->assertTrue($this->cf->flag('user-1', 'post', '42'));
+    }
+
+    public function testFlagIsIdempotentForSameReporter(): void
+    {
+        $this->cf->flag('user-1', 'post', '42');
+        $this->assertFalse($this->cf->flag('user-1', 'post', '42'));
+    }
+
+    public function testMultipleReportersFlagSameEntity(): void
+    {
+        $this->cf->flag('user-1', 'post', '42');
+        $this->cf->flag('user-2', 'post', '42');
+        $queue = $this->cf->queue();
+        $this->assertSame('2', (string)$queue[0]['flag_count']);
+    }
+
+    public function testFlagThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cf->flag('user-1', '', '42');
+    }
+
+    public function testFlagThrowsOnEmptyEntityId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cf->flag('user-1', 'post', '');
+    }
+
+    public function testFlagStoresReason(): void
+    {
+        $this->cf->flag('user-1', 'post', '42', reason: 'spam');
+        $flags = $this->cf->byReporter('user-1');
+        $this->assertSame('spam', $flags[0]['reason']);
+    }
+
+    // ── moderate ──────────────────────────────────────────────────────────────
+
+    public function testModerateApprovesFlags(): void
+    {
+        $this->cf->flag('user-1', 'post', '42');
+        $count = $this->cf->moderate('post', '42', 'approve', 'mod-1');
+        $this->assertSame(1, $count);
+        $this->assertSame('approve', $this->cf->status('post', '42'));
+    }
+
+    public function testModerateRemovesFlags(): void
+    {
+        $this->cf->flag('user-1', 'post', '42');
+        $this->cf->moderate('post', '42', 'remove', 'mod-1', 'Confirmed spam');
+        $this->assertSame('remove', $this->cf->status('post', '42'));
+    }
+
+    public function testModerateUpdateAllPendingFlags(): void
+    {
+        $this->cf->flag('user-1', 'post', '42');
+        $this->cf->flag('user-2', 'post', '42');
+        $count = $this->cf->moderate('post', '42', 'dismiss', 'mod-1');
+        $this->assertSame(2, $count);
+    }
+
+    public function testModerateThrowsOnInvalidAction(): void
+    {
+        $this->cf->flag('user-1', 'post', '42');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cf->moderate('post', '42', 'invalid', 'mod-1');
+    }
+
+    public function testModerateReturnZeroIfNoFlags(): void
+    {
+        $this->assertSame(0, $this->cf->moderate('post', '99', 'dismiss', 'mod-1'));
+    }
+
+    // ── status ────────────────────────────────────────────────────────────────
+
+    public function testStatusReturnsNullForNeverFlagged(): void
+    {
+        $this->assertNull($this->cf->status('post', '99'));
+    }
+
+    public function testStatusReturnsPendingForUnresolvedFlag(): void
+    {
+        $this->cf->flag('user-1', 'post', '42');
+        $this->assertSame('pending', $this->cf->status('post', '42'));
+    }
+
+    // ── queue ─────────────────────────────────────────────────────────────────
+
+    public function testQueueReturnsOnlyMatchingStatus(): void
+    {
+        $this->cf->flag('user-1', 'post', '42');
+        $this->cf->flag('user-1', 'post', '99');
+        $this->cf->moderate('post', '99', 'remove', 'mod-1');
+
+        $pending = $this->cf->queue('pending');
+        $this->assertCount(1, $pending);
+        $this->assertSame('42', $pending[0]['entity_id']);
+    }
+
+    public function testQueueRespectsLimit(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->cf->flag('user-1', 'post', (string)$i);
+        }
+        $this->assertCount(2, $this->cf->queue(limit: 2));
+    }
+
+    // ── byReporter ────────────────────────────────────────────────────────────
+
+    public function testByReporterReturnsAllFlagsForUser(): void
+    {
+        $this->cf->flag('user-1', 'post', '42');
+        $this->cf->flag('user-1', 'comment', '7');
+        $flags = $this->cf->byReporter('user-1');
+        $this->assertCount(2, $flags);
+    }
+
+    public function testByReporterReturnsEmptyForUnknownUser(): void
+    {
+        $this->assertSame([], $this->cf->byReporter('nobody'));
+    }
+}


### PR DESCRIPTION
## FT88 — ContentFlag

User content flagging system with moderator action queue.

### Features
- `flag(reporterId, entityType, entityId, reason?)` — submit flag; idempotent per reporter+entity
- `moderate(entityType, entityId, action, moderatorId, note?)` — resolve pending flags: `approve`, `remove`, `dismiss`
- `status(entityType, entityId)` — `'pending'|'approve'|'remove'|'dismiss'|null`
- `queue(status?, limit?)` — moderation queue grouped by entity; shows flag count
- `byReporter(reporterId)` — all flags submitted by a user

### Implementation notes
- `UNIQUE (reporter_id, entity_type, entity_id)` — INSERT OR IGNORE for idempotency
- `moderate()` updates all pending flags for an entity atomically
- `queue()` groups by entity so high-volume entities show flag counts

### Tests
17 tests, 19 assertions — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)