### PR TITLE
feat(xion): JobQueue — DB-backed background job queue with retry (FT125)

### DIFF
--- a/class/xion/JobQueue.php
+++ b/class/xion/JobQueue.php
@@ -7,257 +7,310 @@ namespace Nene\Xion;
 use PDO;
 
 /**
- * Simple DB-backed job queue for lightweight background task processing.
+ * JobQueue — simple DB-backed background job queue.
  *
- * Jobs are stored as serialized payloads with status tracking.
- * A worker calls `dequeue()` to claim the next available job (atomic),
- * then processes it, then calls `complete()` or `fail()`.
- * Failed jobs can be retried up to a configurable limit.
+ * Jobs are enqueued with a type, JSON payload, and optional delay.
+ * Workers claim a single job atomically, process it, then mark it done or failed.
+ * Failed jobs are retried up to a configurable maximum; after that they are
+ * moved to a permanent `failed` status.
  *
- * ## Schema
- *
- * ```sql
- * CREATE TABLE job_queue (
- *     id           INTEGER      PRIMARY KEY AUTOINCREMENT,
- *     queue        VARCHAR(64)  NOT NULL DEFAULT 'default',
- *     payload      TEXT         NOT NULL,
- *     status       VARCHAR(16)  NOT NULL DEFAULT 'pending',
- *     attempts     INTEGER      NOT NULL DEFAULT 0,
- *     max_attempts INTEGER      NOT NULL DEFAULT 3,
- *     error        TEXT         DEFAULT NULL,
- *     available_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
- *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
- *     updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
- * );
- * CREATE INDEX idx_job_queue_dequeue ON job_queue (queue, status, available_at);
- * ```
- *
- * ## Status values
- *
- * - `pending`    — waiting to be picked up.
- * - `processing` — claimed by a worker; being executed.
- * - `completed`  — finished successfully.
- * - `failed`     — all attempts exhausted.
+ * Status lifecycle: `pending` → `running` → `done` | `failed`
  *
  * ## Usage
  *
  * ```php
- * $q = new JobQueue($pdo);
+ * $jq = new JobQueue($pdo);
  *
- * // Enqueue
- * $id = $q->enqueue(['type' => 'send_email', 'to' => 'user@example.com']);
+ * // Enqueue a job
+ * $id = $jq->enqueue('send_email', ['to' => 'user@example.com']);
  *
- * // Worker loop
- * while ($job = $q->dequeue()) {
- *     try {
- *         $payload = $job['payload']; // decoded array
- *         // ... process ...
- *         $q->complete($job['id']);
- *     } catch (\Throwable $e) {
- *         $q->fail($job['id'], $e->getMessage());
- *     }
+ * // Claim next available job
+ * $job = $jq->claim();
+ *
+ * if ($job !== null) {
+ *     // ... process ...
+ *     $jq->complete($job['id']);
+ *     // or on failure:
+ *     $jq->fail($job['id'], 'SMTP timeout');
  * }
+ *
+ * // Inspect queue
+ * $jq->count('pending');
+ * $jq->listPending(10);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE job_queue (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     type         VARCHAR(100) NOT NULL,
+ *     payload      TEXT         NOT NULL DEFAULT '{}',
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     attempts     INT          NOT NULL DEFAULT 0,
+ *     max_attempts INT          NOT NULL DEFAULT 3,
+ *     error        TEXT         NOT NULL DEFAULT '',
+ *     run_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     claimed_at   DATETIME     DEFAULT NULL,
+ *     done_at      DATETIME     DEFAULT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
  * ```
  */
 final class JobQueue
 {
-    private const TABLE           = 'job_queue';
-    private const DEFAULT_QUEUE   = 'default';
-    private const STATUS_PENDING  = 'pending';
-    private const STATUS_PROCESS  = 'processing';
-    private const STATUS_COMPLETE = 'completed';
-    private const STATUS_FAILED   = 'failed';
-
     public function __construct(
         private readonly ?PDO $db = null,
-        private readonly string $table = self::TABLE,
+        private readonly int $maxAttempts = 3,
     ) {
     }
 
+    // ── public API ────────────────────────────────────────────────────────────
+
     /**
-     * Add a job to the queue.
+     * Enqueue a new job.
      *
-     * @param  array<mixed> $payload     Job data (will be JSON-encoded).
-     * @param  string       $queue       Queue name (default: 'default').
-     * @param  int          $maxAttempts Maximum number of delivery attempts.
-     * @param  int          $delaySeconds Seconds before job becomes available.
-     * @return int New job ID.
+     * @param  array<string,mixed> $payload      Arbitrary data passed to the worker.
+     * @param  int                 $delaySeconds Delay before the job becomes available.
+     * @return int The new job ID.
+     * @throws \InvalidArgumentException if type is empty.
      */
-    public function enqueue(
-        array $payload,
-        string $queue = self::DEFAULT_QUEUE,
-        int $maxAttempts = 3,
-        int $delaySeconds = 0,
-    ): int {
-        $db          = $this->db ?? PdoConnection::getInstance();
-        $now         = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
-        $availableAt = $delaySeconds > 0
-            ? (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
-                ->modify('+' . $delaySeconds . ' seconds')
-                ->format('Y-m-d H:i:s')
-            : $now;
+    public function enqueue(string $type, array $payload = [], int $delaySeconds = 0): int
+    {
+        $type  = $this->validateType($type);
+        $db    = $this->db();
+        $runAt = (new \DateTimeImmutable())->modify("+{$delaySeconds} seconds")->format('Y-m-d H:i:s');
 
-        $stmt = $db->prepare(
-            'INSERT INTO ' . $this->table .
-            ' (queue, payload, status, max_attempts, available_at, created_at, updated_at)' .
-            ' VALUES (:q, :payload, :status, :max, :avail, :now, :now)'
-        );
-        $stmt->bindValue(':q', $queue, PDO::PARAM_STR);
-        $stmt->bindValue(':payload', json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE), PDO::PARAM_STR);
-        $stmt->bindValue(':status', self::STATUS_PENDING, PDO::PARAM_STR);
-        $stmt->bindValue(':max', $maxAttempts, PDO::PARAM_INT);
-        $stmt->bindValue(':avail', $availableAt, PDO::PARAM_STR);
-        $stmt->bindValue(':now', $now, PDO::PARAM_STR);
-        $stmt->execute();
-
+        $db->prepare(
+            'INSERT INTO job_queue (type, payload, max_attempts, run_at)
+             VALUES (:type, :payload, :max, :run_at)'
+        )->execute([
+            ':type'    => $type,
+            ':payload' => json_encode($payload, JSON_THROW_ON_ERROR),
+            ':max'     => $this->maxAttempts,
+            ':run_at'  => $runAt,
+        ]);
         return (int)$db->lastInsertId();
     }
 
     /**
-     * Claim the next available job from a queue (atomic).
+     * Claim the next available pending job for processing.
      *
-     * Returns null when the queue is empty.
-     * The returned payload is decoded from JSON.
+     * A claimed job transitions to `running` and has its attempt counter
+     * incremented. Returns null if no jobs are available.
      *
-     * @param  string $queue Queue name.
-     * @return array{id:int,queue:string,payload:array<mixed>,attempts:int,max_attempts:int,created_at:string}|null
+     * @return array<string,mixed>|null
      */
-    public function dequeue(string $queue = self::DEFAULT_QUEUE): ?array
+    public function claim(): ?array
     {
-        $db  = $this->db ?? PdoConnection::getInstance();
-        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        $db  = $this->db();
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
 
-        $db->beginTransaction();
-        try {
-            $stmt = $db->prepare(
-                'SELECT id, queue, payload, attempts, max_attempts, created_at' .
-                ' FROM ' . $this->table .
-                ' WHERE queue = :q AND status = :status AND available_at <= :now' .
-                ' ORDER BY id ASC LIMIT 1'
-            );
-            $stmt->bindValue(':q', $queue, PDO::PARAM_STR);
-            $stmt->bindValue(':status', self::STATUS_PENDING, PDO::PARAM_STR);
-            $stmt->bindValue(':now', $now, PDO::PARAM_STR);
-            $stmt->execute();
-            $row = $stmt->fetch(PDO::FETCH_ASSOC);
-
-            if (!is_array($row)) {
-                $db->rollBack();
-                return null;
-            }
-
-            $upd = $db->prepare(
-                'UPDATE ' . $this->table .
-                ' SET status = :status, attempts = attempts + 1, updated_at = :now' .
-                ' WHERE id = :id'
-            );
-            $upd->bindValue(':status', self::STATUS_PROCESS, PDO::PARAM_STR);
-            $upd->bindValue(':now', $now, PDO::PARAM_STR);
-            $upd->bindValue(':id', (int)$row['id'], PDO::PARAM_INT);
-            $upd->execute();
-
-            $db->commit();
-
-            return [
-                'id'           => (int)$row['id'],
-                'queue'        => (string)$row['queue'],
-                'payload'      => json_decode((string)$row['payload'], true, 512, JSON_THROW_ON_ERROR),
-                'attempts'     => (int)$row['attempts'] + 1,
-                'max_attempts' => (int)$row['max_attempts'],
-                'created_at'   => (string)$row['created_at'],
-            ];
-        } catch (\Throwable $e) {
-            $db->rollBack();
-            throw $e;
-        }
-    }
-
-    /**
-     * Mark a job as successfully completed.
-     *
-     * @param int $jobId Job ID returned by dequeue().
-     */
-    public function complete(int $jobId): void
-    {
-        $this->updateStatus($jobId, self::STATUS_COMPLETE);
-    }
-
-    /**
-     * Mark a job as failed. If attempts < max_attempts, re-queues it as pending.
-     *
-     * @param int    $jobId   Job ID returned by dequeue().
-     * @param string $error   Error message to record.
-     */
-    public function fail(int $jobId, string $error = ''): void
-    {
-        $db  = $this->db ?? PdoConnection::getInstance();
-        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
-
-        // Check if retries remain
         $stmt = $db->prepare(
-            'SELECT attempts, max_attempts FROM ' . $this->table . ' WHERE id = :id LIMIT 1'
+            "SELECT id FROM job_queue
+             WHERE status = 'pending' AND run_at <= :now
+             ORDER BY run_at ASC, id ASC
+             LIMIT 1"
         );
-        $stmt->bindValue(':id', $jobId, PDO::PARAM_INT);
-        $stmt->execute();
+        $stmt->execute([':now' => $now]);
+        $id = $stmt->fetchColumn();
+
+        if ($id === false) {
+            return null;
+        }
+
+        $stmt = $db->prepare(
+            "UPDATE job_queue
+             SET status = 'running', claimed_at = :now, attempts = attempts + 1
+             WHERE id = :id AND status = 'pending'"
+        );
+        $stmt->execute([':now' => $now, ':id' => (int)$id]);
+
+        if ($stmt->rowCount() === 0) {
+            return null;
+        }
+
+        return $this->find((int)$id);
+    }
+
+    /**
+     * Mark a running job as successfully completed.
+     *
+     * @return bool True if the job was running and is now done.
+     */
+    public function complete(int $jobId): bool
+    {
+        $stmt = $this->db()->prepare(
+            "UPDATE job_queue
+             SET status = 'done', done_at = CURRENT_TIMESTAMP
+             WHERE id = :id AND status = 'running'"
+        );
+        $stmt->execute([':id' => $jobId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark a running job as failed.
+     *
+     * If attempts < max_attempts the job is reset to `pending` for retry.
+     * Otherwise it is permanently marked `failed`.
+     *
+     * @return bool True if the job was running.
+     */
+    public function fail(int $jobId, string $error = ''): bool
+    {
+        $db   = $this->db();
+        $stmt = $db->prepare(
+            "SELECT attempts, max_attempts FROM job_queue WHERE id = :id AND status = 'running'"
+        );
+        $stmt->execute([':id' => $jobId]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        if (!is_array($row)) {
-            return;
+        if ($row === false) {
+            return false;
         }
 
-        $newStatus = (int)$row['attempts'] >= (int)$row['max_attempts']
-            ? self::STATUS_FAILED
-            : self::STATUS_PENDING;
+        if ((int)$row['attempts'] < (int)$row['max_attempts']) {
+            $delay = (int)$row['attempts'] * 60;
+            $runAt = (new \DateTimeImmutable())->modify("+{$delay} seconds")->format('Y-m-d H:i:s');
+            $db->prepare(
+                "UPDATE job_queue
+                 SET status = 'pending', error = :error, claimed_at = NULL, run_at = :run_at
+                 WHERE id = :id"
+            )->execute([':error' => $error, ':run_at' => $runAt, ':id' => $jobId]);
+        } else {
+            $db->prepare(
+                "UPDATE job_queue
+                 SET status = 'failed', error = :error, done_at = CURRENT_TIMESTAMP
+                 WHERE id = :id"
+            )->execute([':error' => $error, ':id' => $jobId]);
+        }
 
-        $upd = $db->prepare(
-            'UPDATE ' . $this->table .
-            ' SET status = :status, error = :error, updated_at = :now WHERE id = :id'
-        );
-        $upd->bindValue(':status', $newStatus, PDO::PARAM_STR);
-        $upd->bindValue(':error', $error !== '' ? $error : null, $error !== '' ? PDO::PARAM_STR : PDO::PARAM_NULL);
-        $upd->bindValue(':now', $now, PDO::PARAM_STR);
-        $upd->bindValue(':id', $jobId, PDO::PARAM_INT);
-        $upd->execute();
+        return true;
     }
 
     /**
-     * Get the number of jobs by status in a queue.
+     * Release a running job back to pending (worker crash recovery).
      *
-     * @param  string      $queue  Queue name.
-     * @param  string|null $status Filter by status. Null = all statuses.
-     * @return int
+     * @return bool True if the job was running and is now pending.
      */
-    public function count(string $queue = self::DEFAULT_QUEUE, ?string $status = null): int
+    public function release(int $jobId): bool
     {
-        $db  = $this->db ?? PdoConnection::getInstance();
-        $sql = 'SELECT COUNT(*) FROM ' . $this->table . ' WHERE queue = :q';
-        if ($status !== null) {
-            $sql .= ' AND status = :status';
+        $stmt = $this->db()->prepare(
+            "UPDATE job_queue
+             SET status = 'pending', claimed_at = NULL
+             WHERE id = :id AND status = 'running'"
+        );
+        $stmt->execute([':id' => $jobId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Get a single job by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $jobId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, type, payload, status, attempts, max_attempts, error,
+                    run_at, claimed_at, done_at, created_at
+             FROM job_queue WHERE id = :id LIMIT 1'
+        );
+        $stmt->execute([':id' => $jobId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+        $row['payload'] = json_decode((string)$row['payload'], true) ?? [];
+        return $row;
+    }
+
+    /**
+     * List pending jobs (run_at <= now), optionally filtered by type.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function listPending(int $limit = 20, ?string $type = null): array
+    {
+        $limit = max(1, $limit);
+        $now   = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        if ($type !== null) {
+            $stmt = $this->db()->prepare(
+                "SELECT id, type, payload, status, attempts, run_at, created_at
+                 FROM job_queue
+                 WHERE status = 'pending' AND run_at <= :now AND type = :type
+                 ORDER BY run_at ASC, id ASC
+                 LIMIT {$limit}"
+            );
+            $stmt->execute([':now' => $now, ':type' => $type]);
+        } else {
+            $stmt = $this->db()->prepare(
+                "SELECT id, type, payload, status, attempts, run_at, created_at
+                 FROM job_queue
+                 WHERE status = 'pending' AND run_at <= :now
+                 ORDER BY run_at ASC, id ASC
+                 LIMIT {$limit}"
+            );
+            $stmt->execute([':now' => $now]);
         }
 
-        $stmt = $db->prepare($sql);
-        $stmt->bindValue(':q', $queue, PDO::PARAM_STR);
-        if ($status !== null) {
-            $stmt->bindValue(':status', $status, PDO::PARAM_STR);
-        }
-        $stmt->execute();
+        return array_map(
+            static function (array $row): array {
+                $row['payload'] = json_decode((string)$row['payload'], true) ?? [];
+                return $row;
+            },
+            $stmt->fetchAll(PDO::FETCH_ASSOC) ?: []
+        );
+    }
 
+    /**
+     * Count jobs, optionally filtered by status.
+     */
+    public function count(?string $status = null): int
+    {
+        if ($status !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM job_queue WHERE status = :status'
+            );
+            $stmt->execute([':status' => $status]);
+        } else {
+            $stmt = $this->db()->prepare('SELECT COUNT(*) FROM job_queue');
+            $stmt->execute();
+        }
         return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Delete completed/failed jobs older than N days.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeCompleted(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            "DELETE FROM job_queue
+             WHERE status IN ('done', 'failed') AND done_at < :cutoff"
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
     }
 
     // ── internal helpers ─────────────────────────────────────────────────────
 
-    private function updateStatus(int $jobId, string $status): void
+    private function db(): PDO
     {
-        $db  = $this->db ?? PdoConnection::getInstance();
-        $now = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        return $this->db ?? PdoConnection::getInstance();
+    }
 
-        $stmt = $db->prepare(
-            'UPDATE ' . $this->table . ' SET status = :status, updated_at = :now WHERE id = :id'
-        );
-        $stmt->bindValue(':status', $status, PDO::PARAM_STR);
-        $stmt->bindValue(':now', $now, PDO::PARAM_STR);
-        $stmt->bindValue(':id', $jobId, PDO::PARAM_INT);
-        $stmt->execute();
+    private function validateType(string $type): string
+    {
+        $type = trim($type);
+        if ($type === '') {
+            throw new \InvalidArgumentException('type must not be empty.');
+        }
+        return $type;
     }
 }

--- a/tests/Unit/Xion/JobQueueTest.php
+++ b/tests/Unit/Xion/JobQueueTest.php
@@ -9,152 +9,236 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit tests for JobQueue using an in-memory SQLite database.
+ * Unit tests for JobQueue.
  */
 final class JobQueueTest extends TestCase
 {
     private PDO $db;
-    private JobQueue $q;
+    private JobQueue $jq;
 
     protected function setUp(): void
     {
         $this->db = new PDO('sqlite::memory:');
         $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $this->db->exec(
-            'CREATE TABLE job_queue (
-                id           INTEGER      PRIMARY KEY AUTOINCREMENT,
-                queue        VARCHAR(64)  NOT NULL DEFAULT \'default\',
-                payload      TEXT         NOT NULL,
-                status       VARCHAR(16)  NOT NULL DEFAULT \'pending\',
-                attempts     INTEGER      NOT NULL DEFAULT 0,
-                max_attempts INTEGER      NOT NULL DEFAULT 3,
-                error        TEXT         DEFAULT NULL,
-                available_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
-            )'
-        );
-        $this->q = new JobQueue($this->db);
+        $this->db->exec('
+            CREATE TABLE job_queue (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                type         VARCHAR(100) NOT NULL,
+                payload      TEXT         NOT NULL DEFAULT \'{}\',
+                status       VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                attempts     INT          NOT NULL DEFAULT 0,
+                max_attempts INT          NOT NULL DEFAULT 3,
+                error        TEXT         NOT NULL DEFAULT \'\',
+                run_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                claimed_at   DATETIME     DEFAULT NULL,
+                done_at      DATETIME     DEFAULT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->jq = new JobQueue($this->db, 3);
     }
 
     // ── enqueue ───────────────────────────────────────────────────────────────
 
     public function testEnqueueReturnsId(): void
     {
-        $id = $this->q->enqueue(['type' => 'email']);
-        $this->assertIsInt($id);
+        $id = $this->jq->enqueue('send_email');
         $this->assertGreaterThan(0, $id);
     }
 
-    public function testEnqueuedJobIsPending(): void
+    public function testEnqueueStoresPayload(): void
     {
-        $this->q->enqueue(['type' => 'email']);
-        $this->assertSame(1, $this->q->count('default', 'pending'));
+        $id  = $this->jq->enqueue('process', ['key' => 'value']);
+        $job = $this->jq->find($id);
+        $this->assertNotNull($job);
+        $this->assertSame(['key' => 'value'], $job['payload']);
     }
 
-    public function testEnqueueWithCustomQueue(): void
+    public function testEnqueueSetsStatusToPending(): void
     {
-        $this->q->enqueue(['type' => 'email'], queue: 'emails');
-        $this->assertSame(1, $this->q->count('emails', 'pending'));
-        $this->assertSame(0, $this->q->count('default', 'pending'));
+        $id  = $this->jq->enqueue('ping');
+        $job = $this->jq->find($id);
+        $this->assertSame('pending', $job['status']);
     }
 
-    public function testEnqueueWithDelay(): void
+    public function testEnqueueThrowsOnEmptyType(): void
     {
-        $this->q->enqueue(['type' => 'email'], delaySeconds: 3600);
-        // Job is not yet available
-        $job = $this->q->dequeue();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->jq->enqueue('');
+    }
+
+    public function testEnqueueWithDelayIsNotImmediatelyClaimed(): void
+    {
+        $this->jq->enqueue('delayed', [], 3600);
+        $job = $this->jq->claim();
         $this->assertNull($job);
     }
 
-    // ── dequeue ───────────────────────────────────────────────────────────────
+    // ── claim ─────────────────────────────────────────────────────────────────
 
-    public function testDequeueReturnsJob(): void
+    public function testClaimReturnsJob(): void
     {
-        $this->q->enqueue(['type' => 'email', 'to' => 'a@b.com']);
-        $job = $this->q->dequeue();
+        $this->jq->enqueue('ping');
+        $job = $this->jq->claim();
         $this->assertNotNull($job);
-        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-        $this->assertSame('email', $job['payload']['type']);
+        $this->assertSame('running', $job['status']);
     }
 
-    public function testDequeueReturnsNullWhenEmpty(): void
+    public function testClaimIncrementsAttempts(): void
     {
-        $this->assertNull($this->q->dequeue());
+        $this->jq->enqueue('ping');
+        $job = $this->jq->claim();
+        $this->assertSame(1, (int)$job['attempts']);
     }
 
-    public function testDequeueChangesStatusToProcessing(): void
+    public function testClaimReturnsNullWhenEmpty(): void
     {
-        $this->q->enqueue(['type' => 'email']);
-        $this->q->dequeue();
-        $this->assertSame(0, $this->q->count('default', 'pending'));
-        $this->assertSame(1, $this->q->count('default', 'processing'));
+        $this->assertNull($this->jq->claim());
     }
 
-    public function testDequeueIncrementsAttempts(): void
+    public function testClaimReturnsJobsInOrder(): void
     {
-        $this->q->enqueue(['type' => 'email']);
-        $job = $this->q->dequeue();
-        $this->assertIsArray($job);
-        $this->assertSame(1, $job['attempts']);
-    }
-
-    public function testDequeueIsFIFO(): void
-    {
-        $id1 = $this->q->enqueue(['order' => 1]);
-        $id2 = $this->q->enqueue(['order' => 2]);
-        $job = $this->q->dequeue();
-        $this->assertIsArray($job);
-        $this->assertSame($id1, $job['id']);
+        $id1 = $this->jq->enqueue('first');
+        $id2 = $this->jq->enqueue('second');
+        $job = $this->jq->claim();
+        $this->assertSame($id1, (int)$job['id']);
     }
 
     // ── complete ──────────────────────────────────────────────────────────────
 
-    public function testCompleteMarksJobDone(): void
+    public function testCompleteMarksDone(): void
     {
-        $this->q->enqueue(['type' => 'email']);
-        $job = $this->q->dequeue();
-        $this->assertIsArray($job);
-        $this->q->complete($job['id']);
-        $this->assertSame(1, $this->q->count('default', 'completed'));
+        $this->jq->enqueue('task');
+        $job = $this->jq->claim();
+        $this->assertTrue($this->jq->complete((int)$job['id']));
+        $done = $this->jq->find((int)$job['id']);
+        $this->assertSame('done', $done['status']);
     }
 
-    // ── fail ──────────────────────────────────────────────────────────────────
-
-    public function testFailWithRemainingAttemptsReQueues(): void
+    public function testCompleteReturnsFalseIfNotRunning(): void
     {
-        $this->q->enqueue(['type' => 'email'], maxAttempts: 3);
-        $job = $this->q->dequeue();
-        $this->assertIsArray($job);
-        $this->q->fail($job['id'], 'connection error');
-        // 1 attempt used, 2 remaining — status should be pending again
-        $this->assertSame(1, $this->q->count('default', 'pending'));
+        $id = $this->jq->enqueue('task');
+        $this->assertFalse($this->jq->complete($id));
     }
 
-    public function testFailWithNoAttemptsRemainingMarksFailed(): void
+    // ── fail / retry ──────────────────────────────────────────────────────────
+
+    public function testFailResetsToPendingWhenAttemptsRemain(): void
     {
-        $this->q->enqueue(['type' => 'email'], maxAttempts: 1);
-        $job = $this->q->dequeue();
-        $this->assertIsArray($job);
-        $this->q->fail($job['id'], 'permanent error');
-        $this->assertSame(1, $this->q->count('default', 'failed'));
-        $this->assertSame(0, $this->q->count('default', 'pending'));
+        $jq = new JobQueue($this->db, 3);
+        $jq->enqueue('task');
+        $job = $jq->claim(); // attempts = 1, max = 3
+        $jq->fail((int)$job['id'], 'timeout');
+        $updated = $jq->find((int)$job['id']);
+        $this->assertSame('pending', $updated['status']);
+        $this->assertSame('timeout', $updated['error']);
+    }
+
+    public function testFailMarksFailedWhenMaxAttemptsReached(): void
+    {
+        $jq = new JobQueue($this->db, 1);
+        $jq->enqueue('task');
+        $job = $jq->claim(); // attempts = 1, max = 1
+        $jq->fail((int)$job['id'], 'fatal');
+        $updated = $jq->find((int)$job['id']);
+        $this->assertSame('failed', $updated['status']);
+    }
+
+    public function testFailReturnsFalseIfNotRunning(): void
+    {
+        $id = $this->jq->enqueue('task');
+        $this->assertFalse($this->jq->fail($id, 'oops'));
+    }
+
+    // ── release ───────────────────────────────────────────────────────────────
+
+    public function testReleaseResetsToTending(): void
+    {
+        $this->jq->enqueue('task');
+        $job = $this->jq->claim();
+        $this->assertTrue($this->jq->release((int)$job['id']));
+        $updated = $this->jq->find((int)$job['id']);
+        $this->assertSame('pending', $updated['status']);
+    }
+
+    public function testReleaseReturnsFalseIfNotRunning(): void
+    {
+        $id = $this->jq->enqueue('task');
+        $this->assertFalse($this->jq->release($id));
+    }
+
+    // ── listPending ───────────────────────────────────────────────────────────
+
+    public function testListPendingReturnsAvailableJobs(): void
+    {
+        $this->jq->enqueue('a');
+        $this->jq->enqueue('b');
+        $list = $this->jq->listPending(10);
+        $this->assertCount(2, $list);
+    }
+
+    public function testListPendingFiltersByType(): void
+    {
+        $this->jq->enqueue('email');
+        $this->jq->enqueue('sms');
+        $list = $this->jq->listPending(10, 'email');
+        $this->assertCount(1, $list);
+        $this->assertSame('email', $list[0]['type']);
+    }
+
+    public function testListPendingExcludesRunning(): void
+    {
+        $this->jq->enqueue('task');
+        $this->jq->claim();
+        $list = $this->jq->listPending(10);
+        $this->assertCount(0, $list);
     }
 
     // ── count ─────────────────────────────────────────────────────────────────
 
-    public function testCountAllStatusesWhenNullFilter(): void
+    public function testCountReturnsAllJobs(): void
     {
-        $this->q->enqueue(['a' => 1]);
-        $this->q->enqueue(['b' => 2]);
-        $this->assertSame(2, $this->q->count('default'));
+        $this->jq->enqueue('a');
+        $this->jq->enqueue('b');
+        $this->assertSame(2, $this->jq->count());
     }
 
-    public function testCountIsQueueIsolated(): void
+    public function testCountByStatus(): void
     {
-        $this->q->enqueue(['a' => 1], queue: 'q1');
-        $this->q->enqueue(['b' => 2], queue: 'q2');
-        $this->assertSame(1, $this->q->count('q1'));
-        $this->assertSame(1, $this->q->count('q2'));
+        $this->jq->enqueue('a');
+        $this->jq->enqueue('b');
+        $this->jq->claim();
+        $this->assertSame(1, $this->jq->count('pending'));
+        $this->assertSame(1, $this->jq->count('running'));
+    }
+
+    public function testCountReturnsZeroForEmptyQueue(): void
+    {
+        $this->assertSame(0, $this->jq->count());
+    }
+
+    // ── purgeCompleted ────────────────────────────────────────────────────────
+
+    public function testPurgeCompletedDeletesOldDoneJobs(): void
+    {
+        $id = $this->jq->enqueue('task');
+        $this->jq->claim();
+        $this->jq->complete($id);
+
+        // Manually set done_at to the past
+        $this->db->exec("UPDATE job_queue SET done_at = '2000-01-01 00:00:00' WHERE id = {$id}");
+
+        $deleted = $this->jq->purgeCompleted(1);
+        $this->assertSame(1, $deleted);
+        $this->assertNull($this->jq->find($id));
+    }
+
+    public function testPurgeCompletedLeavesRecentJobs(): void
+    {
+        $this->jq->enqueue('task');
+        $job = $this->jq->claim();
+        $this->jq->complete((int)$job['id']);
+        $deleted = $this->jq->purgeCompleted(30);
+        $this->assertSame(0, $deleted);
     }
 }

--- a/tests/Unit/Xion/JobQueueTest.php
+++ b/tests/Unit/Xion/JobQueueTest.php
@@ -51,6 +51,7 @@ final class JobQueueTest extends TestCase
         $id  = $this->jq->enqueue('process', ['key' => 'value']);
         $job = $this->jq->find($id);
         $this->assertNotNull($job);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(['key' => 'value'], $job['payload']);
     }
 
@@ -58,6 +59,7 @@ final class JobQueueTest extends TestCase
     {
         $id  = $this->jq->enqueue('ping');
         $job = $this->jq->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('pending', $job['status']);
     }
 
@@ -81,6 +83,7 @@ final class JobQueueTest extends TestCase
         $this->jq->enqueue('ping');
         $job = $this->jq->claim();
         $this->assertNotNull($job);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('running', $job['status']);
     }
 
@@ -88,6 +91,7 @@ final class JobQueueTest extends TestCase
     {
         $this->jq->enqueue('ping');
         $job = $this->jq->claim();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(1, (int)$job['attempts']);
     }
 
@@ -101,6 +105,7 @@ final class JobQueueTest extends TestCase
         $id1 = $this->jq->enqueue('first');
         $id2 = $this->jq->enqueue('second');
         $job = $this->jq->claim();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame($id1, (int)$job['id']);
     }
 
@@ -110,8 +115,11 @@ final class JobQueueTest extends TestCase
     {
         $this->jq->enqueue('task');
         $job = $this->jq->claim();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertTrue($this->jq->complete((int)$job['id']));
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $done = $this->jq->find((int)$job['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('done', $done['status']);
     }
 
@@ -128,9 +136,13 @@ final class JobQueueTest extends TestCase
         $jq = new JobQueue($this->db, 3);
         $jq->enqueue('task');
         $job = $jq->claim(); // attempts = 1, max = 3
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $jq->fail((int)$job['id'], 'timeout');
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $updated = $jq->find((int)$job['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('pending', $updated['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('timeout', $updated['error']);
     }
 
@@ -139,8 +151,11 @@ final class JobQueueTest extends TestCase
         $jq = new JobQueue($this->db, 1);
         $jq->enqueue('task');
         $job = $jq->claim(); // attempts = 1, max = 1
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $jq->fail((int)$job['id'], 'fatal');
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $updated = $jq->find((int)$job['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('failed', $updated['status']);
     }
 
@@ -156,8 +171,11 @@ final class JobQueueTest extends TestCase
     {
         $this->jq->enqueue('task');
         $job = $this->jq->claim();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertTrue($this->jq->release((int)$job['id']));
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $updated = $this->jq->find((int)$job['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('pending', $updated['status']);
     }
 
@@ -237,6 +255,7 @@ final class JobQueueTest extends TestCase
     {
         $this->jq->enqueue('task');
         $job = $this->jq->claim();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->jq->complete((int)$job['id']);
         $deleted = $this->jq->purgeCompleted(30);
         $this->assertSame(0, $deleted);


### PR DESCRIPTION
## JobQueue

Simple DB-backed background job queue with retry and crash recovery.

### Schema
```sql
CREATE TABLE job_queue (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    type         VARCHAR(100) NOT NULL,
    payload      TEXT         NOT NULL DEFAULT '{}',
    status       VARCHAR(20)  NOT NULL DEFAULT 'pending',
    attempts     INT          NOT NULL DEFAULT 0,
    max_attempts INT          NOT NULL DEFAULT 3,
    error        TEXT         NOT NULL DEFAULT '',
    run_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    claimed_at   DATETIME     DEFAULT NULL,
    done_at      DATETIME     DEFAULT NULL,
    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### API
- `enqueue(type, payload, delaySeconds)` — add job with optional delay
- `claim()` — atomically claims next pending job, increments attempts
- `complete(jobId)` — marks job done
- `fail(jobId, error)` — retries if attempts < max, else permanently fails
- `release(jobId)` — reset running → pending (crash recovery)
- `find(jobId)` — get job with decoded payload
- `listPending(limit, ?type)` — list available jobs
- `count(?status)` — count by status or total
- `purgeCompleted(days)` — delete old done/failed records

### Tests
24 tests, 32 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)