### PR TITLE
feat(xion): MediaMetadata — media file registry with key-value metadata (FT131)

### DIFF
--- a/class/xion/MediaMetadata.php
+++ b/class/xion/MediaMetadata.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * MediaMetadata — store and retrieve metadata for uploaded media files.
+ *
+ * Tracks file attributes (MIME type, size, dimensions) and arbitrary
+ * key-value metadata (alt text, caption, credits, etc.) per file.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $mm = new MediaMetadata($pdo);
+ *
+ * // Register a file
+ * $id = $mm->register('file-uuid-1', 'image/jpeg', 204800, ['width' => 1920, 'height' => 1080]);
+ *
+ * // Set metadata
+ * $mm->setMeta($id, 'alt_text', 'A scenic mountain photo');
+ *
+ * // Retrieve
+ * $mm->find($id);
+ * $mm->getMeta($id, 'alt_text');
+ * $mm->allMeta($id);
+ *
+ * // Delete
+ * $mm->remove($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE media_files (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     file_key    VARCHAR(255) NOT NULL UNIQUE,
+ *     mime_type   VARCHAR(100) NOT NULL DEFAULT '',
+ *     file_size   BIGINT       NOT NULL DEFAULT 0,
+ *     attributes  TEXT         NOT NULL DEFAULT '{}',
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE media_meta (
+ *     file_id    INTEGER      NOT NULL,
+ *     meta_key   VARCHAR(100) NOT NULL,
+ *     meta_value TEXT         NOT NULL DEFAULT '',
+ *     PRIMARY KEY (file_id, meta_key)
+ * );
+ * ```
+ */
+final class MediaMetadata
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Register a media file.
+     *
+     * @param  array<string,mixed> $attributes Extra attributes (width, height, duration…)
+     * @return int The new file record ID.
+     * @throws \InvalidArgumentException if file_key is empty.
+     * @throws \RuntimeException if file_key is already registered.
+     */
+    public function register(
+        string $fileKey,
+        string $mimeType = '',
+        int $fileSize = 0,
+        array $attributes = []
+    ): int {
+        $fileKey = $this->validateFileKey($fileKey);
+        $db      = $this->db();
+
+        $db->prepare(
+            'INSERT INTO media_files (file_key, mime_type, file_size, attributes)
+             VALUES (:key, :mime, :size, :attrs)'
+        )->execute([
+            ':key'   => $fileKey,
+            ':mime'  => $mimeType,
+            ':size'  => $fileSize,
+            ':attrs' => json_encode($attributes, JSON_THROW_ON_ERROR),
+        ]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Find a media file by its database ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, file_key, mime_type, file_size, attributes, created_at
+             FROM media_files WHERE id = :id LIMIT 1'
+        );
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+        $row['attributes'] = json_decode((string)$row['attributes'], true) ?? [];
+        return $row;
+    }
+
+    /**
+     * Find a media file by its file key.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function findByKey(string $fileKey): ?array
+    {
+        $fileKey = $this->validateFileKey($fileKey);
+        $stmt    = $this->db()->prepare(
+            'SELECT id, file_key, mime_type, file_size, attributes, created_at
+             FROM media_files WHERE file_key = :key LIMIT 1'
+        );
+        $stmt->execute([':key' => $fileKey]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+        $row['attributes'] = json_decode((string)$row['attributes'], true) ?? [];
+        return $row;
+    }
+
+    /**
+     * Set (upsert) a metadata key-value pair for a file.
+     */
+    public function setMeta(int $fileId, string $key, string $value): void
+    {
+        $key = $this->validateMetaKey($key);
+        $db  = $this->db();
+
+        if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO media_meta (file_id, meta_key, meta_value)
+                 VALUES (:fid, :key, :val)
+                 ON CONFLICT (file_id, meta_key)
+                 DO UPDATE SET meta_value = excluded.meta_value'
+            )->execute([':fid' => $fileId, ':key' => $key, ':val' => $value]);
+        } else {
+            $db->prepare(
+                'INSERT INTO media_meta (file_id, meta_key, meta_value)
+                 VALUES (:fid, :key, :val)
+                 ON DUPLICATE KEY UPDATE meta_value = VALUES(meta_value)'
+            )->execute([':fid' => $fileId, ':key' => $key, ':val' => $value]);
+        }
+    }
+
+    /**
+     * Get a single metadata value (with default).
+     */
+    public function getMeta(int $fileId, string $key, string $default = ''): string
+    {
+        $key  = $this->validateMetaKey($key);
+        $stmt = $this->db()->prepare(
+            'SELECT meta_value FROM media_meta WHERE file_id = :fid AND meta_key = :key LIMIT 1'
+        );
+        $stmt->execute([':fid' => $fileId, ':key' => $key]);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : $default;
+    }
+
+    /**
+     * Get all metadata for a file as key-value map.
+     *
+     * @return array<string,string>
+     */
+    public function allMeta(int $fileId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT meta_key, meta_value FROM media_meta WHERE file_id = :fid ORDER BY meta_key ASC'
+        );
+        $stmt->execute([':fid' => $fileId]);
+        $result = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $result[(string)$row['meta_key']] = (string)$row['meta_value'];
+        }
+        return $result;
+    }
+
+    /**
+     * Delete a single metadata key.
+     *
+     * @return bool True if a row was deleted.
+     */
+    public function deleteMeta(int $fileId, string $key): bool
+    {
+        $key  = $this->validateMetaKey($key);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM media_meta WHERE file_id = :fid AND meta_key = :key'
+        );
+        $stmt->execute([':fid' => $fileId, ':key' => $key]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Remove a media file and all its metadata (hard delete).
+     *
+     * @return bool True if the file was found and deleted.
+     */
+    public function remove(int $id): bool
+    {
+        $db = $this->db();
+        $db->prepare('DELETE FROM media_meta WHERE file_id = :id')->execute([':id' => $id]);
+        $stmt = $db->prepare('DELETE FROM media_files WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Count all registered media files.
+     */
+    public function count(): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM media_files');
+        $stmt->execute();
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateFileKey(string $fileKey): string
+    {
+        $fileKey = trim($fileKey);
+        if ($fileKey === '') {
+            throw new \InvalidArgumentException('file_key must not be empty.');
+        }
+        return $fileKey;
+    }
+
+    private function validateMetaKey(string $key): string
+    {
+        $key = trim($key);
+        if ($key === '') {
+            throw new \InvalidArgumentException('meta_key must not be empty.');
+        }
+        return $key;
+    }
+}

--- a/tests/Unit/Xion/MediaMetadataTest.php
+++ b/tests/Unit/Xion/MediaMetadataTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\MediaMetadata;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for MediaMetadata.
+ */
+final class MediaMetadataTest extends TestCase
+{
+    private PDO $db;
+    private MediaMetadata $mm;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE media_files (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_key   VARCHAR(255) NOT NULL UNIQUE,
+                mime_type  VARCHAR(100) NOT NULL DEFAULT \'\',
+                file_size  BIGINT       NOT NULL DEFAULT 0,
+                attributes TEXT         NOT NULL DEFAULT \'{}\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->db->exec('
+            CREATE TABLE media_meta (
+                file_id    INTEGER      NOT NULL,
+                meta_key   VARCHAR(100) NOT NULL,
+                meta_value TEXT         NOT NULL DEFAULT \'\',
+                PRIMARY KEY (file_id, meta_key)
+            )
+        ');
+        $this->mm = new MediaMetadata($this->db);
+    }
+
+    // ── register + find ───────────────────────────────────────────────────────
+
+    public function testRegisterReturnsId(): void
+    {
+        $id = $this->mm->register('file-1');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testRegisterStoresAttributes(): void
+    {
+        $id  = $this->mm->register('img-1', 'image/jpeg', 204800, ['width' => 1920, 'height' => 1080]);
+        $row = $this->mm->find($id);
+        $this->assertSame('image/jpeg', $row['mime_type']);
+        $this->assertSame(204800, (int)$row['file_size']);
+        $this->assertSame(['width' => 1920, 'height' => 1080], $row['attributes']);
+    }
+
+    public function testFindReturnsNullForUnknownId(): void
+    {
+        $this->assertNull($this->mm->find(999));
+    }
+
+    public function testRegisterThrowsOnEmptyFileKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mm->register('');
+    }
+
+    // ── findByKey ─────────────────────────────────────────────────────────────
+
+    public function testFindByKeyReturnsFile(): void
+    {
+        $this->mm->register('uuid-abc', 'video/mp4');
+        $row = $this->mm->findByKey('uuid-abc');
+        $this->assertSame('video/mp4', $row['mime_type']);
+    }
+
+    public function testFindByKeyReturnsNullForUnknown(): void
+    {
+        $this->assertNull($this->mm->findByKey('no-such-key'));
+    }
+
+    // ── setMeta + getMeta ─────────────────────────────────────────────────────
+
+    public function testSetMetaAndGetMeta(): void
+    {
+        $id = $this->mm->register('img-2');
+        $this->mm->setMeta($id, 'alt_text', 'A mountain');
+        $this->assertSame('A mountain', $this->mm->getMeta($id, 'alt_text'));
+    }
+
+    public function testGetMetaReturnsDefaultWhenNotSet(): void
+    {
+        $id = $this->mm->register('img-3');
+        $this->assertSame('n/a', $this->mm->getMeta($id, 'caption', 'n/a'));
+    }
+
+    public function testSetMetaIsUpsert(): void
+    {
+        $id = $this->mm->register('img-4');
+        $this->mm->setMeta($id, 'alt_text', 'original');
+        $this->mm->setMeta($id, 'alt_text', 'updated');
+        $this->assertSame('updated', $this->mm->getMeta($id, 'alt_text'));
+    }
+
+    public function testSetMetaThrowsOnEmptyKey(): void
+    {
+        $id = $this->mm->register('img-5');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mm->setMeta($id, '', 'value');
+    }
+
+    // ── allMeta ───────────────────────────────────────────────────────────────
+
+    public function testAllMetaReturnsKeyValueMap(): void
+    {
+        $id = $this->mm->register('img-6');
+        $this->mm->setMeta($id, 'alt_text', 'hello');
+        $this->mm->setMeta($id, 'caption', 'world');
+        $meta = $this->mm->allMeta($id);
+        $this->assertSame(['alt_text' => 'hello', 'caption' => 'world'], $meta);
+    }
+
+    public function testAllMetaReturnsEmptyForNoMeta(): void
+    {
+        $id = $this->mm->register('img-7');
+        $this->assertSame([], $this->mm->allMeta($id));
+    }
+
+    // ── deleteMeta ────────────────────────────────────────────────────────────
+
+    public function testDeleteMetaRemovesKey(): void
+    {
+        $id = $this->mm->register('img-8');
+        $this->mm->setMeta($id, 'alt_text', 'hello');
+        $this->assertTrue($this->mm->deleteMeta($id, 'alt_text'));
+        $this->assertSame('', $this->mm->getMeta($id, 'alt_text'));
+    }
+
+    public function testDeleteMetaReturnsFalseIfNotPresent(): void
+    {
+        $id = $this->mm->register('img-9');
+        $this->assertFalse($this->mm->deleteMeta($id, 'missing'));
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesFileAndMeta(): void
+    {
+        $id = $this->mm->register('to-delete');
+        $this->mm->setMeta($id, 'alt_text', 'bye');
+        $this->assertTrue($this->mm->remove($id));
+        $this->assertNull($this->mm->find($id));
+        $this->assertSame([], $this->mm->allMeta($id));
+    }
+
+    public function testRemoveReturnsFalseForUnknownId(): void
+    {
+        $this->assertFalse($this->mm->remove(999));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountReturnsZeroInitially(): void
+    {
+        $this->assertSame(0, $this->mm->count());
+    }
+
+    public function testCountIncrementsOnRegister(): void
+    {
+        $this->mm->register('f1');
+        $this->mm->register('f2');
+        $this->assertSame(2, $this->mm->count());
+    }
+
+    public function testCountDecrementsOnRemove(): void
+    {
+        $id = $this->mm->register('f1');
+        $this->mm->remove($id);
+        $this->assertSame(0, $this->mm->count());
+    }
+}

--- a/tests/Unit/Xion/MediaMetadataTest.php
+++ b/tests/Unit/Xion/MediaMetadataTest.php
@@ -53,8 +53,11 @@ final class MediaMetadataTest extends TestCase
     {
         $id  = $this->mm->register('img-1', 'image/jpeg', 204800, ['width' => 1920, 'height' => 1080]);
         $row = $this->mm->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('image/jpeg', $row['mime_type']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(204800, (int)$row['file_size']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(['width' => 1920, 'height' => 1080], $row['attributes']);
     }
 
@@ -75,6 +78,7 @@ final class MediaMetadataTest extends TestCase
     {
         $this->mm->register('uuid-abc', 'video/mp4');
         $row = $this->mm->findByKey('uuid-abc');
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('video/mp4', $row['mime_type']);
     }
 


### PR DESCRIPTION
## MediaMetadata

Media file registry with flexible key-value metadata storage.

### Schema
```sql
CREATE TABLE media_files (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    file_key   VARCHAR(255) NOT NULL UNIQUE,
    mime_type  VARCHAR(100) NOT NULL DEFAULT '',
    file_size  BIGINT       NOT NULL DEFAULT 0,
    attributes TEXT         NOT NULL DEFAULT '{}',
    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);

CREATE TABLE media_meta (
    file_id    INTEGER      NOT NULL,
    meta_key   VARCHAR(100) NOT NULL,
    meta_value TEXT         NOT NULL DEFAULT '',
    PRIMARY KEY (file_id, meta_key)
);
```

### API
- `register(fileKey, mimeType, fileSize, attributes)` — store file with JSON attributes
- `find(id)` / `findByKey(fileKey)` — retrieve file with decoded attributes
- `setMeta(fileId, key, value)` — upsert metadata key-value
- `getMeta(fileId, key, default='')` — retrieve single meta
- `allMeta(fileId)` — get all meta as key-value map
- `deleteMeta(fileId, key)` — remove single meta key
- `remove(id)` — hard-delete file and all metadata
- `count()` — count registered files

### Tests
19 tests, 24 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)