### PR TITLE
feat(ft95): StorageQuota — per-owner byte tracking with configurable limits and overflow guard

### DIFF
--- a/class/xion/StorageQuota.php
+++ b/class/xion/StorageQuota.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * StorageQuota — per-owner storage usage tracking with configurable limits.
+ *
+ * Tracks bytes used by each owner (user, organisation, bucket) and enforces
+ * a maximum quota. Usage is stored as an aggregate value and updated atomically.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $sq = new StorageQuota($pdo);
+ *
+ * // Set a quota for a user
+ * $sq->setLimit('user', 'user-1', 1_073_741_824); // 1 GiB
+ *
+ * // Record a file upload (add bytes)
+ * $sq->add('user', 'user-1', 5_242_880); // +5 MiB
+ *
+ * // Check before uploading
+ * if (!$sq->wouldExceed('user', 'user-1', $fileSize)) {
+ *     // proceed
+ * }
+ *
+ * // Get current usage
+ * $info = $sq->usage('user', 'user-1');
+ * // ['used' => 5242880, 'limit' => 1073741824, 'available' => 1068498944]
+ *
+ * // Release bytes on delete
+ * $sq->release('user', 'user-1', 5_242_880);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE storage_quotas (
+ *     owner_type  VARCHAR(100) NOT NULL,
+ *     owner_id    VARCHAR(255) NOT NULL,
+ *     used_bytes  BIGINT       NOT NULL DEFAULT 0,
+ *     limit_bytes BIGINT       DEFAULT NULL,
+ *     updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     PRIMARY KEY (owner_type, owner_id)
+ * );
+ * ```
+ */
+final class StorageQuota
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set (or update) the storage limit for an owner.
+     *
+     * Pass null to remove the limit (unlimited).
+     *
+     * @throws \InvalidArgumentException if owner_type or owner_id is empty.
+     * @throws \InvalidArgumentException if limit_bytes is negative.
+     */
+    public function setLimit(string $ownerType, string $ownerId, ?int $limitBytes): void
+    {
+        [$ownerType, $ownerId] = $this->normalise($ownerType, $ownerId);
+        if ($limitBytes !== null && $limitBytes < 0) {
+            throw new \InvalidArgumentException('limit_bytes must be non-negative.');
+        }
+
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO storage_quotas (owner_type, owner_id, limit_bytes)
+                 VALUES (:type, :id, :limit)
+                 ON CONFLICT (owner_type, owner_id) DO UPDATE SET limit_bytes = :limit2, updated_at = CURRENT_TIMESTAMP'
+            )->execute([':type' => $ownerType, ':id' => $ownerId, ':limit' => $limitBytes, ':limit2' => $limitBytes]);
+        } else {
+            $db->prepare(
+                'INSERT INTO storage_quotas (owner_type, owner_id, limit_bytes)
+                 VALUES (:type, :id, :limit)
+                 ON DUPLICATE KEY UPDATE limit_bytes = VALUES(limit_bytes), updated_at = CURRENT_TIMESTAMP'
+            )->execute([':type' => $ownerType, ':id' => $ownerId, ':limit' => $limitBytes]);
+        }
+    }
+
+    /**
+     * Add bytes to an owner's usage (e.g., after a file upload).
+     *
+     * Creates the quota record if it does not exist (no limit set — unlimited).
+     *
+     * @throws \InvalidArgumentException if bytes is not positive.
+     * @throws \OverflowException if adding bytes would exceed the set limit.
+     */
+    public function add(string $ownerType, string $ownerId, int $bytes): void
+    {
+        [$ownerType, $ownerId] = $this->normalise($ownerType, $ownerId);
+        if ($bytes <= 0) {
+            throw new \InvalidArgumentException('bytes must be positive.');
+        }
+
+        if ($this->wouldExceed($ownerType, $ownerId, $bytes)) {
+            throw new \OverflowException('Storage quota would be exceeded.');
+        }
+
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO storage_quotas (owner_type, owner_id, used_bytes)
+                 VALUES (:type, :id, :bytes)
+                 ON CONFLICT (owner_type, owner_id) DO UPDATE SET used_bytes = used_bytes + :bytes2, updated_at = CURRENT_TIMESTAMP'
+            )->execute([':type' => $ownerType, ':id' => $ownerId, ':bytes' => $bytes, ':bytes2' => $bytes]);
+        } else {
+            $db->prepare(
+                'INSERT INTO storage_quotas (owner_type, owner_id, used_bytes)
+                 VALUES (:type, :id, :bytes)
+                 ON DUPLICATE KEY UPDATE used_bytes = used_bytes + VALUES(used_bytes), updated_at = CURRENT_TIMESTAMP'
+            )->execute([':type' => $ownerType, ':id' => $ownerId, ':bytes' => $bytes]);
+        }
+    }
+
+    /**
+     * Release bytes from an owner's usage (e.g., after a file deletion).
+     *
+     * Usage will not go below zero.
+     *
+     * @throws \InvalidArgumentException if bytes is not positive.
+     */
+    public function release(string $ownerType, string $ownerId, int $bytes): void
+    {
+        [$ownerType, $ownerId] = $this->normalise($ownerType, $ownerId);
+        if ($bytes <= 0) {
+            throw new \InvalidArgumentException('bytes must be positive.');
+        }
+
+        $this->db()->prepare(
+            'UPDATE storage_quotas
+             SET used_bytes = MAX(0, used_bytes - :bytes), updated_at = CURRENT_TIMESTAMP
+             WHERE owner_type = :type AND owner_id = :id'
+        )->execute([':bytes' => $bytes, ':type' => $ownerType, ':id' => $ownerId]);
+    }
+
+    /**
+     * Return current usage info for an owner.
+     *
+     * Returns null if no record exists (owner has never used storage).
+     *
+     * @return array{used: int, limit: int|null, available: int|null}|null
+     */
+    public function usage(string $ownerType, string $ownerId): ?array
+    {
+        [$ownerType, $ownerId] = $this->normalise($ownerType, $ownerId);
+        $stmt = $this->db()->prepare(
+            'SELECT used_bytes, limit_bytes FROM storage_quotas
+             WHERE owner_type = :type AND owner_id = :id LIMIT 1'
+        );
+        $stmt->execute([':type' => $ownerType, ':id' => $ownerId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+
+        $used  = (int)$row['used_bytes'];
+        $limit = $row['limit_bytes'] !== null ? (int)$row['limit_bytes'] : null;
+
+        return [
+            'used'      => $used,
+            'limit'     => $limit,
+            'available' => $limit !== null ? max(0, $limit - $used) : null,
+        ];
+    }
+
+    /**
+     * Check whether adding `$bytes` would exceed the quota.
+     *
+     * Returns false if no limit is set (unlimited).
+     */
+    public function wouldExceed(string $ownerType, string $ownerId, int $bytes): bool
+    {
+        $info = $this->usage($ownerType, $ownerId);
+        if ($info === null || $info['limit'] === null) {
+            return false;
+        }
+        return ($info['used'] + $bytes) > $info['limit'];
+    }
+
+    /**
+     * Get the percentage of quota used (0–100).
+     *
+     * Returns null if no limit is set or owner has no record.
+     */
+    public function percentUsed(string $ownerType, string $ownerId): ?float
+    {
+        $info = $this->usage($ownerType, $ownerId);
+        if ($info === null || $info['limit'] === null || $info['limit'] === 0) {
+            return null;
+        }
+        return round(($info['used'] / $info['limit']) * 100, 2);
+    }
+
+    /**
+     * Reset usage to zero (e.g., on account purge).
+     */
+    public function reset(string $ownerType, string $ownerId): bool
+    {
+        [$ownerType, $ownerId] = $this->normalise($ownerType, $ownerId);
+        $stmt = $this->db()->prepare(
+            'UPDATE storage_quotas SET used_bytes = 0, updated_at = CURRENT_TIMESTAMP
+             WHERE owner_type = :type AND owner_id = :id'
+        );
+        $stmt->execute([':type' => $ownerType, ':id' => $ownerId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function normalise(string $ownerType, string $ownerId): array
+    {
+        $ownerType = trim($ownerType);
+        $ownerId   = trim($ownerId);
+        if ($ownerType === '') {
+            throw new \InvalidArgumentException('owner_type must not be empty.');
+        }
+        if ($ownerId === '') {
+            throw new \InvalidArgumentException('owner_id must not be empty.');
+        }
+        return [$ownerType, $ownerId];
+    }
+}

--- a/tests/Unit/Xion/StorageQuotaTest.php
+++ b/tests/Unit/Xion/StorageQuotaTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\StorageQuota;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for StorageQuota.
+ */
+final class StorageQuotaTest extends TestCase
+{
+    private PDO $db;
+    private StorageQuota $sq;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE storage_quotas (
+                owner_type  VARCHAR(100) NOT NULL,
+                owner_id    VARCHAR(255) NOT NULL,
+                used_bytes  BIGINT       NOT NULL DEFAULT 0,
+                limit_bytes BIGINT       DEFAULT NULL,
+                updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (owner_type, owner_id)
+            )
+        ');
+        $this->sq = new StorageQuota($this->db);
+    }
+
+    // ── setLimit ──────────────────────────────────────────────────────────────
+
+    public function testSetLimitCreatesRecord(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 1000);
+        $info = $this->sq->usage('user', 'user-1');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1000, $info['limit']);
+    }
+
+    public function testSetLimitUpdatesExistingRecord(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 1000);
+        $this->sq->setLimit('user', 'user-1', 2000);
+        $info = $this->sq->usage('user', 'user-1');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(2000, $info['limit']);
+    }
+
+    public function testSetLimitNullRemovesLimit(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 1000);
+        $this->sq->setLimit('user', 'user-1', null);
+        $info = $this->sq->usage('user', 'user-1');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNull($info['limit']);
+    }
+
+    public function testSetLimitThrowsOnNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sq->setLimit('user', 'user-1', -1);
+    }
+
+    // ── add ───────────────────────────────────────────────────────────────────
+
+    public function testAddIncreasesUsage(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 10000);
+        $this->sq->add('user', 'user-1', 500);
+        $info = $this->sq->usage('user', 'user-1');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(500, $info['used']);
+    }
+
+    public function testAddAccumulatesMultipleCalls(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 10000);
+        $this->sq->add('user', 'user-1', 300);
+        $this->sq->add('user', 'user-1', 200);
+        $info = $this->sq->usage('user', 'user-1');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(500, $info['used']);
+    }
+
+    public function testAddCreatesRecordIfNotExists(): void
+    {
+        // No setLimit call — unlimited owner
+        $this->sq->add('user', 'user-new', 100);
+        $info = $this->sq->usage('user', 'user-new');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(100, $info['used']);
+    }
+
+    public function testAddThrowsIfZeroBytes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sq->add('user', 'user-1', 0);
+    }
+
+    public function testAddThrowsOnQuotaExceeded(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 100);
+        $this->sq->add('user', 'user-1', 90);
+        $this->expectException(\OverflowException::class);
+        $this->sq->add('user', 'user-1', 20); // 90 + 20 > 100
+    }
+
+    // ── release ───────────────────────────────────────────────────────────────
+
+    public function testReleaseDecreasesUsage(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 10000);
+        $this->sq->add('user', 'user-1', 500);
+        $this->sq->release('user', 'user-1', 200);
+        $info = $this->sq->usage('user', 'user-1');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(300, $info['used']);
+    }
+
+    public function testReleaseDoesNotGoBelowZero(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 10000);
+        $this->sq->add('user', 'user-1', 100);
+        $this->sq->release('user', 'user-1', 500); // more than used
+        $info = $this->sq->usage('user', 'user-1');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, $info['used']);
+    }
+
+    public function testReleaseThrowsOnNonPositiveBytes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sq->release('user', 'user-1', 0);
+    }
+
+    // ── usage ─────────────────────────────────────────────────────────────────
+
+    public function testUsageReturnsNullForUnknownOwner(): void
+    {
+        $this->assertNull($this->sq->usage('user', 'nobody'));
+    }
+
+    public function testUsageAvailableReflectsLimit(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 1000);
+        $this->sq->add('user', 'user-1', 300);
+        $info = $this->sq->usage('user', 'user-1');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(700, $info['available']);
+    }
+
+    public function testUsageAvailableIsNullWithoutLimit(): void
+    {
+        $this->sq->add('user', 'user-1', 300);
+        $info = $this->sq->usage('user', 'user-1');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNull($info['available']);
+    }
+
+    // ── wouldExceed ───────────────────────────────────────────────────────────
+
+    public function testWouldExceedReturnsTrueOverLimit(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 100);
+        $this->sq->add('user', 'user-1', 90);
+        $this->assertTrue($this->sq->wouldExceed('user', 'user-1', 20));
+    }
+
+    public function testWouldExceedReturnsFalseUnderLimit(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 100);
+        $this->sq->add('user', 'user-1', 50);
+        $this->assertFalse($this->sq->wouldExceed('user', 'user-1', 40));
+    }
+
+    public function testWouldExceedReturnsFalseWithNoLimit(): void
+    {
+        $this->sq->add('user', 'user-1', 1000);
+        $this->assertFalse($this->sq->wouldExceed('user', 'user-1', 999_999_999));
+    }
+
+    // ── percentUsed ───────────────────────────────────────────────────────────
+
+    public function testPercentUsedReturnsCorrectValue(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 200);
+        $this->sq->add('user', 'user-1', 50);
+        $this->assertSame(25.0, $this->sq->percentUsed('user', 'user-1'));
+    }
+
+    public function testPercentUsedReturnsNullWithoutLimit(): void
+    {
+        $this->sq->add('user', 'user-1', 100);
+        $this->assertNull($this->sq->percentUsed('user', 'user-1'));
+    }
+
+    // ── reset ─────────────────────────────────────────────────────────────────
+
+    public function testResetSetsUsageToZero(): void
+    {
+        $this->sq->setLimit('user', 'user-1', 1000);
+        $this->sq->add('user', 'user-1', 500);
+        $this->assertTrue($this->sq->reset('user', 'user-1'));
+        $info = $this->sq->usage('user', 'user-1');
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, $info['used']);
+    }
+
+    public function testResetReturnsFalseForNonExistentOwner(): void
+    {
+        $this->assertFalse($this->sq->reset('user', 'nobody'));
+    }
+
+    // ── isolation ─────────────────────────────────────────────────────────────
+
+    public function testOwnerTypeIsolation(): void
+    {
+        $this->sq->setLimit('user', 'x', 100);
+        $this->sq->setLimit('org', 'x', 500);
+        $userInfo = $this->sq->usage('user', 'x');
+        $orgInfo  = $this->sq->usage('org', 'x');
+        $this->assertNotNull($userInfo);
+        $this->assertNotNull($orgInfo);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(100, $userInfo['limit']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(500, $orgInfo['limit']);
+    }
+}


### PR DESCRIPTION
## FT95 — StorageQuota

Tracks storage usage per owner (user, organisation, bucket) and enforces configurable byte limits.

### Class: `Nene\Xion\StorageQuota`

| Method | Description |
|--------|-------------|
| `setLimit(type, id, ?bytes)` | Set/update quota limit (null = unlimited) |
| `add(type, id, bytes)` | Record byte usage; throws `OverflowException` on quota breach |
| `release(type, id, bytes)` | Release bytes on deletion; floors at zero |
| `usage(type, id): ?array` | Returns `{used, limit, available}` |
| `wouldExceed(type, id, bytes): bool` | Pre-flight check before upload |
| `percentUsed(type, id): ?float` | 0–100 percent of quota consumed |
| `reset(type, id): bool` | Zero out usage (account purge) |

### Tests
- 23 tests, 38 assertions
- In-memory SQLite — no external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)