### PR TITLE
feat(ft116): DraftManager — versioned draft persistence with history and prune

### DIFF
--- a/class/xion/DraftManager.php
+++ b/class/xion/DraftManager.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * DraftManager — versioned draft persistence for any content type.
+ *
+ * Users save drafts while composing content; each save creates a new version.
+ * The latest version is the "current" draft. Supports restore to any past version.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $dm = new DraftManager($pdo);
+ *
+ * // Save a draft (auto-increments version)
+ * $dm->save('post', 'user-1', 'Draft title', ['body' => 'Hello world']);
+ *
+ * // Get latest draft
+ * $dm->latest('post', 'user-1');
+ *
+ * // Get specific version
+ * $dm->version('post', 'user-1', 2);
+ *
+ * // List all versions
+ * $dm->history('post', 'user-1');
+ *
+ * // Discard all drafts
+ * $dm->discard('post', 'user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE drafts (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     draft_type   VARCHAR(100) NOT NULL,
+ *     user_id      VARCHAR(255) NOT NULL,
+ *     version      INTEGER      NOT NULL DEFAULT 1,
+ *     title        VARCHAR(500) NOT NULL DEFAULT '',
+ *     content      TEXT         NOT NULL DEFAULT '{}',
+ *     saved_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class DraftManager
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Save a new draft version.
+     *
+     * Each call increments the version number for this (draft_type, user_id) pair.
+     *
+     * @param  array<string,mixed> $content  Arbitrary content payload (stored as JSON).
+     * @return int  The new version number.
+     * @throws \InvalidArgumentException if draft_type or user_id is empty.
+     */
+    public function save(
+        string $draftType,
+        string $userId,
+        string $title = '',
+        array $content = []
+    ): int {
+        [$draftType, $userId] = $this->normalise($draftType, $userId);
+
+        $currentVersion = $this->currentVersion($draftType, $userId);
+        $newVersion     = $currentVersion + 1;
+        $contentJson    = json_encode($content, JSON_UNESCAPED_UNICODE) ?: '{}';
+
+        $this->db()->prepare(
+            'INSERT INTO drafts (draft_type, user_id, version, title, content)
+             VALUES (:type, :uid, :ver, :title, :content)'
+        )->execute([
+            ':type'    => $draftType,
+            ':uid'     => $userId,
+            ':ver'     => $newVersion,
+            ':title'   => $title,
+            ':content' => $contentJson,
+        ]);
+
+        return $newVersion;
+    }
+
+    /**
+     * Get the latest draft for a user.
+     *
+     * @return array<string,mixed>|null  null if no drafts exist.
+     */
+    public function latest(string $draftType, string $userId): ?array
+    {
+        [$draftType, $userId] = $this->normalise($draftType, $userId);
+        $stmt = $this->db()->prepare(
+            'SELECT id, draft_type, user_id, version, title, content, saved_at
+             FROM drafts WHERE draft_type = :type AND user_id = :uid
+             ORDER BY version DESC LIMIT 1'
+        );
+        $stmt->execute([':type' => $draftType, ':uid' => $userId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $this->decode($row) : null;
+    }
+
+    /**
+     * Get a specific version of a draft.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function version(string $draftType, string $userId, int $version): ?array
+    {
+        [$draftType, $userId] = $this->normalise($draftType, $userId);
+        $stmt = $this->db()->prepare(
+            'SELECT id, draft_type, user_id, version, title, content, saved_at
+             FROM drafts WHERE draft_type = :type AND user_id = :uid AND version = :ver LIMIT 1'
+        );
+        $stmt->execute([':type' => $draftType, ':uid' => $userId, ':ver' => $version]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $this->decode($row) : null;
+    }
+
+    /**
+     * List all saved versions for a user's draft (newest first).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function history(string $draftType, string $userId): array
+    {
+        [$draftType, $userId] = $this->normalise($draftType, $userId);
+        $stmt = $this->db()->prepare(
+            'SELECT id, draft_type, user_id, version, title, content, saved_at
+             FROM drafts WHERE draft_type = :type AND user_id = :uid
+             ORDER BY version DESC'
+        );
+        $stmt->execute([':type' => $draftType, ':uid' => $userId]);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        return array_map(fn (array $r) => $this->decode($r), $rows);
+    }
+
+    /**
+     * Check whether a user has any draft of this type.
+     */
+    public function hasDraft(string $draftType, string $userId): bool
+    {
+        [$draftType, $userId] = $this->normalise($draftType, $userId);
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM drafts WHERE draft_type = :type AND user_id = :uid'
+        );
+        $stmt->execute([':type' => $draftType, ':uid' => $userId]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Count the number of saved versions for a draft.
+     */
+    public function versionCount(string $draftType, string $userId): int
+    {
+        [$draftType, $userId] = $this->normalise($draftType, $userId);
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM drafts WHERE draft_type = :type AND user_id = :uid'
+        );
+        $stmt->execute([':type' => $draftType, ':uid' => $userId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Discard all draft versions for a user.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function discard(string $draftType, string $userId): int
+    {
+        [$draftType, $userId] = $this->normalise($draftType, $userId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM drafts WHERE draft_type = :type AND user_id = :uid'
+        );
+        $stmt->execute([':type' => $draftType, ':uid' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Prune old versions, keeping only the N most recent.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function pruneHistory(string $draftType, string $userId, int $keepVersions = 5): int
+    {
+        [$draftType, $userId] = $this->normalise($draftType, $userId);
+        $keepVersions = max(1, $keepVersions);
+
+        // Find the minimum version to keep
+        $stmt = $this->db()->prepare(
+            "SELECT version FROM drafts WHERE draft_type = :type AND user_id = :uid
+             ORDER BY version DESC LIMIT 1 OFFSET {$keepVersions}"
+        );
+        $stmt->execute([':type' => $draftType, ':uid' => $userId]);
+        $cutoffVersion = $stmt->fetchColumn();
+
+        if ($cutoffVersion === false) {
+            return 0; // Fewer than keepVersions versions exist
+        }
+
+        $del = $this->db()->prepare(
+            'DELETE FROM drafts WHERE draft_type = :type AND user_id = :uid AND version <= :cutoff'
+        );
+        $del->execute([':type' => $draftType, ':uid' => $userId, ':cutoff' => (int)$cutoffVersion]);
+        return $del->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function currentVersion(string $draftType, string $userId): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COALESCE(MAX(version), 0) FROM drafts WHERE draft_type = :type AND user_id = :uid'
+        );
+        $stmt->execute([':type' => $draftType, ':uid' => $userId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * @param  array<string,mixed> $row
+     * @return array<string,mixed>
+     */
+    private function decode(array $row): array
+    {
+        $decoded = json_decode((string)($row['content'] ?? '{}'), true);
+        $row['content'] = is_array($decoded) ? $decoded : [];
+        return $row;
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function normalise(string $draftType, string $userId): array
+    {
+        $draftType = trim($draftType);
+        $userId    = trim($userId);
+        if ($draftType === '') {
+            throw new \InvalidArgumentException('draft_type must not be empty.');
+        }
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        return [$draftType, $userId];
+    }
+}

--- a/tests/Unit/Xion/DraftManagerTest.php
+++ b/tests/Unit/Xion/DraftManagerTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\DraftManager;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for DraftManager.
+ */
+final class DraftManagerTest extends TestCase
+{
+    private PDO $db;
+    private DraftManager $dm;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE drafts (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                draft_type VARCHAR(100) NOT NULL,
+                user_id    VARCHAR(255) NOT NULL,
+                version    INTEGER      NOT NULL DEFAULT 1,
+                title      VARCHAR(500) NOT NULL DEFAULT \'\',
+                content    TEXT         NOT NULL DEFAULT \'{}\',
+                saved_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->dm = new DraftManager($this->db);
+    }
+
+    // ── save ──────────────────────────────────────────────────────────────────
+
+    public function testSaveReturnsVersion1OnFirstSave(): void
+    {
+        $v = $this->dm->save('post', 'user-1', 'Draft 1', ['body' => 'Hello']);
+        $this->assertSame(1, $v);
+    }
+
+    public function testSaveIncrementsVersion(): void
+    {
+        $this->dm->save('post', 'user-1', 'v1');
+        $v2 = $this->dm->save('post', 'user-1', 'v2');
+        $this->assertSame(2, $v2);
+    }
+
+    public function testSaveStoresContent(): void
+    {
+        $this->dm->save('post', 'user-1', 'Title', ['body' => 'World']);
+        $draft = $this->dm->latest('post', 'user-1');
+        $this->assertNotNull($draft);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(['body' => 'World'], $draft['content']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Title', $draft['title']);
+    }
+
+    public function testSaveThrowsOnEmptyDraftType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->dm->save('', 'user-1');
+    }
+
+    public function testSaveThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->dm->save('post', '');
+    }
+
+    // ── latest ────────────────────────────────────────────────────────────────
+
+    public function testLatestReturnsNewestVersion(): void
+    {
+        $this->dm->save('post', 'user-1', 'v1');
+        $this->dm->save('post', 'user-1', 'v2');
+        $draft = $this->dm->latest('post', 'user-1');
+        $this->assertNotNull($draft);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(2, (int)$draft['version']);
+    }
+
+    public function testLatestReturnsNullWhenNoDrafts(): void
+    {
+        $this->assertNull($this->dm->latest('post', 'user-1'));
+    }
+
+    public function testLatestIsUserScoped(): void
+    {
+        $this->dm->save('post', 'user-1', 'v1');
+        $this->assertNull($this->dm->latest('post', 'user-2'));
+    }
+
+    // ── version ───────────────────────────────────────────────────────────────
+
+    public function testVersionReturnsSpecificVersion(): void
+    {
+        $this->dm->save('post', 'user-1', 'v1-title');
+        $this->dm->save('post', 'user-1', 'v2-title');
+        $row = $this->dm->version('post', 'user-1', 1);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('v1-title', $row['title']);
+    }
+
+    public function testVersionReturnsNullForNonExistentVersion(): void
+    {
+        $this->assertNull($this->dm->version('post', 'user-1', 99));
+    }
+
+    // ── history ───────────────────────────────────────────────────────────────
+
+    public function testHistoryReturnsAllVersionsNewestFirst(): void
+    {
+        $this->dm->save('post', 'user-1', 'v1');
+        $this->dm->save('post', 'user-1', 'v2');
+        $this->dm->save('post', 'user-1', 'v3');
+        $history = $this->dm->history('post', 'user-1');
+        $this->assertCount(3, $history);
+        $this->assertSame(3, (int)$history[0]['version']);
+        $this->assertSame(1, (int)$history[2]['version']);
+    }
+
+    public function testHistoryReturnsEmptyWhenNoDrafts(): void
+    {
+        $this->assertSame([], $this->dm->history('post', 'user-1'));
+    }
+
+    // ── hasDraft ──────────────────────────────────────────────────────────────
+
+    public function testHasDraftTrueAfterSave(): void
+    {
+        $this->dm->save('post', 'user-1');
+        $this->assertTrue($this->dm->hasDraft('post', 'user-1'));
+    }
+
+    public function testHasDraftFalseBeforeSave(): void
+    {
+        $this->assertFalse($this->dm->hasDraft('post', 'user-1'));
+    }
+
+    // ── versionCount ──────────────────────────────────────────────────────────
+
+    public function testVersionCountReturnsCorrectCount(): void
+    {
+        $this->dm->save('post', 'user-1');
+        $this->dm->save('post', 'user-1');
+        $this->assertSame(2, $this->dm->versionCount('post', 'user-1'));
+    }
+
+    // ── discard ───────────────────────────────────────────────────────────────
+
+    public function testDiscardRemovesAllVersions(): void
+    {
+        $this->dm->save('post', 'user-1');
+        $this->dm->save('post', 'user-1');
+        $this->assertSame(2, $this->dm->discard('post', 'user-1'));
+        $this->assertFalse($this->dm->hasDraft('post', 'user-1'));
+    }
+
+    public function testDiscardDoesNotAffectOtherUsers(): void
+    {
+        $this->dm->save('post', 'user-1');
+        $this->dm->save('post', 'user-2');
+        $this->dm->discard('post', 'user-1');
+        $this->assertTrue($this->dm->hasDraft('post', 'user-2'));
+    }
+
+    // ── pruneHistory ──────────────────────────────────────────────────────────
+
+    public function testPruneHistoryKeepsNewestVersions(): void
+    {
+        $this->dm->save('post', 'user-1');
+        $this->dm->save('post', 'user-1');
+        $this->dm->save('post', 'user-1');
+        $this->dm->save('post', 'user-1');
+        $this->dm->save('post', 'user-1');
+        $deleted = $this->dm->pruneHistory('post', 'user-1', 3);
+        $this->assertSame(2, $deleted);
+        $this->assertSame(3, $this->dm->versionCount('post', 'user-1'));
+        // Newest 3 remain: versions 3, 4, 5
+        $latest = $this->dm->latest('post', 'user-1');
+        $this->assertNotNull($latest);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(5, (int)$latest['version']);
+    }
+
+    public function testPruneHistoryReturnsZeroWhenNotEnoughVersions(): void
+    {
+        $this->dm->save('post', 'user-1');
+        $this->dm->save('post', 'user-1');
+        $this->assertSame(0, $this->dm->pruneHistory('post', 'user-1', 5));
+    }
+}


### PR DESCRIPTION
## FT116 · DraftManager

Versioned draft persistence for any content type. Each save creates a new version; users can view history and prune old versions.

### Features
- Save new version (auto-increments version number)
- Get latest draft or specific version
- List full version history (newest first)
- Check presence, count versions
- Discard all drafts for a user
- Prune old versions, keeping N most recent

### Schema
```sql
CREATE TABLE drafts (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    draft_type VARCHAR(100) NOT NULL,
    user_id    VARCHAR(255) NOT NULL,
    version    INTEGER      NOT NULL DEFAULT 1,
    title      VARCHAR(500) NOT NULL DEFAULT '',
    content    TEXT         NOT NULL DEFAULT '{}',
    saved_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### Tests
19 tests, 29 assertions — all green ✅