### PR TITLE
feat(ft100): OnlineStatus — heartbeat-based online/idle/offline tracking

### DIFF
--- a/class/xion/OnlineStatus.php
+++ b/class/xion/OnlineStatus.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * OnlineStatus — track user presence with heartbeat-based online/idle/offline states.
+ *
+ * Users update their heartbeat; the status is derived from how long ago the
+ * last heartbeat was received:
+ * - `online`  → seen within the online threshold (default 60 s)
+ * - `idle`    → seen within the idle threshold (default 300 s)
+ * - `offline` → not seen within the idle threshold, or never seen
+ *
+ * ## Usage
+ *
+ * ```php
+ * $os = new OnlineStatus($pdo);
+ *
+ * // Client sends heartbeat
+ * $os->heartbeat('user-1');
+ *
+ * // Check status
+ * $os->status('user-1'); // 'online'|'idle'|'offline'
+ *
+ * // Explicitly mark offline (on logout / websocket close)
+ * $os->setOffline('user-1');
+ *
+ * // Get all currently online users
+ * $os->listOnline();
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE online_status (
+ *     user_id    VARCHAR(255) NOT NULL PRIMARY KEY,
+ *     last_seen  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     is_offline TINYINT(1)   NOT NULL DEFAULT 0
+ * );
+ * ```
+ */
+final class OnlineStatus
+{
+    private const DEFAULT_ONLINE_SECONDS = 60;
+    private const DEFAULT_IDLE_SECONDS   = 300;
+
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly int $onlineSeconds = self::DEFAULT_ONLINE_SECONDS,
+        private readonly int $idleSeconds = self::DEFAULT_IDLE_SECONDS
+    ) {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record a heartbeat for a user (marks them as online).
+     *
+     * @throws \InvalidArgumentException if user_id is empty.
+     */
+    public function heartbeat(string $userId): void
+    {
+        $userId = $this->validateUserId($userId);
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO online_status (user_id, last_seen, is_offline) VALUES (:uid, CURRENT_TIMESTAMP, 0)
+                 ON CONFLICT (user_id) DO UPDATE SET last_seen = CURRENT_TIMESTAMP, is_offline = 0'
+            )->execute([':uid' => $userId]);
+        } else {
+            $db->prepare(
+                'INSERT INTO online_status (user_id, last_seen, is_offline) VALUES (:uid, CURRENT_TIMESTAMP, 0)
+                 ON DUPLICATE KEY UPDATE last_seen = CURRENT_TIMESTAMP, is_offline = 0'
+            )->execute([':uid' => $userId]);
+        }
+    }
+
+    /**
+     * Explicitly mark a user as offline (e.g. on logout or socket close).
+     *
+     * @throws \InvalidArgumentException if user_id is empty.
+     */
+    public function setOffline(string $userId): void
+    {
+        $userId = $this->validateUserId($userId);
+        $this->db()->prepare(
+            'UPDATE online_status SET is_offline = 1 WHERE user_id = :uid'
+        )->execute([':uid' => $userId]);
+    }
+
+    /**
+     * Get the status for a user.
+     *
+     * @return 'online'|'idle'|'offline'
+     */
+    public function status(string $userId): string
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'SELECT last_seen, is_offline FROM online_status WHERE user_id = :uid LIMIT 1'
+        );
+        $stmt->execute([':uid' => $userId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false || (int)$row['is_offline'] === 1) {
+            return 'offline';
+        }
+
+        return $this->computeStatus((string)$row['last_seen']);
+    }
+
+    /**
+     * Get the last seen timestamp for a user.
+     *
+     * Returns null if the user has never been seen.
+     */
+    public function lastSeen(string $userId): ?\DateTimeImmutable
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'SELECT last_seen FROM online_status WHERE user_id = :uid LIMIT 1'
+        );
+        $stmt->execute([':uid' => $userId]);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? new \DateTimeImmutable((string)$val) : null;
+    }
+
+    /**
+     * Get all users with 'online' status (seen within online threshold, not offline).
+     *
+     * @return list<string>
+     */
+    public function listOnline(): array
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$this->onlineSeconds} seconds")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'SELECT user_id FROM online_status
+             WHERE last_seen >= :cutoff AND is_offline = 0
+             ORDER BY last_seen DESC'
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Get all users with 'idle' status (seen within idle threshold but not online threshold).
+     *
+     * @return list<string>
+     */
+    public function listIdle(): array
+    {
+        $onlineCutoff = (new \DateTimeImmutable())->modify("-{$this->onlineSeconds} seconds")->format('Y-m-d H:i:s');
+        $idleCutoff   = (new \DateTimeImmutable())->modify("-{$this->idleSeconds} seconds")->format('Y-m-d H:i:s');
+        $stmt         = $this->db()->prepare(
+            'SELECT user_id FROM online_status
+             WHERE last_seen < :online_cutoff AND last_seen >= :idle_cutoff AND is_offline = 0
+             ORDER BY last_seen DESC'
+        );
+        $stmt->execute([':online_cutoff' => $onlineCutoff, ':idle_cutoff' => $idleCutoff]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Remove stale records for users who have been offline beyond the idle threshold.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeStale(): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$this->idleSeconds} seconds")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM online_status WHERE last_seen < :cutoff OR is_offline = 1'
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateUserId(string $userId): string
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        return $userId;
+    }
+
+    private function computeStatus(string $lastSeen): string
+    {
+        $now  = new \DateTimeImmutable();
+        $seen = new \DateTimeImmutable($lastSeen);
+        $diff = $now->getTimestamp() - $seen->getTimestamp();
+
+        if ($diff <= $this->onlineSeconds) {
+            return 'online';
+        }
+        if ($diff <= $this->idleSeconds) {
+            return 'idle';
+        }
+        return 'offline';
+    }
+}

