### PR TITLE
feat(xion): PasswordHistory — prevent recent password reuse (FT91)

### DIFF
--- a/class/xion/PasswordHistory.php
+++ b/class/xion/PasswordHistory.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Password history — prevent users from reusing recent passwords.
+ *
+ * Stores the last N password hashes per user and checks whether a proposed
+ * new password matches any of them. Uses `password_verify()` for comparison
+ * so any hash algorithm supported by PHP is accepted.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ph = new PasswordHistory($pdo);
+ *
+ * // After a successful password change, record the OLD hash
+ * $ph->push('user-1', $oldHash);
+ *
+ * // Before accepting a new password, check it
+ * if ($ph->wasUsed('user-1', $newPlainText)) {
+ *     throw new \RuntimeException('Cannot reuse a recent password.');
+ * }
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE password_history (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     hash        VARCHAR(255) NOT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class PasswordHistory
+{
+    /** Number of past hashes to retain and check by default. */
+    private const DEFAULT_DEPTH = 5;
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly int $depth = self::DEFAULT_DEPTH
+    ) {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Store a password hash in the user's history.
+     *
+     * After inserting, old entries beyond `$depth` are pruned automatically.
+     *
+     * @param string $userId   User whose history to update.
+     * @param string $hash     bcrypt/argon/etc. hash of the password to record.
+     * @throws \InvalidArgumentException if hash is empty.
+     */
+    public function push(string $userId, string $hash): void
+    {
+        $hash = trim($hash);
+        if ($hash === '') {
+            throw new \InvalidArgumentException('Password hash must not be empty.');
+        }
+
+        $db = $this->db();
+        $db->prepare(
+            'INSERT INTO password_history (user_id, hash) VALUES (:user, :hash)'
+        )->execute([':user' => $userId, ':hash' => $hash]);
+
+        $this->prune($db, $userId);
+    }
+
+    /**
+     * Check if a plain-text password matches any of the stored hashes.
+     *
+     * Uses `password_verify()` so it works with bcrypt, argon2i, argon2id.
+     *
+     * @param string $userId        User to check.
+     * @param string $plainPassword Plain-text password to test.
+     * @return bool True if the password was previously used.
+     */
+    public function wasUsed(string $userId, string $plainPassword): bool
+    {
+        $hashes = $this->recent($userId);
+        foreach ($hashes as $hash) {
+            if (password_verify($plainPassword, $hash)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return the stored hashes for a user (newest first, up to `$depth`).
+     *
+     * @return list<string>
+     */
+    public function recent(string $userId): array
+    {
+        $depth = max(1, $this->depth);
+        $stmt  = $this->db()->prepare(
+            "SELECT hash FROM password_history
+             WHERE user_id = :user
+             ORDER BY id DESC
+             LIMIT {$depth}"
+        );
+        $stmt->execute([':user' => $userId]);
+        return array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'hash');
+    }
+
+    /**
+     * Count how many hashes are stored for a user.
+     */
+    public function count(string $userId): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM password_history WHERE user_id = :user');
+        $stmt->execute([':user' => $userId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Clear all password history for a user (e.g. on account deletion).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function clear(string $userId): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM password_history WHERE user_id = :user');
+        $stmt->execute([':user' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * Delete oldest entries beyond the configured depth.
+     */
+    private function prune(PDO $db, string $userId): void
+    {
+        $depth = max(1, $this->depth);
+
+        // Find the ID of the Nth-newest row
+        $stmt = $db->prepare(
+            "SELECT id FROM password_history
+             WHERE user_id = :user
+             ORDER BY id DESC
+             LIMIT 1 OFFSET {$depth}"
+        );
+        $stmt->execute([':user' => $userId]);
+        $cutoffId = $stmt->fetchColumn();
+
+        if ($cutoffId !== false) {
+            $db->prepare(
+                'DELETE FROM password_history WHERE user_id = :user AND id <= :cutoff'
+            )->execute([':user' => $userId, ':cutoff' => (int)$cutoffId]);
+        }
+    }
+}

--- a/tests/Unit/Xion/PasswordHistoryTest.php
+++ b/tests/Unit/Xion/PasswordHistoryTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\PasswordHistory;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PasswordHistory.
+ */
+final class PasswordHistoryTest extends TestCase
+{
+    private PDO $db;
+    private PasswordHistory $ph;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE password_history (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL,
+                hash       VARCHAR(255) NOT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->ph = new PasswordHistory($this->db, depth: 3);
+    }
+
+    // ── push ──────────────────────────────────────────────────────────────────
+
+    public function testPushStoresHash(): void
+    {
+        $hash = password_hash('secret', PASSWORD_BCRYPT);
+        $this->ph->push('user-1', $hash);
+        $this->assertSame(1, $this->ph->count('user-1'));
+    }
+
+    public function testPushThrowsOnEmptyHash(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ph->push('user-1', '');
+    }
+
+    public function testPushPrunesOldEntriesBeyondDepth(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->ph->push('user-1', password_hash("pass{$i}", PASSWORD_BCRYPT));
+        }
+        $this->assertSame(3, $this->ph->count('user-1'));
+    }
+
+    public function testPushKeepsNewestHashes(): void
+    {
+        $hashes = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $h = password_hash("pass{$i}", PASSWORD_BCRYPT);
+            $hashes[] = $h;
+            $this->ph->push('user-1', $h);
+        }
+        // The last 3 hashes should remain
+        $stored = $this->ph->recent('user-1');
+        $this->assertSame($hashes[4], $stored[0]); // newest
+        $this->assertSame($hashes[3], $stored[1]);
+        $this->assertSame($hashes[2], $stored[2]); // oldest kept
+    }
+
+    // ── wasUsed ───────────────────────────────────────────────────────────────
+
+    public function testWasUsedReturnsTrueForRecentPassword(): void
+    {
+        $plain = 'MyPassword123';
+        $this->ph->push('user-1', password_hash($plain, PASSWORD_BCRYPT));
+        $this->assertTrue($this->ph->wasUsed('user-1', $plain));
+    }
+
+    public function testWasUsedReturnsFalseForNewPassword(): void
+    {
+        $this->ph->push('user-1', password_hash('OldPass', PASSWORD_BCRYPT));
+        $this->assertFalse($this->ph->wasUsed('user-1', 'NewPass'));
+    }
+
+    public function testWasUsedReturnsFalseForEmptyHistory(): void
+    {
+        $this->assertFalse($this->ph->wasUsed('user-1', 'AnyPass'));
+    }
+
+    public function testWasUsedOnlyChecksWithinDepth(): void
+    {
+        $oldPlain = 'VeryOldPass';
+        $this->ph->push('user-1', password_hash($oldPlain, PASSWORD_BCRYPT));
+        // Push 3 more to push the old one out
+        for ($i = 1; $i <= 3; $i++) {
+            $this->ph->push('user-1', password_hash("NewPass{$i}", PASSWORD_BCRYPT));
+        }
+        $this->assertFalse($this->ph->wasUsed('user-1', $oldPlain));
+    }
+
+    // ── recent ────────────────────────────────────────────────────────────────
+
+    public function testRecentReturnsEmptyForNewUser(): void
+    {
+        $this->assertSame([], $this->ph->recent('nobody'));
+    }
+
+    public function testRecentReturnsHashesNewestFirst(): void
+    {
+        $h1 = password_hash('p1', PASSWORD_BCRYPT);
+        $h2 = password_hash('p2', PASSWORD_BCRYPT);
+        $this->ph->push('user-1', $h1);
+        $this->ph->push('user-1', $h2);
+        $recent = $this->ph->recent('user-1');
+        $this->assertSame($h2, $recent[0]);
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountReturnsZeroForNewUser(): void
+    {
+        $this->assertSame(0, $this->ph->count('user-1'));
+    }
+
+    // ── clear ─────────────────────────────────────────────────────────────────
+
+    public function testClearDeletesAllRows(): void
+    {
+        $this->ph->push('user-1', password_hash('p1', PASSWORD_BCRYPT));
+        $this->ph->push('user-1', password_hash('p2', PASSWORD_BCRYPT));
+        $this->assertSame(2, $this->ph->clear('user-1'));
+        $this->assertSame(0, $this->ph->count('user-1'));
+    }
+
+    public function testClearDoesNotAffectOtherUsers(): void
+    {
+        $this->ph->push('user-1', password_hash('p1', PASSWORD_BCRYPT));
+        $this->ph->push('user-2', password_hash('p2', PASSWORD_BCRYPT));
+        $this->ph->clear('user-1');
+        $this->assertSame(1, $this->ph->count('user-2'));
+    }
+}


### PR DESCRIPTION
## FT91 — PasswordHistory

Track last N password hashes per user to prevent reuse.

### Features
- `push(userId, hash)` — store a hash; auto-prunes oldest beyond depth
- `wasUsed(userId, plainPassword)` — check against stored hashes via `password_verify()`
- `recent(userId)` — list stored hashes (newest first)
- `count(userId)` — how many hashes are stored
- `clear(userId)` — delete all history (e.g. on account deletion)

### Implementation notes
- Works with any PHP password hash (bcrypt, argon2i, argon2id)
- `depth` constructor parameter (default 5) controls how many hashes to retain
- Prune on `push()`: finds the Nth-newest row by `id`, deletes everything older
- `wasUsed()` iterates stored hashes — stays within depth limit, so ≤5 `password_verify()` calls

### Tests
13 tests, 16 assertions — all green (bcrypt hashing makes these slower ~5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)