### PR TITLE
docs: update candidates, todo, and roadmap to reflect FT78–FT140 completion

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -12,37 +12,9 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ---
 
-## Active candidates (FT78+)
+## Active candidates
 
-### FT78 — Newsletter Subscription
-
-**Why**: メーリングリスト購読管理。ダブルオプトイン・購読解除・ステータス管理。
-**Scope**: `Nene\Xion\NewsletterSubscription` — subscribe/confirm/unsubscribe/status/list、確認トークン管理。
-**Size**: small–medium.
-
-### FT79 — User Block List
-
-**Why**: ユーザー間のブロック機能。コンテンツ非表示・フォロー防止等の基盤。
-**Scope**: `Nene\Xion\BlockList` — block/unblock/isBlocked/blockedBy/list、双方向チェック。
-**Size**: small.
-
-### FT80 — Poll / Survey
-
-**Why**: 選択式投票。単一/複数選択・集計・ユーザー投票履歴。
-**Scope**: `Nene\Xion\Poll` — createPoll/addOption/vote/results/hasVoted、設問+選択肢+集計。
-**Size**: medium.
-
-### FT81 — Wishlist
-
-**Why**: ユーザーの「お気に入り商品」管理。entity-agnostic設計でどんなコンテンツにも対応。
-**Scope**: `Nene\Xion\Wishlist` — add/remove/contains/list、entity_type+entity_idペア。
-**Size**: small.
-
-### FT82 — Notification Preferences
-
-**Why**: 通知チャンネル・種別ごとの受信設定。メール/Push/SMS等の配信制御基盤。
-**Scope**: `Nene\Xion\NotificationPreference` — setEnabled/isEnabled/all/reset、チャンネル×種別マトリクス。
-**Size**: small.
+The Xion helper wave (FT78–FT140) is complete as of 2026-05-27. No immediate Xion-class candidates remain. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -82,6 +54,69 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT140 — TaskList** (2026-05-27): `Nene\Xion\TaskList` — per-user to-do list with named lists and completion tracking. PR #574.
+- **FT139 — GeoFence** (2026-05-27): `Nene\Xion\GeoFence` — named circular geo-fence definition and point containment; Haversine. PR #573.
+- **FT138 — CreditLedger** (2026-05-27): `Nene\Xion\CreditLedger` — append-only credit/debit ledger per user; balance guard. PR #572.
+- **FT137 — Referral** (2026-05-27): `Nene\Xion\Referral` — referral code generation, attribution, and conversion tracking. PR #571.
+- **FT136 — SearchIndex** (2026-05-27): `Nene\Xion\SearchIndex` — lightweight full-text search index with token frequency ranking. PR #570.
+- **FT135 — Subscription** (2026-05-27): `Nene\Xion\Subscription` — recurring subscription plan tracking with auto-expiry detection. PR #569.
+- **FT134 — Poll** (2026-05-27): `Nene\Xion\Poll` — polls with named options and per-user vote tracking. PR #568.
+- **FT133 — CommentThread** (2026-05-27): `Nene\Xion\CommentThread` — threaded comments with soft-delete (revised design). PR #567.
+- **FT132 — AbTest** (2026-05-27): `Nene\Xion\AbTest` — A/B test variant assignment (deterministic crc32) and conversion tracking. PR #566.
+- **FT131 — MediaMetadata** (2026-05-27): `Nene\Xion\MediaMetadata` — media file registry with key-value metadata sidecar table. PR #565.
+- **FT130 — SessionFlash** (2026-05-27): `Nene\Xion\SessionFlash` — DB-backed one-time flash messages for post/redirect/get. PR #564.
+- **FT129 — UserPreference** (2026-05-27): `Nene\Xion\UserPreference` — key-value preference store with upsert (revised design). PR #563.
+- **FT128 — WebhookDelivery** (2026-05-27): `Nene\Xion\WebhookDelivery` — outbound webhook delivery log with exponential backoff retry. PR #562.
+- **FT127 — ConsentLog** (2026-05-27): `Nene\Xion\ConsentLog` — immutable GDPR/CCPA consent audit log; eraseUser GDPR right. PR #561.
+- **FT126 — EventLog** (2026-05-27): `Nene\Xion\EventLog` — append-only domain event store with aggregate and event-type queries. PR #560.
+- **FT125 — JobQueue** (2026-05-27): `Nene\Xion\JobQueue` — DB-backed background job queue with retry and delay (revised design). PR #559.
+- **FT124 — FeatureFlag** (2026-05-27): `Nene\Xion\FeatureFlag` — DB-backed feature flags with global on/off and per-user overrides. PR #558.
+- **FT123 — PriceHistory** (2026-05-27): `Nene\Xion\PriceHistory` — append-only price change log with lowest/highest aggregation. PR #557.
+- **FT122 — UserSession** (2026-05-27): `Nene\Xion\UserSession` — DB-backed server-side session store with TTL and payload. PR #556.
+- **FT121 — IpAllowlist** (2026-05-27): `Nene\Xion\IpAllowlist` — per-resource IP allowlist with CIDR range support. PR #555.
+- **FT120 — HealthCheck** (2026-05-27): `Nene\Xion\HealthCheck` — service health status with history and isHealthy aggregate. PR #554.
+- **FT119 — SupportTicket** (2026-05-27): `Nene\Xion\SupportTicket` — help-desk ticketing with replies and status lifecycle. PR #553.
+- **FT118 — InviteCode** (2026-05-27): `Nene\Xion\InviteCode` — single-use invite codes with quota and expiry. PR #552.
+- **FT117 — BookmarkCollection** (2026-05-27): `Nene\Xion\BookmarkCollection` — user-curated bookmark collections with move and clear. PR #551.
+- **FT116 — DraftManager** (2026-05-27): `Nene\Xion\DraftManager` — versioned draft persistence with history and prune. PR #550.
+- **FT115 — AccessToken** (2026-05-27): `Nene\Xion\AccessToken` — personal access token issue/verify/revoke with SHA-256 hash storage. PR #549.
+- **FT114 — TagIndex** (2026-05-27): `Nene\Xion\TagIndex` — flexible entity tagging with multi-tag AND queries. PR #548.
+- **FT113 — PresenceChannel** (2026-05-27): `Nene\Xion\PresenceChannel` — heartbeat-based channel presence tracking. PR #547.
+- **FT112 — LeaderBoard** (2026-05-27): `Nene\Xion\LeaderBoard` — named scoreboards with upsert, ranking, and windowed queries. PR #546.
+- **FT111 — AuditLog** (2026-05-27): `Nene\Xion\AuditLog` — append-only action log with JSON context and actor/resource filtering. PR #545.
+- **FT110 — TokenBucket** (2026-05-27): `Nene\Xion\TokenBucket` — DB-backed token bucket for flexible rate limiting. PR #544.
+- **FT109 — FileQuarantine** (2026-05-27): `Nene\Xion\FileQuarantine` — file quarantine/release/reject workflow. PR #543.
+- **FT108 — SurveyResponse** (2026-05-27): `Nene\Xion\SurveyResponse` — structured survey/quiz answer storage with tally. PR #542.
+- **FT107 — NoticeBoard** (2026-05-27): `Nene\Xion\NoticeBoard` — admin announcements with per-user read-acknowledgment. PR #541.
+- **FT106 — MediaProcessing** (2026-05-27): `Nene\Xion\MediaProcessing` — async media job tracking with pending/processing/ready/failed states and retry. PR #540.
+- **FT105 — EventTicket** (2026-05-27): `Nene\Xion\EventTicket` — event ticketing with capacity management and check-in. PR #539.
+- **FT104 — ShortUrl** (2026-05-27): `Nene\Xion\ShortUrl` — URL shortener with auto-code, custom slug, click tracking, and expiry. PR #538.
+- **FT103 — CommentThread** (2026-05-27): `Nene\Xion\CommentThread` — threaded comments with soft-delete tombstones (first version). PR #537.
+- **FT102 — LoginHistory** (2026-05-27): `Nene\Xion\LoginHistory` — append-only login attempt log with IP, user-agent, and failure tracking. PR #536.
+- **FT101 — FriendRequest** (2026-05-27): `Nene\Xion\FriendRequest` — friend request lifecycle with pending/accepted/declined/cancelled states. PR #535.
+- **FT100 — OnlineStatus** (2026-05-27): `Nene\Xion\OnlineStatus` — heartbeat-based online/idle/offline tracking. PR #534.
+- **FT99 — UserBan** (2026-05-27): `Nene\Xion\UserBan` — user ban/unban with reason, expiry, and full history. PR #533.
+- **FT98 — EmailVerification** (2026-05-27): `Nene\Xion\EmailVerification` — token-based email verification with TTL and SHA-256 hash storage. PR #532.
+- **FT97 — GeoBlocker** (2026-05-27): `Nene\Xion\GeoBlocker` — country-level access control with blocklist/allowlist modes. PR #531.
+- **FT96 — ReactionCounter** (2026-05-27): `Nene\Xion\ReactionCounter` — per-user emoji reactions with toggle and switch semantics. PR #530.
+- **FT95 — StorageQuota** (2026-05-27): `Nene\Xion\StorageQuota` — per-owner byte tracking with configurable limits and overflow guard. PR #529.
+- **FT94 — ContentSchedule** (2026-05-27): `Nene\Xion\ContentSchedule` — publish/expire windows with draft/published/expired/cancelled lifecycle. PR #528.
+- **FT93 — Waitlist** (2026-05-27): `Nene\Xion\Waitlist` — join/invite/confirm/cancel/status/position/count. PR #527.
+- **FT92 — PriceList** (2026-05-27): `Nene\Xion\PriceList` — SKU/currency/tier pricing table. PR #526.
+- **FT91 — PasswordHistory** (2026-05-27): `Nene\Xion\PasswordHistory` — prevent recent password reuse. PR #525.
+- **FT90 — DownloadCounter** (2026-05-27): `Nene\Xion\DownloadCounter` — per-entity download tracking with user limits. PR #524.
+- **FT89 — TermConsent** (2026-05-27): `Nene\Xion\TermConsent` — ToS/privacy acceptance tracking with audit trail. PR #523.
+- **FT88 — ContentFlag** (2026-05-27): `Nene\Xion\ContentFlag` — user content flagging and moderation queue. PR #522.
+- **FT87 — MaintenanceMode** (2026-05-27): `Nene\Xion\MaintenanceMode` — global maintenance flag with user allowlist. PR #521.
+- **FT86 — ActivityFeed** (2026-05-27): `Nene\Xion\ActivityFeed` — append-only user event timeline with cursor pagination. PR #520.
+- **FT85 — ReferralCode** (2026-05-27): `Nene\Xion\ReferralCode` — referral code generation and conversion tracking (first version). PR #519.
+- **FT84 — DeviceToken** (2026-05-27): `Nene\Xion\DeviceToken` — remember-me / trusted-device token with expiry. PR #518.
+- **FT83 — ReadProgress** (2026-05-27): `Nene\Xion\ReadProgress` — track user read position with completion flag. PR #517.
+- **FT82 — NotificationPreference** (2026-05-27): `Nene\Xion\NotificationPreference` — channel×type opt-in/out with default opt-in. PR #516.
+- **FT81 — Wishlist** (2026-05-27): `Nene\Xion\Wishlist` — entity-agnostic per-user saved items with notes. PR #515.
+- **FT80 — Poll** (2026-05-27): `Nene\Xion\Poll` — single-choice poll with vote tally and per-user state (first version). PR #514.
+- **FT79 — BlockList** (2026-05-27): `Nene\Xion\BlockList` — directional user block with bidirectional query. PR #513.
+- **FT78 — NewsletterSubscription** (2026-05-27): `Nene\Xion\NewsletterSubscription` — double opt-in mailing list subscribe/confirm/unsubscribe. PR #512.
 - **FT77 — Address Book** (2026-05-27): `Nene\Xion\AddressBook` — add/update/remove/list/setDefault; default swap transaction; partial update. PR #511.
 - **FT76 — Two-Factor Authentication (TOTP)** (2026-05-27): `Nene\Xion\TotpAuthenticator` — RFC 6238; generateSecret/verifyCode/otpauthUri/generateBackupCodes; HMAC-SHA1 HOTP. PR #510.
 - **FT75 — File Storage Metadata** (2026-05-27): `Nene\Xion\FileMetadata` — register/find/findByOwner/delete; MIME prefix filter; soft delete; storage field. PR #509.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT6 complete as of 2026-05-21.
