### PR TITLE
feat(xion): CronLog — scheduled task execution log (FT146)

### DIFF
--- a/class/xion/CronLog.php
+++ b/class/xion/CronLog.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * CronLog — scheduled task execution log.
+ *
+ * Tracks cron job runs with start/finish/fail lifecycle, output capture,
+ * and execution time. Useful for monitoring, alerting, and debugging
+ * scheduled tasks.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $log = new CronLog($pdo);
+ *
+ * // Start a run
+ * $runId = $log->start('cleanup:old-files');
+ *
+ * // ... do work ...
+ *
+ * // Mark as finished (success)
+ * $log->finish($runId, 'Deleted 42 files.');
+ *
+ * // or mark as failed
+ * $log->fail($runId, 'Permission denied on /tmp/uploads');
+ *
+ * // Query history
+ * $log->recent('cleanup:old-files', 20);
+ * $log->lastSuccess('cleanup:old-files');
+ * $log->count('cleanup:old-files');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE cron_log (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     job_name    VARCHAR(255) NOT NULL,
+ *     status      VARCHAR(20)  NOT NULL DEFAULT 'running',
+ *     output      TEXT         NOT NULL DEFAULT '',
+ *     started_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     finished_at DATETIME     DEFAULT NULL
+ * );
+ * ```
+ */
+final class CronLog
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record the start of a cron job run.
+     *
+     * @return int The run log ID (pass to finish() or fail()).
+     * @throws \InvalidArgumentException if job_name is empty.
+     */
+    public function start(string $jobName): int
+    {
+        $jobName = $this->validateJobName($jobName);
+        $db      = $this->db();
+        $db->prepare(
+            'INSERT INTO cron_log (job_name, status) VALUES (:name, \'running\')'
+        )->execute([':name' => $jobName]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Mark a run as successfully finished.
+     *
+     * @return bool True if the run existed and was updated.
+     */
+    public function finish(int $runId, string $output = ''): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE cron_log
+             SET status = \'finished\', output = :out, finished_at = CURRENT_TIMESTAMP
+             WHERE id = :id AND status = \'running\''
+        );
+        $stmt->execute([':out' => $output, ':id' => $runId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark a run as failed.
+     *
+     * @return bool True if the run existed and was updated.
+     */
+    public function fail(int $runId, string $output = ''): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE cron_log
+             SET status = \'failed\', output = :out, finished_at = CURRENT_TIMESTAMP
+             WHERE id = :id AND status = \'running\''
+        );
+        $stmt->execute([':out' => $output, ':id' => $runId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Find a run by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $runId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, job_name, status, output, started_at, finished_at
+             FROM cron_log WHERE id = :id LIMIT 1'
+        );
+        $stmt->execute([':id' => $runId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Get the most recent runs for a job, newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function recent(string $jobName, int $limit = 20): array
+    {
+        $jobName = $this->validateJobName($jobName);
+        $limit   = max(1, $limit);
+        $stmt    = $this->db()->prepare(
+            "SELECT id, job_name, status, output, started_at, finished_at
+             FROM cron_log
+             WHERE job_name = :name
+             ORDER BY id DESC
+             LIMIT {$limit}"
+        );
+        $stmt->execute([':name' => $jobName]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Get the most recent successful run for a job.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function lastSuccess(string $jobName): ?array
+    {
+        $jobName = $this->validateJobName($jobName);
+        $stmt    = $this->db()->prepare(
+            'SELECT id, job_name, status, output, started_at, finished_at
+             FROM cron_log
+             WHERE job_name = :name AND status = \'finished\'
+             ORDER BY id DESC LIMIT 1'
+        );
+        $stmt->execute([':name' => $jobName]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Get the most recent failed run for a job.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function lastFailure(string $jobName): ?array
+    {
+        $jobName = $this->validateJobName($jobName);
+        $stmt    = $this->db()->prepare(
+            'SELECT id, job_name, status, output, started_at, finished_at
+             FROM cron_log
+             WHERE job_name = :name AND status = \'failed\'
+             ORDER BY id DESC LIMIT 1'
+        );
+        $stmt->execute([':name' => $jobName]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Count runs for a job, optionally filtered by status.
+     *
+     * @param string|null $status 'running', 'finished', 'failed', or null for all.
+     */
+    public function count(string $jobName, ?string $status = null): int
+    {
+        $jobName = $this->validateJobName($jobName);
+        if ($status === null) {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM cron_log WHERE job_name = :name'
+            );
+            $stmt->execute([':name' => $jobName]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM cron_log WHERE job_name = :name AND status = :status'
+            );
+            $stmt->execute([':name' => $jobName, ':status' => $status]);
+        }
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Purge run records older than N days.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM cron_log WHERE started_at < :cutoff'
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateJobName(string $jobName): string
+    {
+        $jobName = trim($jobName);
+        if ($jobName === '') {
+            throw new \InvalidArgumentException('job_name must not be empty.');
+        }
+        return $jobName;
+    }
+}

--- a/tests/Unit/Xion/CronLogTest.php
+++ b/tests/Unit/Xion/CronLogTest.php
@@ -46,7 +46,9 @@ final class CronLogTest extends TestCase
         $id  = $this->log->start('cleanup');
         $row = $this->log->find($id);
         $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('running', $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertNull($row['finished_at']);
     }
 
@@ -63,8 +65,11 @@ final class CronLogTest extends TestCase
         $id = $this->log->start('cleanup');
         $this->assertTrue($this->log->finish($id, 'Done.'));
         $row = $this->log->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('finished', $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Done.', $row['output']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertNotNull($row['finished_at']);
     }
 
@@ -82,7 +87,9 @@ final class CronLogTest extends TestCase
         $id = $this->log->start('sync');
         $this->assertTrue($this->log->fail($id, 'Timeout'));
         $row = $this->log->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('failed', $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('Timeout', $row['output']);
     }
 
@@ -138,6 +145,7 @@ final class CronLogTest extends TestCase
         $this->log->finish($id, 'ok');
         $row = $this->log->lastSuccess('job-a');
         $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('finished', $row['status']);
     }
 
@@ -154,6 +162,7 @@ final class CronLogTest extends TestCase
         $this->log->fail($id, 'err');
         $row = $this->log->lastFailure('job-a');
         $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('failed', $row['status']);
     }
 

--- a/tests/Unit/Xion/CronLogTest.php
+++ b/tests/Unit/Xion/CronLogTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\CronLog;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for CronLog.
+ */
+final class CronLogTest extends TestCase
+{
+    private PDO $db;
+    private CronLog $log;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE cron_log (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_name    VARCHAR(255) NOT NULL,
+                status      VARCHAR(20)  NOT NULL DEFAULT \'running\',
+                output      TEXT         NOT NULL DEFAULT \'\',
+                started_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                finished_at DATETIME     DEFAULT NULL
+            )
+        ');
+        $this->log = new CronLog($this->db);
+    }
+
+    // ── start ─────────────────────────────────────────────────────────────────
+
+    public function testStartReturnsId(): void
+    {
+        $id = $this->log->start('cleanup');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testStartSetsRunningStatus(): void
+    {
+        $id  = $this->log->start('cleanup');
+        $row = $this->log->find($id);
+        $this->assertNotNull($row);
+        $this->assertSame('running', $row['status']);
+        $this->assertNull($row['finished_at']);
+    }
+
+    public function testStartThrowsOnEmptyJobName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->log->start('');
+    }
+
+    // ── finish ────────────────────────────────────────────────────────────────
+
+    public function testFinishSetsFinishedStatus(): void
+    {
+        $id = $this->log->start('cleanup');
+        $this->assertTrue($this->log->finish($id, 'Done.'));
+        $row = $this->log->find($id);
+        $this->assertSame('finished', $row['status']);
+        $this->assertSame('Done.', $row['output']);
+        $this->assertNotNull($row['finished_at']);
+    }
+
+    public function testFinishReturnsFalseForNonRunningRun(): void
+    {
+        $id = $this->log->start('cleanup');
+        $this->log->finish($id);
+        $this->assertFalse($this->log->finish($id));
+    }
+
+    // ── fail ──────────────────────────────────────────────────────────────────
+
+    public function testFailSetsFailedStatus(): void
+    {
+        $id = $this->log->start('sync');
+        $this->assertTrue($this->log->fail($id, 'Timeout'));
+        $row = $this->log->find($id);
+        $this->assertSame('failed', $row['status']);
+        $this->assertSame('Timeout', $row['output']);
+    }
+
+    public function testFailReturnsFalseForNonRunningRun(): void
+    {
+        $id = $this->log->start('sync');
+        $this->log->fail($id);
+        $this->assertFalse($this->log->fail($id));
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsNullForMissing(): void
+    {
+        $this->assertNull($this->log->find(999));
+    }
+
+    // ── recent ────────────────────────────────────────────────────────────────
+
+    public function testRecentReturnsNewestFirst(): void
+    {
+        $id1 = $this->log->start('job-a');
+        $this->log->finish($id1);
+        $id2 = $this->log->start('job-a');
+        $this->log->finish($id2);
+        $rows = $this->log->recent('job-a', 10);
+        $this->assertCount(2, $rows);
+        $this->assertSame($id2, (int)$rows[0]['id']);
+    }
+
+    public function testRecentRespectsLimit(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $id = $this->log->start('job-b');
+            $this->log->finish($id);
+        }
+        $this->assertCount(3, $this->log->recent('job-b', 3));
+    }
+
+    public function testRecentIsolatesJobs(): void
+    {
+        $id = $this->log->start('job-a');
+        $this->log->finish($id);
+        $this->log->start('job-b');
+        $this->assertCount(1, $this->log->recent('job-a'));
+    }
+
+    // ── lastSuccess / lastFailure ─────────────────────────────────────────────
+
+    public function testLastSuccess(): void
+    {
+        $id = $this->log->start('job-a');
+        $this->log->finish($id, 'ok');
+        $row = $this->log->lastSuccess('job-a');
+        $this->assertNotNull($row);
+        $this->assertSame('finished', $row['status']);
+    }
+
+    public function testLastSuccessReturnsNullWhenNone(): void
+    {
+        $id = $this->log->start('job-a');
+        $this->log->fail($id, 'err');
+        $this->assertNull($this->log->lastSuccess('job-a'));
+    }
+
+    public function testLastFailure(): void
+    {
+        $id = $this->log->start('job-a');
+        $this->log->fail($id, 'err');
+        $row = $this->log->lastFailure('job-a');
+        $this->assertNotNull($row);
+        $this->assertSame('failed', $row['status']);
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountAll(): void
+    {
+        $id1 = $this->log->start('job-a');
+        $this->log->finish($id1);
+        $id2 = $this->log->start('job-a');
+        $this->log->fail($id2);
+        $this->assertSame(2, $this->log->count('job-a'));
+    }
+
+    public function testCountByStatus(): void
+    {
+        $id1 = $this->log->start('job-a');
+        $this->log->finish($id1);
+        $this->log->start('job-a');
+        $this->assertSame(1, $this->log->count('job-a', 'finished'));
+        $this->assertSame(1, $this->log->count('job-a', 'running'));
+        $this->assertSame(0, $this->log->count('job-a', 'failed'));
+    }
+}


### PR DESCRIPTION
Tracks cron job runs with start/finish/fail lifecycle and output capture.

## Schema

```sql
CREATE TABLE cron_log (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    job_name VARCHAR(255) NOT NULL,
    status VARCHAR(20) NOT NULL DEFAULT 'running',
    output TEXT NOT NULL DEFAULT '',
    started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
    finished_at DATETIME DEFAULT NULL
);
```

## API

| Method | Description |
|--------|-------------|
| `start(jobName)` | Begin a run; returns run ID |
| `finish(runId, output)` | Mark successful |
| `fail(runId, output)` | Mark failed |
| `find(runId)` | Lookup |
| `recent(jobName, limit)` | Newest-first history |
| `lastSuccess/lastFailure` | Last run by status |
| `count(jobName, status)` | Aggregate count |
| `purgeOlderThan(days)` | Retention |

## Tests

16 tests, 28 assertions. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)