### PR TITLE
feat(xion): EmailQueue — DB-backed outgoing email queue with retry (FT154)

### DIFF
--- a/class/xion/EmailQueue.php
+++ b/class/xion/EmailQueue.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * EmailQueue — DB-backed outgoing email queue with retry and exponential backoff.
+ *
+ * Decouples email sending from the request lifecycle. Emails are enqueued
+ * immediately and sent asynchronously by a worker. Failed sends are retried
+ * with exponential backoff up to a configurable maximum.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $eq = new EmailQueue($pdo, maxAttempts: 3);
+ *
+ * // Enqueue
+ * $id = $eq->enqueue('user@example.com', 'Welcome!', '<h1>Hi</h1>', 'text/html');
+ *
+ * // Worker: claim next due email
+ * $email = $eq->claim();
+ * if ($email) {
+ *     // → send via Mailer
+ *     $eq->markSent($email['id']);
+ *     // or on failure:
+ *     $eq->markFailed($email['id'], 'SMTP timeout');
+ * }
+ *
+ * // Maintenance
+ * $eq->purgeSent(30);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE email_queue (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     to_address  VARCHAR(255) NOT NULL,
+ *     subject     VARCHAR(500) NOT NULL DEFAULT '',
+ *     body        TEXT         NOT NULL DEFAULT '',
+ *     content_type VARCHAR(50) NOT NULL DEFAULT 'text/plain',
+ *     status      VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     attempts    INTEGER      NOT NULL DEFAULT 0,
+ *     max_attempts INTEGER     NOT NULL DEFAULT 3,
+ *     error       TEXT         NOT NULL DEFAULT '',
+ *     send_after  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     sent_at     DATETIME     DEFAULT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class EmailQueue
+{
+    public function __construct(
+        private readonly ?PDO $db = null,
+        private readonly int $maxAttempts = 3
+    ) {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add an email to the send queue.
+     *
+     * @return int The queue entry ID.
+     * @throws \InvalidArgumentException if to_address is empty.
+     */
+    public function enqueue(
+        string $toAddress,
+        string $subject,
+        string $body,
+        string $contentType = 'text/plain'
+    ): int {
+        $toAddress = trim($toAddress);
+        if ($toAddress === '') {
+            throw new \InvalidArgumentException('to_address must not be empty.');
+        }
+        $db = $this->db();
+        $db->prepare(
+            'INSERT INTO email_queue (to_address, subject, body, content_type, max_attempts)
+             VALUES (:to, :sub, :body, :ct, :max)'
+        )->execute([
+            ':to'   => $toAddress,
+            ':sub'  => $subject,
+            ':body' => $body,
+            ':ct'   => $contentType,
+            ':max'  => $this->maxAttempts,
+        ]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Claim the next pending email that is due for sending.
+     *
+     * Increments attempt count and returns the record, or null if nothing is due.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function claim(): ?array
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $db   = $this->db();
+        $stmt = $db->prepare(
+            'SELECT id, to_address, subject, body, content_type, attempts, max_attempts
+             FROM email_queue
+             WHERE status = \'pending\' AND send_after <= :now
+             ORDER BY send_after ASC LIMIT 1'
+        );
+        $stmt->execute([':now' => $now]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+
+        $db->prepare(
+            'UPDATE email_queue SET attempts = attempts + 1 WHERE id = :id'
+        )->execute([':id' => $row['id']]);
+
+        $row['attempts'] = (int)$row['attempts'] + 1;
+        return $row;
+    }
+
+    /**
+     * Mark an email as successfully sent.
+     *
+     * @return bool True if the record was updated.
+     */
+    public function markSent(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE email_queue SET status = \'sent\', sent_at = CURRENT_TIMESTAMP WHERE id = :id'
+        );
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark an email as failed.
+     *
+     * If attempts < max_attempts the email is rescheduled with exponential
+     * backoff (60 × 2^(attempts-1) seconds). Otherwise it is permanently failed.
+     *
+     * @return bool True if the record was updated.
+     */
+    public function markFailed(int $id, string $error = ''): bool
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT attempts, max_attempts FROM email_queue WHERE id = :id LIMIT 1'
+        );
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return false;
+        }
+
+        $attempts    = (int)$row['attempts'];
+        $maxAttempts = (int)$row['max_attempts'];
+
+        if ($attempts < $maxAttempts) {
+            $delaySeconds = 60 * (2 ** ($attempts - 1));
+            $sendAfter    = (new \DateTimeImmutable())->modify("+{$delaySeconds} seconds")->format('Y-m-d H:i:s');
+            $upd = $this->db()->prepare(
+                'UPDATE email_queue SET error = :err, send_after = :sa WHERE id = :id'
+            );
+            $upd->execute([':err' => $error, ':sa' => $sendAfter, ':id' => $id]);
+        } else {
+            $upd = $this->db()->prepare(
+                'UPDATE email_queue SET status = \'failed\', error = :err WHERE id = :id'
+            );
+            $upd->execute([':err' => $error, ':id' => $id]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Find a queue entry by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, to_address, subject, body, content_type, status, attempts,
+                    max_attempts, error, send_after, sent_at, created_at
+             FROM email_queue WHERE id = :id LIMIT 1'
+        );
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Count queue entries, optionally by status.
+     */
+    public function count(?string $status = null): int
+    {
+        if ($status === null) {
+            $stmt = $this->db()->prepare('SELECT COUNT(*) FROM email_queue');
+            $stmt->execute();
+        } else {
+            $stmt = $this->db()->prepare('SELECT COUNT(*) FROM email_queue WHERE status = :s');
+            $stmt->execute([':s' => $status]);
+        }
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Delete sent emails older than N days.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeSent(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM email_queue WHERE status = \'sent\' AND sent_at < :cutoff'
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/EmailQueueTest.php
+++ b/tests/Unit/Xion/EmailQueueTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\EmailQueue;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class EmailQueueTest extends TestCase
+{
+    private PDO $db;
+    private EmailQueue $eq;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE email_queue (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                to_address   VARCHAR(255) NOT NULL,
+                subject      VARCHAR(500) NOT NULL DEFAULT \'\',
+                body         TEXT         NOT NULL DEFAULT \'\',
+                content_type VARCHAR(50)  NOT NULL DEFAULT \'text/plain\',
+                status       VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                attempts     INTEGER      NOT NULL DEFAULT 0,
+                max_attempts INTEGER      NOT NULL DEFAULT 3,
+                error        TEXT         NOT NULL DEFAULT \'\',
+                send_after   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                sent_at      DATETIME     DEFAULT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->eq = new EmailQueue($this->db, 3);
+    }
+
+    public function testEnqueueReturnsId(): void
+    {
+        $id = $this->eq->enqueue('user@example.com', 'Hi', 'Hello!');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testEnqueueThrowsOnEmptyAddress(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->eq->enqueue('', 'Hi', 'Hello');
+    }
+
+    public function testClaimReturnsPendingEmail(): void
+    {
+        $id  = $this->eq->enqueue('user@example.com', 'Hi', 'Hello');
+        $row = $this->eq->claim();
+        $this->assertNotNull($row);
+        $this->assertSame($id, (int)$row['id']);
+        $this->assertSame(1, (int)$row['attempts']);
+    }
+
+    public function testClaimReturnsNullWhenEmpty(): void
+    {
+        $this->assertNull($this->eq->claim());
+    }
+
+    public function testClaimIncrementsAttempts(): void
+    {
+        $this->eq->enqueue('a@b.com', 'x', 'y');
+        $this->eq->claim();
+        // After claim, mark failed to re-queue
+        $this->eq->markFailed(1, 'err');
+        // Manually set send_after to past for retry
+        $this->db->exec("UPDATE email_queue SET send_after = '2000-01-01' WHERE id = 1");
+        $row = $this->eq->claim();
+        $this->assertNotNull($row);
+        $this->assertSame(2, (int)$row['attempts']);
+    }
+
+    public function testMarkSent(): void
+    {
+        $id = $this->eq->enqueue('a@b.com', 'x', 'y');
+        $this->eq->claim();
+        $this->assertTrue($this->eq->markSent($id));
+        $row = $this->eq->find($id);
+        $this->assertSame('sent', $row['status']);
+        $this->assertNotNull($row['sent_at']);
+    }
+
+    public function testMarkFailedReschedulesBeforeMax(): void
+    {
+        $id = $this->eq->enqueue('a@b.com', 'x', 'y');
+        $this->eq->claim();
+        $this->assertTrue($this->eq->markFailed($id, 'timeout'));
+        $row = $this->eq->find($id);
+        $this->assertSame('pending', $row['status']);
+        $this->assertSame('timeout', $row['error']);
+    }
+
+    public function testMarkFailedPermanentlyFailsAtMax(): void
+    {
+        $id = $this->eq->enqueue('a@b.com', 'x', 'y');
+        // Simulate max attempts reached
+        $this->db->exec("UPDATE email_queue SET attempts = 3 WHERE id = {$id}");
+        $this->assertTrue($this->eq->markFailed($id, 'final error'));
+        $row = $this->eq->find($id);
+        $this->assertSame('failed', $row['status']);
+    }
+
+    public function testMarkFailedReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->eq->markFailed(999, 'err'));
+    }
+
+    public function testFindReturnsNullForMissing(): void
+    {
+        $this->assertNull($this->eq->find(999));
+    }
+
+    public function testCountAll(): void
+    {
+        $this->eq->enqueue('a@b.com', 'x', 'y');
+        $this->eq->enqueue('b@c.com', 'x', 'y');
+        $this->assertSame(2, $this->eq->count());
+    }
+
+    public function testCountByStatus(): void
+    {
+        $id1 = $this->eq->enqueue('a@b.com', 'x', 'y');
+        $id2 = $this->eq->enqueue('b@c.com', 'x', 'y');
+        $this->eq->claim();
+        $this->eq->markSent($id1);
+        $this->assertSame(1, $this->eq->count('sent'));
+        $this->assertSame(1, $this->eq->count('pending'));
+    }
+
+    public function testPurgeSent(): void
+    {
+        $id = $this->eq->enqueue('a@b.com', 'x', 'y');
+        $this->eq->claim();
+        $this->eq->markSent($id);
+        // Manually set sent_at to past
+        $this->db->exec("UPDATE email_queue SET sent_at = '2000-01-01' WHERE id = {$id}");
+        $deleted = $this->eq->purgeSent(1);
+        $this->assertSame(1, $deleted);
+    }
+}

--- a/tests/Unit/Xion/EmailQueueTest.php
+++ b/tests/Unit/Xion/EmailQueueTest.php
@@ -53,7 +53,9 @@ final class EmailQueueTest extends TestCase
         $id  = $this->eq->enqueue('user@example.com', 'Hi', 'Hello');
         $row = $this->eq->claim();
         $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame($id, (int)$row['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(1, (int)$row['attempts']);
     }
 
@@ -72,6 +74,7 @@ final class EmailQueueTest extends TestCase
         $this->db->exec("UPDATE email_queue SET send_after = '2000-01-01' WHERE id = 1");
         $row = $this->eq->claim();
         $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame(2, (int)$row['attempts']);
     }
 
@@ -81,7 +84,9 @@ final class EmailQueueTest extends TestCase
         $this->eq->claim();
         $this->assertTrue($this->eq->markSent($id));
         $row = $this->eq->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('sent', $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertNotNull($row['sent_at']);
     }
 
@@ -91,7 +96,9 @@ final class EmailQueueTest extends TestCase
         $this->eq->claim();
         $this->assertTrue($this->eq->markFailed($id, 'timeout'));
         $row = $this->eq->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('pending', $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('timeout', $row['error']);
     }
 
@@ -102,6 +109,7 @@ final class EmailQueueTest extends TestCase
         $this->db->exec("UPDATE email_queue SET attempts = 3 WHERE id = {$id}");
         $this->assertTrue($this->eq->markFailed($id, 'final error'));
         $row = $this->eq->find($id);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame('failed', $row['status']);
     }
 


### PR DESCRIPTION
Async email send queue with exponential backoff retry. Decouples sending from the request lifecycle.

## Tests
13 tests, 22 assertions. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)