+Status: methodology adopted (ADR 0002). FT1–FT140 complete as of 2026-05-27 (FT36 deferred as ADR-class).
 
 Goal:
 
@@ -215,6 +215,10 @@ Completed:
 - **FT4** — server-rendered HTML trial from `ft4-smarty-html`. 9 findings covering Smarty escape behavior, asset auto-discovery convention, HTML form POST handling, compile cache hygiene, and a small `location()` URI fix. Report: `docs/field-trials/2026-05-field-trial-4.md`.
 - **FT5** — auth × HTML cross trial from `ft5-protected-notes`. 10 findings; ADR-0004 (`ControllerBase::unauthorizedRedirect()` hook) born. The CI workflow's `Wait for /health` step was hardened to require `healthStatus=ok` with a 120s budget after a debugging mis-diagnosis. Report: `docs/field-trials/2026-05-field-trial-5.md`.
 - **FT6** — CLI installer trial from `ft6-cli-tooling` (first CLI-only trial). 7 findings; `composer setup` shortcut, `cli/setupDatabase.php` `--env=PATH` strict mode, `cli/initSQLite.php` `--yes` / `--help`, schema 3-way parity documentation, new `docs/development/cli.md` declaring `setupDatabase.php` canonical and `initSQLite.php` legacy. Report: `docs/field-trials/2026-05-field-trial-6.md`.
