### PR TITLE
feat(ft109): FileQuarantine — file quarantine/release/reject workflow

### DIFF
--- a/class/xion/FileQuarantine.php
+++ b/class/xion/FileQuarantine.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * FileQuarantine — quarantine suspicious or policy-violating files with release/reject workflow.
+ *
+ * Files are quarantined when flagged for review (e.g. AV scan, policy check).
+ * A reviewer then either releases them (safe) or rejects them (removed/destroyed).
+ *
+ * Status lifecycle: `quarantined` → `released` | `rejected`
+ *
+ * ## Usage
+ *
+ * ```php
+ * $fq = new FileQuarantine($pdo);
+ *
+ * // Quarantine a file
+ * $id = $fq->quarantine('file-abc', 'user-1', 'antivirus_flag', 'Trojan.Gen detected');
+ *
+ * // Release (safe to use)
+ * $fq->release('file-abc', 'admin-1');
+ *
+ * // Reject (permanently flagged/removed)
+ * $fq->reject('file-abc', 'admin-1', 'confirmed malware');
+ *
+ * // Check status
+ * $fq->status('file-abc'); // 'quarantined'|'released'|'rejected'|null
+ *
+ * // List all quarantined files
+ * $fq->listQuarantined();
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE file_quarantine (
+ *     id            INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     file_id       VARCHAR(255) NOT NULL UNIQUE,
+ *     owner_id      VARCHAR(255) NOT NULL DEFAULT '',
+ *     reason        VARCHAR(100) NOT NULL DEFAULT '',
+ *     notes         TEXT         NOT NULL DEFAULT '',
+ *     status        VARCHAR(20)  NOT NULL DEFAULT 'quarantined',
+ *     reviewed_by   VARCHAR(255) NOT NULL DEFAULT '',
+ *     review_notes  TEXT         NOT NULL DEFAULT '',
+ *     quarantined_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     reviewed_at   DATETIME     DEFAULT NULL
+ * );
+ * ```
+ */
+final class FileQuarantine
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Quarantine a file for review.
+     *
+     * If the file is already quarantined, updates the reason and notes.
+     *
+     * @param  string $fileId   Unique file identifier.
+     * @param  string $ownerId  User who owns the file.
+     * @param  string $reason   Short reason code (e.g. 'antivirus_flag', 'policy_violation').
+     * @param  string $notes    Optional additional details.
+     * @return int  The quarantine record ID.
+     * @throws \InvalidArgumentException if file_id is empty.
+     */
+    public function quarantine(
+        string $fileId,
+        string $ownerId = '',
+        string $reason = '',
+        string $notes = ''
+    ): int {
+        $fileId = trim($fileId);
+        if ($fileId === '') {
+            throw new \InvalidArgumentException('file_id must not be empty.');
+        }
+
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO file_quarantine (file_id, owner_id, reason, notes)
+                 VALUES (:fid, :oid, :reason, :notes)
+                 ON CONFLICT (file_id)
+                 DO UPDATE SET reason = excluded.reason,
+                               notes = excluded.notes,
+                               status = \'quarantined\',
+                               reviewed_by = \'\',
+                               review_notes = \'\',
+                               reviewed_at = NULL'
+            )->execute([':fid' => $fileId, ':oid' => $ownerId, ':reason' => $reason, ':notes' => $notes]);
+        } else {
+            $db->prepare(
+                'INSERT INTO file_quarantine (file_id, owner_id, reason, notes)
+                 VALUES (:fid, :oid, :reason, :notes)
+                 ON DUPLICATE KEY UPDATE reason = VALUES(reason),
+                                         notes = VALUES(notes),
+                                         status = \'quarantined\',
+                                         reviewed_by = \'\',
+                                         review_notes = \'\',
+                                         reviewed_at = NULL'
+            )->execute([':fid' => $fileId, ':oid' => $ownerId, ':reason' => $reason, ':notes' => $notes]);
+        }
+
+        $stmt = $db->prepare('SELECT id FROM file_quarantine WHERE file_id = :fid LIMIT 1');
+        $stmt->execute([':fid' => $fileId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Release a quarantined file (mark as safe).
+     *
+     * @param  string $reviewedBy  Admin/reviewer identifier.
+     * @param  string $reviewNotes Optional notes from reviewer.
+     * @return bool True if the file was in 'quarantined' status and was released.
+     * @throws \InvalidArgumentException if file_id is empty.
+     */
+    public function release(string $fileId, string $reviewedBy, string $reviewNotes = ''): bool
+    {
+        $fileId = trim($fileId);
+        if ($fileId === '') {
+            throw new \InvalidArgumentException('file_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare(
+            'UPDATE file_quarantine
+             SET status = \'released\', reviewed_by = :by, review_notes = :notes,
+                 reviewed_at = CURRENT_TIMESTAMP
+             WHERE file_id = :fid AND status = \'quarantined\''
+        );
+        $stmt->execute([':fid' => $fileId, ':by' => $reviewedBy, ':notes' => $reviewNotes]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Reject a quarantined file (permanently flagged/removed).
+     *
+     * @param  string $reviewedBy  Admin/reviewer identifier.
+     * @param  string $reviewNotes Optional notes from reviewer.
+     * @return bool True if the file was in 'quarantined' status and was rejected.
+     * @throws \InvalidArgumentException if file_id is empty.
+     */
+    public function reject(string $fileId, string $reviewedBy, string $reviewNotes = ''): bool
+    {
+        $fileId = trim($fileId);
+        if ($fileId === '') {
+            throw new \InvalidArgumentException('file_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare(
+            'UPDATE file_quarantine
+             SET status = \'rejected\', reviewed_by = :by, review_notes = :notes,
+                 reviewed_at = CURRENT_TIMESTAMP
+             WHERE file_id = :fid AND status = \'quarantined\''
+        );
+        $stmt->execute([':fid' => $fileId, ':by' => $reviewedBy, ':notes' => $reviewNotes]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Get the current status of a file.
+     *
+     * @return 'quarantined'|'released'|'rejected'|null  null if not found.
+     */
+    public function status(string $fileId): ?string
+    {
+        $fileId = trim($fileId);
+        $stmt   = $this->db()->prepare(
+            'SELECT status FROM file_quarantine WHERE file_id = :fid LIMIT 1'
+        );
+        $stmt->execute([':fid' => $fileId]);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : null;
+    }
+
+    /**
+     * Get the full quarantine record for a file.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(string $fileId): ?array
+    {
+        $fileId = trim($fileId);
+        $stmt   = $this->db()->prepare(
+            'SELECT id, file_id, owner_id, reason, notes, status,
+                    reviewed_by, review_notes, quarantined_at, reviewed_at
+             FROM file_quarantine WHERE file_id = :fid LIMIT 1'
+        );
+        $stmt->execute([':fid' => $fileId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * List all files currently in quarantine (oldest first).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function listQuarantined(): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, file_id, owner_id, reason, notes, quarantined_at
+             FROM file_quarantine
+             WHERE status = \'quarantined\'
+             ORDER BY id ASC'
+        );
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Check whether a file is currently under quarantine.
+     */
+    public function isQuarantined(string $fileId): bool
+    {
+        return $this->status($fileId) === 'quarantined';
+    }
+
+    /**
+     * Hard-delete a quarantine record.
+     *
+     * @return bool True if a row was deleted.
+     */
+    public function remove(string $fileId): bool
+    {
+        $fileId = trim($fileId);
+        $stmt   = $this->db()->prepare('DELETE FROM file_quarantine WHERE file_id = :fid');
+        $stmt->execute([':fid' => $fileId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/FileQuarantineTest.php
+++ b/tests/Unit/Xion/FileQuarantineTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\FileQuarantine;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for FileQuarantine.
+ */
+final class FileQuarantineTest extends TestCase
+{
+    private PDO $db;
+    private FileQuarantine $fq;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE file_quarantine (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_id        VARCHAR(255) NOT NULL UNIQUE,
+                owner_id       VARCHAR(255) NOT NULL DEFAULT \'\',
+                reason         VARCHAR(100) NOT NULL DEFAULT \'\',
+                notes          TEXT         NOT NULL DEFAULT \'\',
+                status         VARCHAR(20)  NOT NULL DEFAULT \'quarantined\',
+                reviewed_by    VARCHAR(255) NOT NULL DEFAULT \'\',
+                review_notes   TEXT         NOT NULL DEFAULT \'\',
+                quarantined_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                reviewed_at    DATETIME     DEFAULT NULL
+            )
+        ');
+        $this->fq = new FileQuarantine($this->db);
+    }
+
+    // ── quarantine ────────────────────────────────────────────────────────────
+
+    public function testQuarantineReturnsId(): void
+    {
+        $id = $this->fq->quarantine('file-1', 'user-1', 'av_flag', 'Malware detected');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testQuarantineSetsStatusToQuarantined(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->assertSame('quarantined', $this->fq->status('file-1'));
+    }
+
+    public function testQuarantineIsIdempotentUpsert(): void
+    {
+        $this->fq->quarantine('file-1', 'user-1', 'av_flag');
+        $this->fq->quarantine('file-1', 'user-1', 'policy_violation'); // re-quarantine
+        $this->assertSame('quarantined', $this->fq->status('file-1'));
+        $row = $this->fq->find('file-1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('policy_violation', $row['reason']);
+    }
+
+    public function testQuarantineResetsReleasedFile(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->fq->release('file-1', 'admin-1');
+        $this->fq->quarantine('file-1', 'user-1', 'second_scan');
+        $this->assertSame('quarantined', $this->fq->status('file-1'));
+    }
+
+    public function testQuarantineThrowsOnEmptyFileId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fq->quarantine('');
+    }
+
+    // ── release ───────────────────────────────────────────────────────────────
+
+    public function testReleaseSetsStatusToReleased(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->assertTrue($this->fq->release('file-1', 'admin-1'));
+        $this->assertSame('released', $this->fq->status('file-1'));
+    }
+
+    public function testReleaseStoresReviewedBy(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->fq->release('file-1', 'admin-1', 'looks clean');
+        $row = $this->fq->find('file-1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('admin-1', $row['reviewed_by']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('looks clean', $row['review_notes']);
+    }
+
+    public function testReleaseReturnsFalseIfNotQuarantined(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->fq->release('file-1', 'admin-1');
+        $this->assertFalse($this->fq->release('file-1', 'admin-1')); // already released
+    }
+
+    public function testReleaseThrowsOnEmptyFileId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fq->release('', 'admin-1');
+    }
+
+    // ── reject ────────────────────────────────────────────────────────────────
+
+    public function testRejectSetsStatusToRejected(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->assertTrue($this->fq->reject('file-1', 'admin-1'));
+        $this->assertSame('rejected', $this->fq->status('file-1'));
+    }
+
+    public function testRejectReturnsFalseIfNotQuarantined(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->fq->reject('file-1', 'admin-1');
+        $this->assertFalse($this->fq->reject('file-1', 'admin-1')); // already rejected
+    }
+
+    public function testRejectThrowsOnEmptyFileId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fq->reject('', 'admin-1');
+    }
+
+    // ── status / isQuarantined ────────────────────────────────────────────────
+
+    public function testStatusReturnsNullForUnknownFile(): void
+    {
+        $this->assertNull($this->fq->status('nonexistent'));
+    }
+
+    public function testIsQuarantinedTrueWhenQuarantined(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->assertTrue($this->fq->isQuarantined('file-1'));
+    }
+
+    public function testIsQuarantinedFalseAfterRelease(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->fq->release('file-1', 'admin-1');
+        $this->assertFalse($this->fq->isQuarantined('file-1'));
+    }
+
+    // ── listQuarantined ───────────────────────────────────────────────────────
+
+    public function testListQuarantinedReturnsActiveOnly(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->fq->quarantine('file-2');
+        $this->fq->release('file-1', 'admin-1');
+        $list = $this->fq->listQuarantined();
+        $this->assertCount(1, $list);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('file-2', $list[0]['file_id']);
+    }
+
+    public function testListQuarantinedReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->fq->listQuarantined());
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesRecord(): void
+    {
+        $this->fq->quarantine('file-1');
+        $this->assertTrue($this->fq->remove('file-1'));
+        $this->assertNull($this->fq->find('file-1'));
+    }
+
+    public function testRemoveReturnsFalseIfNotFound(): void
+    {
+        $this->assertFalse($this->fq->remove('nonexistent'));
+    }
+}


### PR DESCRIPTION
## FT109 · FileQuarantine

Quarantine suspicious or policy-violating files with a reviewer release/reject workflow.

### Status lifecycle
`quarantined` → `released` | `rejected`

### Features
- Quarantine files with owner, reason code, and notes (upsert — re-quarantines released files)
- Release (mark as safe) with reviewer ID and notes
- Reject (permanently flagged) with reviewer ID and notes
- Status query per file
- List all currently quarantined files
- Hard remove

### Schema
```sql
CREATE TABLE file_quarantine (
    id             INTEGER PRIMARY KEY AUTOINCREMENT,
    file_id        VARCHAR(255) NOT NULL UNIQUE,
    owner_id       VARCHAR(255) NOT NULL DEFAULT '',
    reason         VARCHAR(100) NOT NULL DEFAULT '',
    notes          TEXT         NOT NULL DEFAULT '',
    status         VARCHAR(20)  NOT NULL DEFAULT 'quarantined',
    reviewed_by    VARCHAR(255) NOT NULL DEFAULT '',
    review_notes   TEXT         NOT NULL DEFAULT '',
    quarantined_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    reviewed_at    DATETIME     DEFAULT NULL
);
```

### Tests
19 tests, 27 assertions — all green ✅