### PR TITLE
feat(ft98): EmailVerification — token-based email verification with TTL and SHA-256 hash storage

### DIFF
--- a/class/xion/EmailVerification.php
+++ b/class/xion/EmailVerification.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * EmailVerification — token-based email address verification with expiry.
+ *
+ * Issues a time-limited verification token for a (user_id, email) pair.
+ * The SHA-256 hash of the token is stored; the raw token is only available
+ * at issue time and is returned to the caller for delivery via email.
+ *
+ * Status lifecycle: `pending` → `verified` (or expired via TTL)
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ev = new EmailVerification($pdo);
+ *
+ * // Issue a token (send it to the user by email)
+ * $token = $ev->issue('user-1', 'user@example.com');
+ *
+ * // Verify when the user clicks the link
+ * $ok = $ev->verify($token);
+ *
+ * // Check whether the address is verified
+ * $ev->isVerified('user-1', 'user@example.com'); // true
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE email_verifications (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     email       VARCHAR(255) NOT NULL,
+ *     token_hash  VARCHAR(64)  NOT NULL,
+ *     verified_at DATETIME     DEFAULT NULL,
+ *     expires_at  DATETIME     NOT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (user_id, email)
+ * );
+ * ```
+ */
+final class EmailVerification
+{
+    private const DEFAULT_TTL_SECONDS = 86400; // 24 hours
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly int $ttlSeconds = self::DEFAULT_TTL_SECONDS
+    ) {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Issue a new verification token for (user_id, email).
+     *
+     * If a previous (unverified) entry exists for this pair, it is replaced.
+     * Returns the raw hex token (64 chars); store only the hash.
+     *
+     * @return string  64-character hex token.
+     * @throws \InvalidArgumentException if user_id or email is empty.
+     */
+    public function issue(string $userId, string $email): string
+    {
+        [$userId, $email] = $this->normalise($userId, $email);
+
+        $raw       = bin2hex(random_bytes(32));
+        $hash      = hash('sha256', $raw);
+        $expiresAt = (new \DateTimeImmutable())->modify("+{$this->ttlSeconds} seconds");
+        $expStr    = $expiresAt->format('Y-m-d H:i:s');
+
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO email_verifications (user_id, email, token_hash, expires_at, verified_at)
+                 VALUES (:uid, :email, :hash, :exp, NULL)
+                 ON CONFLICT (user_id, email) DO UPDATE SET
+                     token_hash  = :hash2,
+                     expires_at  = :exp2,
+                     verified_at = NULL,
+                     created_at  = CURRENT_TIMESTAMP'
+            )->execute([
+                ':uid'   => $userId,
+                ':email' => $email,
+                ':hash'  => $hash,
+                ':exp'   => $expStr,
+                ':hash2' => $hash,
+                ':exp2'  => $expStr,
+            ]);
+        } else {
+            $db->prepare(
+                'INSERT INTO email_verifications (user_id, email, token_hash, expires_at, verified_at)
+                 VALUES (:uid, :email, :hash, :exp, NULL)
+                 ON DUPLICATE KEY UPDATE
+                     token_hash  = VALUES(token_hash),
+                     expires_at  = VALUES(expires_at),
+                     verified_at = NULL,
+                     created_at  = CURRENT_TIMESTAMP'
+            )->execute([':uid' => $userId, ':email' => $email, ':hash' => $hash, ':exp' => $expStr]);
+        }
+
+        return $raw;
+    }
+
+    /**
+     * Verify a token.
+     *
+     * @return bool True if the token is valid, not expired, and not already verified.
+     */
+    public function verify(string $token): bool
+    {
+        $hash = hash('sha256', $token);
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        $stmt = $this->db()->prepare(
+            'UPDATE email_verifications
+             SET verified_at = CURRENT_TIMESTAMP
+             WHERE token_hash  = :hash
+               AND verified_at IS NULL
+               AND expires_at  > :now'
+        );
+        $stmt->execute([':hash' => $hash, ':now' => $now]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Check whether the (user_id, email) pair has been verified.
+     */
+    public function isVerified(string $userId, string $email): bool
+    {
+        [$userId, $email] = $this->normalise($userId, $email);
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM email_verifications
+             WHERE user_id = :uid AND email = :email AND verified_at IS NOT NULL'
+        );
+        $stmt->execute([':uid' => $userId, ':email' => $email]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Check whether a pending (unverified, unexpired) token exists.
+     */
+    public function isPending(string $userId, string $email): bool
+    {
+        [$userId, $email] = $this->normalise($userId, $email);
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM email_verifications
+             WHERE user_id = :uid AND email = :email
+               AND verified_at IS NULL AND expires_at > :now'
+        );
+        $stmt->execute([':uid' => $userId, ':email' => $email, ':now' => $now]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Get the expiry time of the current token for (user_id, email).
+     *
+     * Returns null if no token exists.
+     */
+    public function expiresAt(string $userId, string $email): ?\DateTimeImmutable
+    {
+        [$userId, $email] = $this->normalise($userId, $email);
+        $stmt = $this->db()->prepare(
+            'SELECT expires_at FROM email_verifications
+             WHERE user_id = :uid AND email = :email LIMIT 1'
+        );
+        $stmt->execute([':uid' => $userId, ':email' => $email]);
+        $val = $stmt->fetchColumn();
+        if ($val === false) {
+            return null;
+        }
+        return new \DateTimeImmutable((string)$val);
+    }
+
+    /**
+     * Revoke a verification (reset to unverified, remove token).
+     *
+     * Useful when the user changes their email address.
+     *
+     * @return bool True if an entry was removed.
+     */
+    public function revoke(string $userId, string $email): bool
+    {
+        [$userId, $email] = $this->normalise($userId, $email);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM email_verifications WHERE user_id = :uid AND email = :email'
+        );
+        $stmt->execute([':uid' => $userId, ':email' => $email]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Purge all expired, unverified tokens.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeExpired(): int
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'DELETE FROM email_verifications WHERE verified_at IS NULL AND expires_at <= :now'
+        );
+        $stmt->execute([':now' => $now]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function normalise(string $userId, string $email): array
+    {
+        $userId = trim($userId);
+        $email  = trim($email);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($email === '') {
+            throw new \InvalidArgumentException('email must not be empty.');
+        }
+        return [$userId, $email];
+    }
+}

--- a/tests/Unit/Xion/EmailVerificationTest.php
+++ b/tests/Unit/Xion/EmailVerificationTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\EmailVerification;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for EmailVerification.
+ */
+final class EmailVerificationTest extends TestCase
+{
+    private PDO $db;
+    private EmailVerification $ev;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE email_verifications (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     VARCHAR(255) NOT NULL,
+                email       VARCHAR(255) NOT NULL,
+                token_hash  VARCHAR(64)  NOT NULL,
+                verified_at DATETIME     DEFAULT NULL,
+                expires_at  DATETIME     NOT NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (user_id, email)
+            )
+        ');
+        $this->ev = new EmailVerification($this->db, ttlSeconds: 3600);
+    }
+
+    // ── issue ─────────────────────────────────────────────────────────────────
+
+    public function testIssueReturns64HexToken(): void
+    {
+        $token = $this->ev->issue('user-1', 'a@example.com');
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $token);
+    }
+
+    public function testIssueStoresHashNotRawToken(): void
+    {
+        $token = $this->ev->issue('user-1', 'a@example.com');
+        $stmt  = $this->db->query('SELECT token_hash FROM email_verifications LIMIT 1');
+        $hash  = $stmt->fetchColumn();
+        $this->assertNotSame($token, $hash);
+        $this->assertSame(hash('sha256', $token), $hash);
+    }
+
+    public function testIssueSetsStatusPending(): void
+    {
+        $this->ev->issue('user-1', 'a@example.com');
+        $this->assertTrue($this->ev->isPending('user-1', 'a@example.com'));
+    }
+
+    public function testIssueReplacesExistingToken(): void
+    {
+        $token1 = $this->ev->issue('user-1', 'a@example.com');
+        $token2 = $this->ev->issue('user-1', 'a@example.com');
+        $this->assertNotSame($token1, $token2);
+        // Only one row should exist
+        $stmt = $this->db->query('SELECT COUNT(*) FROM email_verifications');
+        $this->assertSame(1, (int)$stmt->fetchColumn());
+    }
+
+    public function testIssueThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ev->issue('', 'a@example.com');
+    }
+
+    public function testIssueThrowsOnEmptyEmail(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ev->issue('user-1', '');
+    }
+
+    // ── verify ────────────────────────────────────────────────────────────────
+
+    public function testVerifyReturnsTrueForValidToken(): void
+    {
+        $token = $this->ev->issue('user-1', 'a@example.com');
+        $this->assertTrue($this->ev->verify($token));
+    }
+
+    public function testVerifySetsIsVerified(): void
+    {
+        $token = $this->ev->issue('user-1', 'a@example.com');
+        $this->ev->verify($token);
+        $this->assertTrue($this->ev->isVerified('user-1', 'a@example.com'));
+    }
+
+    public function testVerifyReturnsFalseForUnknownToken(): void
+    {
+        $this->assertFalse($this->ev->verify(str_repeat('0', 64)));
+    }
+
+    public function testVerifyReturnsFalseForAlreadyVerifiedToken(): void
+    {
+        $token = $this->ev->issue('user-1', 'a@example.com');
+        $this->ev->verify($token);
+        $this->assertFalse($this->ev->verify($token)); // second call
+    }
+
+    public function testVerifyReturnsFalseForExpiredToken(): void
+    {
+        // Insert an already-expired token directly
+        $raw  = bin2hex(random_bytes(32));
+        $hash = hash('sha256', $raw);
+        $this->db->prepare(
+            "INSERT INTO email_verifications (user_id, email, token_hash, expires_at)
+             VALUES ('user-9', 'exp@example.com', :hash, '2000-01-01 00:00:00')"
+        )->execute([':hash' => $hash]);
+        $this->assertFalse($this->ev->verify($raw));
+    }
+
+    // ── isVerified / isPending ────────────────────────────────────────────────
+
+    public function testIsVerifiedReturnsFalseBeforeVerification(): void
+    {
+        $this->ev->issue('user-1', 'a@example.com');
+        $this->assertFalse($this->ev->isVerified('user-1', 'a@example.com'));
+    }
+
+    public function testIsVerifiedReturnsFalseForNonExistentEntry(): void
+    {
+        $this->assertFalse($this->ev->isVerified('user-1', 'nope@example.com'));
+    }
+
+    public function testIsPendingReturnsFalseAfterVerification(): void
+    {
+        $token = $this->ev->issue('user-1', 'a@example.com');
+        $this->ev->verify($token);
+        $this->assertFalse($this->ev->isPending('user-1', 'a@example.com'));
+    }
+
+    // ── expiresAt ─────────────────────────────────────────────────────────────
+
+    public function testExpiresAtReturnsDateTimeImmutable(): void
+    {
+        $this->ev->issue('user-1', 'a@example.com');
+        $exp = $this->ev->expiresAt('user-1', 'a@example.com');
+        $this->assertInstanceOf(\DateTimeImmutable::class, $exp);
+    }
+
+    public function testExpiresAtReturnsNullForNonExistentEntry(): void
+    {
+        $this->assertNull($this->ev->expiresAt('user-1', 'nope@example.com'));
+    }
+
+    // ── revoke ────────────────────────────────────────────────────────────────
+
+    public function testRevokeDeletesEntry(): void
+    {
+        $this->ev->issue('user-1', 'a@example.com');
+        $this->assertTrue($this->ev->revoke('user-1', 'a@example.com'));
+        $this->assertFalse($this->ev->isPending('user-1', 'a@example.com'));
+    }
+
+    public function testRevokeReturnsFalseIfNotPresent(): void
+    {
+        $this->assertFalse($this->ev->revoke('user-1', 'nope@example.com'));
+    }
+
+    // ── purgeExpired ──────────────────────────────────────────────────────────
+
+    public function testPurgeExpiredRemovesExpiredTokens(): void
+    {
+        $this->db->exec(
+            "INSERT INTO email_verifications (user_id, email, token_hash, expires_at)
+             VALUES ('user-old', 'old@example.com', 'aabbcc', '2000-01-01 00:00:00')"
+        );
+        $this->ev->issue('user-1', 'a@example.com'); // valid
+        $this->assertSame(1, $this->ev->purgeExpired());
+    }
+}


### PR DESCRIPTION
## FT98 — EmailVerification

Token-based email address verification. Issues a time-limited 64-hex token; stores only the SHA-256 hash. Supports re-issue, expiry check, and purge of stale tokens.

### Class: `Nene\Xion\EmailVerification`

**Status lifecycle:** `pending` → `verified` (or expired)

| Method | Description |
|--------|-------------|
| `issue(userId, email): string` | Generate token; replaces any existing pending token |
| `verify(token): bool` | Verify token; sets verified_at |
| `isVerified(userId, email): bool` | Check if address is verified |
| `isPending(userId, email): bool` | Check if unexpired token exists |
| `expiresAt(userId, email): ?DateTimeImmutable` | Token expiry time |
| `revoke(userId, email): bool` | Delete verification record |
| `purgeExpired(): int` | Remove expired unverified tokens |

### Tests
- 19 tests, 22 assertions
- In-memory SQLite — no external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)