### PR TITLE
feat(xion): SessionFlash — DB-backed one-time flash messages (FT130)

### DIFF
--- a/class/xion/SessionFlash.php
+++ b/class/xion/SessionFlash.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * SessionFlash — one-time flash messages stored in DB, consumed on next read.
+ *
+ * Flash messages are written with a session token and a category (e.g. 'success',
+ * 'error', 'info'). On the next page load the caller reads them — each message
+ * is returned exactly once and then deleted.
+ *
+ * Suitable for post/redirect/get patterns where the PHP session is unavailable
+ * (e.g. API-first apps, multi-server deployments sharing a DB).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $sf = new SessionFlash($pdo);
+ *
+ * // Write flash messages (before redirect)
+ * $sf->add('tok-abc', 'success', 'Profile saved.');
+ * $sf->add('tok-abc', 'info', 'Email verification sent.');
+ *
+ * // Read and consume (after redirect)
+ * $messages = $sf->consume('tok-abc'); // returns all, then deletes them
+ *
+ * // Or consume only one category
+ * $errors = $sf->consumeCategory('tok-abc', 'error');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE session_flash (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     token      VARCHAR(255) NOT NULL,
+ *     category   VARCHAR(50)  NOT NULL DEFAULT 'info',
+ *     message    TEXT         NOT NULL DEFAULT '',
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class SessionFlash
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add a flash message.
+     *
+     * @return int The new record ID.
+     * @throws \InvalidArgumentException if token is empty.
+     */
+    public function add(string $token, string $category, string $message): int
+    {
+        $token = $this->validateToken($token);
+        $db    = $this->db();
+
+        $db->prepare(
+            'INSERT INTO session_flash (token, category, message) VALUES (:token, :cat, :msg)'
+        )->execute([':token' => $token, ':cat' => $category, ':msg' => $message]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Consume all flash messages for a token (returns them and deletes them).
+     *
+     * @return list<array{id: int, category: string, message: string}>
+     */
+    public function consume(string $token): array
+    {
+        $token = $this->validateToken($token);
+        $db    = $this->db();
+
+        $stmt = $db->prepare(
+            'SELECT id, category, message FROM session_flash
+             WHERE token = :token ORDER BY id ASC'
+        );
+        $stmt->execute([':token' => $token]);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        if (!empty($rows)) {
+            $db->prepare('DELETE FROM session_flash WHERE token = :token')->execute([':token' => $token]);
+        }
+
+        return array_map(
+            static fn (array $r) => [
+                'id'       => (int)$r['id'],
+                'category' => (string)$r['category'],
+                'message'  => (string)$r['message'],
+            ],
+            $rows
+        );
+    }
+
+    /**
+     * Consume flash messages of a specific category (returns and deletes them).
+     *
+     * @return list<array{id: int, category: string, message: string}>
+     */
+    public function consumeCategory(string $token, string $category): array
+    {
+        $token = $this->validateToken($token);
+        $db    = $this->db();
+
+        $stmt = $db->prepare(
+            'SELECT id, category, message FROM session_flash
+             WHERE token = :token AND category = :cat ORDER BY id ASC'
+        );
+        $stmt->execute([':token' => $token, ':cat' => $category]);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        if (!empty($rows)) {
+            $ids = array_column($rows, 'id');
+            $in  = implode(',', array_fill(0, count($ids), '?'));
+            $db->prepare("DELETE FROM session_flash WHERE id IN ({$in})")->execute($ids);
+        }
+
+        return array_map(
+            static fn (array $r) => [
+                'id'       => (int)$r['id'],
+                'category' => (string)$r['category'],
+                'message'  => (string)$r['message'],
+            ],
+            $rows
+        );
+    }
+
+    /**
+     * Peek at flash messages without consuming them.
+     *
+     * @return list<array{id: int, category: string, message: string}>
+     */
+    public function peek(string $token): array
+    {
+        $token = $this->validateToken($token);
+        $stmt  = $this->db()->prepare(
+            'SELECT id, category, message FROM session_flash
+             WHERE token = :token ORDER BY id ASC'
+        );
+        $stmt->execute([':token' => $token]);
+        return array_map(
+            static fn (array $r) => [
+                'id'       => (int)$r['id'],
+                'category' => (string)$r['category'],
+                'message'  => (string)$r['message'],
+            ],
+            $stmt->fetchAll(PDO::FETCH_ASSOC) ?: []
+        );
+    }
+
+    /**
+     * Check whether any flash messages exist for a token.
+     */
+    public function has(string $token, ?string $category = null): bool
+    {
+        $token = $this->validateToken($token);
+
+        if ($category !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM session_flash WHERE token = :token AND category = :cat'
+            );
+            $stmt->execute([':token' => $token, ':cat' => $category]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM session_flash WHERE token = :token'
+            );
+            $stmt->execute([':token' => $token]);
+        }
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Count flash messages for a token.
+     */
+    public function count(string $token): int
+    {
+        $token = $this->validateToken($token);
+        $stmt  = $this->db()->prepare('SELECT COUNT(*) FROM session_flash WHERE token = :token');
+        $stmt->execute([':token' => $token]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Purge messages older than N days (for cleanup jobs).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare('DELETE FROM session_flash WHERE created_at < :cutoff');
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateToken(string $token): string
+    {
+        $token = trim($token);
+        if ($token === '') {
+            throw new \InvalidArgumentException('token must not be empty.');
+        }
+        return $token;
+    }
+}

--- a/tests/Unit/Xion/SessionFlashTest.php
+++ b/tests/Unit/Xion/SessionFlashTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\SessionFlash;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for SessionFlash.
+ */
+final class SessionFlashTest extends TestCase
+{
+    private PDO $db;
+    private SessionFlash $sf;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE session_flash (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                token      VARCHAR(255) NOT NULL,
+                category   VARCHAR(50)  NOT NULL DEFAULT \'info\',
+                message    TEXT         NOT NULL DEFAULT \'\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->sf = new SessionFlash($this->db);
+    }
+
+    // ── add ───────────────────────────────────────────────────────────────────
+
+    public function testAddReturnsId(): void
+    {
+        $id = $this->sf->add('tok-1', 'success', 'Saved.');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testAddThrowsOnEmptyToken(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sf->add('', 'info', 'hello');
+    }
+
+    // ── consume ───────────────────────────────────────────────────────────────
+
+    public function testConsumeReturnsMessages(): void
+    {
+        $this->sf->add('tok-1', 'success', 'Saved.');
+        $this->sf->add('tok-1', 'info', 'Check email.');
+        $msgs = $this->sf->consume('tok-1');
+        $this->assertCount(2, $msgs);
+    }
+
+    public function testConsumeDeletesMessages(): void
+    {
+        $this->sf->add('tok-1', 'success', 'Saved.');
+        $this->sf->consume('tok-1');
+        $this->assertSame([], $this->sf->consume('tok-1'));
+    }
+
+    public function testConsumeReturnsInInsertOrder(): void
+    {
+        $this->sf->add('tok-1', 'info', 'first');
+        $this->sf->add('tok-1', 'error', 'second');
+        $msgs = $this->sf->consume('tok-1');
+        $this->assertSame('first', $msgs[0]['message']);
+        $this->assertSame('second', $msgs[1]['message']);
+    }
+
+    public function testConsumeReturnsEmptyForUnknownToken(): void
+    {
+        $this->assertSame([], $this->sf->consume('nobody'));
+    }
+
+    public function testConsumeIsTokenScoped(): void
+    {
+        $this->sf->add('tok-1', 'info', 'for tok-1');
+        $this->sf->add('tok-2', 'info', 'for tok-2');
+        $msgs = $this->sf->consume('tok-1');
+        $this->assertCount(1, $msgs);
+        $this->assertSame(1, $this->sf->count('tok-2'));
+    }
+
+    // ── consumeCategory ───────────────────────────────────────────────────────
+
+    public function testConsumeCategoryReturnsOnlyMatchingCategory(): void
+    {
+        $this->sf->add('tok-1', 'success', 'ok');
+        $this->sf->add('tok-1', 'error', 'bad');
+        $msgs = $this->sf->consumeCategory('tok-1', 'error');
+        $this->assertCount(1, $msgs);
+        $this->assertSame('error', $msgs[0]['category']);
+    }
+
+    public function testConsumeCategoryDeletesOnlyMatchingCategory(): void
+    {
+        $this->sf->add('tok-1', 'success', 'ok');
+        $this->sf->add('tok-1', 'error', 'bad');
+        $this->sf->consumeCategory('tok-1', 'error');
+        $this->assertSame(1, $this->sf->count('tok-1'));
+    }
+
+    // ── peek ──────────────────────────────────────────────────────────────────
+
+    public function testPeekDoesNotDeleteMessages(): void
+    {
+        $this->sf->add('tok-1', 'info', 'hello');
+        $this->sf->peek('tok-1');
+        $this->assertSame(1, $this->sf->count('tok-1'));
+    }
+
+    public function testPeekReturnsMessages(): void
+    {
+        $this->sf->add('tok-1', 'info', 'hello');
+        $msgs = $this->sf->peek('tok-1');
+        $this->assertCount(1, $msgs);
+        $this->assertSame('hello', $msgs[0]['message']);
+    }
+
+    // ── has ───────────────────────────────────────────────────────────────────
+
+    public function testHasReturnsTrueWhenMessagesExist(): void
+    {
+        $this->sf->add('tok-1', 'info', 'hello');
+        $this->assertTrue($this->sf->has('tok-1'));
+    }
+
+    public function testHasReturnsFalseWhenNoMessages(): void
+    {
+        $this->assertFalse($this->sf->has('tok-1'));
+    }
+
+    public function testHasByCategory(): void
+    {
+        $this->sf->add('tok-1', 'success', 'ok');
+        $this->assertTrue($this->sf->has('tok-1', 'success'));
+        $this->assertFalse($this->sf->has('tok-1', 'error'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountReturnsZeroInitially(): void
+    {
+        $this->assertSame(0, $this->sf->count('tok-1'));
+    }
+
+    public function testCountReturnsNumberOfMessages(): void
+    {
+        $this->sf->add('tok-1', 'info', 'a');
+        $this->sf->add('tok-1', 'error', 'b');
+        $this->assertSame(2, $this->sf->count('tok-1'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldMessages(): void
+    {
+        $id = $this->sf->add('tok-1', 'info', 'old');
+        $this->db->exec("UPDATE session_flash SET created_at = '2000-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->sf->purgeOlderThan(1);
+        $this->assertSame(1, $deleted);
+        $this->assertSame(0, $this->sf->count('tok-1'));
+    }
+
+    public function testPurgeOlderThanLeavesRecentMessages(): void
+    {
+        $this->sf->add('tok-1', 'info', 'fresh');
+        $this->assertSame(0, $this->sf->purgeOlderThan(30));
+    }
+}


### PR DESCRIPTION
## SessionFlash

DB-backed flash message store for post/redirect/get patterns.

### Schema
```sql
CREATE TABLE session_flash (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    token      VARCHAR(255) NOT NULL,
    category   VARCHAR(50)  NOT NULL DEFAULT 'info',
    message    TEXT         NOT NULL DEFAULT '',
    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### API
- `add(token, category, message)` — store a flash message
- `consume(token)` — read all messages and delete them (one-time)
- `consumeCategory(token, category)` — read and delete by category
- `peek(token)` — read without deleting
- `has(token, ?category)` — check existence
- `count(token)` — count pending messages
- `purgeOlderThan(days)` — clean stale messages

### Tests
18 tests, 24 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)