--- a/tests/Unit/Xion/OnlineStatusTest.php
+++ b/tests/Unit/Xion/OnlineStatusTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\OnlineStatus;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for OnlineStatus.
+ */
+final class OnlineStatusTest extends TestCase
+{
+    private PDO $db;
+    private OnlineStatus $os;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE online_status (
+                user_id    VARCHAR(255) NOT NULL PRIMARY KEY,
+                last_seen  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                is_offline TINYINT(1)   NOT NULL DEFAULT 0
+            )
+        ');
+        // Use short thresholds for tests: 10s online, 30s idle
+        $this->os = new OnlineStatus($this->db, onlineSeconds: 10, idleSeconds: 30);
+    }
+
+    // ── heartbeat ─────────────────────────────────────────────────────────────
+
+    public function testHeartbeatMakesUserOnline(): void
+    {
+        $this->os->heartbeat('user-1');
+        $this->assertSame('online', $this->os->status('user-1'));
+    }
+
+    public function testHeartbeatIsIdempotent(): void
+    {
+        $this->os->heartbeat('user-1');
+        $this->os->heartbeat('user-1');
+        $stmt = $this->db->query("SELECT COUNT(*) FROM online_status WHERE user_id = 'user-1'");
+        $this->assertSame(1, (int)$stmt->fetchColumn());
+    }
+
+    public function testHeartbeatClearsOfflineFlag(): void
+    {
+        $this->os->heartbeat('user-1');
+        $this->os->setOffline('user-1');
+        $this->os->heartbeat('user-1'); // come back online
+        $this->assertSame('online', $this->os->status('user-1'));
+    }
+
+    public function testHeartbeatThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->os->heartbeat('');
+    }
+
+    // ── setOffline ────────────────────────────────────────────────────────────
+
+    public function testSetOfflineMakesUserOffline(): void
+    {
+        $this->os->heartbeat('user-1');
+        $this->os->setOffline('user-1');
+        $this->assertSame('offline', $this->os->status('user-1'));
+    }
+
+    // ── status ────────────────────────────────────────────────────────────────
+
+    public function testStatusIsOfflineForUnseenUser(): void
+    {
+        $this->assertSame('offline', $this->os->status('user-1'));
+    }
+
+    public function testStatusIsIdleWhenBetweenThresholds(): void
+    {
+        // Insert a last_seen that's 15 seconds ago: > online (10s) but < idle (30s)
+        $lastSeen = (new \DateTimeImmutable())->modify('-15 seconds')->format('Y-m-d H:i:s');
+        $this->db->prepare(
+            "INSERT INTO online_status (user_id, last_seen, is_offline) VALUES ('user-1', :ts, 0)"
+        )->execute([':ts' => $lastSeen]);
+        $this->assertSame('idle', $this->os->status('user-1'));
+    }
+
+    public function testStatusIsOfflineWhenBeyondIdleThreshold(): void
+    {
+        // Insert a last_seen that's 60 seconds ago: > idle (30s)
+        $lastSeen = (new \DateTimeImmutable())->modify('-60 seconds')->format('Y-m-d H:i:s');
+        $this->db->prepare(
+            "INSERT INTO online_status (user_id, last_seen, is_offline) VALUES ('user-1', :ts, 0)"
+        )->execute([':ts' => $lastSeen]);
+        $this->assertSame('offline', $this->os->status('user-1'));
+    }
+
+    // ── lastSeen ──────────────────────────────────────────────────────────────
+
+    public function testLastSeenReturnsDateTimeImmutable(): void
+    {
+        $this->os->heartbeat('user-1');
+        $this->assertInstanceOf(\DateTimeImmutable::class, $this->os->lastSeen('user-1'));
+    }
+
+    public function testLastSeenReturnsNullForUnseenUser(): void
+    {
+        $this->assertNull($this->os->lastSeen('user-1'));
+    }
+
+    // ── listOnline / listIdle ─────────────────────────────────────────────────
+
+    public function testListOnlineReturnsRecentUsers(): void
+    {
+        $this->os->heartbeat('user-1');
+        $this->os->heartbeat('user-2');
+        $online = $this->os->listOnline();
+        $this->assertContains('user-1', $online);
+        $this->assertContains('user-2', $online);
+    }
+
+    public function testListOnlineExcludesOfflineUsers(): void
+    {
+        $this->os->heartbeat('user-1');
+        $this->os->setOffline('user-1');
+        $this->assertNotContains('user-1', $this->os->listOnline());
+    }
+
+    public function testListIdleReturnsIdleUsers(): void
+    {
+        $lastSeen = (new \DateTimeImmutable())->modify('-15 seconds')->format('Y-m-d H:i:s');
+        $this->db->prepare(
+            "INSERT INTO online_status (user_id, last_seen, is_offline) VALUES ('user-1', :ts, 0)"
+        )->execute([':ts' => $lastSeen]);
+        $this->assertContains('user-1', $this->os->listIdle());
+        $this->assertNotContains('user-1', $this->os->listOnline());
+    }
+
+    // ── purgeStale ────────────────────────────────────────────────────────────
+
+    public function testPurgeStaleRemovesOldRecords(): void
+    {
+        $oldTs = (new \DateTimeImmutable())->modify('-60 seconds')->format('Y-m-d H:i:s');
+        $this->db->prepare(
+            "INSERT INTO online_status (user_id, last_seen, is_offline) VALUES ('old-user', :ts, 0)"
+        )->execute([':ts' => $oldTs]);
+        $this->os->heartbeat('user-1'); // recent — should not be purged
+        $purged = $this->os->purgeStale();
+        $this->assertGreaterThan(0, $purged);
+        $this->assertNotNull($this->os->lastSeen('user-1')); // recent user still present
+    }
+
+    public function testPurgeStaleRemovesExplicitlyOfflineUsers(): void
+    {
+        $this->os->heartbeat('user-1');
+        $this->os->setOffline('user-1');
+        $purged = $this->os->purgeStale();
+        $this->assertGreaterThan(0, $purged);
+        $this->assertNull($this->os->lastSeen('user-1'));
+    }
+}


### PR DESCRIPTION
## FT100 — OnlineStatus

User presence tracking via heartbeat. Status is derived from time since last heartbeat: online (within threshold), idle (between thresholds), offline (beyond idle threshold or explicitly set).

### Class: `Nene\Xion\OnlineStatus`

**Thresholds** (configurable via constructor): default 60s online, 300s idle.

| Method | Description |
|--------|-------------|
| `heartbeat(userId)` | Record presence; creates or updates record |
| `setOffline(userId)` | Mark user as explicitly offline |
| `status(userId): 'online'/'idle'/'offline'` | Current status |
| `lastSeen(userId): ?DateTimeImmutable` | Timestamp of last heartbeat |
| `listOnline(): list<string>` | All users with online status |
| `listIdle(): list<string>` | All users with idle status |
| `purgeStale(): int` | Remove old/offline records |

### Tests
- 15 tests, 19 assertions
- In-memory SQLite — no external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)