### PR TITLE
feat(xion): ApiUsageLog — per-API-key request tracking with endpoint and status logging (FT156)

### DIFF
--- a/class/xion/ApiUsageLog.php
+++ b/class/xion/ApiUsageLog.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ApiUsageLog — per-API-key request tracking with endpoint and status logging.
+ *
+ * Records every API call with key, endpoint, method, status code, and latency.
+ * Useful for usage analytics, quota enforcement, and debugging.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $log = new ApiUsageLog($pdo);
+ *
+ * // Record a call
+ * $log->record('key-abc', '/api/posts', 'GET', 200, 45);
+ *
+ * // Query usage
+ * $log->countByKey('key-abc');                  // total calls
+ * $log->countByKey('key-abc', since: '-1 hour'); // calls in last hour
+ * $log->recent('key-abc', 20);                  // 20 most recent
+ * $log->topEndpoints('key-abc', 5);             // most-called endpoints
+ * $log->errorRate('key-abc');                   // fraction of 4xx/5xx
+ * $log->purgeOlderThan(30);                     // maintenance
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE api_usage_log (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     api_key      VARCHAR(255) NOT NULL,
+ *     endpoint     VARCHAR(500) NOT NULL DEFAULT '',
+ *     http_method  VARCHAR(10)  NOT NULL DEFAULT '',
+ *     status_code  SMALLINT     NOT NULL DEFAULT 0,
+ *     latency_ms   INT          NOT NULL DEFAULT 0,
+ *     logged_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ApiUsageLog
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record an API call.
+     *
+     * @param  string $apiKey      The API key used.
+     * @param  string $endpoint    Request path/endpoint.
+     * @param  string $httpMethod  HTTP verb (GET, POST, …).
+     * @param  int    $statusCode  HTTP response status code.
+     * @param  int    $latencyMs   Response latency in milliseconds.
+     * @return int    The new record ID.
+     * @throws \InvalidArgumentException if api_key is empty.
+     */
+    public function record(
+        string $apiKey,
+        string $endpoint = '',
+        string $httpMethod = '',
+        int $statusCode = 0,
+        int $latencyMs = 0
+    ): int {
+        $apiKey = $this->validateKey($apiKey);
+        $stmt   = $this->db()->prepare(
+            'INSERT INTO api_usage_log (api_key, endpoint, http_method, status_code, latency_ms)
+             VALUES (:key, :ep, :method, :status, :latency)'
+        );
+        $stmt->execute([
+            ':key'     => $apiKey,
+            ':ep'      => $endpoint,
+            ':method'  => strtoupper($httpMethod),
+            ':status'  => $statusCode,
+            ':latency' => max(0, $latencyMs),
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Count API calls for a key, optionally since a datetime string.
+     *
+     * @param  string|null $since  Datetime string accepted by strtotime() or DateTimeImmutable,
+     *                             e.g. '-1 hour', '2026-05-01 00:00:00'. Null = no time filter.
+     */
+    public function countByKey(string $apiKey, ?string $since = null): int
+    {
+        $apiKey = $this->validateKey($apiKey);
+        if ($since !== null) {
+            $cutoff = (new \DateTimeImmutable($since))->format('Y-m-d H:i:s');
+            $stmt   = $this->db()->prepare(
+                'SELECT COUNT(*) FROM api_usage_log
+                 WHERE api_key = :key AND logged_at >= :since'
+            );
+            $stmt->execute([':key' => $apiKey, ':since' => $cutoff]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT COUNT(*) FROM api_usage_log WHERE api_key = :key'
+            );
+            $stmt->execute([':key' => $apiKey]);
+        }
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Get the N most recent log entries for a key.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function recent(string $apiKey, int $limit = 20): array
+    {
+        $apiKey = $this->validateKey($apiKey);
+        $limit  = max(1, $limit);
+        $stmt   = $this->db()->prepare(
+            "SELECT id, api_key, endpoint, http_method, status_code, latency_ms, logged_at
+             FROM api_usage_log
+             WHERE api_key = :key
+             ORDER BY id DESC
+             LIMIT {$limit}"
+        );
+        $stmt->execute([':key' => $apiKey]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return the top N endpoints by call count for a key.
+     *
+     * @return list<array{endpoint: string, calls: int}>
+     */
+    public function topEndpoints(string $apiKey, int $limit = 10): array
+    {
+        $apiKey = $this->validateKey($apiKey);
+        $limit  = max(1, $limit);
+        $stmt   = $this->db()->prepare(
+            "SELECT endpoint, COUNT(*) AS calls
+             FROM api_usage_log
+             WHERE api_key = :key
+             GROUP BY endpoint
+             ORDER BY calls DESC
+             LIMIT {$limit}"
+        );
+        $stmt->execute([':key' => $apiKey]);
+        return array_map(
+            static fn (array $r) => ['endpoint' => (string)$r['endpoint'], 'calls' => (int)$r['calls']],
+            $stmt->fetchAll(PDO::FETCH_ASSOC) ?: []
+        );
+    }
+
+    /**
+     * Return the fraction of calls with 4xx or 5xx status codes (0.0–1.0).
+     *
+     * Returns 0.0 if no calls have been recorded.
+     */
+    public function errorRate(string $apiKey): float
+    {
+        $apiKey = $this->validateKey($apiKey);
+        $stmt   = $this->db()->prepare(
+            'SELECT COUNT(*) AS total,
+                    SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END) AS errors
+             FROM api_usage_log WHERE api_key = :key'
+        );
+        $stmt->execute([':key' => $apiKey]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row || (int)$row['total'] === 0) {
+            return 0.0;
+        }
+        return round((int)$row['errors'] / (int)$row['total'], 4);
+    }
+
+    /**
+     * Return the average latency in milliseconds for a key.
+     *
+     * Returns 0.0 if no calls have been recorded.
+     */
+    public function avgLatency(string $apiKey): float
+    {
+        $apiKey = $this->validateKey($apiKey);
+        $stmt   = $this->db()->prepare(
+            'SELECT AVG(latency_ms) FROM api_usage_log WHERE api_key = :key'
+        );
+        $stmt->execute([':key' => $apiKey]);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? round((float)$val, 2) : 0.0;
+    }
+
+    /**
+     * Purge log entries older than N days.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM api_usage_log WHERE logged_at < :cutoff'
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateKey(string $apiKey): string
+    {
+        $apiKey = trim($apiKey);
+        if ($apiKey === '') {
+            throw new \InvalidArgumentException('api_key must not be empty.');
+        }
+        return $apiKey;
+    }
+}

--- a/tests/Unit/Xion/ApiUsageLogTest.php
+++ b/tests/Unit/Xion/ApiUsageLogTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ApiUsageLog;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ApiUsageLog.
+ */
+final class ApiUsageLogTest extends TestCase
+{
+    private PDO $db;
+    private ApiUsageLog $log;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE api_usage_log (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                api_key     VARCHAR(255) NOT NULL,
+                endpoint    VARCHAR(500) NOT NULL DEFAULT \'\',
+                http_method VARCHAR(10)  NOT NULL DEFAULT \'\',
+                status_code SMALLINT     NOT NULL DEFAULT 0,
+                latency_ms  INT          NOT NULL DEFAULT 0,
+                logged_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->log = new ApiUsageLog($this->db);
+    }
+
+    // ── record ────────────────────────────────────────────────────────────────
+
+    public function testRecordReturnsId(): void
+    {
+        $id = $this->log->record('key-1', '/api/posts', 'GET', 200, 45);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testRecordMultipleEntries(): void
+    {
+        $this->log->record('key-1', '/api/posts', 'GET', 200, 10);
+        $this->log->record('key-1', '/api/posts', 'POST', 201, 30);
+        $this->log->record('key-2', '/api/users', 'GET', 200, 20);
+        $this->assertSame(2, $this->log->countByKey('key-1'));
+        $this->assertSame(1, $this->log->countByKey('key-2'));
+    }
+
+    public function testRecordNormalizesHttpMethodToUpperCase(): void
+    {
+        $this->log->record('key-1', '/api/posts', 'get', 200, 10);
+        $recent = $this->log->recent('key-1', 1);
+        $this->assertSame('GET', $recent[0]['http_method']);
+    }
+
+    public function testRecordThrowsOnEmptyKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->log->record('');
+    }
+
+    // ── countByKey ────────────────────────────────────────────────────────────
+
+    public function testCountByKeyReturnsZeroForUnknown(): void
+    {
+        $this->assertSame(0, $this->log->countByKey('unknown'));
+    }
+
+    public function testCountByKeyWithSinceFilter(): void
+    {
+        // Insert an old entry manually
+        $old = (new \DateTimeImmutable())->modify('-2 hours')->format('Y-m-d H:i:s');
+        $this->db->exec("INSERT INTO api_usage_log (api_key, logged_at) VALUES ('key-1', '{$old}')");
+        $this->log->record('key-1'); // recent entry
+
+        $this->assertSame(2, $this->log->countByKey('key-1'));
+        $this->assertSame(1, $this->log->countByKey('key-1', since: '-1 hour'));
+    }
+
+    // ── recent ────────────────────────────────────────────────────────────────
+
+    public function testRecentReturnsEntriesNewestFirst(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->log->record('key-1', "/api/item/{$i}", 'GET', 200, $i * 10);
+        }
+        $rows = $this->log->recent('key-1', 3);
+        $this->assertCount(3, $rows);
+        // Newest first — highest id first
+        $this->assertGreaterThan((int)$rows[1]['id'], (int)$rows[0]['id']);
+    }
+
+    public function testRecentReturnsEmptyForUnknownKey(): void
+    {
+        $this->assertSame([], $this->log->recent('unknown'));
+    }
+
+    // ── topEndpoints ─────────────────────────────────────────────────────────
+
+    public function testTopEndpointsRanksByCallCount(): void
+    {
+        $this->log->record('key-1', '/a', 'GET', 200);
+        $this->log->record('key-1', '/b', 'GET', 200);
+        $this->log->record('key-1', '/b', 'GET', 200);
+        $this->log->record('key-1', '/c', 'GET', 200);
+        $this->log->record('key-1', '/c', 'GET', 200);
+        $this->log->record('key-1', '/c', 'GET', 200);
+
+        $top = $this->log->topEndpoints('key-1', 2);
+        $this->assertCount(2, $top);
+        $this->assertSame('/c', $top[0]['endpoint']);
+        $this->assertSame(3, $top[0]['calls']);
+        $this->assertSame('/b', $top[1]['endpoint']);
+    }
+
+    public function testTopEndpointsReturnsEmptyWhenNoData(): void
+    {
+        $this->assertSame([], $this->log->topEndpoints('key-1'));
+    }
+
+    // ── errorRate ─────────────────────────────────────────────────────────────
+
+    public function testErrorRateReturnsZeroWhenNoData(): void
+    {
+        $this->assertSame(0.0, $this->log->errorRate('key-1'));
+    }
+
+    public function testErrorRateCalculation(): void
+    {
+        $this->log->record('key-1', '/a', 'GET', 200);
+        $this->log->record('key-1', '/a', 'GET', 200);
+        $this->log->record('key-1', '/a', 'GET', 500);
+        $this->log->record('key-1', '/a', 'GET', 404);
+        // 2 errors out of 4 = 0.5
+        $this->assertSame(0.5, $this->log->errorRate('key-1'));
+    }
+
+    public function testErrorRateZeroWhenAllSuccessful(): void
+    {
+        $this->log->record('key-1', '/a', 'GET', 200);
+        $this->log->record('key-1', '/a', 'GET', 201);
+        $this->assertSame(0.0, $this->log->errorRate('key-1'));
+    }
+
+    // ── avgLatency ────────────────────────────────────────────────────────────
+
+    public function testAvgLatencyReturnsZeroWhenNoData(): void
+    {
+        $this->assertSame(0.0, $this->log->avgLatency('key-1'));
+    }
+
+    public function testAvgLatencyCalculation(): void
+    {
+        $this->log->record('key-1', '/a', 'GET', 200, 100);
+        $this->log->record('key-1', '/a', 'GET', 200, 200);
+        $this->assertSame(150.0, $this->log->avgLatency('key-1'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldEntries(): void
+    {
+        $old = (new \DateTimeImmutable())->modify('-2 days')->format('Y-m-d H:i:s');
+        $this->db->exec("INSERT INTO api_usage_log (api_key, logged_at) VALUES ('key-1', '{$old}')");
+        $this->db->exec("INSERT INTO api_usage_log (api_key, logged_at) VALUES ('key-1', '{$old}')");
+        $this->log->record('key-1'); // recent
+
+        $deleted = $this->log->purgeOlderThan(1);
+        $this->assertSame(2, $deleted);
+        $this->assertSame(1, $this->log->countByKey('key-1'));
+    }
+
+    public function testPurgeReturnsZeroWhenNothingOld(): void
+    {
+        $this->log->record('key-1');
+        $this->assertSame(0, $this->log->purgeOlderThan(1));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ApiUsageLog` — per-API-key request tracking with endpoint, method, status, and latency.

## Class

`class/xion/ApiUsageLog.php`

- `record(apiKey, endpoint, httpMethod, statusCode, latencyMs)` — log an API call
- `countByKey(apiKey, ?since)` — total call count with optional time filter
- `recent(apiKey, limit=20)` — N most recent entries newest-first
- `topEndpoints(apiKey, limit=10)` — most-called endpoints ranked by call count
- `errorRate(apiKey)` — fraction of 4xx/5xx responses (0.0–1.0)
- `avgLatency(apiKey)` — average response latency in ms
- `purgeOlderThan(days)` — delete old log entries

## Schema

```sql
CREATE TABLE api_usage_log (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    api_key     VARCHAR(255) NOT NULL,
    endpoint    VARCHAR(500) NOT NULL DEFAULT '',
    http_method VARCHAR(10)  NOT NULL DEFAULT '',
    status_code SMALLINT     NOT NULL DEFAULT 0,
    latency_ms  INT          NOT NULL DEFAULT 0,
    logged_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## Tests

17 tests, 24 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)