### PR TITLE
docs: update candidates, todo, and roadmap to reflect FT141–FT165 completion

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -14,7 +14,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ## Active candidates
 
-The Xion helper wave (FT78–FT140) is complete as of 2026-05-27. No immediate Xion-class candidates remain. Trigger-based and structural candidates are listed in the next section.
+The Xion helper wave (FT78–FT165) is complete as of 2026-05-27. No immediate Xion-class candidates remain. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -54,6 +54,31 @@ The Xion helper wave (FT78–FT140) is complete as of 2026-05-27. No immediate X
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT165 — FileChunk** (2026-05-27): `Nene\Xion\FileChunk` — chunked file upload tracking and reassembly coordination. PR #600.
+- **FT164 — CounterMetric** (2026-05-27): `Nene\Xion\CounterMetric` — named metric counters with daily/hourly bucket aggregation. PR #599.
+- **FT163 — PushSubscription** (2026-05-27): `Nene\Xion\PushSubscription` — Web Push notification subscription registry. PR #598.
+- **FT162 — ChangeLog** (2026-05-27): `Nene\Xion\ChangeLog` — human-readable entity change history with before/after snapshots. PR #597.
+- **FT161 — ServiceAccount** (2026-05-27): `Nene\Xion\ServiceAccount` — machine-to-machine auth credentials with key rotation. PR #596.
+- **FT160 — BatchJob** (2026-05-27): `Nene\Xion\BatchJob` — batch processing job tracking with progress lifecycle. PR #595.
+- **FT159 — EmailTemplate** (2026-05-27): `Nene\Xion\EmailTemplate` — DB-stored email templates with {{variable}} substitution and locale support. PR #594.
+- **FT158 — UserActivity** (2026-05-27): `Nene\Xion\UserActivity` — user last-seen tracking and named action event log. PR #593.
+- **FT157 — OAuthToken** (2026-05-27): `Nene\Xion\OAuthToken` — OAuth2 access/refresh token storage with rotation; SHA-256 hashed. PR #592.
+- **FT156 — ApiUsageLog** (2026-05-27): `Nene\Xion\ApiUsageLog` — per-API-key request tracking with endpoint and status logging. PR #591.
+- **FT155 — DocumentLock** (2026-05-27): `Nene\Xion\DocumentLock` — collaborative editing lock with TTL; only holder can refresh/release. PR #590.
+- **FT154 — EmailQueue** (2026-05-27): `Nene\Xion\EmailQueue` — DB-backed outgoing email queue with exponential backoff retry. PR #589.
+- **FT153 — SlugRegistry** (2026-05-27): `Nene\Xion\SlugRegistry` — namespace-scoped URL slug generation and uniqueness enforcement. PR #588.
+- **FT152 — MagicLink** (2026-05-27): `Nene\Xion\MagicLink` — email-based passwordless auth; single-use time-limited tokens. PR #587.
+- **FT151 — Announcement** (2026-05-27): `Nene\Xion\Announcement` — site-wide announcements with scheduling and per-user dismissal. PR #586.
+- **FT150 — AlertRule** (2026-05-27): `Nene\Xion\AlertRule` — metric threshold alerts with condition evaluation and event log. PR #585.
+- **FT149 — ContentVersion** (2026-05-27): `Nene\Xion\ContentVersion` — append-only content versioning with rollback. PR #584.
+- **FT148 — IpBlocklist** (2026-05-27): `Nene\Xion\IpBlocklist` — global IP address blocklist with optional expiry. PR #583.
+- **FT147 — ExportJob** (2026-05-27): `Nene\Xion\ExportJob` — async data export job tracking with status lifecycle. PR #582.
+- **FT146 — CronLog** (2026-05-27): `Nene\Xion\CronLog` — scheduled task execution log. PR #581.
+- **FT145 — ShoppingCart** (2026-05-27): `Nene\Xion\ShoppingCart` — cart item management with qty and price tracking. PR #580.
+- **FT144 — ChatMessage** (2026-05-27): `Nene\Xion\ChatMessage` — simple chat room message store with soft-delete. PR #579.
+- **FT143 — UserGroup** (2026-05-27): `Nene\Xion\UserGroup` — user group membership with per-member roles. PR #578.
+- **FT142 — CacheEntry** (2026-05-27): `Nene\Xion\CacheEntry` — DB-backed key-value cache with TTL. PR #577.
+- **FT141 — ConfigStore** (2026-05-27): `Nene\Xion\ConfigStore` — global app key-value config store. PR #576.
 - **FT140 — TaskList** (2026-05-27): `Nene\Xion\TaskList` — per-user to-do list with named lists and completion tracking. PR #574.
 - **FT139 — GeoFence** (2026-05-27): `Nene\Xion\GeoFence` — named circular geo-fence definition and point containment; Haversine. PR #573.
 - **FT138 — CreditLedger** (2026-05-27): `Nene\Xion\CreditLedger` — append-only credit/debit ledger per user; balance guard. PR #572.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT140 complete as of 2026-05-27 (FT36 deferred as ADR-class).
