### PR TITLE
feat(xion): FileChunk — chunked file upload tracking and reassembly coordination (FT165)

### DIFF
--- a/class/xion/FileChunk.php
+++ b/class/xion/FileChunk.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * FileChunk — chunked file upload tracking and reassembly coordination.
+ *
+ * Tracks the state of multi-chunk file uploads. The caller uploads each chunk
+ * and marks it received; once all chunks are received, the upload is complete
+ * and the chunks can be assembled.
+ *
+ * This class handles state tracking only. Actual chunk storage and
+ * file assembly are the caller's responsibility.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $fc = new FileChunk($pdo);
+ *
+ * // Start an upload (called by client before first chunk)
+ * $uploadId = $fc->start('user-1', 'document.pdf', 1024000, 10); // 10 chunks
+ *
+ * // Mark each chunk received (called after storing chunk to disk/S3)
+ * $fc->received($uploadId, 0); // chunk index 0
+ * $fc->received($uploadId, 1);
+ * // ...
+ *
+ * // Check completion
+ * if ($fc->isComplete($uploadId)) {
+ *     $upload = $fc->find($uploadId);
+ *     // assemble chunks into final file
+ *     $fc->markDone($uploadId);
+ * }
+ *
+ * // Stale cleanup
+ * $fc->purgeOlderThan(24); // hours
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE file_chunk_uploads (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     upload_id    VARCHAR(36)  NOT NULL UNIQUE,
+ *     user_id      VARCHAR(255) NOT NULL DEFAULT '',
+ *     filename     VARCHAR(500) NOT NULL DEFAULT '',
+ *     total_size   BIGINT       NOT NULL DEFAULT 0,
+ *     total_chunks INT          NOT NULL DEFAULT 1,
+ *     received     INT          NOT NULL DEFAULT 0,
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'uploading',
+ *     started_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class FileChunk
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Start a new chunked upload.
+     *
+     * @param  string $userId       The uploading user (optional).
+     * @param  string $filename     Original file name.
+     * @param  int    $totalSize    Total file size in bytes.
+     * @param  int    $totalChunks  Total number of chunks expected.
+     * @return string  The upload_id (UUID-like random hex).
+     * @throws \InvalidArgumentException if totalChunks < 1.
+     */
+    public function start(
+        string $userId = '',
+        string $filename = '',
+        int $totalSize = 0,
+        int $totalChunks = 1
+    ): string {
+        if ($totalChunks < 1) {
+            throw new \InvalidArgumentException('totalChunks must be at least 1.');
+        }
+
+        $uploadId = sprintf(
+            '%s-%s-%s-%s-%s',
+            bin2hex(random_bytes(4)),
+            bin2hex(random_bytes(2)),
+            bin2hex(random_bytes(2)),
+            bin2hex(random_bytes(2)),
+            bin2hex(random_bytes(6))
+        );
+
+        $this->db()->prepare(
+            'INSERT INTO file_chunk_uploads (upload_id, user_id, filename, total_size, total_chunks)
+             VALUES (:uid, :user, :file, :size, :chunks)'
+        )->execute([
+            ':uid'    => $uploadId,
+            ':user'   => $userId,
+            ':file'   => $filename,
+            ':size'   => max(0, $totalSize),
+            ':chunks' => $totalChunks,
+        ]);
+
+        return $uploadId;
+    }
+
+    /**
+     * Mark a chunk as received.
+     *
+     * Increments the received counter. The chunk index is informational only.
+     *
+     * @return bool True if the upload exists and is still uploading.
+     */
+    public function received(string $uploadId, int $chunkIndex = 0): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            "UPDATE file_chunk_uploads
+             SET received = received + 1, updated_at = :now
+             WHERE upload_id = :uid AND status = 'uploading'"
+        );
+        $stmt->execute([':now' => $now, ':uid' => $uploadId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Check whether all chunks have been received.
+     */
+    public function isComplete(string $uploadId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT received >= total_chunks FROM file_chunk_uploads WHERE upload_id = :uid LIMIT 1'
+        );
+        $stmt->execute([':uid' => $uploadId]);
+        $val = $stmt->fetchColumn();
+        return $val !== false && (int)$val === 1;
+    }
+
+    /**
+     * Mark the upload as done (assembly complete).
+     */
+    public function markDone(string $uploadId): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            "UPDATE file_chunk_uploads SET status = 'done', updated_at = :now WHERE upload_id = :uid"
+        );
+        $stmt->execute([':now' => $now, ':uid' => $uploadId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark the upload as failed.
+     */
+    public function markFailed(string $uploadId): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            "UPDATE file_chunk_uploads SET status = 'failed', updated_at = :now WHERE upload_id = :uid"
+        );
+        $stmt->execute([':now' => $now, ':uid' => $uploadId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Find an upload record by upload_id.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(string $uploadId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, upload_id, user_id, filename, total_size, total_chunks, received, status, started_at, updated_at
+             FROM file_chunk_uploads WHERE upload_id = :uid LIMIT 1'
+        );
+        $stmt->execute([':uid' => $uploadId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * List incomplete uploads for a user.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function pendingForUser(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            "SELECT id, upload_id, filename, total_chunks, received, status, started_at
+             FROM file_chunk_uploads WHERE user_id = :uid AND status = 'uploading'
+             ORDER BY id DESC"
+        );
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Delete uploads older than N hours (stale cleanup).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(int $hours): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$hours} hours")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM file_chunk_uploads WHERE started_at < :cutoff'
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/FileChunkTest.php
+++ b/tests/Unit/Xion/FileChunkTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\FileChunk;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for FileChunk.
+ */
+final class FileChunkTest extends TestCase
+{
+    private PDO $db;
+    private FileChunk $fc;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE file_chunk_uploads (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                upload_id    VARCHAR(36)  NOT NULL UNIQUE,
+                user_id      VARCHAR(255) NOT NULL DEFAULT \'\',
+                filename     VARCHAR(500) NOT NULL DEFAULT \'\',
+                total_size   BIGINT       NOT NULL DEFAULT 0,
+                total_chunks INT          NOT NULL DEFAULT 1,
+                received     INT          NOT NULL DEFAULT 0,
+                status       VARCHAR(20)  NOT NULL DEFAULT \'uploading\',
+                started_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->fc = new FileChunk($this->db);
+    }
+
+    // ── start ─────────────────────────────────────────────────────────────────
+
+    public function testStartReturnsUploadId(): void
+    {
+        $id = $this->fc->start('user-1', 'doc.pdf', 1024, 3);
+        $this->assertNotEmpty($id);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $id);
+    }
+
+    public function testStartCreatesRecord(): void
+    {
+        $id  = $this->fc->start('user-1', 'file.zip', 500000, 5);
+        $row = $this->fc->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('file.zip', $row['filename']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(5, (int)$row['total_chunks']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('uploading', $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['received']);
+    }
+
+    public function testStartThrowsOnZeroChunks(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fc->start('user-1', 'file.zip', 100, 0);
+    }
+
+    public function testStartProducesUniqueIds(): void
+    {
+        $id1 = $this->fc->start();
+        $id2 = $this->fc->start();
+        $this->assertNotSame($id1, $id2);
+    }
+
+    // ── received ──────────────────────────────────────────────────────────────
+
+    public function testReceivedIncrementsCounter(): void
+    {
+        $id = $this->fc->start('user-1', 'f.zip', 0, 3);
+        $this->assertTrue($this->fc->received($id, 0));
+        $this->assertTrue($this->fc->received($id, 1));
+        $row = $this->fc->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(2, (int)$row['received']);
+    }
+
+    public function testReceivedReturnsFalseForUnknownUpload(): void
+    {
+        $this->assertFalse($this->fc->received('bad-id', 0));
+    }
+
+    public function testReceivedReturnsFalseAfterDone(): void
+    {
+        $id = $this->fc->start('user-1', 'f.zip', 0, 1);
+        $this->fc->received($id, 0);
+        $this->fc->markDone($id);
+        $this->assertFalse($this->fc->received($id, 1));
+    }
+
+    // ── isComplete ────────────────────────────────────────────────────────────
+
+    public function testIsCompleteReturnsTrueWhenAllChunksReceived(): void
+    {
+        $id = $this->fc->start('user-1', 'f.zip', 0, 2);
+        $this->assertFalse($this->fc->isComplete($id));
+        $this->fc->received($id, 0);
+        $this->assertFalse($this->fc->isComplete($id));
+        $this->fc->received($id, 1);
+        $this->assertTrue($this->fc->isComplete($id));
+    }
+
+    public function testIsCompleteReturnsFalseForUnknown(): void
+    {
+        $this->assertFalse($this->fc->isComplete('unknown'));
+    }
+
+    // ── markDone / markFailed ─────────────────────────────────────────────────
+
+    public function testMarkDoneSetsStatus(): void
+    {
+        $id = $this->fc->start();
+        $this->assertTrue($this->fc->markDone($id));
+        $row = $this->fc->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('done', $row['status']);
+    }
+
+    public function testMarkFailedSetsStatus(): void
+    {
+        $id = $this->fc->start();
+        $this->assertTrue($this->fc->markFailed($id));
+        $row = $this->fc->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('failed', $row['status']);
+    }
+
+    public function testMarkDoneReturnsFalseForUnknown(): void
+    {
+        $this->assertFalse($this->fc->markDone('unknown'));
+    }
+
+    // ── pendingForUser ────────────────────────────────────────────────────────
+
+    public function testPendingForUserReturnsInProgressUploads(): void
+    {
+        $id1 = $this->fc->start('user-1', 'a.zip', 0, 3);
+        $id2 = $this->fc->start('user-1', 'b.zip', 0, 2);
+        $this->fc->start('user-2', 'c.zip', 0, 1);
+        $this->fc->markDone($id2);
+
+        $pending = $this->fc->pendingForUser('user-1');
+        $this->assertCount(1, $pending);
+        $this->assertSame($id1, $pending[0]['upload_id']);
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldUploads(): void
+    {
+        $id  = $this->fc->start();
+        $old = (new \DateTimeImmutable())->modify('-2 hours')->format('Y-m-d H:i:s');
+        $this->db->exec("UPDATE file_chunk_uploads SET started_at = '{$old}' WHERE upload_id = '{$id}'");
+
+        $this->fc->start(); // recent upload
+        $deleted = $this->fc->purgeOlderThan(1);
+        $this->assertSame(1, $deleted);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `FileChunk` — tracks multi-chunk file upload state. Storage/assembly remains the caller's responsibility; this class manages the upload lifecycle.

## Class

`class/xion/FileChunk.php`

- `start(userId, filename, totalSize, totalChunks=1)` — begin upload; returns UUID-like `upload_id`
- `received(uploadId, chunkIndex)` — increment received counter
- `isComplete(uploadId)` — true when received ≥ total_chunks
- `markDone(uploadId)` — set status to done after assembly
- `markFailed(uploadId)` — set status to failed
- `find(uploadId)` — fetch upload record
- `pendingForUser(userId)` — in-progress uploads for a user
- `purgeOlderThan(hours)` — delete stale uploads (hours, not days)

## Schema

```sql
CREATE TABLE file_chunk_uploads (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    upload_id    VARCHAR(36)  NOT NULL UNIQUE,
    user_id      VARCHAR(255) NOT NULL DEFAULT '',
    filename     VARCHAR(500) NOT NULL DEFAULT '',
    total_size   BIGINT       NOT NULL DEFAULT 0,
    total_chunks INT          NOT NULL DEFAULT 1,
    received     INT          NOT NULL DEFAULT 0,
    status       VARCHAR(20)  NOT NULL DEFAULT 'uploading',
    started_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## Tests

14 tests, 29 assertions — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)