### PR TITLE
feat(xion): SlugRegistry — URL slug generation and uniqueness enforcement (FT153)

### DIFF
--- a/class/xion/SlugRegistry.php
+++ b/class/xion/SlugRegistry.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * SlugRegistry — URL slug generation and uniqueness enforcement.
+ *
+ * Generates URL-friendly slugs from text and ensures uniqueness within a
+ * namespace. If the desired slug is already taken, a numeric suffix is
+ * appended (e.g. `my-post`, `my-post-2`, `my-post-3`).
+ *
+ * Each slug is bound to an entity (entity_type + entity_id), enabling
+ * reverse lookup and slug reassignment.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $sr = new SlugRegistry($pdo);
+ *
+ * // Register a slug (auto-generates if taken)
+ * $slug = $sr->register('post', '42', 'Hello World!');  // 'hello-world'
+ * $slug = $sr->register('post', '43', 'Hello World!');  // 'hello-world-2'
+ *
+ * // Resolve slug → entity
+ * $sr->resolve('post', 'hello-world');  // ['entity_id' => '42', ...]
+ *
+ * // Find entity's current slug
+ * $sr->forEntity('post', '42');  // 'hello-world'
+ *
+ * // Release a slug
+ * $sr->release('post', '42');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE slug_registry (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     namespace   VARCHAR(100) NOT NULL,
+ *     slug        VARCHAR(255) NOT NULL,
+ *     entity_id   VARCHAR(255) NOT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (namespace, slug),
+ *     UNIQUE (namespace, entity_id)
+ * );
+ * ```
+ */
+final class SlugRegistry
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Register a slug for an entity.
+     *
+     * Generates a URL-safe slug from $text. If the slug is already taken by a
+     * different entity, a numeric suffix is appended until a free slot is found.
+     * If the entity already has a slug, it is replaced.
+     *
+     * @return string The registered slug.
+     * @throws \InvalidArgumentException on empty namespace, entity_id, or text.
+     */
+    public function register(string $namespace, string $entityId, string $text): string
+    {
+        [$namespace, $entityId] = $this->validateNsEntity($namespace, $entityId);
+        $text = trim($text);
+        if ($text === '') {
+            throw new \InvalidArgumentException('text must not be empty.');
+        }
+
+        $base = $this->slugify($text);
+        $slug = $base;
+        $n    = 1;
+        $db   = $this->db();
+
+        // Release any existing slug for this entity first
+        $db->prepare(
+            'DELETE FROM slug_registry WHERE namespace = :ns AND entity_id = :eid'
+        )->execute([':ns' => $namespace, ':eid' => $entityId]);
+
+        // Find a free slug
+        while (true) {
+            $check = $db->prepare(
+                'SELECT COUNT(*) FROM slug_registry WHERE namespace = :ns AND slug = :slug'
+            );
+            $check->execute([':ns' => $namespace, ':slug' => $slug]);
+            if ((int)$check->fetchColumn() === 0) {
+                break;
+            }
+            $n++;
+            $slug = "{$base}-{$n}";
+        }
+
+        $db->prepare(
+            'INSERT INTO slug_registry (namespace, slug, entity_id) VALUES (:ns, :slug, :eid)'
+        )->execute([':ns' => $namespace, ':slug' => $slug, ':eid' => $entityId]);
+
+        return $slug;
+    }
+
+    /**
+     * Resolve a slug to its entity record.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function resolve(string $namespace, string $slug): ?array
+    {
+        $namespace = trim($namespace);
+        $stmt      = $this->db()->prepare(
+            'SELECT id, namespace, slug, entity_id, created_at
+             FROM slug_registry WHERE namespace = :ns AND slug = :slug LIMIT 1'
+        );
+        $stmt->execute([':ns' => $namespace, ':slug' => trim($slug)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Get the current slug for an entity.
+     *
+     * @return string|null null if the entity has no registered slug.
+     */
+    public function forEntity(string $namespace, string $entityId): ?string
+    {
+        [$namespace, $entityId] = $this->validateNsEntity($namespace, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT slug FROM slug_registry WHERE namespace = :ns AND entity_id = :eid LIMIT 1'
+        );
+        $stmt->execute([':ns' => $namespace, ':eid' => $entityId]);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : null;
+    }
+
+    /**
+     * Release an entity's slug.
+     *
+     * @return bool True if a slug was released.
+     */
+    public function release(string $namespace, string $entityId): bool
+    {
+        [$namespace, $entityId] = $this->validateNsEntity($namespace, $entityId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM slug_registry WHERE namespace = :ns AND entity_id = :eid'
+        );
+        $stmt->execute([':ns' => $namespace, ':eid' => $entityId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Check whether a slug is already taken in a namespace.
+     */
+    public function isTaken(string $namespace, string $slug): bool
+    {
+        $namespace = trim($namespace);
+        $stmt      = $this->db()->prepare(
+            'SELECT COUNT(*) FROM slug_registry WHERE namespace = :ns AND slug = :slug'
+        );
+        $stmt->execute([':ns' => $namespace, ':slug' => trim($slug)]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Count registered slugs in a namespace.
+     */
+    public function count(string $namespace = ''): int
+    {
+        $namespace = trim($namespace);
+        if ($namespace === '') {
+            $stmt = $this->db()->prepare('SELECT COUNT(*) FROM slug_registry');
+            $stmt->execute();
+        } else {
+            $stmt = $this->db()->prepare('SELECT COUNT(*) FROM slug_registry WHERE namespace = :ns');
+            $stmt->execute([':ns' => $namespace]);
+        }
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * Convert text to a URL-safe slug.
+     * Lowercase, replace non-alphanumeric runs with hyphens, trim hyphens.
+     */
+    private function slugify(string $text): string
+    {
+        $text = mb_strtolower($text, 'UTF-8');
+        $text = (string)preg_replace('/[^\p{L}\p{N}]+/u', '-', $text);
+        return trim($text, '-') ?: 'slug';
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function validateNsEntity(string $namespace, string $entityId): array
+    {
+        $namespace = trim($namespace);
+        $entityId  = trim($entityId);
+        if ($namespace === '') {
+            throw new \InvalidArgumentException('namespace must not be empty.');
+        }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        return [$namespace, $entityId];
+    }
+}

--- a/tests/Unit/Xion/SlugRegistryTest.php
+++ b/tests/Unit/Xion/SlugRegistryTest.php
@@ -77,6 +77,7 @@ final class SlugRegistryTest extends TestCase
         $this->sr->register('post', '1', 'Hello World');
         $row = $this->sr->resolve('post', 'hello-world');
         $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('1', $row['entity_id']);
     }
 

--- a/tests/Unit/Xion/SlugRegistryTest.php
+++ b/tests/Unit/Xion/SlugRegistryTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\SlugRegistry;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class SlugRegistryTest extends TestCase
+{
+    private PDO $db;
+    private SlugRegistry $sr;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE slug_registry (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                namespace  VARCHAR(100) NOT NULL,
+                slug       VARCHAR(255) NOT NULL,
+                entity_id  VARCHAR(255) NOT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (namespace, slug),
+                UNIQUE (namespace, entity_id)
+            )
+        ');
+        $this->sr = new SlugRegistry($this->db);
+    }
+
+    public function testRegisterReturnsSlug(): void
+    {
+        $slug = $this->sr->register('post', '1', 'Hello World');
+        $this->assertSame('hello-world', $slug);
+    }
+
+    public function testRegisterAppendsNumberOnConflict(): void
+    {
+        $this->sr->register('post', '1', 'Hello World');
+        $slug2 = $this->sr->register('post', '2', 'Hello World');
+        $this->assertSame('hello-world-2', $slug2);
+        $slug3 = $this->sr->register('post', '3', 'Hello World');
+        $this->assertSame('hello-world-3', $slug3);
+    }
+
+    public function testRegisterReplacesExistingSlugForEntity(): void
+    {
+        $this->sr->register('post', '1', 'Old Title');
+        $slug = $this->sr->register('post', '1', 'New Title');
+        $this->assertSame('new-title', $slug);
+        $this->assertSame(1, $this->sr->count('post'));
+    }
+
+    public function testRegisterStripsSpecialChars(): void
+    {
+        $slug = $this->sr->register('post', '1', 'Hello, World! (2026)');
+        $this->assertSame('hello-world-2026', $slug);
+    }
+
+    public function testRegisterThrowsOnEmptyNamespace(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sr->register('', '1', 'text');
+    }
+
+    public function testRegisterThrowsOnEmptyText(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sr->register('post', '1', '');
+    }
+
+    public function testResolveReturnsRecord(): void
+    {
+        $this->sr->register('post', '1', 'Hello World');
+        $row = $this->sr->resolve('post', 'hello-world');
+        $this->assertNotNull($row);
+        $this->assertSame('1', $row['entity_id']);
+    }
+
+    public function testResolveReturnsNullForMissing(): void
+    {
+        $this->assertNull($this->sr->resolve('post', 'nope'));
+    }
+
+    public function testForEntity(): void
+    {
+        $this->sr->register('post', '42', 'My Post');
+        $this->assertSame('my-post', $this->sr->forEntity('post', '42'));
+    }
+
+    public function testForEntityReturnsNullWhenNoSlug(): void
+    {
+        $this->assertNull($this->sr->forEntity('post', '99'));
+    }
+
+    public function testRelease(): void
+    {
+        $this->sr->register('post', '1', 'Hello');
+        $this->assertTrue($this->sr->release('post', '1'));
+        $this->assertNull($this->sr->forEntity('post', '1'));
+    }
+
+    public function testReleaseReturnsFalseWhenNoSlug(): void
+    {
+        $this->assertFalse($this->sr->release('post', '999'));
+    }
+
+    public function testIsTaken(): void
+    {
+        $this->sr->register('post', '1', 'Hello World');
+        $this->assertTrue($this->sr->isTaken('post', 'hello-world'));
+        $this->assertFalse($this->sr->isTaken('post', 'nope'));
+    }
+
+    public function testNamespacesAreIsolated(): void
+    {
+        $this->sr->register('post', '1', 'Hello World');
+        $slug = $this->sr->register('page', '1', 'Hello World');
+        $this->assertSame('hello-world', $slug); // no conflict across namespaces
+    }
+
+    public function testCount(): void
+    {
+        $this->assertSame(0, $this->sr->count('post'));
+        $this->sr->register('post', '1', 'a');
+        $this->sr->register('post', '2', 'b');
+        $this->sr->register('page', '1', 'c');
+        $this->assertSame(2, $this->sr->count('post'));
+        $this->assertSame(3, $this->sr->count());
+    }
+}


### PR DESCRIPTION
Namespace-scoped slug registry with auto-suffix on collision.

## Tests
15 tests, 22 assertions. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)