### PR TITLE
feat(xion): EventLog — append-only domain event store (FT126)

### DIFF
--- a/class/xion/EventLog.php
+++ b/class/xion/EventLog.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * EventLog — append-only domain event store.
+ *
+ * Records business events (user_registered, order_placed, payment_failed, …)
+ * with a subject, optional aggregate context, and arbitrary JSON data.
+ * All entries are immutable once written.
+ *
+ * Intended for event sourcing lite, audit trails, and analytics pipelines.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $el = new EventLog($pdo);
+ *
+ * // Record an event
+ * $el->record('user_registered', 'user', 'u-1', ['email' => 'a@b.com']);
+ *
+ * // Replay events for an aggregate
+ * $el->forAggregate('user', 'u-1');
+ *
+ * // Recent events of a type
+ * $el->forEvent('user_registered', 10);
+ *
+ * // Cursor-based paging (for large replays)
+ * $el->since($lastSeenId, 100);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE event_log (
+ *     id             INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     event_type     VARCHAR(100) NOT NULL,
+ *     aggregate_type VARCHAR(100) NOT NULL DEFAULT '',
+ *     aggregate_id   VARCHAR(255) NOT NULL DEFAULT '',
+ *     data           TEXT         NOT NULL DEFAULT '{}',
+ *     occurred_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class EventLog
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record a domain event.
+     *
+     * @param  array<string,mixed> $data Arbitrary event payload.
+     * @return int The new event ID.
+     * @throws \InvalidArgumentException if event_type is empty.
+     */
+    public function record(
+        string $eventType,
+        string $aggregateType = '',
+        string $aggregateId = '',
+        array $data = []
+    ): int {
+        $eventType = $this->validateEventType($eventType);
+        $db        = $this->db();
+
+        $db->prepare(
+            'INSERT INTO event_log (event_type, aggregate_type, aggregate_id, data)
+             VALUES (:type, :agg_type, :agg_id, :data)'
+        )->execute([
+            ':type'     => $eventType,
+            ':agg_type' => $aggregateType,
+            ':agg_id'   => $aggregateId,
+            ':data'     => json_encode($data, JSON_THROW_ON_ERROR),
+        ]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Get all events for an aggregate (ordered by id ASC for replay).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forAggregate(string $aggregateType, string $aggregateId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, event_type, aggregate_type, aggregate_id, data, occurred_at
+             FROM event_log
+             WHERE aggregate_type = :agg_type AND aggregate_id = :agg_id
+             ORDER BY id ASC'
+        );
+        $stmt->execute([':agg_type' => $aggregateType, ':agg_id' => $aggregateId]);
+        return $this->decodeAll($stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
+    }
+
+    /**
+     * Get recent events of a specific type.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forEvent(string $eventType, int $limit = 20): array
+    {
+        $eventType = $this->validateEventType($eventType);
+        $limit     = max(1, $limit);
+        $stmt      = $this->db()->prepare(
+            "SELECT id, event_type, aggregate_type, aggregate_id, data, occurred_at
+             FROM event_log
+             WHERE event_type = :type
+             ORDER BY id DESC
+             LIMIT {$limit}"
+        );
+        $stmt->execute([':type' => $eventType]);
+        return $this->decodeAll($stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
+    }
+
+    /**
+     * Get all events after a given ID (cursor-based paging for replays).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function since(int $afterId, int $limit = 100): array
+    {
+        $limit = max(1, $limit);
+        $stmt  = $this->db()->prepare(
+            "SELECT id, event_type, aggregate_type, aggregate_id, data, occurred_at
+             FROM event_log
+             WHERE id > :after
+             ORDER BY id ASC
+             LIMIT {$limit}"
+        );
+        $stmt->execute([':after' => $afterId]);
+        return $this->decodeAll($stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
+    }
+
+    /**
+     * Get the most recent N events across all types.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function recent(int $limit = 20): array
+    {
+        $limit = max(1, $limit);
+        $stmt  = $this->db()->prepare(
+            "SELECT id, event_type, aggregate_type, aggregate_id, data, occurred_at
+             FROM event_log
+             ORDER BY id DESC
+             LIMIT {$limit}"
+        );
+        $stmt->execute();
+        return $this->decodeAll($stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
+    }
+
+    /**
+     * Count all events, optionally filtered by event type.
+     */
+    public function count(?string $eventType = null): int
+    {
+        if ($eventType !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM event_log WHERE event_type = :type'
+            );
+            $stmt->execute([':type' => $eventType]);
+        } else {
+            $stmt = $this->db()->prepare('SELECT COUNT(*) FROM event_log');
+            $stmt->execute();
+        }
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Count events per type (event_type => count mapping).
+     *
+     * @return array<string,int>
+     */
+    public function countByType(): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT event_type, COUNT(*) AS cnt FROM event_log GROUP BY event_type ORDER BY cnt DESC'
+        );
+        $stmt->execute();
+        $result = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $result[(string)$row['event_type']] = (int)$row['cnt'];
+        }
+        return $result;
+    }
+
+    /**
+     * Purge events older than N days.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM event_log WHERE occurred_at < :cutoff'
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateEventType(string $eventType): string
+    {
+        $eventType = trim($eventType);
+        if ($eventType === '') {
+            throw new \InvalidArgumentException('event_type must not be empty.');
+        }
+        return $eventType;
+    }
+
+    /**
+     * @param  list<array<string,mixed>> $rows
+     * @return list<array<string,mixed>>
+     */
+    private function decodeAll(array $rows): array
+    {
+        return array_map(
+            static function (array $row): array {
+                $row['data'] = json_decode((string)$row['data'], true) ?? [];
+                return $row;
+            },
+            $rows
+        );
+    }
+}

