### PR TITLE
feat(xion): CacheEntry — DB-backed key-value cache with TTL (FT142)

### DIFF
--- a/class/xion/CacheEntry.php
+++ b/class/xion/CacheEntry.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * CacheEntry — DB-backed key-value cache with optional TTL.
+ *
+ * Lightweight caching layer backed by the application database. Suitable
+ * for caching small, infrequently-changing values (config, computed results,
+ * external API responses). For high-throughput scenarios prefer Redis or
+ * Memcached; this is the "zero extra infrastructure" fallback.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cache = new CacheEntry($pdo);
+ *
+ * // Store with 60-second TTL
+ * $cache->set('user:42:profile', json_encode($profile), 60);
+ *
+ * // Store forever
+ * $cache->set('static:countries', json_encode($countries));
+ *
+ * // Retrieve
+ * $raw = $cache->get('user:42:profile'); // null if missing or expired
+ *
+ * // Clean up
+ * $cache->flushExpired();
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE cache_entries (
+ *     cache_key  VARCHAR(255) NOT NULL PRIMARY KEY,
+ *     cache_value TEXT        NOT NULL DEFAULT '',
+ *     expires_at DATETIME     DEFAULT NULL,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class CacheEntry
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Store a value in the cache.
+     *
+     * @param int|null $ttlSeconds Time-to-live in seconds; null = never expires.
+     * @throws \InvalidArgumentException if the key is empty.
+     */
+    public function set(string $key, string $value, ?int $ttlSeconds = null): void
+    {
+        $key       = $this->validateKey($key);
+        $expiresAt = $ttlSeconds !== null
+            ? (new \DateTimeImmutable())->modify("+{$ttlSeconds} seconds")->format('Y-m-d H:i:s')
+            : null;
+
+        $db = $this->db();
+        if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO cache_entries (cache_key, cache_value, expires_at)
+                 VALUES (:k, :v, :exp)
+                 ON CONFLICT (cache_key)
+                 DO UPDATE SET cache_value = excluded.cache_value,
+                               expires_at  = excluded.expires_at,
+                               created_at  = CURRENT_TIMESTAMP'
+            )->execute([':k' => $key, ':v' => $value, ':exp' => $expiresAt]);
+        } else {
+            $db->prepare(
+                'INSERT INTO cache_entries (cache_key, cache_value, expires_at)
+                 VALUES (:k, :v, :exp)
+                 ON DUPLICATE KEY UPDATE cache_value = VALUES(cache_value),
+                                         expires_at  = VALUES(expires_at),
+                                         created_at  = CURRENT_TIMESTAMP'
+            )->execute([':k' => $key, ':v' => $value, ':exp' => $expiresAt]);
+        }
+    }
+
+    /**
+     * Retrieve a cached value.
+     *
+     * Returns null if the key does not exist or has expired.
+     */
+    public function get(string $key): ?string
+    {
+        $key  = $this->validateKey($key);
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'SELECT cache_value FROM cache_entries
+             WHERE cache_key = :k
+               AND (expires_at IS NULL OR expires_at > :now)
+             LIMIT 1'
+        );
+        $stmt->execute([':k' => $key, ':now' => $now]);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : null;
+    }
+
+    /**
+     * Check whether a non-expired entry exists for the key.
+     */
+    public function has(string $key): bool
+    {
+        return $this->get($key) !== null;
+    }
+
+    /**
+     * Delete a cache entry.
+     *
+     * @return bool True if an entry was deleted.
+     */
+    public function delete(string $key): bool
+    {
+        $key  = $this->validateKey($key);
+        $stmt = $this->db()->prepare('DELETE FROM cache_entries WHERE cache_key = :k');
+        $stmt->execute([':k' => $key]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete all cache entries.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function flush(): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM cache_entries');
+        $stmt->execute();
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Delete all expired cache entries.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function flushExpired(): int
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'DELETE FROM cache_entries WHERE expires_at IS NOT NULL AND expires_at <= :now'
+        );
+        $stmt->execute([':now' => $now]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Count all stored entries (including expired).
+     */
+    public function count(): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM cache_entries');
+        $stmt->execute();
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateKey(string $key): string
+    {
+        $key = trim($key);
+        if ($key === '') {
+            throw new \InvalidArgumentException('cache_key must not be empty.');
+        }
+        return $key;
+    }
+}

--- a/tests/Unit/Xion/CacheEntryTest.php
+++ b/tests/Unit/Xion/CacheEntryTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\CacheEntry;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for CacheEntry.
+ */
+final class CacheEntryTest extends TestCase
+{
+    private PDO $db;
+    private CacheEntry $cache;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE cache_entries (
+                cache_key   VARCHAR(255) NOT NULL PRIMARY KEY,
+                cache_value TEXT         NOT NULL DEFAULT \'\',
+                expires_at  DATETIME     DEFAULT NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->cache = new CacheEntry($this->db);
+    }
+
+    // ── set / get ─────────────────────────────────────────────────────────────
+
+    public function testSetAndGet(): void
+    {
+        $this->cache->set('key', 'value');
+        $this->assertSame('value', $this->cache->get('key'));
+    }
+
+    public function testGetReturnsNullWhenMissing(): void
+    {
+        $this->assertNull($this->cache->get('missing'));
+    }
+
+    public function testSetIsUpsert(): void
+    {
+        $this->cache->set('key', 'a');
+        $this->cache->set('key', 'b');
+        $this->assertSame('b', $this->cache->get('key'));
+        $this->assertSame(1, $this->cache->count());
+    }
+
+    public function testSetThrowsOnEmptyKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cache->set('', 'value');
+    }
+
+    // ── TTL ───────────────────────────────────────────────────────────────────
+
+    public function testSetWithTtlStoresEntry(): void
+    {
+        $this->cache->set('ttl-key', 'data', 60);
+        $this->assertSame('data', $this->cache->get('ttl-key'));
+    }
+
+    public function testExpiredEntryReturnsNull(): void
+    {
+        // Manually insert an already-expired entry
+        $this->db->exec(
+            "INSERT INTO cache_entries (cache_key, cache_value, expires_at)
+             VALUES ('expired', 'old', '2000-01-01 00:00:00')"
+        );
+        $this->assertNull($this->cache->get('expired'));
+    }
+
+    public function testNonExpiredEntryIsReturned(): void
+    {
+        $this->db->exec(
+            "INSERT INTO cache_entries (cache_key, cache_value, expires_at)
+             VALUES ('fresh', 'data', '2099-12-31 23:59:59')"
+        );
+        $this->assertSame('data', $this->cache->get('fresh'));
+    }
+
+    public function testNullTtlNeverExpires(): void
+    {
+        $this->cache->set('forever', 'permanent', null);
+        $this->assertSame('permanent', $this->cache->get('forever'));
+    }
+
+    // ── has ───────────────────────────────────────────────────────────────────
+
+    public function testHasReturnsTrueForExistingKey(): void
+    {
+        $this->cache->set('k', 'v');
+        $this->assertTrue($this->cache->has('k'));
+    }
+
+    public function testHasReturnsFalseForMissingKey(): void
+    {
+        $this->assertFalse($this->cache->has('nope'));
+    }
+
+    public function testHasReturnsFalseForExpiredKey(): void
+    {
+        $this->db->exec(
+            "INSERT INTO cache_entries (cache_key, cache_value, expires_at)
+             VALUES ('ex', 'v', '2000-01-01 00:00:00')"
+        );
+        $this->assertFalse($this->cache->has('ex'));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDelete(): void
+    {
+        $this->cache->set('k', 'v');
+        $this->assertTrue($this->cache->delete('k'));
+        $this->assertNull($this->cache->get('k'));
+    }
+
+    public function testDeleteReturnsFalseWhenMissing(): void
+    {
+        $this->assertFalse($this->cache->delete('nope'));
+    }
+
+    // ── flush ─────────────────────────────────────────────────────────────────
+
+    public function testFlushDeletesAll(): void
+    {
+        $this->cache->set('a', '1');
+        $this->cache->set('b', '2');
+        $deleted = $this->cache->flush();
+        $this->assertSame(2, $deleted);
+        $this->assertSame(0, $this->cache->count());
+    }
+
+    public function testFlushReturnsZeroWhenEmpty(): void
+    {
+        $this->assertSame(0, $this->cache->flush());
+    }
+
+    // ── flushExpired ──────────────────────────────────────────────────────────
+
+    public function testFlushExpiredRemovesOnlyExpiredEntries(): void
+    {
+        $this->cache->set('live', 'data', 3600);
+        $this->db->exec(
+            "INSERT INTO cache_entries (cache_key, cache_value, expires_at)
+             VALUES ('dead1', 'x', '2000-01-01 00:00:00'),
+                    ('dead2', 'y', '2000-01-02 00:00:00')"
+        );
+        $deleted = $this->cache->flushExpired();
+        $this->assertSame(2, $deleted);
+        $this->assertSame('data', $this->cache->get('live'));
+    }
+
+    public function testFlushExpiredIgnoresNullExpiry(): void
+    {
+        $this->cache->set('forever', 'v', null);
+        $this->assertSame(0, $this->cache->flushExpired());
+        $this->assertSame('v', $this->cache->get('forever'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCount(): void
+    {
+        $this->assertSame(0, $this->cache->count());
+        $this->cache->set('a', '1');
+        $this->cache->set('b', '2');
+        $this->assertSame(2, $this->cache->count());
+    }
+
+    public function testCountIncludesExpiredEntries(): void
+    {
+        $this->db->exec(
+            "INSERT INTO cache_entries (cache_key, cache_value, expires_at)
+             VALUES ('old', 'x', '2000-01-01 00:00:00')"
+        );
+        $this->assertSame(1, $this->cache->count());
+    }
+}


### PR DESCRIPTION
DB-backed cache with optional TTL. Zero extra infrastructure — backed by the application database.

## Schema

```sql
CREATE TABLE cache_entries (
    cache_key   VARCHAR(255) NOT NULL PRIMARY KEY,
    cache_value TEXT         NOT NULL DEFAULT '',
    expires_at  DATETIME     DEFAULT NULL,
    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API

| Method | Description |
|--------|-------------|
| `set(key, value, ttlSeconds)` | Upsert with optional TTL |
| `get(key)` | Returns null if missing or expired |
| `has(key)` | Non-expired existence check |
| `delete(key)` | Delete one entry |
| `flush()` | Delete all entries |
| `flushExpired()` | Delete expired entries only |
| `count()` | Total entries (including expired) |

## Tests

19 tests, 25 assertions. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)