### PR TITLE
feat(ft115): AccessToken — personal access token issue/verify/revoke with SHA-256 hash storage

### DIFF
--- a/class/xion/AccessToken.php
+++ b/class/xion/AccessToken.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * AccessToken — issue, verify, and revoke personal access tokens (PATs).
+ *
+ * Tokens are 32-byte random hex strings (64 chars). Only the SHA-256 hash is stored.
+ * The raw token is returned once at creation and never again. Tokens can be scoped
+ * and have optional expiry.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $at = new AccessToken($pdo);
+ *
+ * // Issue a token
+ * $token = $at->issue('user-1', 'My CI token', ['repo:read', 'deploy:push']);
+ *
+ * // Verify incoming request token
+ * $info = $at->verify($token); // null if invalid/revoked/expired
+ *
+ * // List tokens for a user (no raw tokens, just metadata)
+ * $at->listForUser('user-1');
+ *
+ * // Revoke by token
+ * $at->revoke($token);
+ *
+ * // Revoke all tokens for a user
+ * $at->revokeAll('user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE access_tokens (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     name        VARCHAR(255) NOT NULL DEFAULT '',
+ *     token_hash  VARCHAR(64)  NOT NULL UNIQUE,
+ *     scopes      TEXT         NOT NULL DEFAULT '[]',
+ *     last_used   DATETIME     DEFAULT NULL,
+ *     expires_at  DATETIME     DEFAULT NULL,
+ *     revoked_at  DATETIME     DEFAULT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class AccessToken
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Issue a new personal access token.
+     *
+     * @param  list<string>           $scopes    Optional list of permission scopes.
+     * @param  \DateTimeImmutable|null $expiresAt Optional expiry time.
+     * @return string  The raw token (64 hex chars). Store it now — it won't be shown again.
+     * @throws \InvalidArgumentException if user_id is empty.
+     */
+    public function issue(
+        string $userId,
+        string $name = '',
+        array $scopes = [],
+        ?\DateTimeImmutable $expiresAt = null
+    ): string {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+
+        $rawToken  = bin2hex(random_bytes(32));
+        $hash      = hash('sha256', $rawToken);
+        $scopeJson = json_encode(array_values($scopes), JSON_UNESCAPED_UNICODE) ?: '[]';
+        $expireStr = $expiresAt?->format('Y-m-d H:i:s');
+
+        $this->db()->prepare(
+            'INSERT INTO access_tokens (user_id, name, token_hash, scopes, expires_at)
+             VALUES (:uid, :name, :hash, :scopes, :exp)'
+        )->execute([':uid' => $userId, ':name' => $name, ':hash' => $hash, ':scopes' => $scopeJson, ':exp' => $expireStr]);
+
+        return $rawToken;
+    }
+
+    /**
+     * Verify a token and return its metadata if valid.
+     *
+     * Updates last_used on successful verification.
+     *
+     * @return array<string,mixed>|null  null if token is invalid, revoked, or expired.
+     */
+    public function verify(string $rawToken): ?array
+    {
+        $hash = hash('sha256', $rawToken);
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, name, scopes, expires_at, last_used, created_at
+             FROM access_tokens
+             WHERE token_hash = :hash
+               AND revoked_at IS NULL
+               AND (expires_at IS NULL OR expires_at > :now)
+             LIMIT 1'
+        );
+        $stmt->execute([':hash' => $hash, ':now' => $now]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        // Touch last_used
+        $this->db()->prepare(
+            'UPDATE access_tokens SET last_used = CURRENT_TIMESTAMP WHERE id = :id'
+        )->execute([':id' => $row['id']]);
+
+        $decoded = json_decode((string)($row['scopes'] ?? '[]'), true);
+        $row['scopes'] = is_array($decoded) ? $decoded : [];
+
+        return $row;
+    }
+
+    /**
+     * Check if a raw token is currently valid (non-revoked, non-expired).
+     */
+    public function isValid(string $rawToken): bool
+    {
+        $hash = hash('sha256', $rawToken);
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM access_tokens
+             WHERE token_hash = :hash AND revoked_at IS NULL
+               AND (expires_at IS NULL OR expires_at > :now)'
+        );
+        $stmt->execute([':hash' => $hash, ':now' => $now]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Revoke a specific token by its raw value.
+     *
+     * @return bool True if the token was found and revoked.
+     */
+    public function revoke(string $rawToken): bool
+    {
+        $hash = hash('sha256', $rawToken);
+        $stmt = $this->db()->prepare(
+            'UPDATE access_tokens SET revoked_at = CURRENT_TIMESTAMP
+             WHERE token_hash = :hash AND revoked_at IS NULL'
+        );
+        $stmt->execute([':hash' => $hash]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Revoke all tokens for a user.
+     *
+     * @return int Number of tokens revoked.
+     * @throws \InvalidArgumentException if user_id is empty.
+     */
+    public function revokeAll(string $userId): int
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare(
+            'UPDATE access_tokens SET revoked_at = CURRENT_TIMESTAMP
+             WHERE user_id = :uid AND revoked_at IS NULL'
+        );
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * List all tokens for a user (metadata only — no raw tokens).
+     *
+     * @return list<array<string,mixed>>
+     * @throws \InvalidArgumentException if user_id is empty.
+     */
+    public function listForUser(string $userId, bool $includeRevoked = false): array
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+
+        if ($includeRevoked) {
+            $stmt = $this->db()->prepare(
+                'SELECT id, user_id, name, scopes, last_used, expires_at, revoked_at, created_at
+                 FROM access_tokens WHERE user_id = :uid ORDER BY id DESC'
+            );
+            $stmt->execute([':uid' => $userId]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT id, user_id, name, scopes, last_used, expires_at, revoked_at, created_at
+                 FROM access_tokens WHERE user_id = :uid AND revoked_at IS NULL ORDER BY id DESC'
+            );
+            $stmt->execute([':uid' => $userId]);
+        }
+
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        foreach ($rows as &$row) {
+            $decoded = json_decode((string)($row['scopes'] ?? '[]'), true);
+            $row['scopes'] = is_array($decoded) ? $decoded : [];
+        }
+        return $rows;
+    }
+
+    /**
+     * Purge revoked and expired tokens older than N days.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $now    = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM access_tokens
+             WHERE created_at < :cutoff
+               AND (revoked_at IS NOT NULL OR (expires_at IS NOT NULL AND expires_at <= :now))'
+        );
+        $stmt->execute([':cutoff' => $cutoff, ':now' => $now]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/AccessTokenTest.php
+++ b/tests/Unit/Xion/AccessTokenTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\AccessToken;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for AccessToken.
+ */
+final class AccessTokenTest extends TestCase
+{
+    private PDO $db;
+    private AccessToken $at;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE access_tokens (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL,
+                name       VARCHAR(255) NOT NULL DEFAULT \'\',
+                token_hash VARCHAR(64)  NOT NULL UNIQUE,
+                scopes     TEXT         NOT NULL DEFAULT \'[]\',
+                last_used  DATETIME     DEFAULT NULL,
+                expires_at DATETIME     DEFAULT NULL,
+                revoked_at DATETIME     DEFAULT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->at = new AccessToken($this->db);
+    }
+
+    // ── issue ─────────────────────────────────────────────────────────────────
+
+    public function testIssueReturns64CharHexToken(): void
+    {
+        $token = $this->at->issue('user-1');
+        $this->assertSame(64, strlen($token));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $token);
+    }
+
+    public function testIssueTokensAreUnique(): void
+    {
+        $t1 = $this->at->issue('user-1');
+        $t2 = $this->at->issue('user-1');
+        $this->assertNotSame($t1, $t2);
+    }
+
+    public function testIssueThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->at->issue('');
+    }
+
+    public function testIssueStoresScopes(): void
+    {
+        $token = $this->at->issue('user-1', 'CI', ['repo:read', 'deploy']);
+        $info  = $this->at->verify($token);
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(['repo:read', 'deploy'], $info['scopes']);
+    }
+
+    // ── verify ────────────────────────────────────────────────────────────────
+
+    public function testVerifyReturnsInfoForValidToken(): void
+    {
+        $token = $this->at->issue('user-1', 'My token');
+        $info  = $this->at->verify($token);
+        $this->assertNotNull($info);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $info['user_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('My token', $info['name']);
+    }
+
+    public function testVerifyReturnsNullForInvalidToken(): void
+    {
+        $this->assertNull($this->at->verify('deadbeef' . str_repeat('0', 56)));
+    }
+
+    public function testVerifyReturnsNullForRevokedToken(): void
+    {
+        $token = $this->at->issue('user-1');
+        $this->at->revoke($token);
+        $this->assertNull($this->at->verify($token));
+    }
+
+    public function testVerifyReturnsNullForExpiredToken(): void
+    {
+        $past  = new \DateTimeImmutable('-1 second');
+        $token = $this->at->issue('user-1', '', [], $past);
+        $this->assertNull($this->at->verify($token));
+    }
+
+    public function testVerifyUpdatesLastUsed(): void
+    {
+        $token = $this->at->issue('user-1');
+        $this->at->verify($token);
+        $list = $this->at->listForUser('user-1');
+        $this->assertNotNull($list[0]['last_used']);
+    }
+
+    // ── isValid ───────────────────────────────────────────────────────────────
+
+    public function testIsValidTrueForActiveToken(): void
+    {
+        $token = $this->at->issue('user-1');
+        $this->assertTrue($this->at->isValid($token));
+    }
+
+    public function testIsValidFalseAfterRevoke(): void
+    {
+        $token = $this->at->issue('user-1');
+        $this->at->revoke($token);
+        $this->assertFalse($this->at->isValid($token));
+    }
+
+    // ── revoke ────────────────────────────────────────────────────────────────
+
+    public function testRevokeReturnsTrueWhenRevoked(): void
+    {
+        $token = $this->at->issue('user-1');
+        $this->assertTrue($this->at->revoke($token));
+    }
+
+    public function testRevokeReturnsFalseIfAlreadyRevoked(): void
+    {
+        $token = $this->at->issue('user-1');
+        $this->at->revoke($token);
+        $this->assertFalse($this->at->revoke($token));
+    }
+
+    public function testRevokeReturnsFalseForUnknownToken(): void
+    {
+        $this->assertFalse($this->at->revoke(str_repeat('0', 64)));
+    }
+
+    // ── revokeAll ─────────────────────────────────────────────────────────────
+
+    public function testRevokeAllRevokesAllUserTokens(): void
+    {
+        $this->at->issue('user-1');
+        $this->at->issue('user-1');
+        $this->assertSame(2, $this->at->revokeAll('user-1'));
+        $this->assertSame([], $this->at->listForUser('user-1'));
+    }
+
+    public function testRevokeAllDoesNotAffectOtherUsers(): void
+    {
+        $this->at->issue('user-1');
+        $this->at->issue('user-2');
+        $this->at->revokeAll('user-1');
+        $this->assertCount(1, $this->at->listForUser('user-2'));
+    }
+
+    public function testRevokeAllThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->at->revokeAll('');
+    }
+
+    // ── listForUser ───────────────────────────────────────────────────────────
+
+    public function testListForUserReturnsActiveTokens(): void
+    {
+        $this->at->issue('user-1', 'Token A');
+        $this->at->issue('user-1', 'Token B');
+        $this->assertCount(2, $this->at->listForUser('user-1'));
+    }
+
+    public function testListForUserExcludesRevokedByDefault(): void
+    {
+        $token = $this->at->issue('user-1', 'Token A');
+        $this->at->issue('user-1', 'Token B');
+        $this->at->revoke($token);
+        $this->assertCount(1, $this->at->listForUser('user-1'));
+    }
+
+    public function testListForUserIncludesRevokedWhenRequested(): void
+    {
+        $token = $this->at->issue('user-1', 'Token A');
+        $this->at->revoke($token);
+        $this->assertCount(1, $this->at->listForUser('user-1', includeRevoked: true));
+    }
+
+    public function testListForUserThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->at->listForUser('');
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesRevokedOldTokens(): void
+    {
+        $token = $this->at->issue('user-1');
+        $this->at->revoke($token);
+        $this->db->exec("UPDATE access_tokens SET created_at = datetime('now', '-8 days')");
+        $this->assertSame(1, $this->at->purgeOlderThan(7));
+    }
+
+    public function testPurgeOlderThanPreservesActiveTokens(): void
+    {
+        $this->at->issue('user-1');
+        $this->db->exec("UPDATE access_tokens SET created_at = datetime('now', '-8 days')");
+        $this->assertSame(0, $this->at->purgeOlderThan(7)); // active token, not purged
+    }
+}


### PR DESCRIPTION
## FT115 · AccessToken

Issue, verify, and revoke personal access tokens (PATs) with secure SHA-256 hash storage.

### Security design
- Raw token (64-char hex) returned **once** at issue time, never stored
- Only SHA-256 hash stored in DB — breach cannot expose raw tokens
- Optional scopes (JSON array) and expiry

### Features
- Issue token for user with name, scopes, and optional expiry
- Verify token (null = invalid/revoked/expired); updates `last_used` on success
- Revoke single token or all tokens for a user
- List tokens with metadata (no raw tokens, optional include revoked)
- Purge old revoked/expired tokens

### Schema
```sql
CREATE TABLE access_tokens (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id    VARCHAR(255) NOT NULL,
    name       VARCHAR(255) NOT NULL DEFAULT '',
    token_hash VARCHAR(64)  NOT NULL UNIQUE,
    scopes     TEXT         NOT NULL DEFAULT '[]',
    last_used  DATETIME     DEFAULT NULL,
    expires_at DATETIME     DEFAULT NULL,
    revoked_at DATETIME     DEFAULT NULL,
    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### Tests
23 tests, 28 assertions — all green ✅