### PR TITLE
feat(xion): OAuthToken — OAuth2 access/refresh token storage with SHA-256 hashing (FT157)

### DIFF
--- a/class/xion/OAuthToken.php
+++ b/class/xion/OAuthToken.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * OAuthToken — OAuth2 access/refresh token storage with TTL.
+ *
+ * Stores access tokens and their paired refresh tokens for OAuth2 flows.
+ * Tokens are stored as SHA-256 hashes; raw values are never persisted.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ot = new OAuthToken($pdo);
+ *
+ * // Issue token pair after authorization
+ * [$accessRaw, $refreshRaw] = $ot->issue('user-1', 'client-app', ['read', 'write'], 3600, 2592000);
+ *
+ * // Verify access token (bearer header)
+ * $record = $ot->verifyAccess($accessRaw);
+ * if ($record === null) { /* expired or invalid *\/ }
+ *
+ * // Rotate tokens via refresh
+ * [$newAccess, $newRefresh] = $ot->refresh($refreshRaw, 3600, 2592000);
+ *
+ * // Revoke all tokens for a user
+ * $ot->revokeAllForUser('user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE oauth_tokens (
+ *     id                INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id           VARCHAR(255) NOT NULL,
+ *     client_id         VARCHAR(255) NOT NULL DEFAULT '',
+ *     scope             TEXT         NOT NULL DEFAULT '',
+ *     access_hash       VARCHAR(64)  NOT NULL UNIQUE,
+ *     refresh_hash      VARCHAR(64)  NOT NULL UNIQUE,
+ *     access_expires_at DATETIME     NOT NULL,
+ *     refresh_expires_at DATETIME    NOT NULL,
+ *     revoked           TINYINT(1)   NOT NULL DEFAULT 0,
+ *     issued_at         DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class OAuthToken
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Issue a new access/refresh token pair.
+     *
+     * @param  string   $userId              The authenticated user.
+     * @param  string   $clientId            OAuth client identifier.
+     * @param  string[] $scopes              Granted scopes.
+     * @param  int      $accessTtlSeconds    Access token lifetime in seconds (default 1 h).
+     * @param  int      $refreshTtlSeconds   Refresh token lifetime in seconds (default 30 d).
+     * @return array{string, string}         [rawAccessToken, rawRefreshToken]
+     * @throws \InvalidArgumentException if user_id is empty.
+     */
+    public function issue(
+        string $userId,
+        string $clientId = '',
+        array $scopes = [],
+        int $accessTtlSeconds = 3600,
+        int $refreshTtlSeconds = 2592000
+    ): array {
+        $userId = $this->validateUserId($userId);
+
+        $rawAccess  = bin2hex(random_bytes(32));
+        $rawRefresh = bin2hex(random_bytes(32));
+
+        $now              = new \DateTimeImmutable();
+        $accessExpiresAt  = $now->modify("+{$accessTtlSeconds} seconds")->format('Y-m-d H:i:s');
+        $refreshExpiresAt = $now->modify("+{$refreshTtlSeconds} seconds")->format('Y-m-d H:i:s');
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO oauth_tokens
+                (user_id, client_id, scope, access_hash, refresh_hash, access_expires_at, refresh_expires_at)
+             VALUES (:uid, :cid, :scope, :ah, :rh, :aexp, :rexp)'
+        );
+        $stmt->execute([
+            ':uid'   => $userId,
+            ':cid'   => $clientId,
+            ':scope' => implode(' ', $scopes),
+            ':ah'    => hash('sha256', $rawAccess),
+            ':rh'    => hash('sha256', $rawRefresh),
+            ':aexp'  => $accessExpiresAt,
+            ':rexp'  => $refreshExpiresAt,
+        ]);
+
+        return [$rawAccess, $rawRefresh];
+    }
+
+    /**
+     * Verify an access token and return the record, or null if invalid/expired/revoked.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function verifyAccess(string $rawToken): ?array
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $hash = hash('sha256', $rawToken);
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, client_id, scope, access_expires_at, issued_at
+             FROM oauth_tokens
+             WHERE access_hash = :hash AND access_expires_at > :now AND revoked = 0
+             LIMIT 1'
+        );
+        $stmt->execute([':hash' => $hash, ':now' => $now]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Rotate tokens using a valid refresh token.
+     *
+     * Revokes the old token pair and issues a new one.
+     * Returns null if the refresh token is invalid, expired, or revoked.
+     *
+     * @param  int $accessTtlSeconds   New access token lifetime.
+     * @param  int $refreshTtlSeconds  New refresh token lifetime.
+     * @return array{string, string}|null  [rawAccessToken, rawRefreshToken] or null.
+     */
+    public function refresh(
+        string $rawRefreshToken,
+        int $accessTtlSeconds = 3600,
+        int $refreshTtlSeconds = 2592000
+    ): ?array {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $hash = hash('sha256', $rawRefreshToken);
+
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, client_id, scope
+             FROM oauth_tokens
+             WHERE refresh_hash = :hash AND refresh_expires_at > :now AND revoked = 0
+             LIMIT 1'
+        );
+        $stmt->execute([':hash' => $hash, ':now' => $now]);
+        $old = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($old === false) {
+            return null;
+        }
+
+        // Revoke old pair
+        $this->revokeById((int)$old['id']);
+
+        // Issue new pair with same user/client/scope
+        $scopes = $old['scope'] !== '' ? explode(' ', (string)$old['scope']) : [];
+        return $this->issue(
+            (string)$old['user_id'],
+            (string)$old['client_id'],
+            $scopes,
+            $accessTtlSeconds,
+            $refreshTtlSeconds
+        );
+    }
+
+    /**
+     * Revoke a specific access token.
+     *
+     * @return bool True if the token existed and was revoked.
+     */
+    public function revokeAccess(string $rawToken): bool
+    {
+        $hash = hash('sha256', $rawToken);
+        $stmt = $this->db()->prepare(
+            'UPDATE oauth_tokens SET revoked = 1 WHERE access_hash = :hash AND revoked = 0'
+        );
+        $stmt->execute([':hash' => $hash]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Revoke all active tokens for a user.
+     *
+     * @return int Number of tokens revoked.
+     */
+    public function revokeAllForUser(string $userId): int
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'UPDATE oauth_tokens SET revoked = 1 WHERE user_id = :uid AND revoked = 0'
+        );
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Count active (non-revoked, non-expired) token pairs for a user.
+     */
+    public function activeCount(string $userId): int
+    {
+        $userId = $this->validateUserId($userId);
+        $now    = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'SELECT COUNT(*) FROM oauth_tokens
+             WHERE user_id = :uid AND revoked = 0 AND refresh_expires_at > :now'
+        );
+        $stmt->execute([':uid' => $userId, ':now' => $now]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Delete expired and revoked tokens (maintenance).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeExpired(): int
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'DELETE FROM oauth_tokens WHERE revoked = 1 OR refresh_expires_at <= :now'
+        );
+        $stmt->execute([':now' => $now]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateUserId(string $userId): string
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        return $userId;
+    }
+
+    private function revokeById(int $id): void
+    {
+        $this->db()->prepare('UPDATE oauth_tokens SET revoked = 1 WHERE id = :id')
+            ->execute([':id' => $id]);
+    }
+}

