### PR TITLE
feat(xion): TrustScore — append-only fraud/trust score per user (FT170)

### DIFF
--- a/class/xion/TrustScore.php
+++ b/class/xion/TrustScore.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * TrustScore — append-only fraud/trust score per user.
+ *
+ * Accumulates signed score deltas for each user into an append-only ledger.
+ * The current trust score is the sum of all deltas. Useful for fraud
+ * prevention, reputation systems, or any domain that needs an auditable
+ * score history.
+ *
+ * Negative deltas reduce the score (suspicious events); positive deltas
+ * increase it (verified identity, good behaviour).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ts = new TrustScore($pdo);
+ *
+ * // Record events
+ * $ts->record('user-1', -20, 'login_from_new_country', 'security-bot');
+ * $ts->record('user-1', +10, 'email_verified', 'auth-service');
+ *
+ * // Query
+ * $score   = $ts->current('user-1');   // -10
+ * $history = $ts->history('user-1');
+ * $risky   = $ts->below(0, 50);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE trust_scores (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     delta       INTEGER      NOT NULL,
+ *     reason      VARCHAR(255) NOT NULL DEFAULT '',
+ *     recorded_by VARCHAR(255) NOT NULL DEFAULT '',
+ *     recorded_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class TrustScore
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record a trust score delta for a user.
+     *
+     * @param  int    $delta       Signed integer (positive = good, negative = bad).
+     * @param  string $reason      Short description of the event.
+     * @param  string $recordedBy  System or user that generated the event.
+     * @throws \InvalidArgumentException on empty userId or zero delta.
+     */
+    public function record(string $userId, int $delta, string $reason = '', string $recordedBy = ''): void
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($delta === 0) {
+            throw new \InvalidArgumentException('delta must not be zero.');
+        }
+
+        $this->db()->prepare(
+            'INSERT INTO trust_scores (user_id, delta, reason, recorded_by)
+             VALUES (:uid, :delta, :reason, :by)'
+        )->execute([
+            ':uid'    => $userId,
+            ':delta'  => $delta,
+            ':reason' => $reason,
+            ':by'     => $recordedBy,
+        ]);
+    }
+
+    /**
+     * Get the current trust score for a user (sum of all deltas).
+     *
+     * Returns 0 if no events exist.
+     */
+    public function current(string $userId): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COALESCE(SUM(delta), 0) FROM trust_scores WHERE user_id = :uid'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Get the full delta history for a user (newest first).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function history(string $userId, int $limit = 50): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, delta, reason, recorded_by, recorded_at
+             FROM trust_scores WHERE user_id = :uid
+             ORDER BY id DESC LIMIT :lim'
+        );
+        $stmt->bindValue(':uid', trim($userId));
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List users whose current score is below a threshold.
+     *
+     * @return list<array{user_id:string, score:int}>
+     */
+    public function below(int $threshold, int $limit = 50): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT user_id, SUM(delta) AS score
+             FROM trust_scores
+             GROUP BY user_id
+             HAVING SUM(delta) < :threshold
+             ORDER BY score ASC
+             LIMIT :lim'
+        );
+        $stmt->bindValue(':threshold', $threshold, PDO::PARAM_INT);
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        if (!$rows) {
+            return [];
+        }
+        return array_map(
+            static fn (array $r): array => ['user_id' => (string)$r['user_id'], 'score' => (int)$r['score']],
+            $rows
+        );
+    }
+
+    /**
+     * Reset (delete) all score entries for a user.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function reset(string $userId): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM trust_scores WHERE user_id = :uid');
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Delete entries older than a given number of days (maintenance).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare('DELETE FROM trust_scores WHERE recorded_at < :cutoff');
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/TrustScoreTest.php
+++ b/tests/Unit/Xion/TrustScoreTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\TrustScore;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for TrustScore.
+ */
+final class TrustScoreTest extends TestCase
+{
+    private PDO $db;
+    private TrustScore $ts;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE trust_scores (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     VARCHAR(255) NOT NULL,
+                delta       INTEGER      NOT NULL,
+                reason      VARCHAR(255) NOT NULL DEFAULT \'\',
+                recorded_by VARCHAR(255) NOT NULL DEFAULT \'\',
+                recorded_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->ts = new TrustScore($this->db);
+    }
+
+    // ── record ────────────────────────────────────────────────────────────────
+
+    public function testRecordStoresDelta(): void
+    {
+        $this->ts->record('user-1', -20, 'suspicious_login', 'security-bot');
+        $this->assertSame(-20, $this->ts->current('user-1'));
+    }
+
+    public function testRecordAccumulatesDeltas(): void
+    {
+        $this->ts->record('user-1', 10);
+        $this->ts->record('user-1', -5);
+        $this->ts->record('user-1', 20);
+        $this->assertSame(25, $this->ts->current('user-1'));
+    }
+
+    public function testRecordThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ts->record('', 10);
+    }
+
+    public function testRecordThrowsOnZeroDelta(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ts->record('user-1', 0);
+    }
+
+    // ── current ───────────────────────────────────────────────────────────────
+
+    public function testCurrentReturnsZeroForUnknownUser(): void
+    {
+        $this->assertSame(0, $this->ts->current('nobody'));
+    }
+
+    public function testCurrentHandlesNegativeScore(): void
+    {
+        $this->ts->record('user-1', -100);
+        $this->ts->record('user-1', 30);
+        $this->assertSame(-70, $this->ts->current('user-1'));
+    }
+
+    // ── history ───────────────────────────────────────────────────────────────
+
+    public function testHistoryReturnsNewestFirst(): void
+    {
+        $this->ts->record('user-1', 10, 'first');
+        $this->ts->record('user-1', -5, 'second');
+        $history = $this->ts->history('user-1');
+        $this->assertCount(2, $history);
+        $this->assertSame(-5, (int)$history[0]['delta']);
+    }
+
+    public function testHistoryReturnsEmptyForUnknownUser(): void
+    {
+        $this->assertSame([], $this->ts->history('nobody'));
+    }
+
+    public function testHistoryRespectsLimit(): void
+    {
+        for ($i = 1; $i <= 10; $i++) {
+            $this->ts->record('user-1', 1);
+        }
+        $history = $this->ts->history('user-1', 5);
+        $this->assertCount(5, $history);
+    }
+
+    public function testHistoryIncludesReasonAndRecordedBy(): void
+    {
+        $this->ts->record('user-1', -10, 'vpn_detected', 'fraud-engine');
+        $history = $this->ts->history('user-1');
+        $this->assertSame('vpn_detected', $history[0]['reason']);
+        $this->assertSame('fraud-engine', $history[0]['recorded_by']);
+    }
+
+    // ── below ─────────────────────────────────────────────────────────────────
+
+    public function testBelowReturnsUsersBelowThreshold(): void
+    {
+        $this->ts->record('user-1', -50);
+        $this->ts->record('user-2', 20);
+        $this->ts->record('user-3', -10);
+        $risky = $this->ts->below(0);
+        $this->assertCount(2, $risky);
+    }
+
+    public function testBelowReturnsEmptyWhenNoneQualify(): void
+    {
+        $this->ts->record('user-1', 100);
+        $this->assertSame([], $this->ts->below(0));
+    }
+
+    public function testBelowOrdersByScoreAscending(): void
+    {
+        $this->ts->record('user-1', -10);
+        $this->ts->record('user-2', -30);
+        $risky = $this->ts->below(0);
+        $this->assertSame('user-2', $risky[0]['user_id']);
+    }
+
+    // ── reset ─────────────────────────────────────────────────────────────────
+
+    public function testResetDeletesAllEntries(): void
+    {
+        $this->ts->record('user-1', 10);
+        $this->ts->record('user-1', -5);
+        $count = $this->ts->reset('user-1');
+        $this->assertGreaterThan(0, $count);
+        $this->assertSame(0, $this->ts->current('user-1'));
+    }
+
+    public function testResetReturnsZeroForUnknownUser(): void
+    {
+        $this->assertSame(0, $this->ts->reset('nobody'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldEntries(): void
+    {
+        $past = (new \DateTimeImmutable())->modify('-31 days')->format('Y-m-d H:i:s');
+        $this->db->exec("INSERT INTO trust_scores (user_id, delta, recorded_at)
+            VALUES ('user-1', 10, '{$past}')");
+        $count = $this->ts->purgeOlderThan(30);
+        $this->assertGreaterThan(0, $count);
+    }
+
+    public function testPurgeOlderThanKeepsRecentEntries(): void
+    {
+        $this->ts->record('user-1', 10);
+        $this->ts->purgeOlderThan(30);
+        $this->assertSame(10, $this->ts->current('user-1'));
+    }
+}


### PR DESCRIPTION
Adds `Nene\Xion\TrustScore` for accumulating signed score deltas per user. Current score = SUM(delta); all events preserved for audit. Negative deltas = suspicious; positive = verified/good behaviour.

## Schema

```sql
CREATE TABLE trust_scores (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id     VARCHAR(255) NOT NULL,
    delta       INTEGER      NOT NULL,
    reason      VARCHAR(255) NOT NULL DEFAULT '',
    recorded_by VARCHAR(255) NOT NULL DEFAULT '',
    recorded_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## Methods

- `record(userId, delta, reason, recordedBy)` — delta ≠ 0; appends row
- `current(userId)` → int — SUM(delta), 0 if no events
- `history(userId, limit=50)` → list — newest first
- `below(threshold, limit=50)` → list of {user_id, score} — score < threshold, sorted asc
- `reset(userId)` → int — deletes all entries for user
- `purgeOlderThan(days)` → int

17 tests, 20 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)