+- **FT7–FT24** — infrastructure, tooling, and survey trials. ADR-0005–0013 established. AI-agent journey (FT22), NENE2 pattern survey (FT23), CLI framework (FT24).
+- **FT25–FT50** — NENE2 parity + extended pattern wave (26 trials). PRs #458–#483. Pagination, soft delete, JWT, RBAC, rate limiting, feature flags, idempotency, webhook signing, circuit breaker, and more.
+- **FT51–FT77** — extended social/content/identity wave (27 trials). PRs #485–#511. i18n, pub-sub, GDPR export, leaderboard, comment threads, TOTP, address book, and more.
+- **FT78–FT140** — Xion helper wave (63 trials). PRs #512–#574. Social, content moderation, SaaS infrastructure, analytics, A/B testing, event sourcing, consent management, and more. See `docs/todo/current.md` for the full list.
 
 Infrastructure landed alongside the trials:
 
@@ -224,7 +228,14 @@ Infrastructure landed alongside the trials:
 - `docs/review/field-trial-report.md` self-review checklist referenced by the methodology.
 - `docs/field-trials/follow-ups.md` rules for deferred findings, with FT2 F-5 escalated and removed during FT3.
 
+Completed (wave summary):
+
+- **FT7–FT24**: Infrastructure, tooling, and pattern survey trials. ADR-0005–0013. NENE2 pattern survey (FT23). AI-agent journey (FT22).
+- **FT25–FT50**: NENE2 parity + extended pattern wave. 26 trials covering pagination, soft delete, JWT, RBAC, rate limiting, feature flags, idempotency, webhook signing, and more. PRs #458–#483.
+- **FT51–FT77**: Extended social/content/identity wave. 27 trials covering i18n, pub-sub, GDPR export, leaderboard, bookmarks, TOTP, address book, and more. PRs #485–#511.
+- **FT78–FT140**: Xion helper wave. 63 trials covering social, content moderation, analytics, SaaS infrastructure, A/B testing, event sourcing, and more. PRs #512–#574.
+
 Future candidates:
 
