### PR TITLE
feat(xion): ConfigStore — global app key-value config store (FT141)

### DIFF
--- a/class/xion/ConfigStore.php
+++ b/class/xion/ConfigStore.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ConfigStore — global application key-value configuration store.
+ *
+ * Stores typed configuration values in the database. Unlike UserPreference
+ * (which is per-user), ConfigStore holds application-wide settings shared
+ * across all users and sessions.
+ *
+ * Keys support a dot-namespace convention (e.g. `mail.from`, `mail.host`)
+ * for logical grouping; the store treats them as plain strings.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cfg = new ConfigStore($pdo);
+ *
+ * $cfg->set('mail.from', 'no-reply@example.com');
+ * $cfg->set('feature.limit', '100');
+ *
+ * $cfg->get('mail.from');             // 'no-reply@example.com'
+ * $cfg->getInt('feature.limit');      // 100
+ * $cfg->getBool('feature.enabled');   // false (missing → false)
+ *
+ * $cfg->all();                        // ['mail.from' => '...', ...]
+ * $cfg->namespace('mail');            // all keys starting with 'mail.'
+ * $cfg->delete('mail.from');
+ * $cfg->deleteNamespace('mail');      // delete all 'mail.*' keys
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE config_store (
+ *     config_key   VARCHAR(255) NOT NULL PRIMARY KEY,
+ *     config_value TEXT         NOT NULL DEFAULT '',
+ *     updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ConfigStore
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set (upsert) a configuration value.
+     *
+     * @throws \InvalidArgumentException if the key is empty.
+     */
+    public function set(string $key, string $value): void
+    {
+        $key = $this->validateKey($key);
+        $db  = $this->db();
+        if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO config_store (config_key, config_value)
+                 VALUES (:k, :v)
+                 ON CONFLICT (config_key)
+                 DO UPDATE SET config_value = excluded.config_value,
+                               updated_at   = CURRENT_TIMESTAMP'
+            )->execute([':k' => $key, ':v' => $value]);
+        } else {
+            $db->prepare(
+                'INSERT INTO config_store (config_key, config_value)
+                 VALUES (:k, :v)
+                 ON DUPLICATE KEY UPDATE config_value = VALUES(config_value),
+                                         updated_at   = CURRENT_TIMESTAMP'
+            )->execute([':k' => $key, ':v' => $value]);
+        }
+    }
+
+    /**
+     * Get a configuration value as a string.
+     *
+     * @param string $default Returned when the key does not exist.
+     */
+    public function get(string $key, string $default = ''): string
+    {
+        $key  = $this->validateKey($key);
+        $stmt = $this->db()->prepare(
+            'SELECT config_value FROM config_store WHERE config_key = :k LIMIT 1'
+        );
+        $stmt->execute([':k' => $key]);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : $default;
+    }
+
+    /**
+     * Get a configuration value as an integer.
+     */
+    public function getInt(string $key, int $default = 0): int
+    {
+        $raw = $this->get($key);
+        return $raw !== '' ? (int)$raw : $default;
+    }
+
+    /**
+     * Get a configuration value as a boolean.
+     *
+     * Truthy strings: '1', 'true', 'yes', 'on' (case-insensitive).
+     */
+    public function getBool(string $key, bool $default = false): bool
+    {
+        $raw = $this->get($key);
+        if ($raw === '') {
+            return $default;
+        }
+        return in_array(strtolower($raw), ['1', 'true', 'yes', 'on'], true);
+    }
+
+    /**
+     * Check whether a key exists.
+     */
+    public function has(string $key): bool
+    {
+        $key  = $this->validateKey($key);
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM config_store WHERE config_key = :k'
+        );
+        $stmt->execute([':k' => $key]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Delete a key.
+     *
+     * @return bool True if the key existed and was deleted.
+     */
+    public function delete(string $key): bool
+    {
+        $key  = $this->validateKey($key);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM config_store WHERE config_key = :k'
+        );
+        $stmt->execute([':k' => $key]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Return all configuration entries as key => value pairs.
+     *
+     * @return array<string,string>
+     */
+    public function all(): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT config_key, config_value FROM config_store ORDER BY config_key ASC'
+        );
+        $stmt->execute();
+        $result = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) ?: [] as $row) {
+            $result[(string)$row['config_key']] = (string)$row['config_value'];
+        }
+        return $result;
+    }
+
+    /**
+     * Return all entries whose key starts with the given prefix followed by '.'.
+     *
+     * For example, `namespace('mail')` returns all `mail.*` entries.
+     *
+     * @return array<string,string>
+     */
+    public function namespace(string $prefix): array
+    {
+        $prefix = trim($prefix);
+        $like   = $this->db()->quote($prefix . '.%');
+        $stmt   = $this->db()->prepare(
+            "SELECT config_key, config_value FROM config_store WHERE config_key LIKE {$like} ORDER BY config_key ASC"
+        );
+        $stmt->execute();
+        $result = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) ?: [] as $row) {
+            $result[(string)$row['config_key']] = (string)$row['config_value'];
+        }
+        return $result;
+    }
+
+    /**
+     * Delete all keys in a namespace (prefix + '.').
+     *
+     * @return int Number of rows deleted.
+     */
+    public function deleteNamespace(string $prefix): int
+    {
+        $prefix = trim($prefix);
+        $like   = $this->db()->quote($prefix . '.%');
+        $stmt   = $this->db()->prepare(
+            "DELETE FROM config_store WHERE config_key LIKE {$like}"
+        );
+        $stmt->execute();
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Count stored keys.
+     */
+    public function count(): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM config_store');
+        $stmt->execute();
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateKey(string $key): string
+    {
+        $key = trim($key);
+        if ($key === '') {
+            throw new \InvalidArgumentException('config_key must not be empty.');
+        }
+        return $key;
+    }
+}

