### PR TITLE
feat(xion): UserNote — admin/staff notes attached to user records (FT175)

### DIFF
--- a/class/xion/UserNote.php
+++ b/class/xion/UserNote.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * UserNote — admin/staff notes attached to a user record.
+ *
+ * Stores freeform text notes about a user, written by admins or support
+ * staff. Notes can be pinned to appear first. Useful for CRM, moderation,
+ * and support scenarios where staff need to track context about a user.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $un = new UserNote($pdo);
+ *
+ * // Add notes
+ * $id = $un->add('user-1', 'admin-1', 'Requested account merge with user-2');
+ *
+ * // Pin a note for visibility
+ * $un->pin($id);
+ *
+ * // Update / delete
+ * $un->update($id, 'Updated context after investigation');
+ * $un->delete($id);
+ *
+ * // List (pinned first, then newest)
+ * $notes = $un->forUser('user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE user_notes (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     author_id  VARCHAR(255) NOT NULL,
+ *     content    TEXT         NOT NULL,
+ *     pinned     TINYINT(1)   NOT NULL DEFAULT 0,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class UserNote
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add a note about a user.
+     *
+     * @return int Row ID of the new note.
+     * @throws \InvalidArgumentException on empty userId or empty content.
+     */
+    public function add(string $userId, string $authorId, string $content): int
+    {
+        $userId  = trim($userId);
+        $content = trim($content);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($content === '') {
+            throw new \InvalidArgumentException('content must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO user_notes (user_id, author_id, content)
+             VALUES (:uid, :author, :content)'
+        );
+        $stmt->execute([
+            ':uid'     => $userId,
+            ':author'  => trim($authorId),
+            ':content' => $content,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Update the content of an existing note.
+     *
+     * @return bool True if found and updated.
+     * @throws \InvalidArgumentException on empty content.
+     */
+    public function update(int $id, string $content): bool
+    {
+        $content = trim($content);
+        if ($content === '') {
+            throw new \InvalidArgumentException('content must not be empty.');
+        }
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE user_notes SET content = :content, updated_at = :now WHERE id = :id'
+        );
+        $stmt->execute([':content' => $content, ':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Pin a note (causes it to appear first in forUser()).
+     *
+     * @return bool True if found and updated.
+     */
+    public function pin(int $id): bool
+    {
+        return $this->setPinned($id, true);
+    }
+
+    /**
+     * Unpin a note.
+     *
+     * @return bool True if found and updated.
+     */
+    public function unpin(int $id): bool
+    {
+        return $this->setPinned($id, false);
+    }
+
+    /**
+     * Delete a note.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM user_notes WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Find a note by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, author_id, content, pinned, created_at, updated_at
+             FROM user_notes WHERE id = :id LIMIT 1'
+        );
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * List all notes for a user (pinned first, then newest).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forUser(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, author_id, content, pinned, created_at, updated_at
+             FROM user_notes WHERE user_id = :uid
+             ORDER BY pinned DESC, id DESC'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Count notes for a user.
+     */
+    public function count(string $userId): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM user_notes WHERE user_id = :uid');
+        $stmt->execute([':uid' => trim($userId)]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Delete all notes for a user.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function deleteAllForUser(string $userId): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM user_notes WHERE user_id = :uid');
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function setPinned(int $id, bool $pinned): bool
+    {
+        $stmt = $this->db()->prepare('UPDATE user_notes SET pinned = :pinned WHERE id = :id');
+        $stmt->execute([':pinned' => $pinned ? 1 : 0, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+}

--- a/tests/Unit/Xion/UserNoteTest.php
+++ b/tests/Unit/Xion/UserNoteTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\UserNote;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for UserNote.
+ */
+final class UserNoteTest extends TestCase
+{
+    private PDO $db;
+    private UserNote $un;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE user_notes (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL,
+                author_id  VARCHAR(255) NOT NULL,
+                content    TEXT         NOT NULL,
+                pinned     TINYINT(1)   NOT NULL DEFAULT 0,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->un = new UserNote($this->db);
+    }
+
+    // ── add ───────────────────────────────────────────────────────────────────
+
+    public function testAddReturnsPositiveId(): void
+    {
+        $id = $this->un->add('user-1', 'admin-1', 'Note content');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testAddStoresContent(): void
+    {
+        $id   = $this->un->add('user-1', 'admin-1', 'Some note');
+        $note = $this->un->find($id);
+        $this->assertNotNull($note);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Some note', $note['content']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('admin-1', $note['author_id']);
+    }
+
+    public function testAddThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->un->add('', 'admin-1', 'Note');
+    }
+
+    public function testAddThrowsOnEmptyContent(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->un->add('user-1', 'admin-1', '');
+    }
+
+    // ── update ────────────────────────────────────────────────────────────────
+
+    public function testUpdateChangesContent(): void
+    {
+        $id = $this->un->add('user-1', 'admin-1', 'Original');
+        $this->assertTrue($this->un->update($id, 'Updated'));
+        $note = $this->un->find($id);
+        $this->assertNotNull($note);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Updated', $note['content']);
+    }
+
+    public function testUpdateReturnsFalseForUnknownId(): void
+    {
+        $this->assertFalse($this->un->update(999, 'Content'));
+    }
+
+    public function testUpdateThrowsOnEmptyContent(): void
+    {
+        $id = $this->un->add('user-1', 'admin-1', 'Note');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->un->update($id, '');
+    }
+
+    // ── pin / unpin ───────────────────────────────────────────────────────────
+
+    public function testPinMarksNoteAsPinned(): void
+    {
+        $id = $this->un->add('user-1', 'admin-1', 'Important');
+        $this->assertTrue($this->un->pin($id));
+        $note = $this->un->find($id);
+        $this->assertNotNull($note);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$note['pinned']);
+    }
+
+    public function testUnpinClearsPinnedFlag(): void
+    {
+        $id = $this->un->add('user-1', 'admin-1', 'Important');
+        $this->un->pin($id);
+        $this->assertTrue($this->un->unpin($id));
+        $note = $this->un->find($id);
+        $this->assertNotNull($note);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$note['pinned']);
+    }
+
+    public function testPinReturnsFalseForUnknownId(): void
+    {
+        $this->assertFalse($this->un->pin(999));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesNote(): void
+    {
+        $id = $this->un->add('user-1', 'admin-1', 'To delete');
+        $this->assertTrue($this->un->delete($id));
+        $this->assertNull($this->un->find($id));
+    }
+
+    public function testDeleteReturnsFalseForUnknownId(): void
+    {
+        $this->assertFalse($this->un->delete(999));
+    }
+
+    // ── forUser ───────────────────────────────────────────────────────────────
+
+    public function testForUserListsAllNotes(): void
+    {
+        $this->un->add('user-1', 'admin-1', 'Note 1');
+        $this->un->add('user-1', 'admin-2', 'Note 2');
+        $this->un->add('user-2', 'admin-1', 'Other user');
+        $notes = $this->un->forUser('user-1');
+        $this->assertCount(2, $notes);
+    }
+
+    public function testForUserReturnsPinnedFirst(): void
+    {
+        $id1 = $this->un->add('user-1', 'admin-1', 'First');
+        $id2 = $this->un->add('user-1', 'admin-1', 'Pinned');
+        $this->un->pin($id2);
+        $notes = $this->un->forUser('user-1');
+        $this->assertSame($id2, (int)$notes[0]['id']);
+        $this->assertSame($id1, (int)$notes[1]['id']);
+    }
+
+    public function testForUserReturnsEmptyForUnknownUser(): void
+    {
+        $this->assertSame([], $this->un->forUser('nobody'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountReturnsCorrectCount(): void
+    {
+        $this->assertSame(0, $this->un->count('user-1'));
+        $this->un->add('user-1', 'admin-1', 'Note 1');
+        $this->un->add('user-1', 'admin-1', 'Note 2');
+        $this->assertSame(2, $this->un->count('user-1'));
+    }
+
+    // ── deleteAllForUser ──────────────────────────────────────────────────────
+
+    public function testDeleteAllForUserRemovesAllNotes(): void
+    {
+        $this->un->add('user-1', 'admin-1', 'A');
+        $this->un->add('user-1', 'admin-1', 'B');
+        $count = $this->un->deleteAllForUser('user-1');
+        $this->assertSame(2, $count);
+        $this->assertSame(0, $this->un->count('user-1'));
+    }
+
+    public function testDeleteAllForUserReturnsZeroForUnknownUser(): void
+    {
+        $this->assertSame(0, $this->un->deleteAllForUser('nobody'));
+    }
+}


### PR DESCRIPTION
Adds `Nene\Xion\UserNote` for storing freeform staff notes about users. Supports pinning for visibility. Notes appear pinned-first in `forUser()`.

## Schema

```sql
CREATE TABLE user_notes (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id    VARCHAR(255) NOT NULL,
    author_id  VARCHAR(255) NOT NULL,
    content    TEXT         NOT NULL,
    pinned     TINYINT(1)   NOT NULL DEFAULT 0,
    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## Methods

- `add(userId, authorId, content)` → int
- `update(id, content)` → bool
- `pin(id)` → bool
- `unpin(id)` → bool
- `delete(id)` → bool
- `find(id)` → ?array
- `forUser(userId)` → list — pinned first, then newest
- `count(userId)` → int
- `deleteAllForUser(userId)` → int

18 tests, 30 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)