### PR TITLE
feat(ft103): CommentThread — threaded comments with soft-delete tombstones

### DIFF
--- a/class/xion/CommentThread.php
+++ b/class/xion/CommentThread.php
@@ -7,232 +7,252 @@ namespace Nene\Xion;
 use PDO;
 
 /**
- * Threaded comment system with nesting depth limit and soft delete.
+ * CommentThread — threaded comments on any entity (posts, products, tickets…).
  *
- * Comments belong to an entity identified by (entity_type, entity_id).
- * Replies are linked via parent_id. Maximum nesting depth is enforced
- * to prevent runaway tree growth.
+ * Supports top-level comments and single-level replies (parent_id).
+ * Comments can be soft-deleted (body replaced, deleted_at set) or hard-deleted.
+ * The thread structure is kept intact — deleted comments show as tombstones.
  *
- * Deleted comments have their body replaced with a placeholder and
- * their author_id set to null, but the row is retained so reply
- * threading is preserved.
+ * Status lifecycle: created → (edited) → soft-deleted
  *
- * ## Schema
+ * ## Schema (SQLite / MySQL compatible)
  *
  * ```sql
  * CREATE TABLE comments (
- *     id          INTEGER      PRIMARY KEY AUTOINCREMENT,
- *     entity_type VARCHAR(64)  NOT NULL,
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     entity_type VARCHAR(100) NOT NULL,
  *     entity_id   VARCHAR(255) NOT NULL,
+ *     user_id     VARCHAR(255) NOT NULL,
  *     parent_id   INTEGER      DEFAULT NULL,
- *     author_id   VARCHAR(255),
  *     body        TEXT         NOT NULL,
- *     depth       INTEGER      NOT NULL DEFAULT 0,
  *     deleted_at  DATETIME     DEFAULT NULL,
- *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
  * );
- * CREATE INDEX idx_comments_entity ON comments (entity_type, entity_id, parent_id);
- * ```
- *
- * ## Usage
- *
- * ```php
- * $ct = new CommentThread($pdo);
- *
- * // Top-level comment
- * $id1 = $ct->post('article', '42', 'user:1', 'Great article!');
- *
- * // Reply (depth = parent.depth + 1)
- * $id2 = $ct->reply($id1, 'user:2', 'Thanks!');
- *
- * // List (non-deleted, ordered by id ASC)
- * $ct->list('article', '42');
- *
- * // Soft delete (body replaced, author_id nulled)
- * $ct->softDelete($id1, 'user:1');
  * ```
  */
 final class CommentThread
 {
-    private const TABLE     = 'comments';
-    private const MAX_DEPTH = 5;
+    private const DELETED_BODY = '[deleted]';
 
-    public function __construct(
-        private readonly ?PDO $db = null,
-        private readonly string $table    = self::TABLE,
-        private readonly int $maxDepth    = self::MAX_DEPTH,
-    ) {
+    public function __construct(private readonly ?PDO $db = null)
+    {
     }
+
+    // ── public API ────────────────────────────────────────────────────────────
 
     /**
      * Post a top-level comment on an entity.
      *
-     * @param  string $entityType Entity type (e.g. 'article', 'product').
-     * @param  string $entityId   Entity ID.
-     * @param  string $authorId   Author identifier.
-     * @param  string $body       Comment body.
-     * @return int New comment ID.
-     * @throws \InvalidArgumentException if $body is empty.
+     * @throws \InvalidArgumentException if any required field is empty.
      */
-    public function post(string $entityType, string $entityId, string $authorId, string $body): int
+    public function post(string $entityType, string $entityId, string $userId, string $body): int
     {
-        $this->assertBody($body);
-
-        $db        = $this->db ?? PdoConnection::getInstance();
-        $createdAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
-
-        $stmt = $db->prepare(
-            'INSERT INTO ' . $this->table .
-            ' (entity_type, entity_id, author_id, body, depth, created_at)' .
-            ' VALUES (:etype, :eid, :author, :body, 0, :t)'
-        );
-        $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
-        $stmt->bindValue(':eid', $entityId, PDO::PARAM_STR);
-        $stmt->bindValue(':author', $authorId, PDO::PARAM_STR);
-        $stmt->bindValue(':body', $body, PDO::PARAM_STR);
-        $stmt->bindValue(':t', $createdAt, PDO::PARAM_STR);
-        $stmt->execute();
-
-        return (int)$db->lastInsertId();
+        return $this->insert($entityType, $entityId, $userId, $body, null);
     }
 
     /**
      * Reply to an existing comment.
      *
-     * @param  int    $parentId Target comment ID to reply to.
-     * @param  string $authorId Author identifier.
-     * @param  string $body     Reply body.
-     * @return int New comment ID.
-     * @throws \InvalidArgumentException if $body is empty, parent not found, or max depth exceeded.
+     * @throws \InvalidArgumentException if any required field is empty.
+     * @throws \RuntimeException         if the parent comment does not exist or is deleted.
      */
-    public function reply(int $parentId, string $authorId, string $body): int
-    {
-        $this->assertBody($body);
-
-        $db     = $this->db ?? PdoConnection::getInstance();
-        $parent = $this->findComment($parentId, $db);
-
+    public function reply(
+        string $entityType,
+        string $entityId,
+        string $userId,
+        string $body,
+        int $parentId
+    ): int {
+        $parent = $this->getRow($parentId);
         if ($parent === null) {
-            throw new \InvalidArgumentException("Parent comment {$parentId} not found.");
+            throw new \RuntimeException("Parent comment {$parentId} does not exist.");
         }
-
-        $newDepth = (int)$parent['depth'] + 1;
-        if ($newDepth > $this->maxDepth) {
-            throw new \InvalidArgumentException(
-                "Maximum comment depth ({$this->maxDepth}) reached."
-            );
+        if ($parent['deleted_at'] !== null) {
+            throw new \RuntimeException('Cannot reply to a deleted comment.');
         }
-
-        $createdAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
-
-        $stmt = $db->prepare(
-            'INSERT INTO ' . $this->table .
-            ' (entity_type, entity_id, parent_id, author_id, body, depth, created_at)' .
-            ' VALUES (:etype, :eid, :pid, :author, :body, :depth, :t)'
-        );
-        $stmt->bindValue(':etype', $parent['entity_type'], PDO::PARAM_STR);
-        $stmt->bindValue(':eid', $parent['entity_id'], PDO::PARAM_STR);
-        $stmt->bindValue(':pid', $parentId, PDO::PARAM_INT);
-        $stmt->bindValue(':author', $authorId, PDO::PARAM_STR);
-        $stmt->bindValue(':body', $body, PDO::PARAM_STR);
-        $stmt->bindValue(':depth', $newDepth, PDO::PARAM_INT);
-        $stmt->bindValue(':t', $createdAt, PDO::PARAM_STR);
-        $stmt->execute();
-
-        return (int)$db->lastInsertId();
+        return $this->insert($entityType, $entityId, $userId, $body, $parentId);
     }
 
     /**
-     * Soft-delete a comment. Only the author can delete their own comment.
+     * Edit a comment body. Only the original author may edit.
      *
-     * The body is replaced with a placeholder and author_id is nulled.
-     * The row is retained to preserve reply threading.
-     *
-     * Returns true if deleted, false if not found or wrong author.
-     *
-     * @param int    $commentId Comment to delete.
-     * @param string $authorId  Must match the comment's author_id.
+     * @return bool True if the comment was found, belongs to the user, and was updated.
+     * @throws \InvalidArgumentException if body is empty.
      */
-    public function softDelete(int $commentId, string $authorId): bool
+    public function edit(int $commentId, string $userId, string $body): bool
     {
-        $db        = $this->db ?? PdoConnection::getInstance();
-        $deletedAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
-
-        $stmt = $db->prepare(
-            'UPDATE ' . $this->table .
-            ' SET body = \'[deleted]\', author_id = NULL, deleted_at = :t' .
-            ' WHERE id = :id AND author_id = :author AND deleted_at IS NULL'
+        $userId = trim($userId);
+        $body   = trim($body);
+        if ($body === '') {
+            throw new \InvalidArgumentException('body must not be empty.');
+        }
+        $stmt = $this->db()->prepare(
+            'UPDATE comments
+             SET body = :body, updated_at = CURRENT_TIMESTAMP
+             WHERE id = :id AND user_id = :uid AND deleted_at IS NULL'
         );
-        $stmt->bindValue(':t', $deletedAt, PDO::PARAM_STR);
-        $stmt->bindValue(':id', $commentId, PDO::PARAM_INT);
-        $stmt->bindValue(':author', $authorId, PDO::PARAM_STR);
-        $stmt->execute();
-
+        $stmt->execute([':body' => $body, ':id' => $commentId, ':uid' => $userId]);
         return $stmt->rowCount() > 0;
     }
 
     /**
-     * List all comments for an entity, ordered by id ASC (includes soft-deleted).
+     * Soft-delete a comment (body replaced with tombstone).
      *
-     * @param  string $entityType Entity type.
-     * @param  string $entityId   Entity ID.
-     * @return list<array{id:int,parent_id:int|null,author_id:string|null,body:string,depth:int,deleted_at:string|null,created_at:string}>
+     * Pass null as userId to force-delete regardless of author (admin use).
+     *
+     * @return bool True if the comment was found and soft-deleted.
      */
-    public function list(string $entityType, string $entityId): array
+    public function delete(int $commentId, ?string $userId = null): bool
     {
-        $db   = $this->db ?? PdoConnection::getInstance();
-        $stmt = $db->prepare(
-            'SELECT id, parent_id, author_id, body, depth, deleted_at, created_at' .
-            ' FROM ' . $this->table .
-            ' WHERE entity_type = :etype AND entity_id = :eid' .
-            ' ORDER BY id ASC'
-        );
-        $stmt->bindValue(':etype', $entityType, PDO::PARAM_STR);
-        $stmt->bindValue(':eid', $entityId, PDO::PARAM_STR);
-        $stmt->execute();
-        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $params = [':body' => self::DELETED_BODY, ':id' => $commentId];
+        if ($userId !== null) {
+            $stmt = $this->db()->prepare(
+                'UPDATE comments
+                 SET body = :body, deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                 WHERE id = :id AND user_id = :uid AND deleted_at IS NULL'
+            );
+            $params[':uid'] = trim($userId);
+        } else {
+            $stmt = $this->db()->prepare(
+                'UPDATE comments
+                 SET body = :body, deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                 WHERE id = :id AND deleted_at IS NULL'
+            );
+        }
+        $stmt->execute($params);
+        return $stmt->rowCount() > 0;
+    }
 
-        return array_map(fn (array $r) => [
-            'id'         => (int)$r['id'],
-            'parent_id'  => $r['parent_id'] !== null ? (int)$r['parent_id'] : null,
-            'author_id'  => $r['author_id'] !== null ? (string)$r['author_id'] : null,
-            'body'       => (string)$r['body'],
-            'depth'      => (int)$r['depth'],
-            'deleted_at' => $r['deleted_at'] !== null ? (string)$r['deleted_at'] : null,
-            'created_at' => (string)$r['created_at'],
-        ], $rows);
+    /**
+     * Get a single comment by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $commentId): ?array
+    {
+        return $this->getRow($commentId);
+    }
+
+    /**
+     * Get all comments for an entity, ordered by id ASC (includes tombstones).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function thread(string $entityType, string $entityId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, parent_id, body, deleted_at, created_at, updated_at
+             FROM comments
+             WHERE entity_type = :type AND entity_id = :eid
+             ORDER BY id ASC'
+        );
+        $stmt->execute([':type' => trim($entityType), ':eid' => trim($entityId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Get top-level comments only (parent_id IS NULL).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function topLevel(string $entityType, string $entityId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, parent_id, body, deleted_at, created_at, updated_at
+             FROM comments
+             WHERE entity_type = :type AND entity_id = :eid AND parent_id IS NULL
+             ORDER BY id ASC'
+        );
+        $stmt->execute([':type' => trim($entityType), ':eid' => trim($entityId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Get all replies to a specific comment.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function replies(int $parentId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, parent_id, body, deleted_at, created_at, updated_at
+             FROM comments WHERE parent_id = :pid ORDER BY id ASC'
+        );
+        $stmt->execute([':pid' => $parentId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Count non-deleted comments for an entity.
+     */
+    public function count(string $entityType, string $entityId): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM comments
+             WHERE entity_type = :type AND entity_id = :eid AND deleted_at IS NULL'
+        );
+        $stmt->execute([':type' => trim($entityType), ':eid' => trim($entityId)]);
+        return (int)$stmt->fetchColumn();
     }
 
     // ── internal helpers ─────────────────────────────────────────────────────
 
-    /**
-     * @return array{entity_type:string,entity_id:string,depth:int}|null
-     */
-    private function findComment(int $id, PDO $db): ?array
+    private function db(): PDO
     {
-        $stmt = $db->prepare(
-            'SELECT entity_type, entity_id, depth FROM ' . $this->table .
-            ' WHERE id = :id LIMIT 1'
-        );
-        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
-        $stmt->execute();
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
-
-        if (!is_array($row)) {
-            return null;
-        }
-
-        return [
-            'entity_type' => (string)$row['entity_type'],
-            'entity_id'   => (string)$row['entity_id'],
-            'depth'       => (int)$row['depth'],
-        ];
+        return $this->db ?? PdoConnection::getInstance();
     }
 
-    private function assertBody(string $body): void
-    {
-        if (trim($body) === '') {
-            throw new \InvalidArgumentException('Comment body must not be empty.');
+    private function insert(
+        string $entityType,
+        string $entityId,
+        string $userId,
+        string $body,
+        ?int $parentId
+    ): int {
+        $entityType = trim($entityType);
+        $entityId   = trim($entityId);
+        $userId     = trim($userId);
+        $body       = trim($body);
+
+        if ($entityType === '') {
+            throw new \InvalidArgumentException('entity_type must not be empty.');
         }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($body === '') {
+            throw new \InvalidArgumentException('body must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO comments (entity_type, entity_id, user_id, parent_id, body)
+             VALUES (:type, :eid, :uid, :pid, :body)'
+        );
+        $stmt->execute([
+            ':type' => $entityType,
+            ':eid'  => $entityId,
+            ':uid'  => $userId,
+            ':pid'  => $parentId,
+            ':body' => $body,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function getRow(int $commentId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, parent_id, body, deleted_at, created_at, updated_at
+             FROM comments WHERE id = :id LIMIT 1'
+        );
+        $stmt->execute([':id' => $commentId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
     }
 }

--- a/tests/Unit/Xion/CommentThreadTest.php
+++ b/tests/Unit/Xion/CommentThreadTest.php
@@ -9,7 +9,7 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit tests for CommentThread using an in-memory SQLite database.
+ * Unit tests for CommentThread.
  */
 final class CommentThreadTest extends TestCase
 {
@@ -20,19 +20,19 @@ final class CommentThreadTest extends TestCase
     {
         $this->db = new PDO('sqlite::memory:');
         $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $this->db->exec(
-            'CREATE TABLE comments (
-                id          INTEGER      PRIMARY KEY AUTOINCREMENT,
-                entity_type VARCHAR(64)  NOT NULL,
+        $this->db->exec('
+            CREATE TABLE comments (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type VARCHAR(100) NOT NULL,
                 entity_id   VARCHAR(255) NOT NULL,
+                user_id     VARCHAR(255) NOT NULL,
                 parent_id   INTEGER      DEFAULT NULL,
-                author_id   VARCHAR(255),
                 body        TEXT         NOT NULL,
-                depth       INTEGER      NOT NULL DEFAULT 0,
                 deleted_at  DATETIME     DEFAULT NULL,
-                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
-            )'
-        );
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
         $this->ct = new CommentThread($this->db);
     }
 
@@ -40,155 +40,164 @@ final class CommentThreadTest extends TestCase
 
     public function testPostReturnsId(): void
     {
-        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->assertIsInt($id);
+        $id = $this->ct->post('post', '1', 'user-1', 'Hello!');
         $this->assertGreaterThan(0, $id);
     }
 
-    public function testPostedCommentAppearsInList(): void
+    public function testPostCreatesTopLevelComment(): void
     {
-        $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $list = $this->ct->list('article', '1');
-        $this->assertCount(1, $list);
-        $this->assertSame('Hello!', $list[0]['body']);
+        $id  = $this->ct->post('post', '1', 'user-1', 'Hello!');
+        $row = $this->ct->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNull($row['parent_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Hello!', $row['body']);
     }
 
-    public function testPostedCommentHasDepthZero(): void
-    {
-        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $list = $this->ct->list('article', '1');
-        $this->assertSame(0, $list[0]['depth']);
-    }
-
-    public function testPostEmptyBodyThrows(): void
+    public function testPostThrowsOnEmptyBody(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->ct->post('article', '1', 'user:1', '');
+        $this->ct->post('post', '1', 'user-1', '');
+    }
+
+    public function testPostThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ct->post('', '1', 'user-1', 'Hello');
     }
 
     // ── reply ─────────────────────────────────────────────────────────────────
 
-    public function testReplyReturnsId(): void
+    public function testReplyLinksToParent(): void
     {
-        $parentId = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $replyId  = $this->ct->reply($parentId, 'user:2', 'Thanks!');
-        $this->assertIsInt($replyId);
-        $this->assertNotSame($parentId, $replyId);
+        $parentId = $this->ct->post('post', '1', 'user-1', 'Parent');
+        $replyId  = $this->ct->reply('post', '1', 'user-2', 'Reply', $parentId);
+        $row      = $this->ct->get($replyId);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame((string)$parentId, (string)$row['parent_id']);
     }
 
-    public function testReplyHasDepthOneMoreThanParent(): void
+    public function testReplyThrowsIfParentNotExists(): void
     {
-        $parentId = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->ct->reply($parentId, 'user:2', 'Thanks!');
-        $list = $this->ct->list('article', '1');
-        $this->assertSame(1, $list[1]['depth']);
+        $this->expectException(\RuntimeException::class);
+        $this->ct->reply('post', '1', 'user-1', 'Reply', 999);
     }
 
-    public function testReplyHasParentIdSet(): void
+    public function testReplyThrowsIfParentIsDeleted(): void
     {
-        $parentId = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $replyId  = $this->ct->reply($parentId, 'user:2', 'Thanks!');
-        $list     = $this->ct->list('article', '1');
-        $reply    = array_values(array_filter($list, fn ($c) => $c['id'] === $replyId))[0];
-        $this->assertSame($parentId, $reply['parent_id']);
+        $parentId = $this->ct->post('post', '1', 'user-1', 'Parent');
+        $this->ct->delete($parentId);
+        $this->expectException(\RuntimeException::class);
+        $this->ct->reply('post', '1', 'user-2', 'Reply', $parentId);
     }
 
-    public function testReplyToNonexistentParentThrows(): void
+    // ── edit ──────────────────────────────────────────────────────────────────
+
+    public function testEditUpdatesBody(): void
     {
+        $id = $this->ct->post('post', '1', 'user-1', 'Original');
+        $this->assertTrue($this->ct->edit($id, 'user-1', 'Updated'));
+        $row = $this->ct->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Updated', $row['body']);
+    }
+
+    public function testEditReturnsFalseForWrongUser(): void
+    {
+        $id = $this->ct->post('post', '1', 'user-1', 'Original');
+        $this->assertFalse($this->ct->edit($id, 'user-2', 'Hijack'));
+    }
+
+    public function testEditThrowsOnEmptyBody(): void
+    {
+        $id = $this->ct->post('post', '1', 'user-1', 'Original');
         $this->expectException(\InvalidArgumentException::class);
-        $this->ct->reply(9999, 'user:1', 'Hello!');
+        $this->ct->edit($id, 'user-1', '');
     }
 
-    public function testReplyEmptyBodyThrows(): void
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteReplacesBodyWithTombstone(): void
     {
-        $parentId = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->expectException(\InvalidArgumentException::class);
-        $this->ct->reply($parentId, 'user:2', '   ');
+        $id = $this->ct->post('post', '1', 'user-1', 'Original');
+        $this->assertTrue($this->ct->delete($id, 'user-1'));
+        $row = $this->ct->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('[deleted]', $row['body']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['deleted_at']);
     }
 
-    public function testReplyMaxDepthEnforced(): void
+    public function testDeleteReturnsFalseForWrongUser(): void
     {
-        // With maxDepth=2, depth 0→1→2 is allowed, depth 3 is not
-        $ct = new CommentThread($this->db, maxDepth: 2);
-        $d0 = $ct->post('article', '1', 'user:1', 'depth 0');
-        $d1 = $ct->reply($d0, 'user:1', 'depth 1');
-        $d2 = $ct->reply($d1, 'user:1', 'depth 2');
-        $this->expectException(\InvalidArgumentException::class);
-        $ct->reply($d2, 'user:1', 'depth 3 — too deep');
+        $id = $this->ct->post('post', '1', 'user-1', 'Original');
+        $this->assertFalse($this->ct->delete($id, 'user-2'));
     }
 
-    // ── softDelete ────────────────────────────────────────────────────────────
-
-    public function testSoftDeleteReturnsTrueByAuthor(): void
+    public function testDeleteWithNullUserIdForceDeletes(): void
     {
-        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->assertTrue($this->ct->softDelete($id, 'user:1'));
+        $id = $this->ct->post('post', '1', 'user-1', 'Original');
+        $this->assertTrue($this->ct->delete($id, null));
     }
 
-    public function testSoftDeleteReturnsFalseByNonAuthor(): void
+    public function testDeleteIsIdempotentReturnsFalseSecondTime(): void
     {
-        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->assertFalse($this->ct->softDelete($id, 'user:2'));
+        $id = $this->ct->post('post', '1', 'user-1', 'Original');
+        $this->ct->delete($id);
+        $this->assertFalse($this->ct->delete($id));
     }
 
-    public function testSoftDeleteReplacesBody(): void
+    // ── thread ────────────────────────────────────────────────────────────────
+
+    public function testThreadReturnsAllComments(): void
     {
-        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->ct->softDelete($id, 'user:1');
-        $list = $this->ct->list('article', '1');
-        $this->assertSame('[deleted]', $list[0]['body']);
+        $this->ct->post('post', '1', 'user-1', 'A');
+        $this->ct->post('post', '1', 'user-2', 'B');
+        $this->assertCount(2, $this->ct->thread('post', '1'));
     }
 
-    public function testSoftDeleteNullsAuthorId(): void
+    public function testThreadIncludesDeletedAsTombstone(): void
     {
-        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->ct->softDelete($id, 'user:1');
-        $list = $this->ct->list('article', '1');
-        $this->assertNull($list[0]['author_id']);
+        $id = $this->ct->post('post', '1', 'user-1', 'A');
+        $this->ct->delete($id);
+        $this->assertCount(1, $this->ct->thread('post', '1'));
     }
 
-    public function testSoftDeleteSetsDeletedAt(): void
+    public function testThreadIsEntityScoped(): void
     {
-        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->ct->softDelete($id, 'user:1');
-        $list = $this->ct->list('article', '1');
-        $this->assertNotNull($list[0]['deleted_at']);
+        $this->ct->post('post', '1', 'user-1', 'A');
+        $this->ct->post('post', '2', 'user-1', 'B');
+        $this->assertCount(1, $this->ct->thread('post', '1'));
     }
 
-    public function testSoftDeleteAlreadyDeletedReturnsFalse(): void
+    // ── topLevel / replies ────────────────────────────────────────────────────
+
+    public function testTopLevelExcludesReplies(): void
     {
-        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->ct->softDelete($id, 'user:1');
-        $this->assertFalse($this->ct->softDelete($id, 'user:1'));
+        $parentId = $this->ct->post('post', '1', 'user-1', 'Parent');
+        $this->ct->reply('post', '1', 'user-2', 'Reply', $parentId);
+        $this->assertCount(1, $this->ct->topLevel('post', '1'));
     }
 
-    // ── list ──────────────────────────────────────────────────────────────────
-
-    public function testListReturnsAllCommentsIncludingDeleted(): void
+    public function testRepliesReturnsChildComments(): void
     {
-        $id = $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->ct->softDelete($id, 'user:1');
-        $this->assertCount(1, $this->ct->list('article', '1'));
+        $parentId = $this->ct->post('post', '1', 'user-1', 'Parent');
+        $this->ct->reply('post', '1', 'user-2', 'Reply 1', $parentId);
+        $this->ct->reply('post', '1', 'user-3', 'Reply 2', $parentId);
+        $this->assertCount(2, $this->ct->replies($parentId));
     }
 
-    public function testListIsEntityTypeIsolated(): void
-    {
-        $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->assertEmpty($this->ct->list('product', '1'));
-    }
+    // ── count ─────────────────────────────────────────────────────────────────
 
-    public function testListIsEntityIdIsolated(): void
+    public function testCountExcludesDeletedComments(): void
     {
-        $this->ct->post('article', '1', 'user:1', 'Hello!');
-        $this->assertEmpty($this->ct->list('article', '2'));
-    }
-
-    public function testListOrdersByIdAscending(): void
-    {
-        $this->ct->post('article', '1', 'user:1', 'first');
-        $this->ct->post('article', '1', 'user:2', 'second');
-        $list = $this->ct->list('article', '1');
-        $this->assertSame('first', $list[0]['body']);
-        $this->assertSame('second', $list[1]['body']);
+        $id = $this->ct->post('post', '1', 'user-1', 'A');
+        $this->ct->post('post', '1', 'user-2', 'B');
+        $this->ct->delete($id);
+        $this->assertSame(1, $this->ct->count('post', '1'));
     }
 }


### PR DESCRIPTION
## FT103 — CommentThread

Threaded comment system for any entity. Single-level reply structure (parent_id). Soft-delete replaces body with tombstone — structure stays intact.

### Class: `Nene\Xion\CommentThread`

| Method | Description |
|--------|-------------|
| `post(type, id, userId, body): int` | Post a top-level comment |
| `reply(type, id, userId, body, parentId): int` | Reply to an existing (non-deleted) comment |
| `edit(commentId, userId, body): bool` | Edit own comment |
| `delete(commentId, ?userId): bool` | Soft-delete (null userId = admin force-delete) |
| `get(commentId): ?array` | Get a comment by ID |
| `thread(type, id): array` | All comments incl. tombstones, id ASC |
| `topLevel(type, id): array` | Top-level comments only |
| `replies(parentId): array` | Replies to a specific comment |
| `count(type, id): int` | Non-deleted comment count |

### Tests
- 20 tests, 28 assertions
- In-memory SQLite — no external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)