--- a/tests/Unit/Xion/ConfigStoreTest.php
+++ b/tests/Unit/Xion/ConfigStoreTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ConfigStore;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ConfigStore.
+ */
+final class ConfigStoreTest extends TestCase
+{
+    private PDO $db;
+    private ConfigStore $cfg;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE config_store (
+                config_key   VARCHAR(255) NOT NULL PRIMARY KEY,
+                config_value TEXT         NOT NULL DEFAULT \'\',
+                updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->cfg = new ConfigStore($this->db);
+    }
+
+    // ── set / get ─────────────────────────────────────────────────────────────
+
+    public function testSetAndGet(): void
+    {
+        $this->cfg->set('app.name', 'MyApp');
+        $this->assertSame('MyApp', $this->cfg->get('app.name'));
+    }
+
+    public function testGetReturnsDefaultWhenMissing(): void
+    {
+        $this->assertSame('', $this->cfg->get('missing'));
+        $this->assertSame('fallback', $this->cfg->get('missing', 'fallback'));
+    }
+
+    public function testSetIsUpsert(): void
+    {
+        $this->cfg->set('x', 'a');
+        $this->cfg->set('x', 'b');
+        $this->assertSame('b', $this->cfg->get('x'));
+        $this->assertSame(1, $this->cfg->count());
+    }
+
+    public function testSetThrowsOnEmptyKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cfg->set('', 'value');
+    }
+
+    // ── getInt ────────────────────────────────────────────────────────────────
+
+    public function testGetInt(): void
+    {
+        $this->cfg->set('limit', '42');
+        $this->assertSame(42, $this->cfg->getInt('limit'));
+    }
+
+    public function testGetIntReturnsDefaultWhenMissing(): void
+    {
+        $this->assertSame(0, $this->cfg->getInt('missing'));
+        $this->assertSame(99, $this->cfg->getInt('missing', 99));
+    }
+
+    // ── getBool ───────────────────────────────────────────────────────────────
+
+    public function testGetBoolTrueValues(): void
+    {
+        foreach (['1', 'true', 'yes', 'on', 'TRUE', 'YES', 'ON'] as $i => $val) {
+            $this->cfg->set("k{$i}", $val);
+            $this->assertTrue($this->cfg->getBool("k{$i}"), "Expected true for '{$val}'");
+        }
+    }
+
+    public function testGetBoolFalseValues(): void
+    {
+        $this->cfg->set('f', '0');
+        $this->assertFalse($this->cfg->getBool('f'));
+        $this->cfg->set('f2', 'false');
+        $this->assertFalse($this->cfg->getBool('f2'));
+    }
+
+    public function testGetBoolReturnsDefaultWhenMissing(): void
+    {
+        $this->assertFalse($this->cfg->getBool('missing'));
+        $this->assertTrue($this->cfg->getBool('missing', true));
+    }
+
+    // ── has ───────────────────────────────────────────────────────────────────
+
+    public function testHas(): void
+    {
+        $this->assertFalse($this->cfg->has('x'));
+        $this->cfg->set('x', 'v');
+        $this->assertTrue($this->cfg->has('x'));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDelete(): void
+    {
+        $this->cfg->set('x', 'v');
+        $this->assertTrue($this->cfg->delete('x'));
+        $this->assertFalse($this->cfg->has('x'));
+    }
+
+    public function testDeleteReturnsFalseWhenMissing(): void
+    {
+        $this->assertFalse($this->cfg->delete('nope'));
+    }
+
+    // ── all ───────────────────────────────────────────────────────────────────
+
+    public function testAll(): void
+    {
+        $this->cfg->set('b', '2');
+        $this->cfg->set('a', '1');
+        $all = $this->cfg->all();
+        $this->assertSame(['a' => '1', 'b' => '2'], $all);
+    }
+
+    public function testAllReturnsEmptyWhenNoKeys(): void
+    {
+        $this->assertSame([], $this->cfg->all());
+    }
+
+    // ── namespace ─────────────────────────────────────────────────────────────
+
+    public function testNamespaceReturnsMatchingKeys(): void
+    {
+        $this->cfg->set('mail.from', 'a@b.com');
+        $this->cfg->set('mail.host', 'smtp.example.com');
+        $this->cfg->set('app.name', 'MyApp');
+        $ns = $this->cfg->namespace('mail');
+        $this->assertSame(['mail.from' => 'a@b.com', 'mail.host' => 'smtp.example.com'], $ns);
+    }
+
+    public function testNamespaceReturnsEmptyWhenNoneMatch(): void
+    {
+        $this->cfg->set('app.name', 'x');
+        $this->assertSame([], $this->cfg->namespace('mail'));
+    }
+
+    // ── deleteNamespace ───────────────────────────────────────────────────────
+
+    public function testDeleteNamespace(): void
+    {
+        $this->cfg->set('mail.from', 'a@b.com');
+        $this->cfg->set('mail.host', 'smtp.example.com');
+        $this->cfg->set('app.name', 'MyApp');
+        $deleted = $this->cfg->deleteNamespace('mail');
+        $this->assertSame(2, $deleted);
+        $this->assertTrue($this->cfg->has('app.name'));
+        $this->assertFalse($this->cfg->has('mail.from'));
+    }
+
+    public function testDeleteNamespaceReturnsZeroWhenNoneMatch(): void
+    {
+        $this->assertSame(0, $this->cfg->deleteNamespace('nope'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCount(): void
+    {
+        $this->assertSame(0, $this->cfg->count());
+        $this->cfg->set('a', '1');
+        $this->cfg->set('b', '2');
+        $this->assertSame(2, $this->cfg->count());
+    }
+}


### PR DESCRIPTION
Global application configuration store, distinct from `UserPreference` (per-user).

## Class

`Nene\Xion\ConfigStore`

## Schema

```sql
CREATE TABLE config_store (
    config_key   VARCHAR(255) NOT NULL PRIMARY KEY,
    config_value TEXT         NOT NULL DEFAULT '',
    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API

| Method | Description |
|--------|-------------|
| `set(key, value)` | Upsert a config value |
| `get(key, default)` | Get as string |
| `getInt(key, default)` | Get as int |
| `getBool(key, default)` | Get as bool (1/true/yes/on) |
| `has(key)` | Check key existence |
| `delete(key)` | Delete a key |
| `all()` | All entries as key⇒value map |
| `namespace(prefix)` | All `prefix.*` entries |
| `deleteNamespace(prefix)` | Delete all `prefix.*` keys |
| `count()` | Total stored keys |

## Tests

19 tests, 35 assertions. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)