### PR TITLE
feat(ft111): AuditLog — append-only action log with JSON context and actor/resource filtering

### DIFF
--- a/class/xion/AuditLog.php
+++ b/class/xion/AuditLog.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * AuditLog — append-only record of significant actions for compliance and forensics.
+ *
+ * Records who did what to which resource, from where, and when.
+ * All entries are immutable once written. Supports structured context payloads
+ * stored as JSON for flexible metadata.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $al = new AuditLog($pdo);
+ *
+ * // Record an action
+ * $al->record('user.login', 'user-1', 'user', 'user-1', ['ip' => '1.2.3.4']);
+ * $al->record('post.delete', 'admin-1', 'post', '42');
+ *
+ * // Query recent activity
+ * $al->recent(20);
+ *
+ * // Filter by actor
+ * $al->forActor('admin-1');
+ *
+ * // Filter by resource
+ * $al->forResource('post', '42');
+ *
+ * // Purge old records
+ * $al->purgeOlderThan(90);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE audit_log (
+ *     id            INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     action        VARCHAR(100) NOT NULL,
+ *     actor_id      VARCHAR(255) NOT NULL DEFAULT '',
+ *     resource_type VARCHAR(100) NOT NULL DEFAULT '',
+ *     resource_id   VARCHAR(255) NOT NULL DEFAULT '',
+ *     context       TEXT         NOT NULL DEFAULT '{}',
+ *     created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class AuditLog
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record an audit event.
+     *
+     * @param  string              $action       Dot-namespaced action string (e.g. 'user.login').
+     * @param  string              $actorId      Who performed the action.
+     * @param  string              $resourceType Type of the affected resource (e.g. 'post').
+     * @param  string              $resourceId   ID of the affected resource.
+     * @param  array<string,mixed> $context      Optional key-value metadata (stored as JSON).
+     * @return int  The new log entry ID.
+     * @throws \InvalidArgumentException if action is empty.
+     */
+    public function record(
+        string $action,
+        string $actorId = '',
+        string $resourceType = '',
+        string $resourceId = '',
+        array $context = []
+    ): int {
+        $action = trim($action);
+        if ($action === '') {
+            throw new \InvalidArgumentException('action must not be empty.');
+        }
+
+        $contextJson = empty($context) ? '{}' : json_encode($context, JSON_UNESCAPED_UNICODE);
+
+        $this->db()->prepare(
+            'INSERT INTO audit_log (action, actor_id, resource_type, resource_id, context)
+             VALUES (:action, :actor, :rtype, :rid, :ctx)'
+        )->execute([
+            ':action' => $action,
+            ':actor'  => $actorId,
+            ':rtype'  => $resourceType,
+            ':rid'    => $resourceId,
+            ':ctx'    => $contextJson,
+        ]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Get the most recent log entries.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function recent(int $limit = 50): array
+    {
+        $limit = max(1, $limit);
+        $stmt  = $this->db()->prepare(
+            "SELECT id, action, actor_id, resource_type, resource_id, context, created_at
+             FROM audit_log
+             ORDER BY id DESC
+             LIMIT {$limit}"
+        );
+        $stmt->execute();
+        return $this->decode($stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
+    }
+
+    /**
+     * Get log entries for a specific actor.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forActor(string $actorId, int $limit = 50): array
+    {
+        $limit = max(1, $limit);
+        $stmt  = $this->db()->prepare(
+            "SELECT id, action, actor_id, resource_type, resource_id, context, created_at
+             FROM audit_log
+             WHERE actor_id = :actor
+             ORDER BY id DESC
+             LIMIT {$limit}"
+        );
+        $stmt->execute([':actor' => $actorId]);
+        return $this->decode($stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
+    }
+
+    /**
+     * Get log entries for a specific resource.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forResource(string $resourceType, string $resourceId, int $limit = 50): array
+    {
+        $limit = max(1, $limit);
+        $stmt  = $this->db()->prepare(
+            "SELECT id, action, actor_id, resource_type, resource_id, context, created_at
+             FROM audit_log
+             WHERE resource_type = :rtype AND resource_id = :rid
+             ORDER BY id DESC
+             LIMIT {$limit}"
+        );
+        $stmt->execute([':rtype' => $resourceType, ':rid' => $resourceId]);
+        return $this->decode($stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
+    }
+
+    /**
+     * Get log entries matching a specific action.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forAction(string $action, int $limit = 50): array
+    {
+        $limit = max(1, $limit);
+        $stmt  = $this->db()->prepare(
+            "SELECT id, action, actor_id, resource_type, resource_id, context, created_at
+             FROM audit_log
+             WHERE action = :action
+             ORDER BY id DESC
+             LIMIT {$limit}"
+        );
+        $stmt->execute([':action' => $action]);
+        return $this->decode($stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
+    }
+
+    /**
+     * Count log entries (optionally filtered by actor or action).
+     */
+    public function count(?string $actorId = null, ?string $action = null): int
+    {
+        if ($actorId !== null && $action !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM audit_log WHERE actor_id = :actor AND action = :action'
+            );
+            $stmt->execute([':actor' => $actorId, ':action' => $action]);
+        } elseif ($actorId !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM audit_log WHERE actor_id = :actor'
+            );
+            $stmt->execute([':actor' => $actorId]);
+        } elseif ($action !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM audit_log WHERE action = :action'
+            );
+            $stmt->execute([':action' => $action]);
+        } else {
+            $stmt = $this->db()->prepare('SELECT COUNT(*) FROM audit_log');
+            $stmt->execute();
+        }
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Purge entries older than N days.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare('DELETE FROM audit_log WHERE created_at < :cutoff');
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * Decode the JSON context field in each row.
+     *
+     * @param  list<array<string,mixed>> $rows
+     * @return list<array<string,mixed>>
+     */
+    private function decode(array $rows): array
+    {
+        foreach ($rows as &$row) {
+            $decoded = json_decode((string)($row['context'] ?? '{}'), true);
+            $row['context'] = is_array($decoded) ? $decoded : [];
+        }
+        return $rows;
+    }
+}

--- a/tests/Unit/Xion/AuditLogTest.php
+++ b/tests/Unit/Xion/AuditLogTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\AuditLog;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for AuditLog.
+ */
+final class AuditLogTest extends TestCase
+{
+    private PDO $db;
+    private AuditLog $al;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE audit_log (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                action        VARCHAR(100) NOT NULL,
+                actor_id      VARCHAR(255) NOT NULL DEFAULT \'\',
+                resource_type VARCHAR(100) NOT NULL DEFAULT \'\',
+                resource_id   VARCHAR(255) NOT NULL DEFAULT \'\',
+                context       TEXT         NOT NULL DEFAULT \'{}\',
+                created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->al = new AuditLog($this->db);
+    }
+
+    // ── record ────────────────────────────────────────────────────────────────
+
+    public function testRecordReturnsId(): void
+    {
+        $id = $this->al->record('user.login', 'user-1');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testRecordStoresAllFields(): void
+    {
+        $this->al->record('post.delete', 'admin-1', 'post', '42', ['reason' => 'spam']);
+        $entries = $this->al->forActor('admin-1');
+        $this->assertCount(1, $entries);
+        $this->assertSame('post.delete', $entries[0]['action']);
+        $this->assertSame('post', $entries[0]['resource_type']);
+        $this->assertSame('42', $entries[0]['resource_id']);
+        $this->assertSame(['reason' => 'spam'], $entries[0]['context']);
+    }
+
+    public function testRecordThrowsOnEmptyAction(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->al->record('');
+    }
+
+    public function testRecordWithEmptyContextStoresEmptyArray(): void
+    {
+        $this->al->record('user.login', 'user-1');
+        $entries = $this->al->recent(1);
+        $this->assertSame([], $entries[0]['context']);
+    }
+
+    // ── recent ────────────────────────────────────────────────────────────────
+
+    public function testRecentReturnsNewestFirst(): void
+    {
+        $this->al->record('a.1', 'user-1');
+        $this->al->record('a.2', 'user-1');
+        $entries = $this->al->recent(10);
+        $this->assertSame('a.2', $entries[0]['action']);
+        $this->assertSame('a.1', $entries[1]['action']);
+    }
+
+    public function testRecentRespectsLimit(): void
+    {
+        $this->al->record('a.1', 'u');
+        $this->al->record('a.2', 'u');
+        $this->al->record('a.3', 'u');
+        $this->assertCount(2, $this->al->recent(2));
+    }
+
+    public function testRecentReturnsEmptyWhenNoEntries(): void
+    {
+        $this->assertSame([], $this->al->recent());
+    }
+
+    // ── forActor ──────────────────────────────────────────────────────────────
+
+    public function testForActorFiltersCorrectly(): void
+    {
+        $this->al->record('a.1', 'user-1');
+        $this->al->record('a.2', 'user-2');
+        $this->assertCount(1, $this->al->forActor('user-1'));
+    }
+
+    public function testForActorReturnsEmptyForUnknownActor(): void
+    {
+        $this->assertSame([], $this->al->forActor('nobody'));
+    }
+
+    // ── forResource ───────────────────────────────────────────────────────────
+
+    public function testForResourceFiltersCorrectly(): void
+    {
+        $this->al->record('post.view', 'u', 'post', '1');
+        $this->al->record('post.view', 'u', 'post', '2');
+        $this->al->record('post.edit', 'u', 'post', '1');
+        $this->assertCount(2, $this->al->forResource('post', '1'));
+    }
+
+    public function testForResourceReturnsEmptyForUnknownResource(): void
+    {
+        $this->assertSame([], $this->al->forResource('post', '999'));
+    }
+
+    // ── forAction ─────────────────────────────────────────────────────────────
+
+    public function testForActionFiltersCorrectly(): void
+    {
+        $this->al->record('user.login', 'user-1');
+        $this->al->record('user.login', 'user-2');
+        $this->al->record('user.logout', 'user-1');
+        $this->assertCount(2, $this->al->forAction('user.login'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountAllEntries(): void
+    {
+        $this->al->record('a.1', 'u');
+        $this->al->record('a.2', 'u');
+        $this->assertSame(2, $this->al->count());
+    }
+
+    public function testCountByActor(): void
+    {
+        $this->al->record('a.1', 'user-1');
+        $this->al->record('a.2', 'user-2');
+        $this->assertSame(1, $this->al->count('user-1'));
+    }
+
+    public function testCountByAction(): void
+    {
+        $this->al->record('user.login', 'u1');
+        $this->al->record('user.login', 'u2');
+        $this->al->record('user.logout', 'u1');
+        $this->assertSame(2, $this->al->count(null, 'user.login'));
+    }
+
+    public function testCountByActorAndAction(): void
+    {
+        $this->al->record('user.login', 'user-1');
+        $this->al->record('user.login', 'user-2');
+        $this->al->record('user.logout', 'user-1');
+        $this->assertSame(1, $this->al->count('user-1', 'user.login'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldEntries(): void
+    {
+        $this->al->record('a.1', 'u');
+        $this->db->exec(
+            "UPDATE audit_log SET created_at = datetime('now', '-91 days')"
+        );
+        $this->assertSame(1, $this->al->purgeOlderThan(90));
+        $this->assertSame(0, $this->al->count());
+    }
+
+    public function testPurgeOlderThanPreservesRecentEntries(): void
+    {
+        $this->al->record('a.1', 'u');
+        $this->assertSame(0, $this->al->purgeOlderThan(90));
+    }
+}


### PR DESCRIPTION
## FT111 · AuditLog

Append-only audit trail for compliance and forensics. Records who did what to which resource, with flexible JSON context.

### Features
- Record action events with actor, resource type/ID, and JSON context
- Query by: recent (newest first), actor, resource, or action name
- Count entries with optional actor/action filters
- Purge old entries by age

### Schema
```sql
CREATE TABLE audit_log (
    id            INTEGER PRIMARY KEY AUTOINCREMENT,
    action        VARCHAR(100) NOT NULL,
    actor_id      VARCHAR(255) NOT NULL DEFAULT '',
    resource_type VARCHAR(100) NOT NULL DEFAULT '',
    resource_id   VARCHAR(255) NOT NULL DEFAULT '',
    context       TEXT         NOT NULL DEFAULT '{}',
    created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### Tests
18 tests, 24 assertions — all green ✅