### PR TITLE
feat(ft104): ShortUrl — URL shortener with auto-code, custom slug, click tracking, and expiry

### DIFF
--- a/class/xion/ShortUrl.php
+++ b/class/xion/ShortUrl.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ShortUrl — URL shortener with click tracking and optional expiry.
+ *
+ * Generates short alphanumeric codes for long URLs. Each redirect is recorded
+ * for analytics. Supports custom slugs, optional expiry, and active/inactive state.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $su = new ShortUrl($pdo);
+ *
+ * // Shorten a URL (auto-generates code)
+ * $code = $su->shorten('https://example.com/very/long/path');
+ *
+ * // Custom slug
+ * $code = $su->shorten('https://example.com/promo', slug: 'summer24');
+ *
+ * // Resolve and record a click
+ * $url = $su->resolve($code); // 'https://example.com/...' or null
+ *
+ * // Stats
+ * $clicks = $su->clickCount($code);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE short_urls (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     code       VARCHAR(20)  NOT NULL UNIQUE,
+ *     target_url TEXT         NOT NULL,
+ *     is_active  TINYINT(1)   NOT NULL DEFAULT 1,
+ *     expires_at DATETIME     DEFAULT NULL,
+ *     clicks     INTEGER      NOT NULL DEFAULT 0,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ShortUrl
+{
+    private const CODE_LENGTH  = 7;
+    private const CODE_CHARSET = 'abcdefghjkmnpqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create a short URL.
+     *
+     * @param  string                   $targetUrl  The URL to shorten.
+     * @param  string|null              $slug       Optional custom code (must be unique).
+     * @param  \DateTimeImmutable|null  $expiresAt  Optional expiry.
+     * @return string  The short code.
+     * @throws \InvalidArgumentException if target_url is empty.
+     * @throws \RuntimeException         if the slug is already taken.
+     */
+    public function shorten(
+        string $targetUrl,
+        ?string $slug = null,
+        ?\DateTimeImmutable $expiresAt = null
+    ): string {
+        $targetUrl = trim($targetUrl);
+        if ($targetUrl === '') {
+            throw new \InvalidArgumentException('target_url must not be empty.');
+        }
+
+        $code    = $slug !== null ? trim($slug) : $this->generateCode();
+        $expStr  = $expiresAt?->format('Y-m-d H:i:s');
+
+        if ($code === '') {
+            throw new \InvalidArgumentException('slug must not be empty.');
+        }
+
+        try {
+            $this->db()->prepare(
+                'INSERT INTO short_urls (code, target_url, expires_at) VALUES (:code, :url, :exp)'
+            )->execute([':code' => $code, ':url' => $targetUrl, ':exp' => $expStr]);
+        } catch (\PDOException $e) {
+            if ($slug !== null) {
+                throw new \RuntimeException("Slug '{$code}' is already taken.", 0, $e);
+            }
+            // Retry once on collision for auto-generated codes
+            $code = $this->generateCode();
+            $this->db()->prepare(
+                'INSERT INTO short_urls (code, target_url, expires_at) VALUES (:code, :url, :exp)'
+            )->execute([':code' => $code, ':url' => $targetUrl, ':exp' => $expStr]);
+        }
+
+        return $code;
+    }
+
+    /**
+     * Resolve a short code to its target URL and increment the click counter.
+     *
+     * Returns null if the code does not exist, is inactive, or has expired.
+     */
+    public function resolve(string $code): ?string
+    {
+        $code = trim($code);
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        $stmt = $this->db()->prepare(
+            'SELECT id, target_url FROM short_urls
+             WHERE code = :code AND is_active = 1
+               AND (expires_at IS NULL OR expires_at > :now)
+             LIMIT 1'
+        );
+        $stmt->execute([':code' => $code, ':now' => $now]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        // Increment click counter
+        $this->db()->prepare(
+            'UPDATE short_urls SET clicks = clicks + 1 WHERE id = :id'
+        )->execute([':id' => $row['id']]);
+
+        return (string)$row['target_url'];
+    }
+
+    /**
+     * Look up a short URL record without recording a click.
+     *
+     * @return array{id: int, code: string, target_url: string, is_active: int, expires_at: string|null, clicks: int, created_at: string}|null
+     */
+    public function find(string $code): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, code, target_url, is_active, expires_at, clicks, created_at
+             FROM short_urls WHERE code = :code LIMIT 1'
+        );
+        $stmt->execute([':code' => trim($code)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Get the click count for a short code.
+     *
+     * Returns 0 if the code does not exist.
+     */
+    public function clickCount(string $code): int
+    {
+        $row = $this->find($code);
+        return $row !== null ? (int)$row['clicks'] : 0;
+    }
+
+    /**
+     * Deactivate a short URL (it will no longer resolve).
+     *
+     * @return bool True if the code was found and deactivated.
+     */
+    public function deactivate(string $code): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE short_urls SET is_active = 0 WHERE code = :code AND is_active = 1'
+        );
+        $stmt->execute([':code' => trim($code)]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Reactivate a deactivated short URL.
+     *
+     * @return bool True if the code was found and reactivated.
+     */
+    public function reactivate(string $code): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE short_urls SET is_active = 1 WHERE code = :code AND is_active = 0'
+        );
+        $stmt->execute([':code' => trim($code)]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Hard-delete a short URL record.
+     *
+     * @return bool True if a row was deleted.
+     */
+    public function remove(string $code): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM short_urls WHERE code = :code');
+        $stmt->execute([':code' => trim($code)]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function generateCode(): string
+    {
+        $charset = self::CODE_CHARSET;
+        $len     = strlen($charset);
+        $code    = '';
+        for ($i = 0; $i < self::CODE_LENGTH; $i++) {
+            $code .= $charset[random_int(0, $len - 1)];
+        }
+        return $code;
+    }
+}

--- a/tests/Unit/Xion/ShortUrlTest.php
+++ b/tests/Unit/Xion/ShortUrlTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ShortUrl;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ShortUrl.
+ */
+final class ShortUrlTest extends TestCase
+{
+    private PDO $db;
+    private ShortUrl $su;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE short_urls (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                code       VARCHAR(20)  NOT NULL UNIQUE,
+                target_url TEXT         NOT NULL,
+                is_active  TINYINT(1)   NOT NULL DEFAULT 1,
+                expires_at DATETIME     DEFAULT NULL,
+                clicks     INTEGER      NOT NULL DEFAULT 0,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->su = new ShortUrl($this->db);
+    }
+
+    // ── shorten ───────────────────────────────────────────────────────────────
+
+    public function testShortenReturnsCode(): void
+    {
+        $code = $this->su->shorten('https://example.com');
+        $this->assertNotEmpty($code);
+    }
+
+    public function testShortenWithSlugUsesSlug(): void
+    {
+        $code = $this->su->shorten('https://example.com', slug: 'test01');
+        $this->assertSame('test01', $code);
+    }
+
+    public function testShortenThrowsOnDuplicateSlug(): void
+    {
+        $this->su->shorten('https://example.com', slug: 'dup');
+        $this->expectException(\RuntimeException::class);
+        $this->su->shorten('https://other.com', slug: 'dup');
+    }
+
+    public function testShortenThrowsOnEmptyUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->su->shorten('');
+    }
+
+    // ── resolve ───────────────────────────────────────────────────────────────
+
+    public function testResolveReturnsTargetUrl(): void
+    {
+        $code = $this->su->shorten('https://example.com/path');
+        $this->assertSame('https://example.com/path', $this->su->resolve($code));
+    }
+
+    public function testResolveIncrementsClickCount(): void
+    {
+        $code = $this->su->shorten('https://example.com');
+        $this->su->resolve($code);
+        $this->su->resolve($code);
+        $this->assertSame(2, $this->su->clickCount($code));
+    }
+
+    public function testResolveReturnsNullForUnknownCode(): void
+    {
+        $this->assertNull($this->su->resolve('notexist'));
+    }
+
+    public function testResolveReturnsNullForInactiveUrl(): void
+    {
+        $code = $this->su->shorten('https://example.com');
+        $this->su->deactivate($code);
+        $this->assertNull($this->su->resolve($code));
+    }
+
+    public function testResolveReturnsNullForExpiredUrl(): void
+    {
+        // Insert an expired URL directly
+        $this->db->exec(
+            "INSERT INTO short_urls (code, target_url, expires_at)
+             VALUES ('exp', 'https://old.com', '2000-01-01 00:00:00')"
+        );
+        $this->assertNull($this->su->resolve('exp'));
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsRowWithoutClickIncrement(): void
+    {
+        $code = $this->su->shorten('https://example.com');
+        $row  = $this->su->find($code);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['clicks']); // no click recorded
+    }
+
+    public function testFindReturnsNullForUnknownCode(): void
+    {
+        $this->assertNull($this->su->find('nope'));
+    }
+
+    // ── clickCount ────────────────────────────────────────────────────────────
+
+    public function testClickCountReturnsZeroBeforeAnyResolve(): void
+    {
+        $code = $this->su->shorten('https://example.com');
+        $this->assertSame(0, $this->su->clickCount($code));
+    }
+
+    public function testClickCountReturnsZeroForNonExistentCode(): void
+    {
+        $this->assertSame(0, $this->su->clickCount('notexist'));
+    }
+
+    // ── deactivate / reactivate ───────────────────────────────────────────────
+
+    public function testDeactivateStopsResolution(): void
+    {
+        $code = $this->su->shorten('https://example.com');
+        $this->assertTrue($this->su->deactivate($code));
+        $this->assertNull($this->su->resolve($code));
+    }
+
+    public function testReactivateRestoresResolution(): void
+    {
+        $code = $this->su->shorten('https://example.com');
+        $this->su->deactivate($code);
+        $this->assertTrue($this->su->reactivate($code));
+        $this->assertNotNull($this->su->resolve($code));
+    }
+
+    public function testDeactivateReturnsFalseIfAlreadyInactive(): void
+    {
+        $code = $this->su->shorten('https://example.com');
+        $this->su->deactivate($code);
+        $this->assertFalse($this->su->deactivate($code));
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesEntry(): void
+    {
+        $code = $this->su->shorten('https://example.com');
+        $this->assertTrue($this->su->remove($code));
+        $this->assertNull($this->su->find($code));
+    }
+
+    public function testRemoveReturnsFalseForNonExistentCode(): void
+    {
+        $this->assertFalse($this->su->remove('nope'));
+    }
+}


### PR DESCRIPTION
## FT104 — ShortUrl

URL shortener with click analytics, optional custom slugs, expiry, and active/inactive toggle.

### Class: `Nene\Xion\ShortUrl`

| Method | Description |
|--------|-------------|
| `shorten(url, ?slug, ?expiresAt): string` | Create short URL; returns code |
| `resolve(code): ?string` | Resolve code → URL and record click |
| `find(code): ?array` | Look up record without click |
| `clickCount(code): int` | Number of clicks |
| `deactivate(code): bool` | Disable resolution |
| `reactivate(code): bool` | Re-enable resolution |
| `remove(code): bool` | Hard-delete |

### Tests
- 18 tests, 22 assertions
- In-memory SQLite — no external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)