--- a/tests/Unit/Xion/OAuthTokenTest.php
+++ b/tests/Unit/Xion/OAuthTokenTest.php
@@ -113,6 +113,7 @@ final class OAuthTokenTest extends TestCase
         $result      = $this->ot->refresh($refresh);
         $this->assertNotNull($result);
         $this->assertIsArray($result);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
         $this->assertCount(2, $result);
     }
 

--- a/tests/Unit/Xion/OAuthTokenTest.php
+++ b/tests/Unit/Xion/OAuthTokenTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\OAuthToken;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for OAuthToken.
+ */
+final class OAuthTokenTest extends TestCase
+{
+    private PDO $db;
+    private OAuthToken $ot;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE oauth_tokens (
+                id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id            VARCHAR(255) NOT NULL,
+                client_id          VARCHAR(255) NOT NULL DEFAULT \'\',
+                scope              TEXT         NOT NULL DEFAULT \'\',
+                access_hash        VARCHAR(64)  NOT NULL UNIQUE,
+                refresh_hash       VARCHAR(64)  NOT NULL UNIQUE,
+                access_expires_at  DATETIME     NOT NULL,
+                refresh_expires_at DATETIME     NOT NULL,
+                revoked            TINYINT(1)   NOT NULL DEFAULT 0,
+                issued_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->ot = new OAuthToken($this->db);
+    }
+
+    // ── issue ─────────────────────────────────────────────────────────────────
+
+    public function testIssueReturnsTwoTokens(): void
+    {
+        [$access, $refresh] = $this->ot->issue('user-1');
+        $this->assertNotEmpty($access);
+        $this->assertNotEmpty($refresh);
+        $this->assertNotSame($access, $refresh);
+    }
+
+    public function testIssueTokensAre64HexChars(): void
+    {
+        [$access, $refresh] = $this->ot->issue('user-1');
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $access);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $refresh);
+    }
+
+    public function testIssueThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ot->issue('');
+    }
+
+    public function testIssueMultipleTokensAreUnique(): void
+    {
+        [$a1] = $this->ot->issue('user-1');
+        [$a2] = $this->ot->issue('user-1');
+        $this->assertNotSame($a1, $a2);
+    }
+
+    // ── verifyAccess ──────────────────────────────────────────────────────────
+
+    public function testVerifyAccessReturnsRecordForValidToken(): void
+    {
+        [$access] = $this->ot->issue('user-1', 'my-app', ['read']);
+        $record   = $this->ot->verifyAccess($access);
+        $this->assertNotNull($record);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $record['user_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('my-app', $record['client_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('read', $record['scope']);
+    }
+
+    public function testVerifyAccessReturnsNullForUnknownToken(): void
+    {
+        $this->assertNull($this->ot->verifyAccess('deadbeef'));
+    }
+
+    public function testVerifyAccessReturnsNullForExpiredToken(): void
+    {
+        $past = (new \DateTimeImmutable())->modify('-1 second')->format('Y-m-d H:i:s');
+        $far  = (new \DateTimeImmutable())->modify('+30 days')->format('Y-m-d H:i:s');
+        $raw  = 'expiredaccesstoken0000000000000000000000000000000000000000000000';
+        $this->db->exec("INSERT INTO oauth_tokens
+            (user_id, access_hash, refresh_hash, access_expires_at, refresh_expires_at)
+            VALUES ('user-1', '" . hash('sha256', $raw) . "', 'aabbcc', '{$past}', '{$far}')");
+        $this->assertNull($this->ot->verifyAccess($raw));
+    }
+
+    public function testVerifyAccessReturnsNullForRevokedToken(): void
+    {
+        [$access] = $this->ot->issue('user-1');
+        $this->ot->revokeAccess($access);
+        $this->assertNull($this->ot->verifyAccess($access));
+    }
+
+    // ── refresh ───────────────────────────────────────────────────────────────
+
+    public function testRefreshIssuesNewTokenPair(): void
+    {
+        [, $refresh] = $this->ot->issue('user-1', 'app', ['read', 'write']);
+        $result      = $this->ot->refresh($refresh);
+        $this->assertNotNull($result);
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+    }
+
+    public function testRefreshRevokesOldTokens(): void
+    {
+        [$access, $refresh] = $this->ot->issue('user-1');
+        $this->ot->refresh($refresh);
+        // Old access token should now be invalid
+        $this->assertNull($this->ot->verifyAccess($access));
+    }
+
+    public function testRefreshReturnsNullForInvalidRefreshToken(): void
+    {
+        $this->assertNull($this->ot->refresh('invalid'));
+    }
+
+    public function testRefreshCannotBeUsedTwice(): void
+    {
+        [, $refresh] = $this->ot->issue('user-1');
+        $this->ot->refresh($refresh);
+        // Second use of the same refresh token should fail
+        $this->assertNull($this->ot->refresh($refresh));
+    }
+
+    // ── revokeAccess ──────────────────────────────────────────────────────────
+
+    public function testRevokeAccessReturnsTrueAndInvalidates(): void
+    {
+        [$access] = $this->ot->issue('user-1');
+        $this->assertTrue($this->ot->revokeAccess($access));
+        $this->assertNull($this->ot->verifyAccess($access));
+    }
+
+    public function testRevokeAccessReturnsFalseForUnknown(): void
+    {
+        $this->assertFalse($this->ot->revokeAccess('unknown'));
+    }
+
+    // ── revokeAllForUser ──────────────────────────────────────────────────────
+
+    public function testRevokeAllForUserRevokesAllPairs(): void
+    {
+        [$a1] = $this->ot->issue('user-1');
+        [$a2] = $this->ot->issue('user-1');
+        $this->ot->issue('user-2'); // different user
+
+        $count = $this->ot->revokeAllForUser('user-1');
+        $this->assertSame(2, $count);
+        $this->assertNull($this->ot->verifyAccess($a1));
+        $this->assertNull($this->ot->verifyAccess($a2));
+    }
+
+    // ── activeCount ───────────────────────────────────────────────────────────
+
+    public function testActiveCountReturnsCorrectNumber(): void
+    {
+        $this->ot->issue('user-1');
+        $this->ot->issue('user-1');
+        $this->assertSame(2, $this->ot->activeCount('user-1'));
+        $this->assertSame(0, $this->ot->activeCount('user-2'));
+    }
+
+    // ── purgeExpired ──────────────────────────────────────────────────────────
+
+    public function testPurgeExpiredDeletesRevokedTokens(): void
+    {
+        [$access] = $this->ot->issue('user-1');
+        $this->ot->revokeAccess($access);
+        $deleted = $this->ot->purgeExpired();
+        $this->assertGreaterThan(0, $deleted);
+    }
+
+    public function testPurgeExpiredKeepsActiveTokens(): void
+    {
+        $this->ot->issue('user-1');
+        $this->assertSame(0, $this->ot->purgeExpired());
+        $this->assertSame(1, $this->ot->activeCount('user-1'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `OAuthToken` — OAuth2 access/refresh token pair storage. Raw tokens never persisted; SHA-256 hashes stored.

## Class

`class/xion/OAuthToken.php`

- `issue(userId, clientId, scopes, accessTtl=3600, refreshTtl=2592000)` — issue token pair; raw values returned once
- `verifyAccess(rawToken)` — validate access token; null if expired/revoked/unknown
- `refresh(rawRefreshToken)` — rotate token pair; revokes old pair on success; single-use
- `revokeAccess(rawToken)` — revoke a single access token
- `revokeAllForUser(userId)` — revoke all active token pairs for a user
- `activeCount(userId)` — count non-revoked, non-expired pairs
- `purgeExpired()` — delete revoked or expired token rows (maintenance)

## Schema

```sql
CREATE TABLE oauth_tokens (
    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id            VARCHAR(255) NOT NULL,
    client_id          VARCHAR(255) NOT NULL DEFAULT '',
    scope              TEXT         NOT NULL DEFAULT '',
    access_hash        VARCHAR(64)  NOT NULL UNIQUE,
    refresh_hash       VARCHAR(64)  NOT NULL UNIQUE,
    access_expires_at  DATETIME     NOT NULL,
    refresh_expires_at DATETIME     NOT NULL,
    revoked            TINYINT(1)   NOT NULL DEFAULT 0,
    issued_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## Tests

18 tests, 31 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)