### PR TITLE
feat(xion): UserGroup — user group membership with roles (FT143)

### DIFF
--- a/class/xion/UserGroup.php
+++ b/class/xion/UserGroup.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * UserGroup — user group and team membership management.
+ *
+ * Groups are named collections of users with optional per-member roles.
+ * Useful for teams, organisations, permission groups, and any scenario
+ * requiring membership-based access control.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ug = new UserGroup($pdo);
+ *
+ * // Create a group
+ * $id = $ug->create('engineers', 'Engineering team');
+ *
+ * // Add members
+ * $ug->addMember($id, 'user-1', 'admin');
+ * $ug->addMember($id, 'user-2');  // default role: 'member'
+ *
+ * // Query membership
+ * $ug->isMember($id, 'user-1');            // true
+ * $ug->getRole($id, 'user-1');             // 'admin'
+ * $ug->listMembers($id);                   // [{user_id, role, joined_at}, ...]
+ * $ug->listGroups('user-1');               // [{id, name, role, joined_at}, ...]
+ *
+ * // Manage
+ * $ug->setRole($id, 'user-2', 'admin');
+ * $ug->removeMember($id, 'user-2');
+ * $ug->delete($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE user_groups (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     name        VARCHAR(100) NOT NULL UNIQUE,
+ *     description TEXT         NOT NULL DEFAULT '',
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE user_group_members (
+ *     group_id   INTEGER      NOT NULL,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     role       VARCHAR(50)  NOT NULL DEFAULT 'member',
+ *     joined_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     PRIMARY KEY (group_id, user_id)
+ * );
+ * ```
+ */
+final class UserGroup
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create a new group.
+     *
+     * @return int The new group ID.
+     * @throws \InvalidArgumentException if name is empty.
+     */
+    public function create(string $name, string $description = ''): int
+    {
+        $name = $this->validateName($name);
+        $db   = $this->db();
+        $db->prepare(
+            'INSERT INTO user_groups (name, description) VALUES (:name, :desc)'
+        )->execute([':name' => $name, ':desc' => $description]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Delete a group and all its memberships.
+     *
+     * @return bool True if the group existed.
+     */
+    public function delete(int $groupId): bool
+    {
+        $db = $this->db();
+        $db->prepare('DELETE FROM user_group_members WHERE group_id = :gid')->execute([':gid' => $groupId]);
+        $stmt = $db->prepare('DELETE FROM user_groups WHERE id = :gid');
+        $stmt->execute([':gid' => $groupId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Find a group by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $groupId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, name, description, created_at FROM user_groups WHERE id = :gid LIMIT 1'
+        );
+        $stmt->execute([':gid' => $groupId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Find a group by name.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function findByName(string $name): ?array
+    {
+        $name = trim($name);
+        $stmt = $this->db()->prepare(
+            'SELECT id, name, description, created_at FROM user_groups WHERE name = :name LIMIT 1'
+        );
+        $stmt->execute([':name' => $name]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Add a user to a group (idempotent; updates role if already a member).
+     *
+     * @throws \InvalidArgumentException if user_id is empty.
+     */
+    public function addMember(int $groupId, string $userId, string $role = 'member'): void
+    {
+        $userId = $this->validateUserId($userId);
+        $db     = $this->db();
+        if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO user_group_members (group_id, user_id, role)
+                 VALUES (:gid, :uid, :role)
+                 ON CONFLICT (group_id, user_id)
+                 DO UPDATE SET role = excluded.role, joined_at = CURRENT_TIMESTAMP'
+            )->execute([':gid' => $groupId, ':uid' => $userId, ':role' => $role]);
+        } else {
+            $db->prepare(
+                'INSERT INTO user_group_members (group_id, user_id, role)
+                 VALUES (:gid, :uid, :role)
+                 ON DUPLICATE KEY UPDATE role = VALUES(role), joined_at = CURRENT_TIMESTAMP'
+            )->execute([':gid' => $groupId, ':uid' => $userId, ':role' => $role]);
+        }
+    }
+
+    /**
+     * Remove a user from a group.
+     *
+     * @return bool True if the user was a member.
+     */
+    public function removeMember(int $groupId, string $userId): bool
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM user_group_members WHERE group_id = :gid AND user_id = :uid'
+        );
+        $stmt->execute([':gid' => $groupId, ':uid' => $userId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Check whether a user is a member of a group.
+     */
+    public function isMember(int $groupId, string $userId): bool
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'SELECT COUNT(*) FROM user_group_members WHERE group_id = :gid AND user_id = :uid'
+        );
+        $stmt->execute([':gid' => $groupId, ':uid' => $userId]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Get a member's role within a group.
+     *
+     * @return string|null null if the user is not a member.
+     */
+    public function getRole(int $groupId, string $userId): ?string
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'SELECT role FROM user_group_members WHERE group_id = :gid AND user_id = :uid LIMIT 1'
+        );
+        $stmt->execute([':gid' => $groupId, ':uid' => $userId]);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : null;
+    }
+
+    /**
+     * Update a member's role.
+     *
+     * @return bool True if the user was a member and the role was updated.
+     */
+    public function setRole(int $groupId, string $userId, string $role): bool
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'UPDATE user_group_members SET role = :role WHERE group_id = :gid AND user_id = :uid'
+        );
+        $stmt->execute([':role' => $role, ':gid' => $groupId, ':uid' => $userId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List all members of a group.
+     *
+     * @return list<array{user_id: string, role: string, joined_at: string}>
+     */
+    public function listMembers(int $groupId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT user_id, role, joined_at FROM user_group_members
+             WHERE group_id = :gid ORDER BY joined_at ASC'
+        );
+        $stmt->execute([':gid' => $groupId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List all groups a user belongs to.
+     *
+     * @return list<array{id: int, name: string, description: string, role: string, joined_at: string}>
+     */
+    public function listGroups(string $userId): array
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'SELECT g.id, g.name, g.description, m.role, m.joined_at
+             FROM user_groups g
+             JOIN user_group_members m ON m.group_id = g.id
+             WHERE m.user_id = :uid
+             ORDER BY m.joined_at ASC'
+        );
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Count total groups.
+     */
+    public function count(): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM user_groups');
+        $stmt->execute();
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Count members in a group.
+     */
+    public function memberCount(int $groupId): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM user_group_members WHERE group_id = :gid'
+        );
+        $stmt->execute([':gid' => $groupId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateName(string $name): string
+    {
+        $name = trim($name);
+        if ($name === '') {
+            throw new \InvalidArgumentException('group name must not be empty.');
+        }
+        return $name;
+    }
+
+    private function validateUserId(string $userId): string
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        return $userId;
+    }
+}

--- a/tests/Unit/Xion/UserGroupTest.php
+++ b/tests/Unit/Xion/UserGroupTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\UserGroup;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for UserGroup.
+ */
+final class UserGroupTest extends TestCase
+{
+    private PDO $db;
+    private UserGroup $ug;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE user_groups (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                name        VARCHAR(100) NOT NULL UNIQUE,
+                description TEXT         NOT NULL DEFAULT \'\',
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->db->exec('
+            CREATE TABLE user_group_members (
+                group_id   INTEGER      NOT NULL,
+                user_id    VARCHAR(255) NOT NULL,
+                role       VARCHAR(50)  NOT NULL DEFAULT \'member\',
+                joined_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (group_id, user_id)
+            )
+        ');
+        $this->ug = new UserGroup($this->db);
+    }
+
+    // ── create / find / delete ────────────────────────────────────────────────
+
+    public function testCreateReturnsId(): void
+    {
+        $id = $this->ug->create('engineers');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testFindReturnsGroup(): void
+    {
+        $id  = $this->ug->create('engineers', 'Engineering team');
+        $row = $this->ug->find($id);
+        $this->assertNotNull($row);
+        $this->assertSame('engineers', $row['name']);
+        $this->assertSame('Engineering team', $row['description']);
+    }
+
+    public function testFindReturnsNullForMissing(): void
+    {
+        $this->assertNull($this->ug->find(999));
+    }
+
+    public function testFindByName(): void
+    {
+        $this->ug->create('devops');
+        $row = $this->ug->findByName('devops');
+        $this->assertNotNull($row);
+        $this->assertSame('devops', $row['name']);
+    }
+
+    public function testFindByNameReturnsNullForMissing(): void
+    {
+        $this->assertNull($this->ug->findByName('nope'));
+    }
+
+    public function testCreateThrowsOnEmptyName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ug->create('');
+    }
+
+    public function testDeleteRemovesGroupAndMembers(): void
+    {
+        $id = $this->ug->create('temp');
+        $this->ug->addMember($id, 'user-1');
+        $this->assertTrue($this->ug->delete($id));
+        $this->assertNull($this->ug->find($id));
+        $this->assertFalse($this->ug->isMember($id, 'user-1'));
+    }
+
+    public function testDeleteReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->ug->delete(999));
+    }
+
+    // ── addMember / isMember ──────────────────────────────────────────────────
+
+    public function testAddMemberDefaultRole(): void
+    {
+        $id = $this->ug->create('g');
+        $this->ug->addMember($id, 'user-1');
+        $this->assertTrue($this->ug->isMember($id, 'user-1'));
+        $this->assertSame('member', $this->ug->getRole($id, 'user-1'));
+    }
+
+    public function testAddMemberWithCustomRole(): void
+    {
+        $id = $this->ug->create('g');
+        $this->ug->addMember($id, 'user-1', 'admin');
+        $this->assertSame('admin', $this->ug->getRole($id, 'user-1'));
+    }
+
+    public function testAddMemberIsIdempotentAndUpdatesRole(): void
+    {
+        $id = $this->ug->create('g');
+        $this->ug->addMember($id, 'user-1', 'member');
+        $this->ug->addMember($id, 'user-1', 'admin');
+        $this->assertSame('admin', $this->ug->getRole($id, 'user-1'));
+        $this->assertSame(1, $this->ug->memberCount($id));
+    }
+
+    public function testIsMemberReturnsFalseForNonMember(): void
+    {
+        $id = $this->ug->create('g');
+        $this->assertFalse($this->ug->isMember($id, 'user-99'));
+    }
+
+    // ── removeMember ─────────────────────────────────────────────────────────
+
+    public function testRemoveMember(): void
+    {
+        $id = $this->ug->create('g');
+        $this->ug->addMember($id, 'user-1');
+        $this->assertTrue($this->ug->removeMember($id, 'user-1'));
+        $this->assertFalse($this->ug->isMember($id, 'user-1'));
+    }
+
+    public function testRemoveMemberReturnsFalseForNonMember(): void
+    {
+        $id = $this->ug->create('g');
+        $this->assertFalse($this->ug->removeMember($id, 'user-99'));
+    }
+
+    // ── setRole ───────────────────────────────────────────────────────────────
+
+    public function testSetRole(): void
+    {
+        $id = $this->ug->create('g');
+        $this->ug->addMember($id, 'user-1', 'member');
+        $this->assertTrue($this->ug->setRole($id, 'user-1', 'admin'));
+        $this->assertSame('admin', $this->ug->getRole($id, 'user-1'));
+    }
+
+    public function testSetRoleReturnsFalseForNonMember(): void
+    {
+        $id = $this->ug->create('g');
+        $this->assertFalse($this->ug->setRole($id, 'user-99', 'admin'));
+    }
+
+    // ── listMembers / listGroups ──────────────────────────────────────────────
+
+    public function testListMembers(): void
+    {
+        $id = $this->ug->create('g');
+        $this->ug->addMember($id, 'user-1', 'admin');
+        $this->ug->addMember($id, 'user-2');
+        $members = $this->ug->listMembers($id);
+        $this->assertCount(2, $members);
+        $this->assertSame('user-1', $members[0]['user_id']);
+        $this->assertSame('admin', $members[0]['role']);
+    }
+
+    public function testListGroups(): void
+    {
+        $id1 = $this->ug->create('g1');
+        $id2 = $this->ug->create('g2');
+        $this->ug->addMember($id1, 'user-1', 'admin');
+        $this->ug->addMember($id2, 'user-1');
+        $groups = $this->ug->listGroups('user-1');
+        $this->assertCount(2, $groups);
+        $this->assertSame('g1', $groups[0]['name']);
+        $this->assertSame('admin', $groups[0]['role']);
+    }
+
+    // ── count / memberCount ───────────────────────────────────────────────────
+
+    public function testCount(): void
+    {
+        $this->assertSame(0, $this->ug->count());
+        $this->ug->create('a');
+        $this->ug->create('b');
+        $this->assertSame(2, $this->ug->count());
+    }
+
+    public function testMemberCount(): void
+    {
+        $id = $this->ug->create('g');
+        $this->assertSame(0, $this->ug->memberCount($id));
+        $this->ug->addMember($id, 'user-1');
+        $this->ug->addMember($id, 'user-2');
+        $this->assertSame(2, $this->ug->memberCount($id));
+    }
+}

--- a/tests/Unit/Xion/UserGroupTest.php
+++ b/tests/Unit/Xion/UserGroupTest.php
@@ -53,7 +53,9 @@ final class UserGroupTest extends TestCase
         $id  = $this->ug->create('engineers', 'Engineering team');
         $row = $this->ug->find($id);
         $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('engineers', $row['name']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Engineering team', $row['description']);
     }
 
@@ -67,6 +69,7 @@ final class UserGroupTest extends TestCase
         $this->ug->create('devops');
         $row = $this->ug->findByName('devops');
         $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('devops', $row['name']);
     }
 


### PR DESCRIPTION
User group and team membership management with per-member roles.

## Schema

```sql
CREATE TABLE user_groups (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    name VARCHAR(100) NOT NULL UNIQUE,
    description TEXT NOT NULL DEFAULT '',
    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
);

CREATE TABLE user_group_members (
    group_id INTEGER NOT NULL,
    user_id VARCHAR(255) NOT NULL,
    role VARCHAR(50) NOT NULL DEFAULT 'member',
    joined_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
    PRIMARY KEY (group_id, user_id)
);
```

## API

| Method | Description |
|--------|-------------|
| `create(name, description)` | Create a named group |
| `delete(groupId)` | Remove group + all memberships |
| `find/findByName` | Group lookup |
| `addMember(groupId, userId, role)` | Idempotent join with role |
| `removeMember(groupId, userId)` | Leave group |
| `isMember/getRole/setRole` | Membership state |
| `listMembers(groupId)` | Members with roles |
| `listGroups(userId)` | Groups a user belongs to |
| `count/memberCount` | Aggregate counts |

## Tests

20 tests, 35 assertions. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)