+Status: methodology adopted (ADR 0002). FT1–FT165 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 
@@ -234,6 +234,7 @@ Completed (wave summary):
 - **FT25–FT50**: NENE2 parity + extended pattern wave. 26 trials covering pagination, soft delete, JWT, RBAC, rate limiting, feature flags, idempotency, webhook signing, and more. PRs #458–#483.
 - **FT51–FT77**: Extended social/content/identity wave. 27 trials covering i18n, pub-sub, GDPR export, leaderboard, bookmarks, TOTP, address book, and more. PRs #485–#511.
 - **FT78–FT140**: Xion helper wave. 63 trials covering social, content moderation, analytics, SaaS infrastructure, A/B testing, event sourcing, and more. PRs #512–#574.
+- **FT141–FT165**: Xion extended wave. 25 trials covering config store, cache, user groups, chat, shopping cart, cron log, export jobs, IP blocklist, content versioning, alert rules, announcements, magic links, slug registry, email queue, document locks, API usage log, OAuth tokens, user activity, email templates, batch jobs, service accounts, change logs, push subscriptions, counter metrics, and file chunk uploads. PRs #576–#600.
 
 Future candidates:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,39 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT140 are complete (FT36 deferred as ADR-class); ADR-0001–0013 are in place. The Xion helper wave is complete — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT165 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is complete — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-27 — FT141–FT165: Xion extended helper wave (25 trials)
+
+Continuous wave of 25 field trials extending the Xion helper library. All PRs #576–#600. FT112 (LeaderBoard) closed as conflicting with existing FT61 Leaderboard class.
+
+**FT141 — ConfigStore**: `ConfigStore` global app key-value config with namespace support. PR #576.
+**FT142 — CacheEntry**: `CacheEntry` DB-backed TTL cache; zero extra infrastructure fallback. PR #577.
+**FT143 — UserGroup**: `UserGroup` user group membership with per-member roles. PR #578.
+**FT144 — ChatMessage**: `ChatMessage` simple chat room message store with soft-delete. PR #579.
+**FT145 — ShoppingCart**: `ShoppingCart` cart item management with qty and integer-cent price tracking. PR #580.
+**FT146 — CronLog**: `CronLog` scheduled task execution log with status lifecycle. PR #581.
+**FT147 — ExportJob**: `ExportJob` async data export job tracking with status lifecycle. PR #582.
+**FT148 — IpBlocklist**: `IpBlocklist` global IP address blocklist with optional expiry. PR #583.
+**FT149 — ContentVersion**: `ContentVersion` append-only content versioning with rollback. PR #584.
+**FT150 — AlertRule**: `AlertRule` metric threshold alerts with condition evaluation and event log. PR #585.
+**FT151 — Announcement**: `Announcement` site-wide announcements with scheduling and per-user dismissal. PR #586.
+**FT152 — MagicLink**: `MagicLink` email-based passwordless auth; single-use time-limited tokens. PR #587.
+**FT153 — SlugRegistry**: `SlugRegistry` namespace-scoped URL slug generation and uniqueness enforcement. PR #588.
+**FT154 — EmailQueue**: `EmailQueue` DB-backed outgoing email queue with exponential backoff retry. PR #589.
+**FT155 — DocumentLock**: `DocumentLock` collaborative editing lock with TTL; holder-only refresh/release. PR #590.
+**FT156 — ApiUsageLog**: `ApiUsageLog` per-API-key request tracking with endpoint/status/latency logging. PR #591.
+**FT157 — OAuthToken**: `OAuthToken` OAuth2 access/refresh token storage with rotation; SHA-256 hashed. PR #592.
+**FT158 — UserActivity**: `UserActivity` user last-seen tracking and named action event log. PR #593.
+**FT159 — EmailTemplate**: `EmailTemplate` DB-stored email templates with {{variable}} substitution and locale support. PR #594.
+**FT160 — BatchJob**: `BatchJob` batch processing job tracking with progress lifecycle. PR #595.
+**FT161 — ServiceAccount**: `ServiceAccount` machine-to-machine auth credentials with key rotation. PR #596.
+**FT162 — ChangeLog**: `ChangeLog` human-readable entity change history with before/after JSON snapshots. PR #597.
+**FT163 — PushSubscription**: `PushSubscription` Web Push notification subscription registry. PR #598.
+**FT164 — CounterMetric**: `CounterMetric` named metric counters with daily/hourly bucket aggregation. PR #599.
+**FT165 — FileChunk**: `FileChunk` chunked file upload tracking and reassembly coordination. PR #600.
 
 ### 2026-05-27 — FT78–FT140: Xion helper wave (63 trials)
 


### PR DESCRIPTION
Updates docs to reflect completion of FT141–FT165 (25 trials) and closure of FT112 (conflicts with FT61 Leaderboard).

- `docs/field-trials/candidates.md`: active section updated to FT78–FT165; FT141–FT165 added to recently picked-up archive trail
- `docs/todo/current.md`: active section updated to FT1–FT165; new recently-completed block for FT141–FT165
- `docs/roadmap.md`: Phase 7 status updated; FT141–FT165 wave summary added to Completed list

🤖 Generated with [Claude Code](https://claude.com/claude-code)