### PR TITLE
feat(xion): WebhookDelivery — outbound webhook delivery log with retry (FT128)

### DIFF
--- a/class/xion/WebhookDelivery.php
+++ b/class/xion/WebhookDelivery.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * WebhookDelivery — outbound webhook delivery log with retry tracking.
+ *
+ * Records every delivery attempt for an outbound webhook call.
+ * Tracks HTTP status, response snippet, attempt count, and next retry time.
+ *
+ * The caller is responsible for making the actual HTTP request;
+ * this class only stores the delivery record and manages retry state.
+ *
+ * Status lifecycle: `pending` → `delivered` | `failed` (after max retries)
+ *
+ * ## Usage
+ *
+ * ```php
+ * $wd = new WebhookDelivery($pdo);
+ *
+ * // Schedule a delivery
+ * $id = $wd->schedule('endpoint-1', 'user.created', ['id' => 42]);
+ *
+ * // Claim next pending delivery for sending
+ * $delivery = $wd->claimNext();
+ *
+ * // Record success
+ * $wd->succeed($delivery['id'], 200, 'ok');
+ *
+ * // Record failure (will auto-schedule retry)
+ * $wd->fail($delivery['id'], 0, 'Connection refused');
+ *
+ * // Pending deliveries for an endpoint
+ * $wd->listPending('endpoint-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE webhook_deliveries (
+ *     id            INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     endpoint_id   VARCHAR(255) NOT NULL,
+ *     event_type    VARCHAR(100) NOT NULL,
+ *     payload       TEXT         NOT NULL DEFAULT '{}',
+ *     status        VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     attempts      INT          NOT NULL DEFAULT 0,
+ *     max_attempts  INT          NOT NULL DEFAULT 5,
+ *     http_status   INT          NOT NULL DEFAULT 0,
+ *     response_body TEXT         NOT NULL DEFAULT '',
+ *     next_attempt_at DATETIME   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     delivered_at  DATETIME     DEFAULT NULL,
+ *     created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class WebhookDelivery
+{
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly int $maxAttempts = 5,
+    ) {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Schedule a new webhook delivery.
+     *
+     * @param  array<string,mixed> $payload      Event payload to deliver.
+     * @param  int                 $delaySeconds Delay before first attempt.
+     * @return int The new delivery ID.
+     * @throws \InvalidArgumentException if endpoint_id or event_type is empty.
+     */
+    public function schedule(
+        string $endpointId,
+        string $eventType,
+        array $payload = [],
+        int $delaySeconds = 0
+    ): int {
+        [$endpointId, $eventType] = $this->normalise($endpointId, $eventType);
+        $db  = $this->db();
+        $at  = (new \DateTimeImmutable())->modify("+{$delaySeconds} seconds")->format('Y-m-d H:i:s');
+
+        $db->prepare(
+            'INSERT INTO webhook_deliveries (endpoint_id, event_type, payload, max_attempts, next_attempt_at)
+             VALUES (:endpoint, :event, :payload, :max, :at)'
+        )->execute([
+            ':endpoint' => $endpointId,
+            ':event'    => $eventType,
+            ':payload'  => json_encode($payload, JSON_THROW_ON_ERROR),
+            ':max'      => $this->maxAttempts,
+            ':at'       => $at,
+        ]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Claim the next pending delivery ready to be sent.
+     *
+     * Atomically transitions status to `sending` and increments attempts.
+     * Returns null if nothing is ready.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function claimNext(): ?array
+    {
+        $db  = $this->db();
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        $stmt = $db->prepare(
+            "SELECT id FROM webhook_deliveries
+             WHERE status = 'pending' AND next_attempt_at <= :now
+             ORDER BY next_attempt_at ASC, id ASC
+             LIMIT 1"
+        );
+        $stmt->execute([':now' => $now]);
+        $id = $stmt->fetchColumn();
+
+        if ($id === false) {
+            return null;
+        }
+
+        $stmt = $db->prepare(
+            "UPDATE webhook_deliveries
+             SET status = 'sending', attempts = attempts + 1
+             WHERE id = :id AND status = 'pending'"
+        );
+        $stmt->execute([':id' => (int)$id]);
+
+        if ($stmt->rowCount() === 0) {
+            return null;
+        }
+
+        return $this->find((int)$id);
+    }
+
+    /**
+     * Record a successful delivery.
+     *
+     * @return bool True if the delivery was in `sending` status.
+     */
+    public function succeed(int $deliveryId, int $httpStatus, string $responseBody = ''): bool
+    {
+        $stmt = $this->db()->prepare(
+            "UPDATE webhook_deliveries
+             SET status = 'delivered', http_status = :code, response_body = :body,
+                 delivered_at = CURRENT_TIMESTAMP
+             WHERE id = :id AND status = 'sending'"
+        );
+        $stmt->execute([':code' => $httpStatus, ':body' => $responseBody, ':id' => $deliveryId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Record a failed delivery attempt.
+     *
+     * If attempts < max_attempts the delivery is rescheduled with exponential backoff.
+     * Otherwise it is permanently marked `failed`.
+     *
+     * @return bool True if the delivery was in `sending` status.
+     */
+    public function fail(int $deliveryId, int $httpStatus = 0, string $responseBody = ''): bool
+    {
+        $db   = $this->db();
+        $stmt = $db->prepare(
+            "SELECT attempts, max_attempts FROM webhook_deliveries WHERE id = :id AND status = 'sending'"
+        );
+        $stmt->execute([':id' => $deliveryId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return false;
+        }
+
+        if ((int)$row['attempts'] < (int)$row['max_attempts']) {
+            // Exponential backoff: 1min, 2min, 4min, 8min, …
+            $delay = 60 * (2 ** ((int)$row['attempts'] - 1));
+            $next  = (new \DateTimeImmutable())->modify("+{$delay} seconds")->format('Y-m-d H:i:s');
+            $db->prepare(
+                "UPDATE webhook_deliveries
+                 SET status = 'pending', http_status = :code, response_body = :body,
+                     next_attempt_at = :next
+                 WHERE id = :id"
+            )->execute([':code' => $httpStatus, ':body' => $responseBody, ':next' => $next, ':id' => $deliveryId]);
+        } else {
+            $db->prepare(
+                "UPDATE webhook_deliveries
+                 SET status = 'failed', http_status = :code, response_body = :body
+                 WHERE id = :id"
+            )->execute([':code' => $httpStatus, ':body' => $responseBody, ':id' => $deliveryId]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Get a single delivery by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $deliveryId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, endpoint_id, event_type, payload, status, attempts, max_attempts,
+                    http_status, response_body, next_attempt_at, delivered_at, created_at
+             FROM webhook_deliveries WHERE id = :id LIMIT 1'
+        );
+        $stmt->execute([':id' => $deliveryId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+        $row['payload'] = json_decode((string)$row['payload'], true) ?? [];
+        return $row;
+    }
+
+    /**
+     * List pending deliveries for an endpoint (or all endpoints if null).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function listPending(string $endpointId, int $limit = 20): array
+    {
+        $limit = max(1, $limit);
+        $now   = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt  = $this->db()->prepare(
+            "SELECT id, endpoint_id, event_type, payload, status, attempts, next_attempt_at
+             FROM webhook_deliveries
+             WHERE endpoint_id = :endpoint AND status = 'pending' AND next_attempt_at <= :now
+             ORDER BY next_attempt_at ASC, id ASC
+             LIMIT {$limit}"
+        );
+        $stmt->execute([':endpoint' => $endpointId, ':now' => $now]);
+        return array_map(
+            static function (array $row): array {
+                $row['payload'] = json_decode((string)$row['payload'], true) ?? [];
+                return $row;
+            },
+            $stmt->fetchAll(PDO::FETCH_ASSOC) ?: []
+        );
+    }
+
+    /**
+     * Count deliveries by status (or all if null).
+     */
+    public function count(?string $status = null): int
+    {
+        if ($status !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM webhook_deliveries WHERE status = :status'
+            );
+            $stmt->execute([':status' => $status]);
+        } else {
+            $stmt = $this->db()->prepare('SELECT COUNT(*) FROM webhook_deliveries');
+            $stmt->execute();
+        }
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Purge delivered/failed records older than N days.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purge(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            "DELETE FROM webhook_deliveries
+             WHERE status IN ('delivered', 'failed') AND created_at < :cutoff"
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function normalise(string $endpointId, string $eventType): array
+    {
+        $endpointId = trim($endpointId);
+        $eventType  = trim($eventType);
+        if ($endpointId === '') {
+            throw new \InvalidArgumentException('endpoint_id must not be empty.');
+        }
+        if ($eventType === '') {
+            throw new \InvalidArgumentException('event_type must not be empty.');
+        }
+        return [$endpointId, $eventType];
+    }
+}

--- a/tests/Unit/Xion/WebhookDeliveryTest.php
+++ b/tests/Unit/Xion/WebhookDeliveryTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\WebhookDelivery;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for WebhookDelivery.
+ */
+final class WebhookDeliveryTest extends TestCase
+{
+    private PDO $db;
+    private WebhookDelivery $wd;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE webhook_deliveries (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                endpoint_id     VARCHAR(255) NOT NULL,
+                event_type      VARCHAR(100) NOT NULL,
+                payload         TEXT         NOT NULL DEFAULT \'{}\',
+                status          VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                attempts        INT          NOT NULL DEFAULT 0,
+                max_attempts    INT          NOT NULL DEFAULT 5,
+                http_status     INT          NOT NULL DEFAULT 0,
+                response_body   TEXT         NOT NULL DEFAULT \'\',
+                next_attempt_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                delivered_at    DATETIME     DEFAULT NULL,
+                created_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->wd = new WebhookDelivery($this->db, 5);
+    }
+
+    // ── schedule ──────────────────────────────────────────────────────────────
+
+    public function testScheduleReturnsId(): void
+    {
+        $id = $this->wd->schedule('ep-1', 'user.created');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testScheduleStoresPayload(): void
+    {
+        $id = $this->wd->schedule('ep-1', 'order.placed', ['amount' => 99]);
+        $d  = $this->wd->find($id);
+        $this->assertSame(['amount' => 99], $d['payload']);
+    }
+
+    public function testScheduleStatusIsPending(): void
+    {
+        $id = $this->wd->schedule('ep-1', 'ping');
+        $d  = $this->wd->find($id);
+        $this->assertSame('pending', $d['status']);
+    }
+
+    public function testScheduleThrowsOnEmptyEndpointId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wd->schedule('', 'ping');
+    }
+
+    public function testScheduleThrowsOnEmptyEventType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wd->schedule('ep-1', '');
+    }
+
+    public function testScheduleWithDelayIsNotImmediatelyClaimed(): void
+    {
+        $this->wd->schedule('ep-1', 'ping', [], 3600);
+        $this->assertNull($this->wd->claimNext());
+    }
+
+    // ── claimNext ─────────────────────────────────────────────────────────────
+
+    public function testClaimNextReturnsDelivery(): void
+    {
+        $this->wd->schedule('ep-1', 'ping');
+        $d = $this->wd->claimNext();
+        $this->assertNotNull($d);
+        $this->assertSame('sending', $d['status']);
+    }
+
+    public function testClaimNextIncrementsAttempts(): void
+    {
+        $this->wd->schedule('ep-1', 'ping');
+        $d = $this->wd->claimNext();
+        $this->assertSame(1, (int)$d['attempts']);
+    }
+
+    public function testClaimNextReturnsNullWhenEmpty(): void
+    {
+        $this->assertNull($this->wd->claimNext());
+    }
+
+    public function testClaimNextReturnsOldestFirst(): void
+    {
+        $id1 = $this->wd->schedule('ep-1', 'first');
+        $id2 = $this->wd->schedule('ep-1', 'second');
+        $d   = $this->wd->claimNext();
+        $this->assertSame($id1, (int)$d['id']);
+    }
+
+    // ── succeed ───────────────────────────────────────────────────────────────
+
+    public function testSucceedMarksDelivered(): void
+    {
+        $this->wd->schedule('ep-1', 'ping');
+        $d = $this->wd->claimNext();
+        $this->assertTrue($this->wd->succeed((int)$d['id'], 200, 'ok'));
+        $updated = $this->wd->find((int)$d['id']);
+        $this->assertSame('delivered', $updated['status']);
+        $this->assertSame(200, (int)$updated['http_status']);
+    }
+
+    public function testSucceedReturnsFalseIfNotSending(): void
+    {
+        $id = $this->wd->schedule('ep-1', 'ping');
+        $this->assertFalse($this->wd->succeed($id, 200));
+    }
+
+    // ── fail ──────────────────────────────────────────────────────────────────
+
+    public function testFailResetsToPendingWhenAttemptsRemain(): void
+    {
+        $wd = new WebhookDelivery($this->db, 3);
+        $wd->schedule('ep-1', 'ping');
+        $d = $wd->claimNext();
+        $wd->fail((int)$d['id'], 500, 'error');
+        $updated = $wd->find((int)$d['id']);
+        $this->assertSame('pending', $updated['status']);
+        $this->assertSame('error', $updated['response_body']);
+    }
+
+    public function testFailMarksFailedWhenMaxAttemptsReached(): void
+    {
+        $wd = new WebhookDelivery($this->db, 1);
+        $wd->schedule('ep-1', 'ping');
+        $d = $wd->claimNext();
+        $wd->fail((int)$d['id'], 0, 'timeout');
+        $updated = $wd->find((int)$d['id']);
+        $this->assertSame('failed', $updated['status']);
+    }
+
+    public function testFailReturnsFalseIfNotSending(): void
+    {
+        $id = $this->wd->schedule('ep-1', 'ping');
+        $this->assertFalse($this->wd->fail($id, 0));
+    }
+
+    // ── listPending ───────────────────────────────────────────────────────────
+
+    public function testListPendingReturnsReadyDeliveries(): void
+    {
+        $this->wd->schedule('ep-1', 'a');
+        $this->wd->schedule('ep-1', 'b');
+        $list = $this->wd->listPending('ep-1');
+        $this->assertCount(2, $list);
+    }
+
+    public function testListPendingIsEndpointScoped(): void
+    {
+        $this->wd->schedule('ep-1', 'ping');
+        $this->wd->schedule('ep-2', 'ping');
+        $list = $this->wd->listPending('ep-1');
+        $this->assertCount(1, $list);
+    }
+
+    public function testListPendingExcludesSending(): void
+    {
+        $this->wd->schedule('ep-1', 'ping');
+        $this->wd->claimNext();
+        $this->assertCount(0, $this->wd->listPending('ep-1'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountReturnsTotal(): void
+    {
+        $this->wd->schedule('ep-1', 'a');
+        $this->wd->schedule('ep-1', 'b');
+        $this->assertSame(2, $this->wd->count());
+    }
+
+    public function testCountByStatus(): void
+    {
+        $this->wd->schedule('ep-1', 'a');
+        $d = $this->wd->claimNext();
+        $this->wd->succeed((int)$d['id'], 200);
+        $this->wd->schedule('ep-1', 'b');
+        $this->assertSame(1, $this->wd->count('pending'));
+        $this->assertSame(1, $this->wd->count('delivered'));
+    }
+
+    // ── purge ─────────────────────────────────────────────────────────────────
+
+    public function testPurgeDeletesOldDelivered(): void
+    {
+        $id = $this->wd->schedule('ep-1', 'ping');
+        $d  = $this->wd->claimNext();
+        $this->wd->succeed((int)$d['id'], 200);
+        $this->db->exec("UPDATE webhook_deliveries SET created_at = '2000-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->wd->purge(1);
+        $this->assertSame(1, $deleted);
+    }
+
+    public function testPurgeDoesNotDeleteRecent(): void
+    {
+        $id = $this->wd->schedule('ep-1', 'ping');
+        $d  = $this->wd->claimNext();
+        $this->wd->succeed((int)$d['id'], 200);
+        $this->assertSame(0, $this->wd->purge(30));
+    }
+}

--- a/tests/Unit/Xion/WebhookDeliveryTest.php
+++ b/tests/Unit/Xion/WebhookDeliveryTest.php
@@ -51,6 +51,7 @@ final class WebhookDeliveryTest extends TestCase
     {
         $id = $this->wd->schedule('ep-1', 'order.placed', ['amount' => 99]);
         $d  = $this->wd->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(['amount' => 99], $d['payload']);
     }
 
@@ -58,6 +59,7 @@ final class WebhookDeliveryTest extends TestCase
     {
         $id = $this->wd->schedule('ep-1', 'ping');
         $d  = $this->wd->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('pending', $d['status']);
     }
 
@@ -86,6 +88,7 @@ final class WebhookDeliveryTest extends TestCase
         $this->wd->schedule('ep-1', 'ping');
         $d = $this->wd->claimNext();
         $this->assertNotNull($d);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('sending', $d['status']);
     }
 
@@ -93,6 +96,7 @@ final class WebhookDeliveryTest extends TestCase
     {
         $this->wd->schedule('ep-1', 'ping');
         $d = $this->wd->claimNext();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(1, (int)$d['attempts']);
     }
 
@@ -106,6 +110,7 @@ final class WebhookDeliveryTest extends TestCase
         $id1 = $this->wd->schedule('ep-1', 'first');
         $id2 = $this->wd->schedule('ep-1', 'second');
         $d   = $this->wd->claimNext();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame($id1, (int)$d['id']);
     }
 
@@ -115,9 +120,13 @@ final class WebhookDeliveryTest extends TestCase
     {
         $this->wd->schedule('ep-1', 'ping');
         $d = $this->wd->claimNext();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertTrue($this->wd->succeed((int)$d['id'], 200, 'ok'));
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $updated = $this->wd->find((int)$d['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('delivered', $updated['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(200, (int)$updated['http_status']);
     }
 
@@ -134,9 +143,13 @@ final class WebhookDeliveryTest extends TestCase
         $wd = new WebhookDelivery($this->db, 3);
         $wd->schedule('ep-1', 'ping');
         $d = $wd->claimNext();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $wd->fail((int)$d['id'], 500, 'error');
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $updated = $wd->find((int)$d['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('pending', $updated['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('error', $updated['response_body']);
     }
 
@@ -145,8 +158,11 @@ final class WebhookDeliveryTest extends TestCase
         $wd = new WebhookDelivery($this->db, 1);
         $wd->schedule('ep-1', 'ping');
         $d = $wd->claimNext();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $wd->fail((int)$d['id'], 0, 'timeout');
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $updated = $wd->find((int)$d['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('failed', $updated['status']);
     }
 
@@ -194,6 +210,7 @@ final class WebhookDeliveryTest extends TestCase
     {
         $this->wd->schedule('ep-1', 'a');
         $d = $this->wd->claimNext();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->wd->succeed((int)$d['id'], 200);
         $this->wd->schedule('ep-1', 'b');
         $this->assertSame(1, $this->wd->count('pending'));
@@ -206,6 +223,7 @@ final class WebhookDeliveryTest extends TestCase
     {
         $id = $this->wd->schedule('ep-1', 'ping');
         $d  = $this->wd->claimNext();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->wd->succeed((int)$d['id'], 200);
         $this->db->exec("UPDATE webhook_deliveries SET created_at = '2000-01-01 00:00:00' WHERE id = {$id}");
         $deleted = $this->wd->purge(1);
@@ -216,6 +234,7 @@ final class WebhookDeliveryTest extends TestCase
     {
         $id = $this->wd->schedule('ep-1', 'ping');
         $d  = $this->wd->claimNext();
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->wd->succeed((int)$d['id'], 200);
         $this->assertSame(0, $this->wd->purge(30));
     }


### PR DESCRIPTION
## WebhookDelivery

Outbound webhook delivery log with exponential backoff retry.

### Schema
```sql
CREATE TABLE webhook_deliveries (
    id              INTEGER PRIMARY KEY AUTOINCREMENT,
    endpoint_id     VARCHAR(255) NOT NULL,
    event_type      VARCHAR(100) NOT NULL,
    payload         TEXT         NOT NULL DEFAULT '{}',
    status          VARCHAR(20)  NOT NULL DEFAULT 'pending',
    attempts        INT          NOT NULL DEFAULT 0,
    max_attempts    INT          NOT NULL DEFAULT 5,
    http_status     INT          NOT NULL DEFAULT 0,
    response_body   TEXT         NOT NULL DEFAULT '',
    next_attempt_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    delivered_at    DATETIME     DEFAULT NULL,
    created_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### API
- `schedule(endpointId, eventType, payload, delaySeconds)` — queue delivery
- `claimNext()` — atomically pick next ready delivery (`sending` state)
- `succeed(id, httpStatus, responseBody)` — mark delivered
- `fail(id, httpStatus, responseBody)` — retry with exponential backoff or mark failed
- `find(id)` — get delivery with decoded payload
- `listPending(endpointId, limit)` — list ready deliveries
- `count(?status)` — count by status or total
- `purge(days)` — clean old delivered/failed records

### Tests
22 tests, 27 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)