### PR TITLE
feat(ft110): TokenBucket — DB-backed token bucket for flexible rate limiting

### DIFF
--- a/class/xion/TokenBucket.php
+++ b/class/xion/TokenBucket.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * TokenBucket — DB-backed token bucket algorithm for flexible rate limiting.
+ *
+ * Each bucket refills at a configurable rate (tokens per second). A request
+ * consumes one or more tokens. If the bucket is empty, the request is denied.
+ *
+ * Complements FT28's fixed-window rate limiter with burst tolerance.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $tb = new TokenBucket($pdo, capacity: 10, refillRate: 1.0);
+ *
+ * // Try to consume 1 token (returns false if bucket is empty)
+ * $tb->consume('user-1');
+ *
+ * // Consume multiple tokens
+ * $tb->consume('user-1', 3);
+ *
+ * // Peek at remaining tokens without consuming
+ * $tb->tokens('user-1');
+ *
+ * // Reset a bucket
+ * $tb->reset('user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE token_buckets (
+ *     bucket_key  VARCHAR(255) NOT NULL PRIMARY KEY,
+ *     tokens      DOUBLE       NOT NULL,
+ *     last_refill DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class TokenBucket
+{
+    /**
+     * @param float $capacity   Maximum tokens the bucket can hold.
+     * @param float $refillRate Tokens added per second.
+     */
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly float $capacity = 10.0,
+        private readonly float $refillRate = 1.0,
+    ) {
+        if ($this->capacity <= 0) {
+            throw new \InvalidArgumentException('capacity must be positive.');
+        }
+        if ($this->refillRate <= 0) {
+            throw new \InvalidArgumentException('refillRate must be positive.');
+        }
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Attempt to consume tokens from a bucket.
+     *
+     * The bucket is refilled based on elapsed time since last refill before consumption.
+     *
+     * @param  string $bucketKey Unique identifier for this rate-limit subject (e.g. user ID, IP).
+     * @param  int    $cost      Number of tokens to consume (default 1).
+     * @return bool   True if tokens were available and consumed; false if rate-limited.
+     * @throws \InvalidArgumentException if bucket_key is empty or cost is not positive.
+     */
+    public function consume(string $bucketKey, int $cost = 1): bool
+    {
+        $bucketKey = trim($bucketKey);
+        if ($bucketKey === '') {
+            throw new \InvalidArgumentException('bucket_key must not be empty.');
+        }
+        if ($cost <= 0) {
+            throw new \InvalidArgumentException('cost must be positive.');
+        }
+
+        $db  = $this->db();
+        $now = microtime(true);
+
+        // Load existing bucket or initialise
+        $stmt = $db->prepare(
+            'SELECT tokens, last_refill FROM token_buckets WHERE bucket_key = :key LIMIT 1'
+        );
+        $stmt->execute([':key' => $bucketKey]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            // First request: full bucket
+            $tokens     = $this->capacity;
+            $lastRefill = $now;
+        } else {
+            $lastRefill  = (float)strtotime((string)$row['last_refill']);
+            $elapsed     = max(0.0, $now - $lastRefill);
+            $tokens      = min($this->capacity, (float)$row['tokens'] + $elapsed * $this->refillRate);
+            $lastRefill  = $now;
+        }
+
+        if ($tokens < $cost) {
+            // Not enough tokens — persist the refilled (but unconsumed) state
+            $this->upsert($db, $bucketKey, $tokens, $lastRefill);
+            return false;
+        }
+
+        $this->upsert($db, $bucketKey, $tokens - $cost, $lastRefill);
+        return true;
+    }
+
+    /**
+     * Get the current token count for a bucket (after applying refill).
+     *
+     * Does not modify the bucket state.
+     *
+     * @throws \InvalidArgumentException if bucket_key is empty.
+     */
+    public function tokens(string $bucketKey): float
+    {
+        $bucketKey = trim($bucketKey);
+        if ($bucketKey === '') {
+            throw new \InvalidArgumentException('bucket_key must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'SELECT tokens, last_refill FROM token_buckets WHERE bucket_key = :key LIMIT 1'
+        );
+        $stmt->execute([':key' => $bucketKey]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return $this->capacity; // never used → full
+        }
+
+        $elapsed = max(0.0, microtime(true) - (float)strtotime((string)$row['last_refill']));
+        return min($this->capacity, (float)$row['tokens'] + $elapsed * $this->refillRate);
+    }
+
+    /**
+     * Reset a bucket to full capacity.
+     *
+     * @return bool True if a record was reset or created.
+     */
+    public function reset(string $bucketKey): bool
+    {
+        $bucketKey = trim($bucketKey);
+        if ($bucketKey === '') {
+            throw new \InvalidArgumentException('bucket_key must not be empty.');
+        }
+        $now = microtime(true);
+        $this->upsert($this->db(), $bucketKey, $this->capacity, $now);
+        return true;
+    }
+
+    /**
+     * Delete a bucket record entirely.
+     *
+     * @return bool True if a row was deleted.
+     */
+    public function remove(string $bucketKey): bool
+    {
+        $bucketKey = trim($bucketKey);
+        $stmt      = $this->db()->prepare('DELETE FROM token_buckets WHERE bucket_key = :key');
+        $stmt->execute([':key' => $bucketKey]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Remove buckets that haven't been used in the given number of seconds.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeStale(int $seconds = 86400): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$seconds} seconds")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM token_buckets WHERE last_refill < :cutoff'
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function upsert(PDO $db, string $key, float $tokens, float $nowTs): void
+    {
+        $nowStr = date('Y-m-d H:i:s', (int)$nowTs);
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO token_buckets (bucket_key, tokens, last_refill)
+                 VALUES (:key, :tokens, :now)
+                 ON CONFLICT (bucket_key)
+                 DO UPDATE SET tokens = excluded.tokens, last_refill = excluded.last_refill'
+            )->execute([':key' => $key, ':tokens' => $tokens, ':now' => $nowStr]);
+        } else {
+            $db->prepare(
+                'INSERT INTO token_buckets (bucket_key, tokens, last_refill)
+                 VALUES (:key, :tokens, :now)
+                 ON DUPLICATE KEY UPDATE tokens = VALUES(tokens), last_refill = VALUES(last_refill)'
+            )->execute([':key' => $key, ':tokens' => $tokens, ':now' => $nowStr]);
+        }
+    }
+}

--- a/tests/Unit/Xion/TokenBucketTest.php
+++ b/tests/Unit/Xion/TokenBucketTest.php
@@ -38,12 +38,14 @@ final class TokenBucketTest extends TestCase
     public function testConstructorThrowsOnNonPositiveCapacity(): void
     {
         $this->expectException(\InvalidArgumentException::class);
+        // @phan-suppress-next-line PhanNoopNew
         new TokenBucket($this->db, 0.0, 1.0);
     }
 
     public function testConstructorThrowsOnNonPositiveRefillRate(): void
     {
         $this->expectException(\InvalidArgumentException::class);
+        // @phan-suppress-next-line PhanNoopNew
         new TokenBucket($this->db, 10.0, 0.0);
     }
 

--- a/tests/Unit/Xion/TokenBucketTest.php
+++ b/tests/Unit/Xion/TokenBucketTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\TokenBucket;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for TokenBucket.
+ */
+final class TokenBucketTest extends TestCase
+{
+    private PDO $db;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE token_buckets (
+                bucket_key  VARCHAR(255) NOT NULL PRIMARY KEY,
+                tokens      DOUBLE       NOT NULL,
+                last_refill DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+    }
+
+    private function bucket(float $capacity = 5.0, float $refillRate = 1.0): TokenBucket
+    {
+        return new TokenBucket($this->db, $capacity, $refillRate);
+    }
+
+    // ── constructor ───────────────────────────────────────────────────────────
+
+    public function testConstructorThrowsOnNonPositiveCapacity(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new TokenBucket($this->db, 0.0, 1.0);
+    }
+
+    public function testConstructorThrowsOnNonPositiveRefillRate(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new TokenBucket($this->db, 10.0, 0.0);
+    }
+
+    // ── consume ───────────────────────────────────────────────────────────────
+
+    public function testConsumeReturnsTrueOnFirstRequest(): void
+    {
+        $tb = $this->bucket(capacity: 5.0);
+        $this->assertTrue($tb->consume('user-1'));
+    }
+
+    public function testConsumeDecreasesTokens(): void
+    {
+        $tb = $this->bucket(capacity: 5.0, refillRate: 0.0001);
+        $tb->consume('user-1'); // 5 - 1 = 4
+        $tb->consume('user-1'); // 4 - 1 = 3
+        $this->assertEqualsWithDelta(3.0, $tb->tokens('user-1'), 0.5);
+    }
+
+    public function testConsumeReturnsFalseWhenEmpty(): void
+    {
+        $tb = $this->bucket(capacity: 2.0, refillRate: 0.0001);
+        $tb->consume('user-1');
+        $tb->consume('user-1');
+        $this->assertFalse($tb->consume('user-1'));
+    }
+
+    public function testConsumeMultipleTokens(): void
+    {
+        $tb = $this->bucket(capacity: 5.0, refillRate: 0.0001);
+        $this->assertTrue($tb->consume('user-1', 3));
+        $this->assertEqualsWithDelta(2.0, $tb->tokens('user-1'), 0.5);
+    }
+
+    public function testConsumeReturnsFalseIfInsufficientTokensForCost(): void
+    {
+        $tb = $this->bucket(capacity: 3.0, refillRate: 0.0001);
+        $tb->consume('user-1', 2); // 3 - 2 = 1
+        $this->assertFalse($tb->consume('user-1', 3)); // only 1 left
+    }
+
+    public function testConsumeIsBucketKeyScoped(): void
+    {
+        $tb = $this->bucket(capacity: 2.0, refillRate: 0.0001);
+        $tb->consume('user-1');
+        $tb->consume('user-1');
+        $this->assertTrue($tb->consume('user-2')); // different bucket
+    }
+
+    public function testConsumeThrowsOnEmptyBucketKey(): void
+    {
+        $tb = $this->bucket();
+        $this->expectException(\InvalidArgumentException::class);
+        $tb->consume('');
+    }
+
+    public function testConsumeThrowsOnNonPositiveCost(): void
+    {
+        $tb = $this->bucket();
+        $this->expectException(\InvalidArgumentException::class);
+        $tb->consume('user-1', 0);
+    }
+
+    // ── tokens ────────────────────────────────────────────────────────────────
+
+    public function testTokensReturnsFullCapacityForNewBucket(): void
+    {
+        $tb = $this->bucket(capacity: 10.0);
+        $this->assertSame(10.0, $tb->tokens('user-1'));
+    }
+
+    public function testTokensDoesNotModifyBucket(): void
+    {
+        $tb = $this->bucket(capacity: 5.0, refillRate: 0.0001);
+        $tb->tokens('user-1');
+        $tb->tokens('user-1');
+        $this->assertTrue($tb->consume('user-1'));
+    }
+
+    public function testTokensThrowsOnEmptyBucketKey(): void
+    {
+        $tb = $this->bucket();
+        $this->expectException(\InvalidArgumentException::class);
+        $tb->tokens('');
+    }
+
+    // ── reset ─────────────────────────────────────────────────────────────────
+
+    public function testResetRestoresFullCapacity(): void
+    {
+        $tb = $this->bucket(capacity: 3.0, refillRate: 0.0001);
+        $tb->consume('user-1');
+        $tb->consume('user-1');
+        $tb->consume('user-1'); // empty
+        $tb->reset('user-1');
+        $this->assertEqualsWithDelta(3.0, $tb->tokens('user-1'), 0.1);
+    }
+
+    public function testResetThrowsOnEmptyBucketKey(): void
+    {
+        $tb = $this->bucket();
+        $this->expectException(\InvalidArgumentException::class);
+        $tb->reset('');
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesBucketRecord(): void
+    {
+        $tb = $this->bucket(capacity: 5.0, refillRate: 0.0001);
+        $tb->consume('user-1');
+        $this->assertTrue($tb->remove('user-1'));
+        // After removal, bucket is considered full (no record = new bucket)
+        $this->assertSame(5.0, $tb->tokens('user-1'));
+    }
+
+    public function testRemoveReturnsFalseIfNoRecord(): void
+    {
+        $tb = $this->bucket();
+        $this->assertFalse($tb->remove('nonexistent'));
+    }
+
+    // ── purgeStale ────────────────────────────────────────────────────────────
+
+    public function testPurgeStaleDeletesOldRecords(): void
+    {
+        $tb = $this->bucket(capacity: 5.0, refillRate: 0.0001);
+        $tb->consume('user-1');
+        // Manually age the record
+        $this->db->exec(
+            "UPDATE token_buckets SET last_refill = datetime('now', '-2 days') WHERE bucket_key = 'user-1'"
+        );
+        $this->assertSame(1, $tb->purgeStale(86400)); // purge older than 1 day
+    }
+
+    public function testPurgeStalePreservesRecentRecords(): void
+    {
+        $tb = $this->bucket(capacity: 5.0, refillRate: 0.0001);
+        $tb->consume('user-1');
+        $this->assertSame(0, $tb->purgeStale(86400));
+    }
+}


### PR DESCRIPTION
## FT110 · TokenBucket

DB-backed token bucket algorithm for flexible, burst-tolerant rate limiting.

Complements FT28's fixed-window `RateLimiter` with burst capacity.

### Features
- Configurable capacity and refill rate (tokens/second)
- Consume tokens with variable cost (default 1)
- Refill computed from elapsed time since last use — no cron/scheduler needed
- Read current token count without consuming
- Reset bucket to full
- Purge stale unused buckets

### Schema
```sql
CREATE TABLE token_buckets (
    bucket_key  VARCHAR(255) NOT NULL PRIMARY KEY,
    tokens      DOUBLE       NOT NULL,
    last_refill DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### Tests
19 tests, 21 assertions — all green ✅