### PR TITLE
feat(xion): FeatureFlag — DB-backed feature flags with per-user overrides (FT124)

### DIFF
--- a/class/xion/FeatureFlag.php
+++ b/class/xion/FeatureFlag.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * FeatureFlag — DB-backed feature flags with global on/off and per-user overrides.
+ *
+ * Flags are globally enabled or disabled, with per-user overrides that take precedence.
+ * Useful for gradual rollouts, A/B testing, and beta access control.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ff = new FeatureFlag($pdo);
+ *
+ * // Enable/disable globally
+ * $ff->enable('dark-mode');
+ * $ff->disable('beta-editor');
+ *
+ * // Per-user override
+ * $ff->enableForUser('beta-editor', 'user-1');
+ * $ff->disableForUser('dark-mode', 'user-2');
+ *
+ * // Check
+ * $ff->isEnabled('dark-mode');               // global check
+ * $ff->isEnabledForUser('dark-mode', 'user-1'); // user-aware check
+ *
+ * // List all flags
+ * $ff->all();
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE feature_flags (
+ *     flag_name  VARCHAR(255) NOT NULL PRIMARY KEY,
+ *     enabled    TINYINT(1)   NOT NULL DEFAULT 0,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE feature_flag_overrides (
+ *     flag_name VARCHAR(255) NOT NULL,
+ *     user_id   VARCHAR(255) NOT NULL,
+ *     enabled   TINYINT(1)   NOT NULL DEFAULT 1,
+ *     PRIMARY KEY (flag_name, user_id)
+ * );
+ * ```
+ */
+final class FeatureFlag
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Enable a feature flag globally.
+     *
+     * Creates the flag if it doesn't exist.
+     *
+     * @throws \InvalidArgumentException if flag_name is empty.
+     */
+    public function enable(string $flagName): void
+    {
+        $this->setGlobal($flagName, true);
+    }
+
+    /**
+     * Disable a feature flag globally.
+     *
+     * Creates the flag if it doesn't exist.
+     *
+     * @throws \InvalidArgumentException if flag_name is empty.
+     */
+    public function disable(string $flagName): void
+    {
+        $this->setGlobal($flagName, false);
+    }
+
+    /**
+     * Check whether a flag is globally enabled (ignores user overrides).
+     *
+     * Returns false if the flag has never been created.
+     */
+    public function isEnabled(string $flagName): bool
+    {
+        $flagName = $this->validateFlag($flagName);
+        $stmt     = $this->db()->prepare(
+            'SELECT enabled FROM feature_flags WHERE flag_name = :name LIMIT 1'
+        );
+        $stmt->execute([':name' => $flagName]);
+        $val = $stmt->fetchColumn();
+        return $val !== false && (int)$val === 1;
+    }
+
+    /**
+     * Check whether a flag is enabled for a specific user.
+     *
+     * Resolution order:
+     * 1. Per-user override (if set) → use it
+     * 2. Global flag value
+     *
+     * @throws \InvalidArgumentException if flag_name or user_id is empty.
+     */
+    public function isEnabledForUser(string $flagName, string $userId): bool
+    {
+        $flagName = $this->validateFlag($flagName);
+        $userId   = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'SELECT enabled FROM feature_flag_overrides
+             WHERE flag_name = :name AND user_id = :uid LIMIT 1'
+        );
+        $stmt->execute([':name' => $flagName, ':uid' => $userId]);
+        $override = $stmt->fetchColumn();
+
+        if ($override !== false) {
+            return (int)$override === 1;
+        }
+
+        return $this->isEnabled($flagName);
+    }
+
+    /**
+     * Set a per-user override to enabled.
+     */
+    public function enableForUser(string $flagName, string $userId): void
+    {
+        $this->setOverride($flagName, $userId, true);
+    }
+
+    /**
+     * Set a per-user override to disabled.
+     */
+    public function disableForUser(string $flagName, string $userId): void
+    {
+        $this->setOverride($flagName, $userId, false);
+    }
+
+    /**
+     * Remove the per-user override (fall back to global setting).
+     *
+     * @return bool True if an override existed and was removed.
+     */
+    public function removeOverride(string $flagName, string $userId): bool
+    {
+        $flagName = $this->validateFlag($flagName);
+        $userId   = trim($userId);
+        $stmt     = $this->db()->prepare(
+            'DELETE FROM feature_flag_overrides WHERE flag_name = :name AND user_id = :uid'
+        );
+        $stmt->execute([':name' => $flagName, ':uid' => $userId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List all feature flags with their global status.
+     *
+     * @return list<array{flag_name: string, enabled: bool}>
+     */
+    public function all(): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT flag_name, enabled FROM feature_flags ORDER BY flag_name ASC'
+        );
+        $stmt->execute();
+        return array_map(
+            static fn (array $r) => ['flag_name' => (string)$r['flag_name'], 'enabled' => (int)$r['enabled'] === 1],
+            $stmt->fetchAll(PDO::FETCH_ASSOC) ?: []
+        );
+    }
+
+    /**
+     * Delete a flag and all its overrides.
+     *
+     * @return bool True if the flag existed.
+     */
+    public function delete(string $flagName): bool
+    {
+        $flagName = $this->validateFlag($flagName);
+        $db       = $this->db();
+        $db->prepare('DELETE FROM feature_flag_overrides WHERE flag_name = :name')->execute([':name' => $flagName]);
+        $stmt = $db->prepare('DELETE FROM feature_flags WHERE flag_name = :name');
+        $stmt->execute([':name' => $flagName]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Count how many users have an explicit override for a flag.
+     */
+    public function overrideCount(string $flagName): int
+    {
+        $flagName = $this->validateFlag($flagName);
+        $stmt     = $this->db()->prepare(
+            'SELECT COUNT(*) FROM feature_flag_overrides WHERE flag_name = :name'
+        );
+        $stmt->execute([':name' => $flagName]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateFlag(string $flagName): string
+    {
+        $flagName = trim($flagName);
+        if ($flagName === '') {
+            throw new \InvalidArgumentException('flag_name must not be empty.');
+        }
+        return $flagName;
+    }
+
+    private function setGlobal(string $flagName, bool $enabled): void
+    {
+        $flagName = $this->validateFlag($flagName);
+        $db       = $this->db();
+        $driver   = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO feature_flags (flag_name, enabled)
+                 VALUES (:name, :enabled)
+                 ON CONFLICT (flag_name)
+                 DO UPDATE SET enabled = excluded.enabled, updated_at = CURRENT_TIMESTAMP'
+            )->execute([':name' => $flagName, ':enabled' => $enabled ? 1 : 0]);
+        } else {
+            $db->prepare(
+                'INSERT INTO feature_flags (flag_name, enabled)
+                 VALUES (:name, :enabled)
+                 ON DUPLICATE KEY UPDATE enabled = VALUES(enabled), updated_at = CURRENT_TIMESTAMP'
+            )->execute([':name' => $flagName, ':enabled' => $enabled ? 1 : 0]);
+        }
+    }
+
+    private function setOverride(string $flagName, string $userId, bool $enabled): void
+    {
+        $flagName = $this->validateFlag($flagName);
+        $userId   = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+
+        $db     = $this->db();
+        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO feature_flag_overrides (flag_name, user_id, enabled)
+                 VALUES (:name, :uid, :enabled)
+                 ON CONFLICT (flag_name, user_id)
+                 DO UPDATE SET enabled = excluded.enabled'
+            )->execute([':name' => $flagName, ':uid' => $userId, ':enabled' => $enabled ? 1 : 0]);
+        } else {
+            $db->prepare(
+                'INSERT INTO feature_flag_overrides (flag_name, user_id, enabled)
+                 VALUES (:name, :uid, :enabled)
+                 ON DUPLICATE KEY UPDATE enabled = VALUES(enabled)'
+            )->execute([':name' => $flagName, ':uid' => $userId, ':enabled' => $enabled ? 1 : 0]);
+        }
+    }
+}

--- a/tests/Unit/Xion/FeatureFlagTest.php
+++ b/tests/Unit/Xion/FeatureFlagTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\FeatureFlag;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for FeatureFlag.
+ */
+final class FeatureFlagTest extends TestCase
+{
+    private PDO $db;
+    private FeatureFlag $ff;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE feature_flags (
+                flag_name  VARCHAR(255) NOT NULL PRIMARY KEY,
+                enabled    TINYINT(1)   NOT NULL DEFAULT 0,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->db->exec('
+            CREATE TABLE feature_flag_overrides (
+                flag_name VARCHAR(255) NOT NULL,
+                user_id   VARCHAR(255) NOT NULL,
+                enabled   TINYINT(1)   NOT NULL DEFAULT 1,
+                PRIMARY KEY (flag_name, user_id)
+            )
+        ');
+        $this->ff = new FeatureFlag($this->db);
+    }
+
+    // ── isEnabled (global) ────────────────────────────────────────────────────
+
+    public function testIsEnabledReturnsFalseForUnknownFlag(): void
+    {
+        $this->assertFalse($this->ff->isEnabled('unknown-flag'));
+    }
+
+    public function testEnableSetsGlobalToTrue(): void
+    {
+        $this->ff->enable('dark-mode');
+        $this->assertTrue($this->ff->isEnabled('dark-mode'));
+    }
+
+    public function testDisableSetsGlobalToFalse(): void
+    {
+        $this->ff->enable('dark-mode');
+        $this->ff->disable('dark-mode');
+        $this->assertFalse($this->ff->isEnabled('dark-mode'));
+    }
+
+    public function testEnableIsUpsert(): void
+    {
+        $this->ff->enable('dark-mode');
+        $this->ff->enable('dark-mode'); // second call should not throw
+        $this->assertTrue($this->ff->isEnabled('dark-mode'));
+    }
+
+    public function testDisableCreatesFlag(): void
+    {
+        $this->ff->disable('new-flag');
+        $this->assertFalse($this->ff->isEnabled('new-flag'));
+    }
+
+    // ── isEnabledForUser — fallback to global ─────────────────────────────────
+
+    public function testIsEnabledForUserFallsBackToGlobal(): void
+    {
+        $this->ff->enable('dark-mode');
+        $this->assertTrue($this->ff->isEnabledForUser('dark-mode', 'user-1'));
+    }
+
+    public function testIsEnabledForUserReturnsFalseWhenGlobalDisabled(): void
+    {
+        $this->ff->disable('dark-mode');
+        $this->assertFalse($this->ff->isEnabledForUser('dark-mode', 'user-1'));
+    }
+
+    public function testIsEnabledForUserReturnsFalseForUnknownFlag(): void
+    {
+        $this->assertFalse($this->ff->isEnabledForUser('unknown', 'user-1'));
+    }
+
+    // ── enableForUser / disableForUser ────────────────────────────────────────
+
+    public function testEnableForUserOverridesGlobalDisabled(): void
+    {
+        $this->ff->disable('beta');
+        $this->ff->enableForUser('beta', 'user-1');
+        $this->assertTrue($this->ff->isEnabledForUser('beta', 'user-1'));
+    }
+
+    public function testDisableForUserOverridesGlobalEnabled(): void
+    {
+        $this->ff->enable('beta');
+        $this->ff->disableForUser('beta', 'user-1');
+        $this->assertFalse($this->ff->isEnabledForUser('beta', 'user-1'));
+    }
+
+    public function testOverrideDoesNotAffectOtherUsers(): void
+    {
+        $this->ff->enable('beta');
+        $this->ff->disableForUser('beta', 'user-1');
+        $this->assertTrue($this->ff->isEnabledForUser('beta', 'user-2'));
+    }
+
+    public function testOverrideIsUpsert(): void
+    {
+        $this->ff->enableForUser('beta', 'user-1');
+        $this->ff->disableForUser('beta', 'user-1'); // update in place
+        $this->assertFalse($this->ff->isEnabledForUser('beta', 'user-1'));
+    }
+
+    // ── removeOverride ────────────────────────────────────────────────────────
+
+    public function testRemoveOverrideFallsBackToGlobal(): void
+    {
+        $this->ff->enable('beta');
+        $this->ff->disableForUser('beta', 'user-1');
+        $this->ff->removeOverride('beta', 'user-1');
+        $this->assertTrue($this->ff->isEnabledForUser('beta', 'user-1'));
+    }
+
+    public function testRemoveOverrideReturnsTrueIfRemoved(): void
+    {
+        $this->ff->enableForUser('beta', 'user-1');
+        $this->assertTrue($this->ff->removeOverride('beta', 'user-1'));
+    }
+
+    public function testRemoveOverrideReturnsFalseIfNotPresent(): void
+    {
+        $this->assertFalse($this->ff->removeOverride('beta', 'user-999'));
+    }
+
+    // ── all ───────────────────────────────────────────────────────────────────
+
+    public function testAllReturnsAllFlags(): void
+    {
+        $this->ff->enable('alpha');
+        $this->ff->disable('beta');
+        $all = $this->ff->all();
+        $this->assertCount(2, $all);
+    }
+
+    public function testAllReturnsCorrectShape(): void
+    {
+        $this->ff->enable('dark-mode');
+        $all = $this->ff->all();
+        $this->assertArrayHasKey('flag_name', $all[0]);
+        $this->assertArrayHasKey('enabled', $all[0]);
+        $this->assertSame('dark-mode', $all[0]['flag_name']);
+        $this->assertTrue($all[0]['enabled']);
+    }
+
+    public function testAllReturnsEmptyWhenNoFlags(): void
+    {
+        $this->assertSame([], $this->ff->all());
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesFlag(): void
+    {
+        $this->ff->enable('to-delete');
+        $this->assertTrue($this->ff->delete('to-delete'));
+        $this->assertFalse($this->ff->isEnabled('to-delete'));
+    }
+
+    public function testDeleteRemovesOverrides(): void
+    {
+        $this->ff->enable('to-delete');
+        $this->ff->enableForUser('to-delete', 'user-1');
+        $this->ff->delete('to-delete');
+        $this->assertSame(0, $this->ff->overrideCount('to-delete'));
+    }
+
+    public function testDeleteReturnsFalseIfNotFound(): void
+    {
+        $this->assertFalse($this->ff->delete('nonexistent'));
+    }
+
+    // ── overrideCount ─────────────────────────────────────────────────────────
+
+    public function testOverrideCountReturnsZeroInitially(): void
+    {
+        $this->assertSame(0, $this->ff->overrideCount('beta'));
+    }
+
+    public function testOverrideCountIncrementsOnOverride(): void
+    {
+        $this->ff->enableForUser('beta', 'user-1');
+        $this->ff->enableForUser('beta', 'user-2');
+        $this->assertSame(2, $this->ff->overrideCount('beta'));
+    }
+
+    // ── validation ────────────────────────────────────────────────────────────
+
+    public function testEnableThrowsOnEmptyFlagName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ff->enable('');
+    }
+
+    public function testDisableThrowsOnEmptyFlagName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ff->disable('');
+    }
+
+    public function testIsEnabledForUserThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ff->isEnabledForUser('beta', '');
+    }
+
+    public function testEnableForUserThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ff->enableForUser('beta', '');
+    }
+}


### PR DESCRIPTION
## FeatureFlag

DB-backed feature flags with global on/off and per-user overrides.

### Schema
```sql
CREATE TABLE feature_flags (
    flag_name  VARCHAR(255) NOT NULL PRIMARY KEY,
    enabled    TINYINT(1)   NOT NULL DEFAULT 0,
    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);

CREATE TABLE feature_flag_overrides (
    flag_name VARCHAR(255) NOT NULL,
    user_id   VARCHAR(255) NOT NULL,
    enabled   TINYINT(1)   NOT NULL DEFAULT 1,
    PRIMARY KEY (flag_name, user_id)
);
```

### API
- `enable/disable(flagName)` — global toggle (upsert)
- `isEnabled(flagName)` — global check, false for unknown
- `isEnabledForUser(flagName, userId)` — override → global resolution
- `enableForUser/disableForUser(flagName, userId)` — per-user override
- `removeOverride(flagName, userId)` — removes override, falls back to global
- `all()` — list all flags with global status
- `delete(flagName)` — removes flag + all overrides
- `overrideCount(flagName)` — count users with explicit overrides

### Tests
27 tests, 31 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)