### PR TITLE
feat(xion): PushSubscription — Web Push notification subscription registry (FT163)

### DIFF
--- a/class/xion/PushSubscription.php
+++ b/class/xion/PushSubscription.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * PushSubscription — Web Push notification subscription registry.
+ *
+ * Stores browser push subscription data (endpoint + keys) per user and device.
+ * A subscription is uniquely identified by its endpoint URL. When a browser
+ * re-subscribes it sends the same endpoint, so saves are idempotent.
+ *
+ * This class only handles storage; actual push delivery is the caller's
+ * responsibility (e.g. via a web-push library or external API).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ps = new PushSubscription($pdo);
+ *
+ * // Save subscription after navigator.serviceWorker.subscribe()
+ * $ps->save('user-1', $endpoint, $p256dhKey, $authKey, 'Chrome/desktop');
+ *
+ * // Retrieve subscriptions to deliver a notification
+ * foreach ($ps->forUser('user-1') as $sub) {
+ *     // send push via $sub['endpoint'], $sub['p256dh'], $sub['auth']
+ * }
+ *
+ * // Remove when browser fires pushsubscriptionchange or push fails with 410
+ * $ps->remove($endpoint);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE push_subscriptions (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     endpoint    TEXT         NOT NULL UNIQUE,
+ *     p256dh      TEXT         NOT NULL DEFAULT '',
+ *     auth        TEXT         NOT NULL DEFAULT '',
+ *     device_hint VARCHAR(100) NOT NULL DEFAULT '',
+ *     subscribed_at DATETIME   NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class PushSubscription
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Save (create or update) a push subscription.
+     *
+     * Idempotent: if the endpoint already exists, the keys and device hint
+     * are updated to their new values.
+     *
+     * @param  string $userId      The authenticated user.
+     * @param  string $endpoint    Push service endpoint URL.
+     * @param  string $p256dh      Client public key (base64url-encoded).
+     * @param  string $auth        Auth secret (base64url-encoded).
+     * @param  string $deviceHint  Optional human-readable device label.
+     * @throws \InvalidArgumentException if user_id or endpoint is empty.
+     */
+    public function save(
+        string $userId,
+        string $endpoint,
+        string $p256dh = '',
+        string $auth = '',
+        string $deviceHint = ''
+    ): void {
+        $userId   = $this->validateUserId($userId);
+        $endpoint = trim($endpoint);
+        if ($endpoint === '') {
+            throw new \InvalidArgumentException('endpoint must not be empty.');
+        }
+
+        $db = $this->db();
+        if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO push_subscriptions (user_id, endpoint, p256dh, auth, device_hint)
+                 VALUES (:uid, :ep, :p256dh, :auth, :hint)
+                 ON CONFLICT (endpoint)
+                 DO UPDATE SET user_id     = excluded.user_id,
+                               p256dh      = excluded.p256dh,
+                               auth        = excluded.auth,
+                               device_hint = excluded.device_hint,
+                               subscribed_at = CURRENT_TIMESTAMP'
+            )->execute([':uid' => $userId, ':ep' => $endpoint, ':p256dh' => $p256dh, ':auth' => $auth, ':hint' => $deviceHint]);
+        } else {
+            $db->prepare(
+                'INSERT INTO push_subscriptions (user_id, endpoint, p256dh, auth, device_hint)
+                 VALUES (:uid, :ep, :p256dh, :auth, :hint)
+                 ON DUPLICATE KEY UPDATE user_id     = VALUES(user_id),
+                                         p256dh      = VALUES(p256dh),
+                                         auth        = VALUES(auth),
+                                         device_hint = VALUES(device_hint),
+                                         subscribed_at = CURRENT_TIMESTAMP'
+            )->execute([':uid' => $userId, ':ep' => $endpoint, ':p256dh' => $p256dh, ':auth' => $auth, ':hint' => $deviceHint]);
+        }
+    }
+
+    /**
+     * Get all push subscriptions for a user.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forUser(string $userId): array
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'SELECT id, user_id, endpoint, p256dh, auth, device_hint, subscribed_at
+             FROM push_subscriptions WHERE user_id = :uid ORDER BY id ASC'
+        );
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Find a subscription by endpoint URL.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function findByEndpoint(string $endpoint): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, endpoint, p256dh, auth, device_hint, subscribed_at
+             FROM push_subscriptions WHERE endpoint = :ep LIMIT 1'
+        );
+        $stmt->execute([':ep' => trim($endpoint)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Remove a subscription by endpoint URL (call on 410 Gone or user opt-out).
+     *
+     * @return bool True if the subscription existed and was removed.
+     */
+    public function remove(string $endpoint): bool
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM push_subscriptions WHERE endpoint = :ep'
+        );
+        $stmt->execute([':ep' => trim($endpoint)]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Remove all push subscriptions for a user.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function removeAllForUser(string $userId): int
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM push_subscriptions WHERE user_id = :uid'
+        );
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Count subscriptions for a user.
+     */
+    public function countForUser(string $userId): int
+    {
+        $userId = $this->validateUserId($userId);
+        $stmt   = $this->db()->prepare(
+            'SELECT COUNT(*) FROM push_subscriptions WHERE user_id = :uid'
+        );
+        $stmt->execute([':uid' => $userId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function validateUserId(string $userId): string
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        return $userId;
+    }
+}

--- a/tests/Unit/Xion/PushSubscriptionTest.php
+++ b/tests/Unit/Xion/PushSubscriptionTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\PushSubscription;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PushSubscription.
+ */
+final class PushSubscriptionTest extends TestCase
+{
+    private PDO $db;
+    private PushSubscription $ps;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE push_subscriptions (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id       VARCHAR(255) NOT NULL,
+                endpoint      TEXT         NOT NULL UNIQUE,
+                p256dh        TEXT         NOT NULL DEFAULT \'\',
+                auth          TEXT         NOT NULL DEFAULT \'\',
+                device_hint   VARCHAR(100) NOT NULL DEFAULT \'\',
+                subscribed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->ps = new PushSubscription($this->db);
+    }
+
+    // ── save ──────────────────────────────────────────────────────────────────
+
+    public function testSaveStoresSubscription(): void
+    {
+        $this->ps->save('user-1', 'https://push.example.com/ep1', 'key123', 'auth456', 'Chrome');
+        $row = $this->ps->findByEndpoint('https://push.example.com/ep1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['user_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('key123', $row['p256dh']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Chrome', $row['device_hint']);
+    }
+
+    public function testSaveIsIdempotentForSameEndpoint(): void
+    {
+        $ep = 'https://push.example.com/ep1';
+        $this->ps->save('user-1', $ep, 'key1', 'auth1');
+        $this->ps->save('user-1', $ep, 'key2', 'auth2'); // update keys
+        $this->assertSame(1, $this->ps->countForUser('user-1'));
+        $row = $this->ps->findByEndpoint($ep);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('key2', $row['p256dh']);
+    }
+
+    public function testSaveThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ps->save('', 'https://push.example.com/ep1');
+    }
+
+    public function testSaveThrowsOnEmptyEndpoint(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ps->save('user-1', '');
+    }
+
+    // ── forUser ───────────────────────────────────────────────────────────────
+
+    public function testForUserReturnsAllSubscriptions(): void
+    {
+        $this->ps->save('user-1', 'https://push.example.com/a');
+        $this->ps->save('user-1', 'https://push.example.com/b');
+        $this->ps->save('user-2', 'https://push.example.com/c');
+        $rows = $this->ps->forUser('user-1');
+        $this->assertCount(2, $rows);
+    }
+
+    public function testForUserReturnsEmptyForUnknownUser(): void
+    {
+        $this->assertSame([], $this->ps->forUser('user-1'));
+    }
+
+    // ── findByEndpoint ────────────────────────────────────────────────────────
+
+    public function testFindByEndpointReturnsNullForUnknown(): void
+    {
+        $this->assertNull($this->ps->findByEndpoint('https://push.example.com/unknown'));
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesSubscription(): void
+    {
+        $ep = 'https://push.example.com/ep1';
+        $this->ps->save('user-1', $ep);
+        $this->assertTrue($this->ps->remove($ep));
+        $this->assertNull($this->ps->findByEndpoint($ep));
+    }
+
+    public function testRemoveReturnsFalseForUnknown(): void
+    {
+        $this->assertFalse($this->ps->remove('https://push.example.com/unknown'));
+    }
+
+    // ── removeAllForUser ──────────────────────────────────────────────────────
+
+    public function testRemoveAllForUserDeletesAll(): void
+    {
+        $this->ps->save('user-1', 'https://push.example.com/a');
+        $this->ps->save('user-1', 'https://push.example.com/b');
+        $this->ps->save('user-2', 'https://push.example.com/c');
+        $count = $this->ps->removeAllForUser('user-1');
+        $this->assertSame(2, $count);
+        $this->assertSame(0, $this->ps->countForUser('user-1'));
+        $this->assertSame(1, $this->ps->countForUser('user-2'));
+    }
+
+    // ── countForUser ──────────────────────────────────────────────────────────
+
+    public function testCountForUserReturnsCorrectCount(): void
+    {
+        $this->assertSame(0, $this->ps->countForUser('user-1'));
+        $this->ps->save('user-1', 'https://push.example.com/a');
+        $this->ps->save('user-1', 'https://push.example.com/b');
+        $this->assertSame(2, $this->ps->countForUser('user-1'));
+    }
+
+    // ── reassign endpoint to different user ───────────────────────────────────
+
+    public function testSaveCanReassignEndpointToNewUser(): void
+    {
+        $ep = 'https://push.example.com/ep1';
+        $this->ps->save('user-1', $ep);
+        $this->ps->save('user-2', $ep); // browser re-subscribed under user-2
+        $row = $this->ps->findByEndpoint($ep);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-2', $row['user_id']);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `PushSubscription` — stores Web Push API subscription data (endpoint + keys) per user. Storage only; delivery is the caller's responsibility.

## Class

`class/xion/PushSubscription.php`

- `save(userId, endpoint, p256dh, auth, deviceHint)` — store/update subscription; idempotent by endpoint
- `forUser(userId)` — all subscriptions for a user
- `findByEndpoint(endpoint)` — find by push service URL
- `remove(endpoint)` — delete subscription (call on 410 Gone or user opt-out)
- `removeAllForUser(userId)` — revoke all for a user
- `countForUser(userId)` — subscription count

## Schema

```sql
CREATE TABLE push_subscriptions (
    id            INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id       VARCHAR(255) NOT NULL,
    endpoint      TEXT         NOT NULL UNIQUE,
    p256dh        TEXT         NOT NULL DEFAULT '',
    auth          TEXT         NOT NULL DEFAULT '',
    device_hint   VARCHAR(100) NOT NULL DEFAULT '',
    subscribed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## Tests

12 tests, 21 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)