### PR TITLE
feat(xion): TeamMembership — team/org membership with roles (FT169)

### DIFF
--- a/class/xion/TeamMembership.php
+++ b/class/xion/TeamMembership.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * TeamMembership — organization/team membership with roles.
+ *
+ * Manages team composition: add/remove members, change roles, and query
+ * membership state. Each user can be in multiple teams; each team member
+ * has a single role string. Use in tandem with a teams table or as a
+ * standalone membership store.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $tm = new TeamMembership($pdo);
+ *
+ * // Add members
+ * $tm->add('team-a', 'user-1', 'owner');
+ * $tm->add('team-a', 'user-2', 'member');
+ *
+ * // Query
+ * $members = $tm->members('team-a');
+ * $teams   = $tm->teams('user-1');
+ * $role    = $tm->role('team-a', 'user-1'); // 'owner'
+ *
+ * // Update role
+ * $tm->changeRole('team-a', 'user-2', 'admin');
+ *
+ * // Remove
+ * $tm->remove('team-a', 'user-2');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE team_members (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     team_id     VARCHAR(255) NOT NULL,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     role        VARCHAR(50)  NOT NULL DEFAULT 'member',
+ *     invited_by  VARCHAR(255) NOT NULL DEFAULT '',
+ *     joined_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (team_id, user_id)
+ * );
+ * ```
+ */
+final class TeamMembership
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add a user to a team. Idempotent — if already a member, updates role.
+     *
+     * @throws \InvalidArgumentException on empty inputs.
+     */
+    public function add(string $teamId, string $userId, string $role = 'member', string $invitedBy = ''): void
+    {
+        [$teamId, $userId] = $this->validateInputs($teamId, $userId);
+        $db = $this->db();
+
+        if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $db->prepare(
+                'INSERT INTO team_members (team_id, user_id, role, invited_by)
+                 VALUES (:team, :user, :role, :inv)
+                 ON CONFLICT (team_id, user_id)
+                 DO UPDATE SET role = excluded.role'
+            )->execute([':team' => $teamId, ':user' => $userId, ':role' => $role, ':inv' => $invitedBy]);
+        } else {
+            $db->prepare(
+                'INSERT INTO team_members (team_id, user_id, role, invited_by)
+                 VALUES (:team, :user, :role, :inv)
+                 ON DUPLICATE KEY UPDATE role = VALUES(role)'
+            )->execute([':team' => $teamId, ':user' => $userId, ':role' => $role, ':inv' => $invitedBy]);
+        }
+    }
+
+    /**
+     * Remove a user from a team.
+     *
+     * @return bool True if the membership existed and was removed.
+     */
+    public function remove(string $teamId, string $userId): bool
+    {
+        [$teamId, $userId] = $this->validateInputs($teamId, $userId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM team_members WHERE team_id = :team AND user_id = :user'
+        );
+        $stmt->execute([':team' => $teamId, ':user' => $userId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Change a member's role.
+     *
+     * @return bool True if the membership existed and was updated.
+     */
+    public function changeRole(string $teamId, string $userId, string $role): bool
+    {
+        [$teamId, $userId] = $this->validateInputs($teamId, $userId);
+        $stmt = $this->db()->prepare(
+            'UPDATE team_members SET role = :role WHERE team_id = :team AND user_id = :user'
+        );
+        $stmt->execute([':role' => $role, ':team' => $teamId, ':user' => $userId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Check whether a user is a member of a team.
+     */
+    public function isMember(string $teamId, string $userId): bool
+    {
+        return $this->role($teamId, $userId) !== null;
+    }
+
+    /**
+     * Check whether a user has a specific role in a team.
+     */
+    public function hasRole(string $teamId, string $userId, string $role): bool
+    {
+        return $this->role($teamId, $userId) === $role;
+    }
+
+    /**
+     * Get the role of a user in a team (null if not a member).
+     */
+    public function role(string $teamId, string $userId): ?string
+    {
+        [$teamId, $userId] = $this->validateInputs($teamId, $userId);
+        $stmt = $this->db()->prepare(
+            'SELECT role FROM team_members WHERE team_id = :team AND user_id = :user LIMIT 1'
+        );
+        $stmt->execute([':team' => $teamId, ':user' => $userId]);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (string)$val : null;
+    }
+
+    /**
+     * List all members of a team.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function members(string $teamId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, team_id, user_id, role, invited_by, joined_at
+             FROM team_members WHERE team_id = :team ORDER BY joined_at ASC'
+        );
+        $stmt->execute([':team' => trim($teamId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List all teams a user belongs to.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function teams(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, team_id, user_id, role, invited_by, joined_at
+             FROM team_members WHERE user_id = :user ORDER BY joined_at ASC'
+        );
+        $stmt->execute([':user' => trim($userId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Count members in a team.
+     */
+    public function count(string $teamId): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM team_members WHERE team_id = :team');
+        $stmt->execute([':team' => trim($teamId)]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Remove all members from a team.
+     *
+     * @return int Number of memberships deleted.
+     */
+    public function disband(string $teamId): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM team_members WHERE team_id = :team');
+        $stmt->execute([':team' => trim($teamId)]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function validateInputs(string $teamId, string $userId): array
+    {
+        $teamId = trim($teamId);
+        $userId = trim($userId);
+        if ($teamId === '') {
+            throw new \InvalidArgumentException('team_id must not be empty.');
+        }
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        return [$teamId, $userId];
+    }
+}

--- a/tests/Unit/Xion/TeamMembershipTest.php
+++ b/tests/Unit/Xion/TeamMembershipTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\TeamMembership;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for TeamMembership.
+ */
+final class TeamMembershipTest extends TestCase
+{
+    private PDO $db;
+    private TeamMembership $tm;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE team_members (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                team_id     VARCHAR(255) NOT NULL,
+                user_id     VARCHAR(255) NOT NULL,
+                role        VARCHAR(50)  NOT NULL DEFAULT \'member\',
+                invited_by  VARCHAR(255) NOT NULL DEFAULT \'\',
+                joined_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (team_id, user_id)
+            )
+        ');
+        $this->tm = new TeamMembership($this->db);
+    }
+
+    // ── add ───────────────────────────────────────────────────────────────────
+
+    public function testAddCreatesMembership(): void
+    {
+        $this->tm->add('team-a', 'user-1', 'owner');
+        $this->assertTrue($this->tm->isMember('team-a', 'user-1'));
+    }
+
+    public function testAddDefaultRoleIsMember(): void
+    {
+        $this->tm->add('team-a', 'user-1');
+        $this->assertSame('member', $this->tm->role('team-a', 'user-1'));
+    }
+
+    public function testAddIsIdempotentAndUpdatesRole(): void
+    {
+        $this->tm->add('team-a', 'user-1', 'member');
+        $this->tm->add('team-a', 'user-1', 'admin');
+        $this->assertSame('admin', $this->tm->role('team-a', 'user-1'));
+        $this->assertSame(1, $this->tm->count('team-a'));
+    }
+
+    public function testAddThrowsOnEmptyTeamId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->tm->add('', 'user-1');
+    }
+
+    public function testAddThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->tm->add('team-a', '');
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesMembership(): void
+    {
+        $this->tm->add('team-a', 'user-1');
+        $this->assertTrue($this->tm->remove('team-a', 'user-1'));
+        $this->assertFalse($this->tm->isMember('team-a', 'user-1'));
+    }
+
+    public function testRemoveReturnsFalseForNonMember(): void
+    {
+        $this->assertFalse($this->tm->remove('team-a', 'nobody'));
+    }
+
+    // ── changeRole ────────────────────────────────────────────────────────────
+
+    public function testChangeRoleUpdatesRole(): void
+    {
+        $this->tm->add('team-a', 'user-1', 'member');
+        $this->assertTrue($this->tm->changeRole('team-a', 'user-1', 'admin'));
+        $this->assertSame('admin', $this->tm->role('team-a', 'user-1'));
+    }
+
+    public function testChangeRoleReturnsFalseForNonMember(): void
+    {
+        $this->assertFalse($this->tm->changeRole('team-a', 'nobody', 'admin'));
+    }
+
+    // ── isMember / hasRole ───────────────────────────────────────────────────
+
+    public function testIsMemberReturnsTrueForMember(): void
+    {
+        $this->tm->add('team-a', 'user-1');
+        $this->assertTrue($this->tm->isMember('team-a', 'user-1'));
+    }
+
+    public function testIsMemberReturnsFalseForNonMember(): void
+    {
+        $this->assertFalse($this->tm->isMember('team-a', 'stranger'));
+    }
+
+    public function testHasRoleReturnsTrueForMatchingRole(): void
+    {
+        $this->tm->add('team-a', 'user-1', 'owner');
+        $this->assertTrue($this->tm->hasRole('team-a', 'user-1', 'owner'));
+    }
+
+    public function testHasRoleReturnsFalseForWrongRole(): void
+    {
+        $this->tm->add('team-a', 'user-1', 'member');
+        $this->assertFalse($this->tm->hasRole('team-a', 'user-1', 'owner'));
+    }
+
+    // ── role ──────────────────────────────────────────────────────────────────
+
+    public function testRoleReturnsNullForNonMember(): void
+    {
+        $this->assertNull($this->tm->role('team-a', 'nobody'));
+    }
+
+    // ── members ───────────────────────────────────────────────────────────────
+
+    public function testMembersListsAllMembersInOrder(): void
+    {
+        $this->tm->add('team-a', 'user-1', 'owner');
+        $this->tm->add('team-a', 'user-2', 'member');
+        $members = $this->tm->members('team-a');
+        $this->assertCount(2, $members);
+    }
+
+    public function testMembersReturnsEmptyForUnknownTeam(): void
+    {
+        $this->assertSame([], $this->tm->members('no-team'));
+    }
+
+    // ── teams ─────────────────────────────────────────────────────────────────
+
+    public function testTeamsListsAllTeamsForUser(): void
+    {
+        $this->tm->add('team-a', 'user-1');
+        $this->tm->add('team-b', 'user-1');
+        $teams = $this->tm->teams('user-1');
+        $this->assertCount(2, $teams);
+    }
+
+    public function testTeamsReturnsEmptyForNonMember(): void
+    {
+        $this->assertSame([], $this->tm->teams('nobody'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountReturnsCorrectMemberCount(): void
+    {
+        $this->assertSame(0, $this->tm->count('team-a'));
+        $this->tm->add('team-a', 'user-1');
+        $this->tm->add('team-a', 'user-2');
+        $this->assertSame(2, $this->tm->count('team-a'));
+    }
+
+    // ── disband ───────────────────────────────────────────────────────────────
+
+    public function testDisbandRemovesAllMembers(): void
+    {
+        $this->tm->add('team-a', 'user-1');
+        $this->tm->add('team-a', 'user-2');
+        $count = $this->tm->disband('team-a');
+        $this->assertSame(2, $count);
+        $this->assertSame(0, $this->tm->count('team-a'));
+    }
+
+    public function testDisbandReturnsZeroForEmptyTeam(): void
+    {
+        $this->assertSame(0, $this->tm->disband('no-team'));
+    }
+}


### PR DESCRIPTION
Adds `Nene\Xion\TeamMembership` for managing team/organization membership. Each user can be in multiple teams; each membership carries a role string. Idempotent `add()` upserts role via cross-driver SQL.

## Schema

```sql
CREATE TABLE team_members (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    team_id     VARCHAR(255) NOT NULL,
    user_id     VARCHAR(255) NOT NULL,
    role        VARCHAR(50)  NOT NULL DEFAULT 'member',
    invited_by  VARCHAR(255) NOT NULL DEFAULT '',
    joined_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    UNIQUE (team_id, user_id)
);
```

## Methods

- `add(teamId, userId, role, invitedBy)` — idempotent; upserts role
- `remove(teamId, userId)` → bool
- `changeRole(teamId, userId, role)` → bool
- `isMember(teamId, userId)` → bool
- `hasRole(teamId, userId, role)` → bool
- `role(teamId, userId)` → ?string
- `members(teamId)` → list
- `teams(userId)` → list
- `count(teamId)` → int
- `disband(teamId)` → int (rows deleted)

21 tests, 26 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)