### PR TITLE
feat(xion): ChatMessage — simple chat room message store with soft-delete (FT144)

### DIFF
--- a/class/xion/ChatMessage.php
+++ b/class/xion/ChatMessage.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ChatMessage — simple chat room message store with soft-delete.
+ *
+ * Provides a persistent message log per room. Messages can be soft-deleted
+ * (body cleared, deleted_at set) by their sender. Rooms are created implicitly
+ * — no separate room setup is required.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $chat = new ChatMessage($pdo);
+ *
+ * // Send a message
+ * $id = $chat->send('room-general', 'user-1', 'Hello!');
+ *
+ * // Fetch recent messages (newest last)
+ * $chat->recent('room-general', 50);
+ *
+ * // Fetch messages before a given ID (for pagination)
+ * $chat->recent('room-general', 20, beforeId: 100);
+ *
+ * // Soft-delete your own message
+ * $chat->delete($id, 'user-1');
+ *
+ * // Count
+ * $chat->count('room-general');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE chat_messages (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     room_id    VARCHAR(255) NOT NULL,
+ *     sender_id  VARCHAR(255) NOT NULL,
+ *     body       TEXT         NOT NULL DEFAULT '',
+ *     deleted_at DATETIME     DEFAULT NULL,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ChatMessage
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Send a message to a room.
+     *
+     * @return int The new message ID.
+     * @throws \InvalidArgumentException if room_id, sender_id, or body is empty.
+     */
+    public function send(string $roomId, string $senderId, string $body): int
+    {
+        $roomId   = $this->validateRoom($roomId);
+        $senderId = $this->validateSender($senderId);
+        $body     = trim($body);
+        if ($body === '') {
+            throw new \InvalidArgumentException('message body must not be empty.');
+        }
+        $db = $this->db();
+        $db->prepare(
+            'INSERT INTO chat_messages (room_id, sender_id, body) VALUES (:room, :sender, :body)'
+        )->execute([':room' => $roomId, ':sender' => $senderId, ':body' => $body]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Soft-delete a message (sender only).
+     *
+     * Clears the body and sets deleted_at. Returns false if the message
+     * does not exist, is already deleted, or belongs to a different sender.
+     */
+    public function delete(int $messageId, string $senderId): bool
+    {
+        $senderId = $this->validateSender($senderId);
+        $stmt     = $this->db()->prepare(
+            'UPDATE chat_messages
+             SET body = \'\', deleted_at = CURRENT_TIMESTAMP
+             WHERE id = :id AND sender_id = :sender AND deleted_at IS NULL'
+        );
+        $stmt->execute([':id' => $messageId, ':sender' => $senderId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Find a message by ID (including deleted messages).
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $messageId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, room_id, sender_id, body, deleted_at, created_at
+             FROM chat_messages WHERE id = :id LIMIT 1'
+        );
+        $stmt->execute([':id' => $messageId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Fetch recent messages for a room, ordered oldest-first.
+     *
+     * @param int      $limit    Maximum number of messages to return (1–200).
+     * @param int|null $beforeId Return only messages with id < beforeId (for backward pagination).
+     * @return list<array<string,mixed>>
+     */
+    public function recent(string $roomId, int $limit = 50, ?int $beforeId = null): array
+    {
+        $roomId = $this->validateRoom($roomId);
+        $limit  = max(1, min(200, $limit));
+
+        if ($beforeId !== null) {
+            $stmt = $this->db()->prepare(
+                "SELECT id, room_id, sender_id, body, deleted_at, created_at
+                 FROM chat_messages
+                 WHERE room_id = :room AND id < :bid
+                 ORDER BY id DESC
+                 LIMIT {$limit}"
+            );
+            $stmt->execute([':room' => $roomId, ':bid' => $beforeId]);
+        } else {
+            $stmt = $this->db()->prepare(
+                "SELECT id, room_id, sender_id, body, deleted_at, created_at
+                 FROM chat_messages
+                 WHERE room_id = :room
+                 ORDER BY id DESC
+                 LIMIT {$limit}"
+            );
+            $stmt->execute([':room' => $roomId]);
+        }
+
+        return array_reverse($stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
+    }
+
+    /**
+     * Count messages in a room (including deleted).
+     */
+    public function count(string $roomId): int
+    {
+        $roomId = $this->validateRoom($roomId);
+        $stmt   = $this->db()->prepare(
+            'SELECT COUNT(*) FROM chat_messages WHERE room_id = :room'
+        );
+        $stmt->execute([':room' => $roomId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Hard-delete all messages in a room.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeRoom(string $roomId): int
+    {
+        $roomId = $this->validateRoom($roomId);
+        $stmt   = $this->db()->prepare('DELETE FROM chat_messages WHERE room_id = :room');
+        $stmt->execute([':room' => $roomId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Purge messages older than N days (hard delete).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare('DELETE FROM chat_messages WHERE created_at < :cutoff');
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateRoom(string $roomId): string
+    {
+        $roomId = trim($roomId);
+        if ($roomId === '') {
+            throw new \InvalidArgumentException('room_id must not be empty.');
+        }
+        return $roomId;
+    }
+
+    private function validateSender(string $senderId): string
+    {
+        $senderId = trim($senderId);
+        if ($senderId === '') {
+            throw new \InvalidArgumentException('sender_id must not be empty.');
+        }
+        return $senderId;
+    }
+}

--- a/tests/Unit/Xion/ChatMessageTest.php
+++ b/tests/Unit/Xion/ChatMessageTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ChatMessage;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ChatMessage.
+ */
+final class ChatMessageTest extends TestCase
+{
+    private PDO $db;
+    private ChatMessage $chat;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE chat_messages (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                room_id    VARCHAR(255) NOT NULL,
+                sender_id  VARCHAR(255) NOT NULL,
+                body       TEXT         NOT NULL DEFAULT \'\',
+                deleted_at DATETIME     DEFAULT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->chat = new ChatMessage($this->db);
+    }
+
+    // ── send ──────────────────────────────────────────────────────────────────
+
+    public function testSendReturnsId(): void
+    {
+        $id = $this->chat->send('room-1', 'user-1', 'Hello!');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testSendThrowsOnEmptyRoom(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->chat->send('', 'user-1', 'Hello!');
+    }
+
+    public function testSendThrowsOnEmptySender(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->chat->send('room-1', '', 'Hello!');
+    }
+
+    public function testSendThrowsOnEmptyBody(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->chat->send('room-1', 'user-1', '');
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsMessage(): void
+    {
+        $id  = $this->chat->send('room-1', 'user-1', 'Hi');
+        $msg = $this->chat->find($id);
+        $this->assertNotNull($msg);
+        $this->assertSame('Hi', $msg['body']);
+        $this->assertSame('user-1', $msg['sender_id']);
+    }
+
+    public function testFindReturnsNullForMissing(): void
+    {
+        $this->assertNull($this->chat->find(999));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteSoftDeletesMessage(): void
+    {
+        $id = $this->chat->send('room-1', 'user-1', 'Hello!');
+        $this->assertTrue($this->chat->delete($id, 'user-1'));
+        $msg = $this->chat->find($id);
+        $this->assertNotNull($msg);
+        $this->assertSame('', $msg['body']);
+        $this->assertNotNull($msg['deleted_at']);
+    }
+
+    public function testDeleteReturnsFalseForWrongSender(): void
+    {
+        $id = $this->chat->send('room-1', 'user-1', 'Hello!');
+        $this->assertFalse($this->chat->delete($id, 'user-2'));
+        $msg = $this->chat->find($id);
+        $this->assertSame('Hello!', $msg['body']);
+    }
+
+    public function testDeleteReturnsFalseForAlreadyDeleted(): void
+    {
+        $id = $this->chat->send('room-1', 'user-1', 'Hello!');
+        $this->chat->delete($id, 'user-1');
+        $this->assertFalse($this->chat->delete($id, 'user-1'));
+    }
+
+    // ── recent ────────────────────────────────────────────────────────────────
+
+    public function testRecentReturnsMessagesOldestFirst(): void
+    {
+        $this->chat->send('room-1', 'user-1', 'First');
+        $this->chat->send('room-1', 'user-1', 'Second');
+        $this->chat->send('room-1', 'user-1', 'Third');
+        $msgs = $this->chat->recent('room-1', 10);
+        $this->assertCount(3, $msgs);
+        $this->assertSame('First', $msgs[0]['body']);
+        $this->assertSame('Third', $msgs[2]['body']);
+    }
+
+    public function testRecentRespectsLimit(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->chat->send('room-1', 'user-1', "msg-{$i}");
+        }
+        $msgs = $this->chat->recent('room-1', 3);
+        $this->assertCount(3, $msgs);
+        $this->assertSame('msg-3', $msgs[0]['body']);
+    }
+
+    public function testRecentWithBeforeId(): void
+    {
+        $id1 = $this->chat->send('room-1', 'user-1', 'First');
+        $this->chat->send('room-1', 'user-1', 'Second');
+        $id3 = $this->chat->send('room-1', 'user-1', 'Third');
+        $msgs = $this->chat->recent('room-1', 10, $id3);
+        $this->assertCount(2, $msgs);
+        $this->assertSame('First', $msgs[0]['body']);
+        $this->assertSame('Second', $msgs[1]['body']);
+    }
+
+    public function testRecentReturnsEmptyForEmptyRoom(): void
+    {
+        $this->assertSame([], $this->chat->recent('empty-room'));
+    }
+
+    public function testRecentIsolatesRooms(): void
+    {
+        $this->chat->send('room-1', 'user-1', 'Room 1 msg');
+        $this->chat->send('room-2', 'user-1', 'Room 2 msg');
+        $msgs = $this->chat->recent('room-1');
+        $this->assertCount(1, $msgs);
+        $this->assertSame('Room 1 msg', $msgs[0]['body']);
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCount(): void
+    {
+        $this->assertSame(0, $this->chat->count('room-1'));
+        $this->chat->send('room-1', 'user-1', 'a');
+        $this->chat->send('room-1', 'user-1', 'b');
+        $this->assertSame(2, $this->chat->count('room-1'));
+    }
+
+    public function testCountIncludesDeletedMessages(): void
+    {
+        $id = $this->chat->send('room-1', 'user-1', 'Hello');
+        $this->chat->delete($id, 'user-1');
+        $this->assertSame(1, $this->chat->count('room-1'));
+    }
+
+    // ── purgeRoom ─────────────────────────────────────────────────────────────
+
+    public function testPurgeRoom(): void
+    {
+        $this->chat->send('room-1', 'user-1', 'a');
+        $this->chat->send('room-1', 'user-1', 'b');
+        $this->chat->send('room-2', 'user-1', 'c');
+        $deleted = $this->chat->purgeRoom('room-1');
+        $this->assertSame(2, $deleted);
+        $this->assertSame(0, $this->chat->count('room-1'));
+        $this->assertSame(1, $this->chat->count('room-2'));
+    }
+}

--- a/tests/Unit/Xion/ChatMessageTest.php
+++ b/tests/Unit/Xion/ChatMessageTest.php
@@ -66,7 +66,9 @@ final class ChatMessageTest extends TestCase
         $id  = $this->chat->send('room-1', 'user-1', 'Hi');
         $msg = $this->chat->find($id);
         $this->assertNotNull($msg);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Hi', $msg['body']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('user-1', $msg['sender_id']);
     }
 
@@ -83,7 +85,9 @@ final class ChatMessageTest extends TestCase
         $this->assertTrue($this->chat->delete($id, 'user-1'));
         $msg = $this->chat->find($id);
         $this->assertNotNull($msg);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('', $msg['body']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertNotNull($msg['deleted_at']);
     }
 
@@ -92,6 +96,7 @@ final class ChatMessageTest extends TestCase
         $id = $this->chat->send('room-1', 'user-1', 'Hello!');
         $this->assertFalse($this->chat->delete($id, 'user-2'));
         $msg = $this->chat->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Hello!', $msg['body']);
     }
 


### PR DESCRIPTION
Persistent chat message log per room. Rooms are implicit — no setup required.

## Schema

```sql
CREATE TABLE chat_messages (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    room_id VARCHAR(255) NOT NULL,
    sender_id VARCHAR(255) NOT NULL,
    body TEXT NOT NULL DEFAULT '',
    deleted_at DATETIME DEFAULT NULL,
    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API

| Method | Description |
|--------|-------------|
| `send(roomId, senderId, body)` | Post a message |
| `delete(messageId, senderId)` | Soft-delete by sender |
| `find(messageId)` | Lookup (includes deleted) |
| `recent(roomId, limit, beforeId)` | Paginated, oldest-first |
| `count(roomId)` | Total messages |
| `purgeRoom(roomId)` | Hard-delete entire room |
| `purgeOlderThan(days)` | Retention cleanup |

## Tests

17 tests, 32 assertions. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)