--- a/tests/Unit/Xion/EventLogTest.php
+++ b/tests/Unit/Xion/EventLogTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\EventLog;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for EventLog.
+ */
+final class EventLogTest extends TestCase
+{
+    private PDO $db;
+    private EventLog $el;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE event_log (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type     VARCHAR(100) NOT NULL,
+                aggregate_type VARCHAR(100) NOT NULL DEFAULT \'\',
+                aggregate_id   VARCHAR(255) NOT NULL DEFAULT \'\',
+                data           TEXT         NOT NULL DEFAULT \'{}\',
+                occurred_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->el = new EventLog($this->db);
+    }
+
+    // ── record ────────────────────────────────────────────────────────────────
+
+    public function testRecordReturnsId(): void
+    {
+        $id = $this->el->record('user_registered');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testRecordStoresEventType(): void
+    {
+        $id   = $this->el->record('order_placed', 'order', 'o-1', ['total' => 99]);
+        $rows = $this->el->forAggregate('order', 'o-1');
+        $this->assertSame('order_placed', $rows[0]['event_type']);
+    }
+
+    public function testRecordStoresData(): void
+    {
+        $id   = $this->el->record('payment_failed', 'payment', 'p-1', ['reason' => 'declined']);
+        $rows = $this->el->forAggregate('payment', 'p-1');
+        $this->assertSame(['reason' => 'declined'], $rows[0]['data']);
+    }
+
+    public function testRecordThrowsOnEmptyEventType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->el->record('');
+    }
+
+    // ── forAggregate ──────────────────────────────────────────────────────────
+
+    public function testForAggregateReturnsEventsInOrder(): void
+    {
+        $this->el->record('created', 'user', 'u-1');
+        $this->el->record('updated', 'user', 'u-1');
+        $this->el->record('deleted', 'user', 'u-1');
+
+        $rows = $this->el->forAggregate('user', 'u-1');
+        $this->assertCount(3, $rows);
+        $this->assertSame('created', $rows[0]['event_type']);
+        $this->assertSame('updated', $rows[1]['event_type']);
+        $this->assertSame('deleted', $rows[2]['event_type']);
+    }
+
+    public function testForAggregateReturnsEmptyForUnknown(): void
+    {
+        $this->assertSame([], $this->el->forAggregate('user', 'nobody'));
+    }
+
+    public function testForAggregateIsScopedToAggregate(): void
+    {
+        $this->el->record('event', 'user', 'u-1');
+        $this->el->record('event', 'user', 'u-2');
+        $rows = $this->el->forAggregate('user', 'u-1');
+        $this->assertCount(1, $rows);
+    }
+
+    // ── forEvent ──────────────────────────────────────────────────────────────
+
+    public function testForEventReturnsMatchingEvents(): void
+    {
+        $this->el->record('login', 'user', 'u-1');
+        $this->el->record('login', 'user', 'u-2');
+        $this->el->record('logout', 'user', 'u-1');
+
+        $rows = $this->el->forEvent('login');
+        $this->assertCount(2, $rows);
+    }
+
+    public function testForEventReturnsInDescendingOrder(): void
+    {
+        $this->el->record('ping', 'svc', 's-1');
+        $this->el->record('ping', 'svc', 's-2');
+        $rows = $this->el->forEvent('ping', 10);
+        $this->assertGreaterThan((int)$rows[1]['id'], (int)$rows[0]['id']);
+    }
+
+    public function testForEventThrowsOnEmptyType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->el->forEvent('');
+    }
+
+    // ── since ─────────────────────────────────────────────────────────────────
+
+    public function testSinceReturnsEventsAfterCursor(): void
+    {
+        $id1 = $this->el->record('a');
+        $id2 = $this->el->record('b');
+        $id3 = $this->el->record('c');
+
+        $rows = $this->el->since($id1, 100);
+        $this->assertCount(2, $rows);
+        $this->assertSame($id2, (int)$rows[0]['id']);
+        $this->assertSame($id3, (int)$rows[1]['id']);
+    }
+
+    public function testSinceReturnsEmptyFromLatestId(): void
+    {
+        $id = $this->el->record('last');
+        $this->assertSame([], $this->el->since($id, 100));
+    }
+
+    // ── recent ────────────────────────────────────────────────────────────────
+
+    public function testRecentReturnsLatestFirst(): void
+    {
+        $this->el->record('first');
+        $this->el->record('second');
+        $this->el->record('third');
+        $rows = $this->el->recent(2);
+        $this->assertCount(2, $rows);
+        $this->assertSame('third', $rows[0]['event_type']);
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountReturnsTotal(): void
+    {
+        $this->el->record('a');
+        $this->el->record('b');
+        $this->el->record('a');
+        $this->assertSame(3, $this->el->count());
+    }
+
+    public function testCountByEventType(): void
+    {
+        $this->el->record('login');
+        $this->el->record('login');
+        $this->el->record('logout');
+        $this->assertSame(2, $this->el->count('login'));
+        $this->assertSame(1, $this->el->count('logout'));
+    }
+
+    public function testCountReturnsZeroForUnknownType(): void
+    {
+        $this->assertSame(0, $this->el->count('no_such_event'));
+    }
+
+    // ── countByType ───────────────────────────────────────────────────────────
+
+    public function testCountByTypeReturnsMap(): void
+    {
+        $this->el->record('login');
+        $this->el->record('login');
+        $this->el->record('logout');
+        $map = $this->el->countByType();
+        $this->assertSame(2, $map['login']);
+        $this->assertSame(1, $map['logout']);
+    }
+
+    public function testCountByTypeReturnsEmptyForNoEvents(): void
+    {
+        $this->assertSame([], $this->el->countByType());
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldEvents(): void
+    {
+        $id = $this->el->record('old_event');
+        $this->db->exec("UPDATE event_log SET occurred_at = '2000-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->el->purgeOlderThan(1);
+        $this->assertSame(1, $deleted);
+        $this->assertSame(0, $this->el->count());
+    }
+
+    public function testPurgeOlderThanLeavesRecentEvents(): void
+    {
+        $this->el->record('recent');
+        $this->assertSame(0, $this->el->purgeOlderThan(30));
+    }
+}


### PR DESCRIPTION
## EventLog

Append-only domain event store for event sourcing lite, audit trails, and analytics.

### Schema
```sql
CREATE TABLE event_log (
    id             INTEGER PRIMARY KEY AUTOINCREMENT,
    event_type     VARCHAR(100) NOT NULL,
    aggregate_type VARCHAR(100) NOT NULL DEFAULT '',
    aggregate_id   VARCHAR(255) NOT NULL DEFAULT '',
    data           TEXT         NOT NULL DEFAULT '{}',
    occurred_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### API
- `record(eventType, aggregateType, aggregateId, data)` — append event
- `forAggregate(type, id)` — replay all events for an aggregate (ASC order)
- `forEvent(eventType, limit)` — recent events of a type (DESC)
- `since(afterId, limit)` — cursor-based paging for large replays
- `recent(limit)` — latest events across all types
- `count(?eventType)` — count total or by type
- `countByType()` — event_type → count map
- `purgeOlderThan(days)` — delete old events

### Tests
20 tests, 29 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)