### PR TITLE
feat(xion): ConsentLog — immutable GDPR/CCPA consent audit log (FT127)

### DIFF
--- a/class/xion/ConsentLog.php
+++ b/class/xion/ConsentLog.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ConsentLog — immutable record of user consent grants and withdrawals.
+ *
+ * Stores each consent action (grant or withdraw) as an append-only entry.
+ * The current state is always the most recent action for a (user, purpose) pair.
+ *
+ * Compliant with GDPR/CCPA audit requirements: every change is time-stamped
+ * and the full history is preserved.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cl = new ConsentLog($pdo);
+ *
+ * // User grants consent
+ * $cl->grant('user-1', 'marketing_email', '1.2', '203.0.113.1');
+ *
+ * // User withdraws consent
+ * $cl->withdraw('user-1', 'marketing_email');
+ *
+ * // Check current state
+ * $cl->hasConsented('user-1', 'marketing_email'); // false
+ *
+ * // Full history for audit
+ * $cl->history('user-1', 'marketing_email');
+ *
+ * // All active consents for a user
+ * $cl->activeConsents('user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE consent_log (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     purpose     VARCHAR(100) NOT NULL,
+ *     action      VARCHAR(10)  NOT NULL,
+ *     policy_ver  VARCHAR(20)  NOT NULL DEFAULT '',
+ *     ip_address  VARCHAR(45)  NOT NULL DEFAULT '',
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ConsentLog
+{
+    private const GRANT    = 'grant';
+    private const WITHDRAW = 'withdraw';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record a consent grant.
+     *
+     * @param  string $policyVersion Version of the policy the user consented to.
+     * @param  string $ipAddress     Remote IP address.
+     * @return int The new record ID.
+     * @throws \InvalidArgumentException if user_id or purpose is empty.
+     */
+    public function grant(
+        string $userId,
+        string $purpose,
+        string $policyVersion = '',
+        string $ipAddress = ''
+    ): int {
+        return $this->append($userId, $purpose, self::GRANT, $policyVersion, $ipAddress);
+    }
+
+    /**
+     * Record a consent withdrawal.
+     *
+     * @return int The new record ID.
+     * @throws \InvalidArgumentException if user_id or purpose is empty.
+     */
+    public function withdraw(
+        string $userId,
+        string $purpose,
+        string $policyVersion = '',
+        string $ipAddress = ''
+    ): int {
+        return $this->append($userId, $purpose, self::WITHDRAW, $policyVersion, $ipAddress);
+    }
+
+    /**
+     * Check whether the user has currently consented to a purpose.
+     *
+     * Returns false if there is no record or if the latest action is a withdrawal.
+     */
+    public function hasConsented(string $userId, string $purpose): bool
+    {
+        [$userId, $purpose] = $this->normalise($userId, $purpose);
+        $stmt = $this->db()->prepare(
+            'SELECT action FROM consent_log
+             WHERE user_id = :uid AND purpose = :purpose
+             ORDER BY id DESC LIMIT 1'
+        );
+        $stmt->execute([':uid' => $userId, ':purpose' => $purpose]);
+        $action = $stmt->fetchColumn();
+        return $action === self::GRANT;
+    }
+
+    /**
+     * Get the most recent consent entry for a (user, purpose) pair.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function current(string $userId, string $purpose): ?array
+    {
+        [$userId, $purpose] = $this->normalise($userId, $purpose);
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, purpose, action, policy_ver, ip_address, created_at
+             FROM consent_log
+             WHERE user_id = :uid AND purpose = :purpose
+             ORDER BY id DESC LIMIT 1'
+        );
+        $stmt->execute([':uid' => $userId, ':purpose' => $purpose]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Get the full consent history for a (user, purpose) pair.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function history(string $userId, string $purpose): array
+    {
+        [$userId, $purpose] = $this->normalise($userId, $purpose);
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, purpose, action, policy_ver, ip_address, created_at
+             FROM consent_log
+             WHERE user_id = :uid AND purpose = :purpose
+             ORDER BY id ASC'
+        );
+        $stmt->execute([':uid' => $userId, ':purpose' => $purpose]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Get all purposes for which a user currently has an active (granted) consent.
+     *
+     * @return list<string>
+     */
+    public function activeConsents(string $userId): array
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+
+        // Latest action per purpose — SQLite and MySQL both support this pattern
+        $stmt = $this->db()->prepare(
+            'SELECT purpose, action FROM consent_log
+             WHERE user_id = :uid
+             AND id = (
+                 SELECT MAX(id) FROM consent_log c2
+                 WHERE c2.user_id = :uid2 AND c2.purpose = consent_log.purpose
+             )
+             AND action = :action'
+        );
+        $stmt->execute([':uid' => $userId, ':uid2' => $userId, ':action' => self::GRANT]);
+        return array_column($stmt->fetchAll(PDO::FETCH_ASSOC) ?: [], 'purpose');
+    }
+
+    /**
+     * Count how many users have currently consented to a purpose.
+     */
+    public function consentedCount(string $purpose): int
+    {
+        $purpose = trim($purpose);
+
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(DISTINCT user_id) FROM consent_log cl
+             WHERE purpose = :purpose
+             AND action = :action
+             AND id = (
+                 SELECT MAX(id) FROM consent_log c2
+                 WHERE c2.user_id = cl.user_id AND c2.purpose = cl.purpose
+             )'
+        );
+        $stmt->execute([':purpose' => $purpose, ':action' => self::GRANT]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Delete all consent records for a user (GDPR erasure).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function eraseUser(string $userId): int
+    {
+        $userId = trim($userId);
+        $stmt   = $this->db()->prepare('DELETE FROM consent_log WHERE user_id = :uid');
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function append(
+        string $userId,
+        string $purpose,
+        string $action,
+        string $policyVersion,
+        string $ipAddress
+    ): int {
+        [$userId, $purpose] = $this->normalise($userId, $purpose);
+        $db                 = $this->db();
+
+        $db->prepare(
+            'INSERT INTO consent_log (user_id, purpose, action, policy_ver, ip_address)
+             VALUES (:uid, :purpose, :action, :policy_ver, :ip)'
+        )->execute([
+            ':uid'        => $userId,
+            ':purpose'    => $purpose,
+            ':action'     => $action,
+            ':policy_ver' => $policyVersion,
+            ':ip'         => $ipAddress,
+        ]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function normalise(string $userId, string $purpose): array
+    {
+        $userId  = trim($userId);
+        $purpose = trim($purpose);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($purpose === '') {
+            throw new \InvalidArgumentException('purpose must not be empty.');
+        }
+        return [$userId, $purpose];
+    }
+}

--- a/tests/Unit/Xion/ConsentLogTest.php
+++ b/tests/Unit/Xion/ConsentLogTest.php
@@ -52,7 +52,9 @@ final class ConsentLogTest extends TestCase
     {
         $this->cl->grant('user-1', 'analytics', '2.0', '1.2.3.4');
         $row = $this->cl->current('user-1', 'analytics');
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('2.0', $row['policy_ver']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('1.2.3.4', $row['ip_address']);
     }
 
@@ -107,6 +109,7 @@ final class ConsentLogTest extends TestCase
         $this->cl->grant('user-1', 'analytics');
         $this->cl->withdraw('user-1', 'analytics');
         $row = $this->cl->current('user-1', 'analytics');
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('withdraw', $row['action']);
     }
 

--- a/tests/Unit/Xion/ConsentLogTest.php
+++ b/tests/Unit/Xion/ConsentLogTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ConsentLog;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ConsentLog.
+ */
+final class ConsentLogTest extends TestCase
+{
+    private PDO $db;
+    private ConsentLog $cl;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE consent_log (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL,
+                purpose    VARCHAR(100) NOT NULL,
+                action     VARCHAR(10)  NOT NULL,
+                policy_ver VARCHAR(20)  NOT NULL DEFAULT \'\',
+                ip_address VARCHAR(45)  NOT NULL DEFAULT \'\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->cl = new ConsentLog($this->db);
+    }
+
+    // ── grant ─────────────────────────────────────────────────────────────────
+
+    public function testGrantReturnsId(): void
+    {
+        $id = $this->cl->grant('user-1', 'marketing_email');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testGrantSetsHasConsentedTrue(): void
+    {
+        $this->cl->grant('user-1', 'marketing_email');
+        $this->assertTrue($this->cl->hasConsented('user-1', 'marketing_email'));
+    }
+
+    public function testGrantStoresPolicyVersion(): void
+    {
+        $this->cl->grant('user-1', 'analytics', '2.0', '1.2.3.4');
+        $row = $this->cl->current('user-1', 'analytics');
+        $this->assertSame('2.0', $row['policy_ver']);
+        $this->assertSame('1.2.3.4', $row['ip_address']);
+    }
+
+    // ── withdraw ──────────────────────────────────────────────────────────────
+
+    public function testWithdrawSetsHasConsentedFalse(): void
+    {
+        $this->cl->grant('user-1', 'marketing_email');
+        $this->cl->withdraw('user-1', 'marketing_email');
+        $this->assertFalse($this->cl->hasConsented('user-1', 'marketing_email'));
+    }
+
+    public function testWithdrawAfterWithdrawStaysWithdrawn(): void
+    {
+        $this->cl->grant('user-1', 'marketing_email');
+        $this->cl->withdraw('user-1', 'marketing_email');
+        $this->cl->withdraw('user-1', 'marketing_email');
+        $this->assertFalse($this->cl->hasConsented('user-1', 'marketing_email'));
+    }
+
+    public function testGrantAfterWithdrawResetsConsent(): void
+    {
+        $this->cl->grant('user-1', 'marketing_email');
+        $this->cl->withdraw('user-1', 'marketing_email');
+        $this->cl->grant('user-1', 'marketing_email');
+        $this->assertTrue($this->cl->hasConsented('user-1', 'marketing_email'));
+    }
+
+    // ── hasConsented ──────────────────────────────────────────────────────────
+
+    public function testHasConsentedReturnsFalseForUnknownUser(): void
+    {
+        $this->assertFalse($this->cl->hasConsented('nobody', 'marketing_email'));
+    }
+
+    public function testConsentIsScopedToPurpose(): void
+    {
+        $this->cl->grant('user-1', 'analytics');
+        $this->assertFalse($this->cl->hasConsented('user-1', 'marketing_email'));
+    }
+
+    public function testConsentIsScopedToUser(): void
+    {
+        $this->cl->grant('user-1', 'analytics');
+        $this->assertFalse($this->cl->hasConsented('user-2', 'analytics'));
+    }
+
+    // ── current ───────────────────────────────────────────────────────────────
+
+    public function testCurrentReturnsLatestEntry(): void
+    {
+        $this->cl->grant('user-1', 'analytics');
+        $this->cl->withdraw('user-1', 'analytics');
+        $row = $this->cl->current('user-1', 'analytics');
+        $this->assertSame('withdraw', $row['action']);
+    }
+
+    public function testCurrentReturnsNullForUnknown(): void
+    {
+        $this->assertNull($this->cl->current('nobody', 'analytics'));
+    }
+
+    // ── history ───────────────────────────────────────────────────────────────
+
+    public function testHistoryReturnsAllEntries(): void
+    {
+        $this->cl->grant('user-1', 'analytics');
+        $this->cl->withdraw('user-1', 'analytics');
+        $this->cl->grant('user-1', 'analytics');
+        $rows = $this->cl->history('user-1', 'analytics');
+        $this->assertCount(3, $rows);
+    }
+
+    public function testHistoryIsInAscendingOrder(): void
+    {
+        $this->cl->grant('user-1', 'analytics');
+        $this->cl->withdraw('user-1', 'analytics');
+        $rows = $this->cl->history('user-1', 'analytics');
+        $this->assertSame('grant', $rows[0]['action']);
+        $this->assertSame('withdraw', $rows[1]['action']);
+    }
+
+    public function testHistoryReturnsEmptyForUnknown(): void
+    {
+        $this->assertSame([], $this->cl->history('nobody', 'analytics'));
+    }
+
+    // ── activeConsents ────────────────────────────────────────────────────────
+
+    public function testActiveConsentsReturnsGrantedPurposes(): void
+    {
+        $this->cl->grant('user-1', 'analytics');
+        $this->cl->grant('user-1', 'marketing_email');
+        $this->cl->withdraw('user-1', 'analytics');
+        $active = $this->cl->activeConsents('user-1');
+        $this->assertCount(1, $active);
+        $this->assertContains('marketing_email', $active);
+    }
+
+    public function testActiveConsentsReturnsEmptyForNoConsents(): void
+    {
+        $this->assertSame([], $this->cl->activeConsents('nobody'));
+    }
+
+    // ── consentedCount ────────────────────────────────────────────────────────
+
+    public function testConsentedCountReturnsNumberOfUsersWithActiveConsent(): void
+    {
+        $this->cl->grant('user-1', 'analytics');
+        $this->cl->grant('user-2', 'analytics');
+        $this->cl->grant('user-3', 'analytics');
+        $this->cl->withdraw('user-3', 'analytics');
+        $this->assertSame(2, $this->cl->consentedCount('analytics'));
+    }
+
+    public function testConsentedCountReturnsZeroForNoneConsented(): void
+    {
+        $this->assertSame(0, $this->cl->consentedCount('analytics'));
+    }
+
+    // ── eraseUser ─────────────────────────────────────────────────────────────
+
+    public function testEraseUserDeletesAllRecords(): void
+    {
+        $this->cl->grant('user-1', 'analytics');
+        $this->cl->grant('user-1', 'marketing_email');
+        $deleted = $this->cl->eraseUser('user-1');
+        $this->assertSame(2, $deleted);
+        $this->assertFalse($this->cl->hasConsented('user-1', 'analytics'));
+    }
+
+    public function testEraseUserDoesNotAffectOtherUsers(): void
+    {
+        $this->cl->grant('user-1', 'analytics');
+        $this->cl->grant('user-2', 'analytics');
+        $this->cl->eraseUser('user-1');
+        $this->assertTrue($this->cl->hasConsented('user-2', 'analytics'));
+    }
+
+    // ── validation ────────────────────────────────────────────────────────────
+
+    public function testGrantThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cl->grant('', 'analytics');
+    }
+
+    public function testGrantThrowsOnEmptyPurpose(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cl->grant('user-1', '');
+    }
+
+    public function testWithdrawThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cl->withdraw('', 'analytics');
+    }
+}


### PR DESCRIPTION
## ConsentLog

Append-only consent management store for GDPR/CCPA compliance.

### Schema
```sql
CREATE TABLE consent_log (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id    VARCHAR(255) NOT NULL,
    purpose    VARCHAR(100) NOT NULL,
    action     VARCHAR(10)  NOT NULL,
    policy_ver VARCHAR(20)  NOT NULL DEFAULT '',
    ip_address VARCHAR(45)  NOT NULL DEFAULT '',
    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### API
- `grant(userId, purpose, policyVersion, ipAddress)` — record consent grant
- `withdraw(userId, purpose)` — record consent withdrawal
- `hasConsented(userId, purpose)` — check current consent state
- `current(userId, purpose)` — latest entry for audit
- `history(userId, purpose)` — full immutable audit trail (ASC)
- `activeConsents(userId)` — all currently active consents for a user
- `consentedCount(purpose)` — distinct users with active consent
- `eraseUser(userId)` — hard-delete all records (GDPR right to erasure)

### Tests
23 tests, 27 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)