### PR TITLE
feat(ft94): ContentSchedule — publish/expire windows with draft/published/expired/cancelled lifecycle

### DIFF
--- a/class/xion/ContentSchedule.php
+++ b/class/xion/ContentSchedule.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ContentSchedule — schedule content for future publish and optional expiry.
+ *
+ * Useful for blog posts, banners, announcements, and any content that should
+ * be visible only within a specific time window.
+ *
+ * Status transitions:
+ * - `draft`     → not yet published (publish_at in the future, or publish_at null)
+ * - `published` → publish_at ≤ now AND (expire_at IS NULL OR expire_at > now)
+ * - `expired`   → expire_at ≤ now
+ * - `cancelled` → explicitly cancelled (removed from all public queries)
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cs = new ContentSchedule($pdo);
+ *
+ * // Schedule a post
+ * $id = $cs->schedule('post', '42', new \DateTimeImmutable('+1 hour'));
+ *
+ * // Publish immediately
+ * $id = $cs->schedule('banner', '7', new \DateTimeImmutable());
+ *
+ * // Check if live
+ * $cs->isLive('post', '42'); // true/false
+ *
+ * // Fetch all currently live items for a type
+ * $live = $cs->listLive('post');
+ *
+ * // Cancel
+ * $cs->cancel('post', '42');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE content_schedules (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     entity_type  VARCHAR(100) NOT NULL,
+ *     entity_id    VARCHAR(255) NOT NULL,
+ *     publish_at   DATETIME     NOT NULL,
+ *     expire_at    DATETIME     DEFAULT NULL,
+ *     cancelled_at DATETIME     DEFAULT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (entity_type, entity_id)
+ * );
+ * ```
+ */
+final class ContentSchedule
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Schedule content for publication.
+     *
+     * If an entry already exists for (entity_type, entity_id), it is replaced.
+     *
+     * @param  \DateTimeImmutable      $publishAt  When to make the content live.
+     * @param  \DateTimeImmutable|null $expireAt   Optional expiry time.
+     * @return int  The schedule record ID.
+     * @throws \InvalidArgumentException if entity_type or entity_id is empty.
+     * @throws \InvalidArgumentException if expire_at is not after publish_at.
+     */
+    public function schedule(
+        string $entityType,
+        string $entityId,
+        \DateTimeImmutable $publishAt,
+        ?\DateTimeImmutable $expireAt = null
+    ): int {
+        [$entityType, $entityId] = $this->normalise($entityType, $entityId);
+
+        if ($expireAt !== null && $expireAt <= $publishAt) {
+            throw new \InvalidArgumentException('expire_at must be after publish_at.');
+        }
+
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $publishStr = $publishAt->format('Y-m-d H:i:s');
+        $expireStr  = $expireAt?->format('Y-m-d H:i:s');
+
+        if ($driver === 'sqlite') {
+            $db->prepare(
+                'INSERT OR REPLACE INTO content_schedules
+                 (entity_type, entity_id, publish_at, expire_at, cancelled_at)
+                 VALUES (:type, :id, :pub, :exp, NULL)'
+            )->execute([':type' => $entityType, ':id' => $entityId, ':pub' => $publishStr, ':exp' => $expireStr]);
+        } else {
+            $db->prepare(
+                'INSERT INTO content_schedules (entity_type, entity_id, publish_at, expire_at, cancelled_at)
+                 VALUES (:type, :id, :pub, :exp, NULL)
+                 ON DUPLICATE KEY UPDATE publish_at = VALUES(publish_at),
+                                         expire_at  = VALUES(expire_at),
+                                         cancelled_at = NULL'
+            )->execute([':type' => $entityType, ':id' => $entityId, ':pub' => $publishStr, ':exp' => $expireStr]);
+        }
+
+        $stmt = $db->prepare(
+            'SELECT id FROM content_schedules WHERE entity_type = :type AND entity_id = :id LIMIT 1'
+        );
+        $stmt->execute([':type' => $entityType, ':id' => $entityId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Check whether the content is currently live (published and not expired/cancelled).
+     */
+    public function isLive(string $entityType, string $entityId): bool
+    {
+        [$entityType, $entityId] = $this->normalise($entityType, $entityId);
+        $now  = $this->nowString();
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM content_schedules
+             WHERE entity_type = :type
+               AND entity_id   = :id
+               AND publish_at  <= :now
+               AND (expire_at IS NULL OR expire_at > :now2)
+               AND cancelled_at IS NULL'
+        );
+        $stmt->execute([':type' => $entityType, ':id' => $entityId, ':now' => $now, ':now2' => $now]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Get the current status of a scheduled entry.
+     *
+     * @return 'draft'|'published'|'expired'|'cancelled'|null  null if not found.
+     */
+    public function status(string $entityType, string $entityId): ?string
+    {
+        [$entityType, $entityId] = $this->normalise($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT publish_at, expire_at, cancelled_at
+             FROM content_schedules
+             WHERE entity_type = :type AND entity_id = :id LIMIT 1'
+        );
+        $stmt->execute([':type' => $entityType, ':id' => $entityId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+        return $this->computeStatus($row);
+    }
+
+    /**
+     * List all currently live entities of a given type.
+     *
+     * @return list<array{id: int, entity_type: string, entity_id: string, publish_at: string, expire_at: string|null}>
+     */
+    public function listLive(string $entityType): array
+    {
+        $entityType = trim($entityType);
+        $now        = $this->nowString();
+        $stmt       = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, publish_at, expire_at
+             FROM content_schedules
+             WHERE entity_type = :type
+               AND publish_at  <= :now
+               AND (expire_at IS NULL OR expire_at > :now2)
+               AND cancelled_at IS NULL
+             ORDER BY publish_at ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':now' => $now, ':now2' => $now]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List all scheduled (not-yet-live) entries of a given type.
+     *
+     * @return list<array{id: int, entity_type: string, entity_id: string, publish_at: string, expire_at: string|null}>
+     */
+    public function listScheduled(string $entityType): array
+    {
+        $entityType = trim($entityType);
+        $now        = $this->nowString();
+        $stmt       = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, publish_at, expire_at
+             FROM content_schedules
+             WHERE entity_type = :type
+               AND publish_at  > :now
+               AND cancelled_at IS NULL
+             ORDER BY publish_at ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':now' => $now]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Cancel a scheduled entry.
+     *
+     * @return bool True if a non-cancelled entry was found and cancelled.
+     */
+    public function cancel(string $entityType, string $entityId): bool
+    {
+        [$entityType, $entityId] = $this->normalise($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'UPDATE content_schedules
+             SET cancelled_at = CURRENT_TIMESTAMP
+             WHERE entity_type = :type AND entity_id = :id AND cancelled_at IS NULL'
+        );
+        $stmt->execute([':type' => $entityType, ':id' => $entityId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Update the publish/expire times for an existing entry.
+     *
+     * @throws \InvalidArgumentException if the entry does not exist or is cancelled.
+     * @throws \InvalidArgumentException if expire_at is not after publish_at.
+     */
+    public function reschedule(
+        string $entityType,
+        string $entityId,
+        \DateTimeImmutable $publishAt,
+        ?\DateTimeImmutable $expireAt = null
+    ): bool {
+        [$entityType, $entityId] = $this->normalise($entityType, $entityId);
+
+        if ($expireAt !== null && $expireAt <= $publishAt) {
+            throw new \InvalidArgumentException('expire_at must be after publish_at.');
+        }
+
+        $publishStr = $publishAt->format('Y-m-d H:i:s');
+        $expireStr  = $expireAt?->format('Y-m-d H:i:s');
+
+        $stmt = $this->db()->prepare(
+            'UPDATE content_schedules
+             SET publish_at = :pub, expire_at = :exp
+             WHERE entity_type = :type AND entity_id = :id AND cancelled_at IS NULL'
+        );
+        $stmt->execute([':pub' => $publishStr, ':exp' => $expireStr, ':type' => $entityType, ':id' => $entityId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Remove a schedule entry entirely (hard delete).
+     *
+     * @return bool True if a row was deleted.
+     */
+    public function remove(string $entityType, string $entityId): bool
+    {
+        [$entityType, $entityId] = $this->normalise($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM content_schedules WHERE entity_type = :type AND entity_id = :id'
+        );
+        $stmt->execute([':type' => $entityType, ':id' => $entityId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function nowString(): string
+    {
+        return (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function computeStatus(array $row): string
+    {
+        if ($row['cancelled_at'] !== null) {
+            return 'cancelled';
+        }
+        $now = $this->nowString();
+        if ($row['expire_at'] !== null && $row['expire_at'] <= $now) {
+            return 'expired';
+        }
+        if ($row['publish_at'] <= $now) {
+            return 'published';
+        }
+        return 'draft';
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function normalise(string $entityType, string $entityId): array
+    {
+        $entityType = trim($entityType);
+        $entityId   = trim($entityId);
+        if ($entityType === '') {
+            throw new \InvalidArgumentException('entity_type must not be empty.');
+        }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        return [$entityType, $entityId];
+    }
+}

--- a/tests/Unit/Xion/ContentScheduleTest.php
+++ b/tests/Unit/Xion/ContentScheduleTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ContentSchedule;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ContentSchedule.
+ */
+final class ContentScheduleTest extends TestCase
+{
+    private PDO $db;
+    private ContentSchedule $cs;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE content_schedules (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type  VARCHAR(100) NOT NULL,
+                entity_id    VARCHAR(255) NOT NULL,
+                publish_at   DATETIME     NOT NULL,
+                expire_at    DATETIME     DEFAULT NULL,
+                cancelled_at DATETIME     DEFAULT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (entity_type, entity_id)
+            )
+        ');
+        $this->cs = new ContentSchedule($this->db);
+    }
+
+    // ── schedule ──────────────────────────────────────────────────────────────
+
+    public function testScheduleReturnsId(): void
+    {
+        $id = $this->cs->schedule('post', '1', new \DateTimeImmutable());
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testScheduleIsIdempotentUpsert(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('-1 hour'));
+        $this->assertSame('published', $this->cs->status('post', '1'));
+
+        // Re-scheduling replaces the entry; new publish_at is in the future
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('+1 hour'));
+        $this->assertSame('draft', $this->cs->status('post', '1'));
+
+        // Only one row should exist
+        $stmt = $this->db->query("SELECT COUNT(*) FROM content_schedules WHERE entity_type='post' AND entity_id='1'");
+        $this->assertSame(1, (int)$stmt->fetchColumn());
+    }
+
+    public function testScheduleThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cs->schedule('', '1', new \DateTimeImmutable());
+    }
+
+    public function testScheduleThrowsOnEmptyEntityId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cs->schedule('post', '', new \DateTimeImmutable());
+    }
+
+    public function testScheduleThrowsIfExpireAtNotAfterPublishAt(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $pub = new \DateTimeImmutable('+1 hour');
+        $exp = $pub; // exactly equal — not strictly after
+        $this->cs->schedule('post', '1', $pub, $exp);
+    }
+
+    // ── isLive ────────────────────────────────────────────────────────────────
+
+    public function testIsLiveTrueForPastPublishAt(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('-1 hour'));
+        $this->assertTrue($this->cs->isLive('post', '1'));
+    }
+
+    public function testIsLiveFalseForFuturePublishAt(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('+1 hour'));
+        $this->assertFalse($this->cs->isLive('post', '1'));
+    }
+
+    public function testIsLiveFalseAfterExpiry(): void
+    {
+        // Use a past publish_at and a past expire_at via direct INSERT
+        $this->db->exec(
+            "INSERT INTO content_schedules (entity_type, entity_id, publish_at, expire_at)
+             VALUES ('post', '99', '2000-01-01 00:00:00', '2000-01-02 00:00:00')"
+        );
+        $this->assertFalse($this->cs->isLive('post', '99'));
+    }
+
+    public function testIsLiveFalseForCancelledEntry(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('-1 hour'));
+        $this->cs->cancel('post', '1');
+        $this->assertFalse($this->cs->isLive('post', '1'));
+    }
+
+    public function testIsLiveFalseForNonExistentEntry(): void
+    {
+        $this->assertFalse($this->cs->isLive('post', 'nonexistent'));
+    }
+
+    // ── status ────────────────────────────────────────────────────────────────
+
+    public function testStatusIsDraftForFuturePublish(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('+1 hour'));
+        $this->assertSame('draft', $this->cs->status('post', '1'));
+    }
+
+    public function testStatusIsPublishedWhenLive(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('-1 hour'));
+        $this->assertSame('published', $this->cs->status('post', '1'));
+    }
+
+    public function testStatusIsExpiredWhenPastExpiry(): void
+    {
+        $this->db->exec(
+            "INSERT INTO content_schedules (entity_type, entity_id, publish_at, expire_at)
+             VALUES ('post', '99', '2000-01-01 00:00:00', '2000-01-02 00:00:00')"
+        );
+        $this->assertSame('expired', $this->cs->status('post', '99'));
+    }
+
+    public function testStatusIsCancelledAfterCancel(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('-1 hour'));
+        $this->cs->cancel('post', '1');
+        $this->assertSame('cancelled', $this->cs->status('post', '1'));
+    }
+
+    public function testStatusReturnsNullForNonExistentEntry(): void
+    {
+        $this->assertNull($this->cs->status('post', 'ghost'));
+    }
+
+    // ── listLive ──────────────────────────────────────────────────────────────
+
+    public function testListLiveReturnsPastPublishedEntries(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('-2 hours'));
+        $this->cs->schedule('post', '2', new \DateTimeImmutable('-1 hour'));
+        $this->cs->schedule('post', '3', new \DateTimeImmutable('+1 hour')); // draft
+        $live = $this->cs->listLive('post');
+        $this->assertCount(2, $live);
+    }
+
+    public function testListLiveExcludesCancelled(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('-1 hour'));
+        $this->cs->cancel('post', '1');
+        $this->assertSame([], $this->cs->listLive('post'));
+    }
+
+    public function testListLiveIsEntityTypeScoped(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('-1 hour'));
+        $this->cs->schedule('banner', '1', new \DateTimeImmutable('-1 hour'));
+        $this->assertCount(1, $this->cs->listLive('post'));
+        $this->assertCount(1, $this->cs->listLive('banner'));
+    }
+
+    // ── listScheduled ─────────────────────────────────────────────────────────
+
+    public function testListScheduledReturnsFutureEntries(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('+1 hour'));
+        $this->cs->schedule('post', '2', new \DateTimeImmutable('+2 hours'));
+        $this->cs->schedule('post', '3', new \DateTimeImmutable('-1 hour')); // already live
+        $scheduled = $this->cs->listScheduled('post');
+        $this->assertCount(2, $scheduled);
+    }
+
+    // ── cancel ────────────────────────────────────────────────────────────────
+
+    public function testCancelReturnsTrueOnSuccess(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable());
+        $this->assertTrue($this->cs->cancel('post', '1'));
+    }
+
+    public function testCancelReturnsFalseForNonExistentEntry(): void
+    {
+        $this->assertFalse($this->cs->cancel('post', 'ghost'));
+    }
+
+    public function testCancelIsIdempotentReturnsFalseSecondTime(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable());
+        $this->cs->cancel('post', '1');
+        $this->assertFalse($this->cs->cancel('post', '1'));
+    }
+
+    // ── reschedule ────────────────────────────────────────────────────────────
+
+    public function testRescheduleChangesTiming(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable('-1 hour'));
+        $this->assertSame('published', $this->cs->status('post', '1'));
+
+        $this->cs->reschedule('post', '1', new \DateTimeImmutable('+1 hour'));
+        $this->assertSame('draft', $this->cs->status('post', '1'));
+    }
+
+    public function testRescheduleReturnsFalseForCancelledEntry(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable());
+        $this->cs->cancel('post', '1');
+        $this->assertFalse($this->cs->reschedule('post', '1', new \DateTimeImmutable('+1 hour')));
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesEntry(): void
+    {
+        $this->cs->schedule('post', '1', new \DateTimeImmutable());
+        $this->assertTrue($this->cs->remove('post', '1'));
+        $this->assertNull($this->cs->status('post', '1'));
+    }
+
+    public function testRemoveReturnsFalseForNonExistentEntry(): void
+    {
+        $this->assertFalse($this->cs->remove('post', 'ghost'));
+    }
+}


### PR DESCRIPTION
## FT94 — ContentSchedule

Schedules content for future publication with optional expiry. Useful for blog posts, banners, announcements, and any time-windowed content.

### Class: `Nene\Xion\ContentSchedule`

**Status lifecycle:** `draft` → `published` → `expired` (or `cancelled`)

| Method | Description |
|--------|-------------|
| `schedule(type, id, publishAt, ?expireAt): int` | Create/replace schedule entry; returns record id |
| `isLive(type, id): bool` | True when publish_at ≤ now AND not expired/cancelled |
| `status(type, id): ?string` | `draft`/`published`/`expired`/`cancelled`/null |
| `listLive(type): array` | All currently live entries of a given type |
| `listScheduled(type): array` | All future-scheduled (not-yet-live) entries |
| `cancel(type, id): bool` | Soft-cancel a non-cancelled entry |
| `reschedule(type, id, publishAt, ?expireAt): bool` | Update timing for non-cancelled entry |
| `remove(type, id): bool` | Hard-delete a schedule record |

### Tests
- 26 tests, 31 assertions
- In-memory SQLite — no external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)