-- **FT7+** — remaining FT-untouched surfaces: error pages (404 / 500 templates and the `htdocs/index.php` catch-all), production-mode deployment probe (`NENE_APP_ENV=production` + secure cookie + log rotation behavior), Smarty custom plugin authoring (`view/plugins/`), OpenAPI authoring workflow round-trip, schema source-of-truth consolidation (ADR-class, triggered when a future trial actually trips on the three-site drift surfaced by FT6 F-2).
-- Subsequent trials should each target a different surface rather than retesting paths already exercised by FT1–FT6.
+- **Trigger-based**: error pages (404/500 templates), production-mode deployment probe (`NENE_APP_ENV=production`), OpenAPI authoring workflow, FT36 (background jobs / ADR-class).
+- Subsequent trials should target surfaces not yet exercised, or validate revised Xion helper designs in a real service context.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,77 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT77 are complete (FT36 deferred as ADR-class); ADR-0001–0013 are in place. Next work is FT78+ — see **Field Trials** and **Backlog Candidates** below.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT140 are complete (FT36 deferred as ADR-class); ADR-0001–0013 are in place. The Xion helper wave is complete — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-27 — FT78–FT140: Xion helper wave (63 trials)
+
+Continuous single-day wave of 63 field trials covering social, content, security, analytics, and infrastructure helpers. All PRs #512–#574 merged.
+
+**FT78 — NewsletterSubscription**: `NewsletterSubscription` double opt-in mailing list subscribe/confirm/unsubscribe. PR #512.
+**FT79 — BlockList**: `BlockList` directional user block with bidirectional query. PR #513.
+**FT80 — Poll**: `Poll` single-choice poll with vote tally and per-user state (first version). PR #514.
+**FT81 — Wishlist**: `Wishlist` entity-agnostic per-user saved items with notes. PR #515.
+**FT82 — NotificationPreference**: `NotificationPreference` channel×type opt-in/out with default opt-in. PR #516.
+**FT83 — ReadProgress**: `ReadProgress` track user read position with completion flag. PR #517.
+**FT84 — DeviceToken**: `DeviceToken` remember-me / trusted-device token with expiry. PR #518.
+**FT85 — ReferralCode**: `ReferralCode` referral code generation and conversion tracking (first version). PR #519.
+**FT86 — ActivityFeed**: `ActivityFeed` append-only user event timeline with cursor pagination. PR #520.
+**FT87 — MaintenanceMode**: `MaintenanceMode` global maintenance flag with user allowlist. PR #521.
+**FT88 — ContentFlag**: `ContentFlag` user content flagging and moderation queue. PR #522.
+**FT89 — TermConsent**: `TermConsent` ToS/privacy acceptance tracking with audit trail. PR #523.
+**FT90 — DownloadCounter**: `DownloadCounter` per-entity download tracking with user limits. PR #524.
+**FT91 — PasswordHistory**: `PasswordHistory` prevent recent password reuse. PR #525.
+**FT92 — PriceList**: `PriceList` SKU/currency/tier pricing table. PR #526.
+**FT93 — Waitlist**: `Waitlist` join/invite/confirm/cancel/status/position/count. PR #527.
+**FT94 — ContentSchedule**: `ContentSchedule` publish/expire windows with draft/published/expired/cancelled lifecycle. PR #528.
+**FT95 — StorageQuota**: `StorageQuota` per-owner byte tracking with configurable limits and overflow guard. PR #529.
+**FT96 — ReactionCounter**: `ReactionCounter` per-user emoji reactions with toggle and switch semantics. PR #530.
+**FT97 — GeoBlocker**: `GeoBlocker` country-level access control with blocklist/allowlist modes. PR #531.
+**FT98 — EmailVerification**: `EmailVerification` token-based email verification with TTL and SHA-256 hash storage. PR #532.
+**FT99 — UserBan**: `UserBan` user ban/unban with reason, expiry, and full history. PR #533.
+**FT100 — OnlineStatus**: `OnlineStatus` heartbeat-based online/idle/offline tracking. PR #534.
+**FT101 — FriendRequest**: `FriendRequest` friend request lifecycle with pending/accepted/declined/cancelled states. PR #535.
+**FT102 — LoginHistory**: `LoginHistory` append-only login attempt log with IP, user-agent, and failure tracking. PR #536.
+**FT103 — CommentThread**: `CommentThread` threaded comments with soft-delete tombstones (first version). PR #537.
+**FT104 — ShortUrl**: `ShortUrl` URL shortener with auto-code, custom slug, click tracking, and expiry. PR #538.
+**FT105 — EventTicket**: `EventTicket` event ticketing with capacity management and check-in. PR #539.
+**FT106 — MediaProcessing**: `MediaProcessing` async media job tracking with pending/processing/ready/failed states and retry. PR #540.
+**FT107 — NoticeBoard**: `NoticeBoard` admin announcements with per-user read-acknowledgment. PR #541.
+**FT108 — SurveyResponse**: `SurveyResponse` structured survey/quiz answer storage with tally. PR #542.
+**FT109 — FileQuarantine**: `FileQuarantine` file quarantine/release/reject workflow. PR #543.
+**FT110 — TokenBucket**: `TokenBucket` DB-backed token bucket for flexible rate limiting. PR #544.
+**FT111 — AuditLog**: `AuditLog` append-only action log with JSON context and actor/resource filtering. PR #545.
+**FT112 — LeaderBoard**: `LeaderBoard` named scoreboards with upsert, ranking, and windowed queries. PR #546.
+**FT113 — PresenceChannel**: `PresenceChannel` heartbeat-based channel presence tracking. PR #547.
+**FT114 — TagIndex**: `TagIndex` flexible entity tagging with multi-tag AND queries. PR #548.
+**FT115 — AccessToken**: `AccessToken` personal access token issue/verify/revoke with SHA-256 hash storage. PR #549.
+**FT116 — DraftManager**: `DraftManager` versioned draft persistence with history and prune. PR #550.
+**FT117 — BookmarkCollection**: `BookmarkCollection` user-curated bookmark collections with move and clear. PR #551.
+**FT118 — InviteCode**: `InviteCode` single-use invite codes with quota and expiry. PR #552.
+**FT119 — SupportTicket**: `SupportTicket` help-desk ticketing with replies and status lifecycle. PR #553.
+**FT120 — HealthCheck**: `HealthCheck` service health status with history and isHealthy aggregate. PR #554.
+**FT121 — IpAllowlist**: `IpAllowlist` per-resource IP allowlist with CIDR range support. PR #555.
+**FT122 — UserSession**: `UserSession` DB-backed server-side session store with TTL and payload. PR #556.
+**FT123 — PriceHistory**: `PriceHistory` append-only price change log with lowest/highest aggregation. PR #557.
+**FT124 — FeatureFlag**: `FeatureFlag` DB-backed feature flags with global on/off and per-user overrides. PR #558.
+**FT125 — JobQueue**: `JobQueue` DB-backed background job queue with retry and delay (revised design). PR #559.
+**FT126 — EventLog**: `EventLog` append-only domain event store with aggregate and event-type queries. PR #560.
+**FT127 — ConsentLog**: `ConsentLog` immutable GDPR/CCPA consent audit log; eraseUser GDPR right. PR #561.
+**FT128 — WebhookDelivery**: `WebhookDelivery` outbound webhook delivery log with exponential backoff retry. PR #562.
+**FT129 — UserPreference**: `UserPreference` key-value preference store with upsert (revised design). PR #563.
+**FT130 — SessionFlash**: `SessionFlash` DB-backed one-time flash messages for post/redirect/get. PR #564.
+**FT131 — MediaMetadata**: `MediaMetadata` media file registry with key-value metadata sidecar table. PR #565.
+**FT132 — AbTest**: `AbTest` A/B test variant assignment (deterministic crc32) and conversion tracking. PR #566.
+**FT133 — CommentThread**: `CommentThread` threaded comments with soft-delete (revised design). PR #567.
+**FT134 — Poll**: `Poll` polls with named options and per-user vote tracking (revised design). PR #568.
+**FT135 — Subscription**: `Subscription` recurring subscription plan tracking with auto-expiry detection. PR #569.
+**FT136 — SearchIndex**: `SearchIndex` lightweight full-text search index with token frequency ranking. PR #570.
+**FT137 — Referral**: `Referral` referral code generation, attribution, and conversion tracking (revised design). PR #571.
+**FT138 — CreditLedger**: `CreditLedger` append-only credit/debit ledger per user; balance guard. PR #572.
+**FT139 — GeoFence**: `GeoFence` named circular geo-fence definition and point containment; Haversine. PR #573.
+**FT140 — TaskList**: `TaskList` per-user to-do list with named lists and completion tracking. PR #574.
 
 ### 2026-05-27 — FT73–FT77: Infrastructure + auth + geo + identity wave (5 trials)
 
