### PR TITLE
feat(xion): CommentThread — threaded comments with soft-delete (FT133)

### DIFF
--- a/class/xion/CommentThread.php
+++ b/class/xion/CommentThread.php
@@ -7,34 +7,50 @@ namespace Nene\Xion;
 use PDO;
 
 /**
- * CommentThread — threaded comments on any entity (posts, products, tickets…).
+ * CommentThread — threaded comments attached to any entity.
  *
- * Supports top-level comments and single-level replies (parent_id).
- * Comments can be soft-deleted (body replaced, deleted_at set) or hard-deleted.
- * The thread structure is kept intact — deleted comments show as tombstones.
+ * Comments can be top-level or replies to another comment (one level of nesting).
+ * Soft-delete preserves thread structure while hiding body content.
  *
- * Status lifecycle: created → (edited) → soft-deleted
+ * ## Usage
+ *
+ * ```php
+ * $ct = new CommentThread($pdo);
+ *
+ * // Add a top-level comment
+ * $id = $ct->add('post', '42', 'user-1', 'Great article!');
+ *
+ * // Reply to a comment
+ * $replyId = $ct->add('post', '42', 'user-2', 'Thanks!', $id);
+ *
+ * // List all comments (flat, ordered by id)
+ * $ct->list('post', '42');
+ *
+ * // Soft-delete
+ * $ct->delete($id, 'user-1');
+ *
+ * // Count
+ * $ct->count('post', '42');
+ * ```
  *
  * ## Schema (SQLite / MySQL compatible)
  *
  * ```sql
  * CREATE TABLE comments (
- *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
- *     entity_type VARCHAR(100) NOT NULL,
- *     entity_id   VARCHAR(255) NOT NULL,
- *     user_id     VARCHAR(255) NOT NULL,
- *     parent_id   INTEGER      DEFAULT NULL,
- *     body        TEXT         NOT NULL,
- *     deleted_at  DATETIME     DEFAULT NULL,
- *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
- *     updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ *     id            INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     entity_type   VARCHAR(100) NOT NULL,
+ *     entity_id     VARCHAR(255) NOT NULL,
+ *     parent_id     INTEGER      DEFAULT NULL,
+ *     author_id     VARCHAR(255) NOT NULL,
+ *     body          TEXT         NOT NULL DEFAULT '',
+ *     deleted_at    DATETIME     DEFAULT NULL,
+ *     created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
  * );
  * ```
  */
 final class CommentThread
 {
-    private const DELETED_BODY = '[deleted]';
-
     public function __construct(private readonly ?PDO $db = null)
     {
     }
@@ -42,85 +58,92 @@ final class CommentThread
     // ── public API ────────────────────────────────────────────────────────────
 
     /**
-     * Post a top-level comment on an entity.
+     * Add a comment (or reply) to an entity.
      *
-     * @throws \InvalidArgumentException if any required field is empty.
-     */
-    public function post(string $entityType, string $entityId, string $userId, string $body): int
-    {
-        return $this->insert($entityType, $entityId, $userId, $body, null);
-    }
-
-    /**
-     * Reply to an existing comment.
-     *
-     * @throws \InvalidArgumentException if any required field is empty.
-     * @throws \RuntimeException         if the parent comment does not exist or is deleted.
-     */
-    public function reply(
-        string $entityType,
-        string $entityId,
-        string $userId,
-        string $body,
-        int $parentId
-    ): int {
-        $parent = $this->getRow($parentId);
-        if ($parent === null) {
-            throw new \RuntimeException("Parent comment {$parentId} does not exist.");
-        }
-        if ($parent['deleted_at'] !== null) {
-            throw new \RuntimeException('Cannot reply to a deleted comment.');
-        }
-        return $this->insert($entityType, $entityId, $userId, $body, $parentId);
-    }
-
-    /**
-     * Edit a comment body. Only the original author may edit.
-     *
-     * @return bool True if the comment was found, belongs to the user, and was updated.
+     * @param  int|null $parentId Parent comment ID for replies; null for top-level.
+     * @return int The new comment ID.
+     * @throws \InvalidArgumentException if entity_type, entity_id, or author_id is empty.
      * @throws \InvalidArgumentException if body is empty.
      */
-    public function edit(int $commentId, string $userId, string $body): bool
-    {
-        $userId = trim($userId);
-        $body   = trim($body);
+    public function add(
+        string $entityType,
+        string $entityId,
+        string $authorId,
+        string $body,
+        ?int $parentId = null
+    ): int {
+        [$entityType, $entityId] = $this->normaliseEntity($entityType, $entityId);
+        $authorId                = trim($authorId);
+        if ($authorId === '') {
+            throw new \InvalidArgumentException('author_id must not be empty.');
+        }
+        $body = trim($body);
         if ($body === '') {
             throw new \InvalidArgumentException('body must not be empty.');
         }
+
+        $db = $this->db();
+        $db->prepare(
+            'INSERT INTO comments (entity_type, entity_id, parent_id, author_id, body)
+             VALUES (:type, :eid, :parent, :author, :body)'
+        )->execute([
+            ':type'   => $entityType,
+            ':eid'    => $entityId,
+            ':parent' => $parentId,
+            ':author' => $authorId,
+            ':body'   => $body,
+        ]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Edit a comment body.
+     *
+     * @return bool True if the comment was found, not deleted, and updated.
+     */
+    public function edit(int $commentId, string $authorId, string $newBody): bool
+    {
+        $newBody = trim($newBody);
+        if ($newBody === '') {
+            throw new \InvalidArgumentException('body must not be empty.');
+        }
+
         $stmt = $this->db()->prepare(
             'UPDATE comments
              SET body = :body, updated_at = CURRENT_TIMESTAMP
-             WHERE id = :id AND user_id = :uid AND deleted_at IS NULL'
+             WHERE id = :id AND author_id = :author AND deleted_at IS NULL'
         );
-        $stmt->execute([':body' => $body, ':id' => $commentId, ':uid' => $userId]);
+        $stmt->execute([':body' => $newBody, ':id' => $commentId, ':author' => $authorId]);
         return $stmt->rowCount() > 0;
     }
 
     /**
-     * Soft-delete a comment (body replaced with tombstone).
-     *
-     * Pass null as userId to force-delete regardless of author (admin use).
+     * Soft-delete a comment (preserves replies structure, blanks body).
      *
      * @return bool True if the comment was found and soft-deleted.
      */
-    public function delete(int $commentId, ?string $userId = null): bool
+    public function delete(int $commentId, string $authorId): bool
     {
-        $params = [':body' => self::DELETED_BODY, ':id' => $commentId];
-        if ($userId !== null) {
-            $stmt = $this->db()->prepare(
-                'UPDATE comments
-                 SET body = :body, deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
-                 WHERE id = :id AND user_id = :uid AND deleted_at IS NULL'
-            );
-            $params[':uid'] = trim($userId);
-        } else {
-            $stmt = $this->db()->prepare(
-                'UPDATE comments
-                 SET body = :body, deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
-                 WHERE id = :id AND deleted_at IS NULL'
-            );
-        }
-        $stmt->execute($params);
+        $stmt = $this->db()->prepare(
+            "UPDATE comments
+             SET body = '', deleted_at = CURRENT_TIMESTAMP
+             WHERE id = :id AND author_id = :author AND deleted_at IS NULL"
+        );
+        $stmt->execute([':id' => $commentId, ':author' => $authorId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Hard-delete a comment (admin use, also removes orphaned replies).
+     *
+     * @return bool True if the comment was found and deleted.
+     */
+    public function remove(int $commentId): bool
+    {
+        $db = $this->db();
+        $db->prepare('DELETE FROM comments WHERE parent_id = :id')->execute([':id' => $commentId]);
+        $stmt = $db->prepare('DELETE FROM comments WHERE id = :id');
+        $stmt->execute([':id' => $commentId]);
         return $stmt->rowCount() > 0;
     }
 
@@ -129,57 +152,47 @@ final class CommentThread
      *
      * @return array<string,mixed>|null
      */
-    public function get(int $commentId): ?array
+    public function find(int $commentId): ?array
     {
-        return $this->getRow($commentId);
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, parent_id, author_id, body,
+                    deleted_at, created_at, updated_at
+             FROM comments WHERE id = :id LIMIT 1'
+        );
+        $stmt->execute([':id' => $commentId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
     }
 
     /**
-     * Get all comments for an entity, ordered by id ASC (includes tombstones).
+     * List all comments for an entity, ordered by id ASC (includes soft-deleted).
      *
      * @return list<array<string,mixed>>
      */
-    public function thread(string $entityType, string $entityId): array
+    public function list(string $entityType, string $entityId, bool $includeDeleted = true): array
     {
-        $stmt = $this->db()->prepare(
-            'SELECT id, user_id, parent_id, body, deleted_at, created_at, updated_at
-             FROM comments
-             WHERE entity_type = :type AND entity_id = :eid
-             ORDER BY id ASC'
-        );
-        $stmt->execute([':type' => trim($entityType), ':eid' => trim($entityId)]);
-        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
-    }
+        [$entityType, $entityId] = $this->normaliseEntity($entityType, $entityId);
 
-    /**
-     * Get top-level comments only (parent_id IS NULL).
-     *
-     * @return list<array<string,mixed>>
-     */
-    public function topLevel(string $entityType, string $entityId): array
-    {
-        $stmt = $this->db()->prepare(
-            'SELECT id, user_id, parent_id, body, deleted_at, created_at, updated_at
-             FROM comments
-             WHERE entity_type = :type AND entity_id = :eid AND parent_id IS NULL
-             ORDER BY id ASC'
-        );
-        $stmt->execute([':type' => trim($entityType), ':eid' => trim($entityId)]);
-        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
-    }
+        if ($includeDeleted) {
+            $stmt = $this->db()->prepare(
+                'SELECT id, entity_type, entity_id, parent_id, author_id, body,
+                        deleted_at, created_at, updated_at
+                 FROM comments
+                 WHERE entity_type = :type AND entity_id = :eid
+                 ORDER BY id ASC'
+            );
+            $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT id, entity_type, entity_id, parent_id, author_id, body,
+                        deleted_at, created_at, updated_at
+                 FROM comments
+                 WHERE entity_type = :type AND entity_id = :eid AND deleted_at IS NULL
+                 ORDER BY id ASC'
+            );
+            $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        }
 
-    /**
-     * Get all replies to a specific comment.
-     *
-     * @return list<array<string,mixed>>
-     */
-    public function replies(int $parentId): array
-    {
-        $stmt = $this->db()->prepare(
-            'SELECT id, user_id, parent_id, body, deleted_at, created_at, updated_at
-             FROM comments WHERE parent_id = :pid ORDER BY id ASC'
-        );
-        $stmt->execute([':pid' => $parentId]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
     }
 
@@ -188,12 +201,29 @@ final class CommentThread
      */
     public function count(string $entityType, string $entityId): int
     {
-        $stmt = $this->db()->prepare(
+        [$entityType, $entityId] = $this->normaliseEntity($entityType, $entityId);
+        $stmt                    = $this->db()->prepare(
             'SELECT COUNT(*) FROM comments
              WHERE entity_type = :type AND entity_id = :eid AND deleted_at IS NULL'
         );
-        $stmt->execute([':type' => trim($entityType), ':eid' => trim($entityId)]);
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
         return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * List replies to a given comment.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function replies(int $parentId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, parent_id, author_id, body,
+                    deleted_at, created_at, updated_at
+             FROM comments WHERE parent_id = :pid ORDER BY id ASC'
+        );
+        $stmt->execute([':pid' => $parentId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
     }
 
     // ── internal helpers ─────────────────────────────────────────────────────
@@ -203,56 +233,19 @@ final class CommentThread
         return $this->db ?? PdoConnection::getInstance();
     }
 
-    private function insert(
-        string $entityType,
-        string $entityId,
-        string $userId,
-        string $body,
-        ?int $parentId
-    ): int {
+    /**
+     * @return array{string, string}
+     */
+    private function normaliseEntity(string $entityType, string $entityId): array
+    {
         $entityType = trim($entityType);
         $entityId   = trim($entityId);
-        $userId     = trim($userId);
-        $body       = trim($body);
-
         if ($entityType === '') {
             throw new \InvalidArgumentException('entity_type must not be empty.');
         }
         if ($entityId === '') {
             throw new \InvalidArgumentException('entity_id must not be empty.');
         }
-        if ($userId === '') {
-            throw new \InvalidArgumentException('user_id must not be empty.');
-        }
-        if ($body === '') {
-            throw new \InvalidArgumentException('body must not be empty.');
-        }
-
-        $stmt = $this->db()->prepare(
-            'INSERT INTO comments (entity_type, entity_id, user_id, parent_id, body)
-             VALUES (:type, :eid, :uid, :pid, :body)'
-        );
-        $stmt->execute([
-            ':type' => $entityType,
-            ':eid'  => $entityId,
-            ':uid'  => $userId,
-            ':pid'  => $parentId,
-            ':body' => $body,
-        ]);
-        return (int)$this->db()->lastInsertId();
-    }
-
-    /**
-     * @return array<string,mixed>|null
-     */
-    private function getRow(int $commentId): ?array
-    {
-        $stmt = $this->db()->prepare(
-            'SELECT id, user_id, parent_id, body, deleted_at, created_at, updated_at
-             FROM comments WHERE id = :id LIMIT 1'
-        );
-        $stmt->execute([':id' => $commentId]);
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        return $row !== false ? $row : null;
+        return [$entityType, $entityId];
     }
 }

--- a/tests/Unit/Xion/CommentThreadTest.php
+++ b/tests/Unit/Xion/CommentThreadTest.php
@@ -25,9 +25,9 @@ final class CommentThreadTest extends TestCase
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
                 entity_type VARCHAR(100) NOT NULL,
                 entity_id   VARCHAR(255) NOT NULL,
-                user_id     VARCHAR(255) NOT NULL,
                 parent_id   INTEGER      DEFAULT NULL,
-                body        TEXT         NOT NULL,
+                author_id   VARCHAR(255) NOT NULL,
+                body        TEXT         NOT NULL DEFAULT \'\',
                 deleted_at  DATETIME     DEFAULT NULL,
                 created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -36,168 +36,154 @@ final class CommentThreadTest extends TestCase
         $this->ct = new CommentThread($this->db);
     }
 
-    // ── post ──────────────────────────────────────────────────────────────────
+    // ── add ───────────────────────────────────────────────────────────────────
 
-    public function testPostReturnsId(): void
+    public function testAddReturnsId(): void
     {
-        $id = $this->ct->post('post', '1', 'user-1', 'Hello!');
+        $id = $this->ct->add('post', '1', 'user-1', 'Hello!');
         $this->assertGreaterThan(0, $id);
     }
 
-    public function testPostCreatesTopLevelComment(): void
+    public function testAddStoresBody(): void
     {
-        $id  = $this->ct->post('post', '1', 'user-1', 'Hello!');
-        $row = $this->ct->get($id);
-        $this->assertNotNull($row);
-        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-        $this->assertNull($row['parent_id']);
-        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-        $this->assertSame('Hello!', $row['body']);
+        $id  = $this->ct->add('post', '1', 'user-1', 'Great post!');
+        $row = $this->ct->find($id);
+        $this->assertSame('Great post!', $row['body']);
     }
 
-    public function testPostThrowsOnEmptyBody(): void
+    public function testAddWithParentId(): void
+    {
+        $id    = $this->ct->add('post', '1', 'user-1', 'Parent');
+        $reply = $this->ct->add('post', '1', 'user-2', 'Reply', $id);
+        $row   = $this->ct->find($reply);
+        $this->assertSame($id, (int)$row['parent_id']);
+    }
+
+    public function testAddThrowsOnEmptyBody(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->ct->post('post', '1', 'user-1', '');
+        $this->ct->add('post', '1', 'user-1', '');
     }
 
-    public function testPostThrowsOnEmptyEntityType(): void
+    public function testAddThrowsOnEmptyAuthorId(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->ct->post('', '1', 'user-1', 'Hello');
+        $this->ct->add('post', '1', '', 'Hello');
     }
 
-    // ── reply ─────────────────────────────────────────────────────────────────
-
-    public function testReplyLinksToParent(): void
+    public function testAddThrowsOnEmptyEntityType(): void
     {
-        $parentId = $this->ct->post('post', '1', 'user-1', 'Parent');
-        $replyId  = $this->ct->reply('post', '1', 'user-2', 'Reply', $parentId);
-        $row      = $this->ct->get($replyId);
-        $this->assertNotNull($row);
-        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-        $this->assertSame((string)$parentId, (string)$row['parent_id']);
-    }
-
-    public function testReplyThrowsIfParentNotExists(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->ct->reply('post', '1', 'user-1', 'Reply', 999);
-    }
-
-    public function testReplyThrowsIfParentIsDeleted(): void
-    {
-        $parentId = $this->ct->post('post', '1', 'user-1', 'Parent');
-        $this->ct->delete($parentId);
-        $this->expectException(\RuntimeException::class);
-        $this->ct->reply('post', '1', 'user-2', 'Reply', $parentId);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ct->add('', '1', 'user-1', 'Hello');
     }
 
     // ── edit ──────────────────────────────────────────────────────────────────
 
     public function testEditUpdatesBody(): void
     {
-        $id = $this->ct->post('post', '1', 'user-1', 'Original');
+        $id = $this->ct->add('post', '1', 'user-1', 'Original');
         $this->assertTrue($this->ct->edit($id, 'user-1', 'Updated'));
-        $row = $this->ct->get($id);
-        $this->assertNotNull($row);
-        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-        $this->assertSame('Updated', $row['body']);
+        $this->assertSame('Updated', $this->ct->find($id)['body']);
     }
 
-    public function testEditReturnsFalseForWrongUser(): void
+    public function testEditReturnsFalseForWrongAuthor(): void
     {
-        $id = $this->ct->post('post', '1', 'user-1', 'Original');
-        $this->assertFalse($this->ct->edit($id, 'user-2', 'Hijack'));
+        $id = $this->ct->add('post', '1', 'user-1', 'Original');
+        $this->assertFalse($this->ct->edit($id, 'user-2', 'Hacked'));
     }
 
     public function testEditThrowsOnEmptyBody(): void
     {
-        $id = $this->ct->post('post', '1', 'user-1', 'Original');
+        $id = $this->ct->add('post', '1', 'user-1', 'Original');
         $this->expectException(\InvalidArgumentException::class);
         $this->ct->edit($id, 'user-1', '');
     }
 
-    // ── delete ────────────────────────────────────────────────────────────────
+    // ── delete (soft) ─────────────────────────────────────────────────────────
 
-    public function testDeleteReplacesBodyWithTombstone(): void
+    public function testDeleteSoftDeletesComment(): void
     {
-        $id = $this->ct->post('post', '1', 'user-1', 'Original');
+        $id = $this->ct->add('post', '1', 'user-1', 'Hello');
         $this->assertTrue($this->ct->delete($id, 'user-1'));
-        $row = $this->ct->get($id);
-        $this->assertNotNull($row);
-        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-        $this->assertSame('[deleted]', $row['body']);
-        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $row = $this->ct->find($id);
+        $this->assertSame('', $row['body']);
         $this->assertNotNull($row['deleted_at']);
     }
 
-    public function testDeleteReturnsFalseForWrongUser(): void
+    public function testDeleteReturnsFalseForWrongAuthor(): void
     {
-        $id = $this->ct->post('post', '1', 'user-1', 'Original');
+        $id = $this->ct->add('post', '1', 'user-1', 'Hello');
         $this->assertFalse($this->ct->delete($id, 'user-2'));
     }
 
-    public function testDeleteWithNullUserIdForceDeletes(): void
+    public function testDeleteReturnsFalseIfAlreadyDeleted(): void
     {
-        $id = $this->ct->post('post', '1', 'user-1', 'Original');
-        $this->assertTrue($this->ct->delete($id, null));
+        $id = $this->ct->add('post', '1', 'user-1', 'Hello');
+        $this->ct->delete($id, 'user-1');
+        $this->assertFalse($this->ct->delete($id, 'user-1'));
     }
 
-    public function testDeleteIsIdempotentReturnsFalseSecondTime(): void
+    // ── remove (hard delete) ──────────────────────────────────────────────────
+
+    public function testRemoveDeletesCommentAndReplies(): void
     {
-        $id = $this->ct->post('post', '1', 'user-1', 'Original');
-        $this->ct->delete($id);
-        $this->assertFalse($this->ct->delete($id));
+        $id    = $this->ct->add('post', '1', 'user-1', 'Parent');
+        $reply = $this->ct->add('post', '1', 'user-2', 'Reply', $id);
+        $this->assertTrue($this->ct->remove($id));
+        $this->assertNull($this->ct->find($id));
+        $this->assertNull($this->ct->find($reply));
     }
 
-    // ── thread ────────────────────────────────────────────────────────────────
+    // ── list ──────────────────────────────────────────────────────────────────
 
-    public function testThreadReturnsAllComments(): void
+    public function testListReturnsAllComments(): void
     {
-        $this->ct->post('post', '1', 'user-1', 'A');
-        $this->ct->post('post', '1', 'user-2', 'B');
-        $this->assertCount(2, $this->ct->thread('post', '1'));
+        $this->ct->add('post', '1', 'user-1', 'A');
+        $this->ct->add('post', '1', 'user-2', 'B');
+        $list = $this->ct->list('post', '1');
+        $this->assertCount(2, $list);
     }
 
-    public function testThreadIncludesDeletedAsTombstone(): void
+    public function testListExcludesDeletedWhenRequested(): void
     {
-        $id = $this->ct->post('post', '1', 'user-1', 'A');
-        $this->ct->delete($id);
-        $this->assertCount(1, $this->ct->thread('post', '1'));
+        $id = $this->ct->add('post', '1', 'user-1', 'A');
+        $this->ct->add('post', '1', 'user-2', 'B');
+        $this->ct->delete($id, 'user-1');
+        $list = $this->ct->list('post', '1', false);
+        $this->assertCount(1, $list);
     }
 
-    public function testThreadIsEntityScoped(): void
+    public function testListIsEntityScoped(): void
     {
-        $this->ct->post('post', '1', 'user-1', 'A');
-        $this->ct->post('post', '2', 'user-1', 'B');
-        $this->assertCount(1, $this->ct->thread('post', '1'));
-    }
-
-    // ── topLevel / replies ────────────────────────────────────────────────────
-
-    public function testTopLevelExcludesReplies(): void
-    {
-        $parentId = $this->ct->post('post', '1', 'user-1', 'Parent');
-        $this->ct->reply('post', '1', 'user-2', 'Reply', $parentId);
-        $this->assertCount(1, $this->ct->topLevel('post', '1'));
-    }
-
-    public function testRepliesReturnsChildComments(): void
-    {
-        $parentId = $this->ct->post('post', '1', 'user-1', 'Parent');
-        $this->ct->reply('post', '1', 'user-2', 'Reply 1', $parentId);
-        $this->ct->reply('post', '1', 'user-3', 'Reply 2', $parentId);
-        $this->assertCount(2, $this->ct->replies($parentId));
+        $this->ct->add('post', '1', 'user-1', 'A');
+        $this->ct->add('post', '2', 'user-1', 'B');
+        $this->assertCount(1, $this->ct->list('post', '1'));
     }
 
     // ── count ─────────────────────────────────────────────────────────────────
 
-    public function testCountExcludesDeletedComments(): void
+    public function testCountIgnoresDeleted(): void
     {
-        $id = $this->ct->post('post', '1', 'user-1', 'A');
-        $this->ct->post('post', '1', 'user-2', 'B');
-        $this->ct->delete($id);
+        $id = $this->ct->add('post', '1', 'user-1', 'A');
+        $this->ct->add('post', '1', 'user-2', 'B');
+        $this->ct->delete($id, 'user-1');
         $this->assertSame(1, $this->ct->count('post', '1'));
+    }
+
+    // ── replies ───────────────────────────────────────────────────────────────
+
+    public function testRepliesReturnsChildComments(): void
+    {
+        $id     = $this->ct->add('post', '1', 'user-1', 'Parent');
+        $reply1 = $this->ct->add('post', '1', 'user-2', 'Reply 1', $id);
+        $reply2 = $this->ct->add('post', '1', 'user-3', 'Reply 2', $id);
+        $replies = $this->ct->replies($id);
+        $this->assertCount(2, $replies);
+    }
+
+    public function testRepliesReturnsEmptyForNoReplies(): void
+    {
+        $id = $this->ct->add('post', '1', 'user-1', 'Alone');
+        $this->assertSame([], $this->ct->replies($id));
     }
 }

--- a/tests/Unit/Xion/CommentThreadTest.php
+++ b/tests/Unit/Xion/CommentThreadTest.php
@@ -48,6 +48,7 @@ final class CommentThreadTest extends TestCase
     {
         $id  = $this->ct->add('post', '1', 'user-1', 'Great post!');
         $row = $this->ct->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Great post!', $row['body']);
     }
 
@@ -56,6 +57,7 @@ final class CommentThreadTest extends TestCase
         $id    = $this->ct->add('post', '1', 'user-1', 'Parent');
         $reply = $this->ct->add('post', '1', 'user-2', 'Reply', $id);
         $row   = $this->ct->find($reply);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame($id, (int)$row['parent_id']);
     }
 
@@ -83,6 +85,7 @@ final class CommentThreadTest extends TestCase
     {
         $id = $this->ct->add('post', '1', 'user-1', 'Original');
         $this->assertTrue($this->ct->edit($id, 'user-1', 'Updated'));
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Updated', $this->ct->find($id)['body']);
     }
 
@@ -106,7 +109,9 @@ final class CommentThreadTest extends TestCase
         $id = $this->ct->add('post', '1', 'user-1', 'Hello');
         $this->assertTrue($this->ct->delete($id, 'user-1'));
         $row = $this->ct->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('', $row['body']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertNotNull($row['deleted_at']);
     }
 


### PR DESCRIPTION
## CommentThread

Threaded comments attached to any entity with soft-delete and reply support.

### Schema
```sql
CREATE TABLE comments (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    entity_type VARCHAR(100) NOT NULL,
    entity_id   VARCHAR(255) NOT NULL,
    parent_id   INTEGER      DEFAULT NULL,
    author_id   VARCHAR(255) NOT NULL,
    body        TEXT         NOT NULL DEFAULT '',
    deleted_at  DATETIME     DEFAULT NULL,
    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### API
- `add(entityType, entityId, authorId, body, ?parentId)` — post comment/reply
- `edit(commentId, authorId, newBody)` — update body (own non-deleted only)
- `delete(commentId, authorId)` — soft-delete (blanks body, sets deleted_at)
- `remove(commentId)` — hard-delete comment and all replies (admin)
- `find(commentId)` — get single comment
- `list(entityType, entityId, includeDeleted=true)` — all comments ASC
- `count(entityType, entityId)` — count non-deleted
- `replies(parentId)` — direct replies to a comment

### Tests
19 tests, 24 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)