### PR TITLE
feat(xion): MagicLink — email-based passwordless authentication tokens (FT152)

### DIFF
--- a/class/xion/MagicLink.php
+++ b/class/xion/MagicLink.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * MagicLink — email-based passwordless authentication tokens.
+ *
+ * Generates single-use, time-limited tokens sent to a user's email address.
+ * Consuming a token marks it as used; it cannot be reused. Expired or used
+ * tokens are ignored by consume().
+ *
+ * Raw tokens are returned once on generation and never stored in plain text.
+ * The DB stores a SHA-256 hash.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ml = new MagicLink($pdo);
+ *
+ * // Generate and send
+ * $raw = $ml->generate('user@example.com', ttlSeconds: 900); // 15 min
+ * // → send email with link: /auth/magic?token={$raw}
+ *
+ * // On click: consume
+ * $record = $ml->consume($raw);
+ * if ($record !== null) {
+ *     // log in the user identified by $record['email']
+ * }
+ *
+ * // Maintenance
+ * $ml->purgeExpired();
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE magic_links (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     email      VARCHAR(255) NOT NULL,
+ *     token_hash VARCHAR(64)  NOT NULL UNIQUE,
+ *     used_at    DATETIME     DEFAULT NULL,
+ *     expires_at DATETIME     NOT NULL,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class MagicLink
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Generate a magic-link token for the given email address.
+     *
+     * @param int $ttlSeconds Time-to-live in seconds (default 15 minutes).
+     * @return string The raw token to embed in the link (not stored).
+     * @throws \InvalidArgumentException if email is empty.
+     */
+    public function generate(string $email, int $ttlSeconds = 900): string
+    {
+        $email = trim($email);
+        if ($email === '') {
+            throw new \InvalidArgumentException('email must not be empty.');
+        }
+        $rawToken  = bin2hex(random_bytes(32));
+        $hash      = hash('sha256', $rawToken);
+        $expiresAt = (new \DateTimeImmutable())->modify("+{$ttlSeconds} seconds")->format('Y-m-d H:i:s');
+
+        $this->db()->prepare(
+            'INSERT INTO magic_links (email, token_hash, expires_at)
+             VALUES (:email, :hash, :exp)'
+        )->execute([':email' => $email, ':hash' => $hash, ':exp' => $expiresAt]);
+
+        return $rawToken;
+    }
+
+    /**
+     * Consume a magic-link token.
+     *
+     * Returns the record and marks the token as used, or returns null if the
+     * token is invalid, expired, or already used.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function consume(string $rawToken): ?array
+    {
+        $hash = hash('sha256', $rawToken);
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $db   = $this->db();
+
+        $stmt = $db->prepare(
+            'SELECT id, email, expires_at FROM magic_links
+             WHERE token_hash = :hash AND used_at IS NULL AND expires_at > :now
+             LIMIT 1'
+        );
+        $stmt->execute([':hash' => $hash, ':now' => $now]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        $db->prepare(
+            'UPDATE magic_links SET used_at = CURRENT_TIMESTAMP WHERE id = :id'
+        )->execute([':id' => $row['id']]);
+
+        return $row;
+    }
+
+    /**
+     * Check whether a raw token is valid (not expired, not used).
+     */
+    public function isValid(string $rawToken): bool
+    {
+        $hash = hash('sha256', $rawToken);
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM magic_links
+             WHERE token_hash = :hash AND used_at IS NULL AND expires_at > :now'
+        );
+        $stmt->execute([':hash' => $hash, ':now' => $now]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Count pending (unused, non-expired) tokens for an email.
+     */
+    public function pendingCount(string $email): int
+    {
+        $email = trim($email);
+        $now   = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt  = $this->db()->prepare(
+            'SELECT COUNT(*) FROM magic_links
+             WHERE email = :email AND used_at IS NULL AND expires_at > :now'
+        );
+        $stmt->execute([':email' => $email, ':now' => $now]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Delete expired and used tokens.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeExpired(): int
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'DELETE FROM magic_links WHERE expires_at <= :now OR used_at IS NOT NULL'
+        );
+        $stmt->execute([':now' => $now]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/MagicLinkTest.php
+++ b/tests/Unit/Xion/MagicLinkTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\MagicLink;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class MagicLinkTest extends TestCase
+{
+    private PDO $db;
+    private MagicLink $ml;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE magic_links (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                email      VARCHAR(255) NOT NULL,
+                token_hash VARCHAR(64)  NOT NULL UNIQUE,
+                used_at    DATETIME     DEFAULT NULL,
+                expires_at DATETIME     NOT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->ml = new MagicLink($this->db);
+    }
+
+    public function testGenerateReturnsRawToken(): void
+    {
+        $token = $this->ml->generate('user@example.com');
+        $this->assertNotEmpty($token);
+        $this->assertSame(64, strlen($token)); // 32 bytes → 64 hex chars
+    }
+
+    public function testGenerateThrowsOnEmptyEmail(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ml->generate('');
+    }
+
+    public function testIsValidReturnsTrueForFreshToken(): void
+    {
+        $token = $this->ml->generate('user@example.com');
+        $this->assertTrue($this->ml->isValid($token));
+    }
+
+    public function testIsValidReturnsFalseForUnknownToken(): void
+    {
+        $this->assertFalse($this->ml->isValid('deadbeef'));
+    }
+
+    public function testIsValidReturnsFalseForExpiredToken(): void
+    {
+        $this->db->exec(
+            "INSERT INTO magic_links (email, token_hash, expires_at)
+             VALUES ('a@b.com', '" . hash('sha256', 'test-token') . "', '2000-01-01 00:00:00')"
+        );
+        $this->assertFalse($this->ml->isValid('test-token'));
+    }
+
+    public function testConsumeReturnsRecordAndMarksUsed(): void
+    {
+        $token  = $this->ml->generate('user@example.com');
+        $record = $this->ml->consume($token);
+        $this->assertNotNull($record);
+        $this->assertSame('user@example.com', $record['email']);
+    }
+
+    public function testConsumeReturnsFalseOnSecondUse(): void
+    {
+        $token = $this->ml->generate('user@example.com');
+        $this->ml->consume($token);
+        $this->assertNull($this->ml->consume($token));
+    }
+
+    public function testConsumeReturnsFalseForInvalidToken(): void
+    {
+        $this->assertNull($this->ml->consume('bad-token'));
+    }
+
+    public function testConsumeReturnsFalseForExpiredToken(): void
+    {
+        $raw  = 'expired-raw-token';
+        $hash = hash('sha256', $raw);
+        $this->db->exec(
+            "INSERT INTO magic_links (email, token_hash, expires_at)
+             VALUES ('a@b.com', '{$hash}', '2000-01-01 00:00:00')"
+        );
+        $this->assertNull($this->ml->consume($raw));
+    }
+
+    public function testConsumedTokenIsNoLongerValid(): void
+    {
+        $token = $this->ml->generate('user@example.com');
+        $this->ml->consume($token);
+        $this->assertFalse($this->ml->isValid($token));
+    }
+
+    public function testPendingCount(): void
+    {
+        $this->assertSame(0, $this->ml->pendingCount('user@example.com'));
+        $this->ml->generate('user@example.com');
+        $this->ml->generate('user@example.com');
+        $this->assertSame(2, $this->ml->pendingCount('user@example.com'));
+    }
+
+    public function testPendingCountExcludesUsedTokens(): void
+    {
+        $token = $this->ml->generate('user@example.com');
+        $this->ml->consume($token);
+        $this->assertSame(0, $this->ml->pendingCount('user@example.com'));
+    }
+
+    public function testPurgeExpired(): void
+    {
+        $this->ml->generate('user@example.com');
+        $this->db->exec(
+            "INSERT INTO magic_links (email, token_hash, expires_at)
+             VALUES ('a@b.com', 'aaa', '2000-01-01 00:00:00')"
+        );
+        $deleted = $this->ml->purgeExpired();
+        $this->assertSame(1, $deleted);
+    }
+
+    public function testPurgeExpiredAlsoRemovesUsedTokens(): void
+    {
+        $token = $this->ml->generate('user@example.com');
+        $this->ml->consume($token);
+        $deleted = $this->ml->purgeExpired();
+        $this->assertSame(1, $deleted);
+    }
+}

--- a/tests/Unit/Xion/MagicLinkTest.php
+++ b/tests/Unit/Xion/MagicLinkTest.php
@@ -68,6 +68,7 @@ final class MagicLinkTest extends TestCase
         $token  = $this->ml->generate('user@example.com');
         $record = $this->ml->consume($token);
         $this->assertNotNull($record);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('user@example.com', $record['email']);
     }
 


### PR DESCRIPTION
Single-use, time-limited magic link tokens for passwordless login. SHA-256 hash storage; raw token returned once only.

## Tests
14 tests, 17 assertions. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)