@@ -189,7 +257,7 @@ Single-day wave of trial-driven improvements across the framework, documentation
 
 ## Next
 
-FT1–FT50 complete (FT36 deferred). Next is FT51+ — see `docs/field-trials/candidates.md` for the active candidate list.
+FT1–FT140 complete (FT36 deferred as ADR-class). The Xion helper wave is complete. Remaining work is trigger-based — see `docs/field-trials/candidates.md` for the 保留候補 list.
 
 ## Field Trials
 
@@ -218,13 +286,12 @@ When a trial is run, summarize it here with the format below, then move the bloc
 
 Active candidates are maintained in `docs/field-trials/candidates.md`. Summary:
 
-### Next field trials (FT51+)
+### Trigger-based candidates
 
-- **FT51** — i18n / メッセージカタログ (`Nene\Func\I18n`). Small.
-- **FT52** — Event dispatcher / 軽量 pub-sub (`EventDispatcher`). Small–medium. Trigger-based.
-- **FT53** — Personal data export / GDPR Article 20. Small. Trigger-based.
-- **FT54** — リクエストボディ JSON Schema 検証. Medium / ADR. Trigger-based.
-- **FT36** — バックグラウンドジョブ (deferred, ADR-class, large).
+- **FT36** — バックグラウンドジョブ (deferred, ADR-class, large). Trigger: real "POST takes 8s" friction.
+- **Observability** — OpenTelemetry traceparent/tracestate. Trigger: OTel collector needed in real deploy.
+- **Structural: Multi-tenancy** — row-scoped tenant isolation. Trigger: real B2B SaaS deploy.
+- **Structural: Constraint-changes ADR** — promote ADR-0009 "warning-only" to hard constraint path. Trigger: 3+ operator friction cases.
 
 ### Real-world surface trials (still unrun)
 


### PR DESCRIPTION
Brings documentation into sync with the completed FT78–FT140 Xion helper wave.

## Changes

### `docs/field-trials/candidates.md`
- Remove FT78–FT82 from "Active candidates" (all completed as PRs #512–#516)
- Add FT78–FT140 (63 entries) to the "Recently picked-up" archive trail
- Active candidates section now notes the Xion helper wave is complete

### `docs/todo/current.md`
- Add FT78–FT140 Recently Completed block (63 trials, PRs #512–#574)
- Update Active section: FT1–FT140 complete, Xion wave complete
- Update Next section: redirect to trigger-based candidates
- Update Backlog Candidates: replace stale FT51+ list with current trigger-based items

### `docs/roadmap.md`
- Update Phase 7 status: FT1–FT140 complete as of 2026-05-27
- Add FT7–FT140 wave summaries to Completed list
- Update Future candidates to reflect current state

🤖 Generated with [Claude Code](https://claude.com/claude-code)