### PR TITLE
docs: update candidates, todo, and roadmap to reflect FT166–FT175 completion

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -14,7 +14,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ## Active candidates
 
-The Xion helper wave (FT78–FT165) is complete as of 2026-05-27. No immediate Xion-class candidates remain. Trigger-based and structural candidates are listed in the next section.
+The Xion helper wave (FT78–FT175) is complete as of 2026-05-27. No immediate Xion-class candidates remain. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -54,6 +54,16 @@ The Xion helper wave (FT78–FT165) is complete as of 2026-05-27. No immediate X
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT175 — UserNote** (2026-05-27): `Nene\Xion\UserNote` — admin/staff notes attached to user records with pinning. PR #611.
+- **FT174 — ScheduledTask** (2026-05-27): `Nene\Xion\ScheduledTask` — cron-style task schedule registry with last-run tracking and due() query. PR #610.
+- **FT173 — GuestSession** (2026-05-27): `Nene\Xion\GuestSession` — anonymous visitor session with key-value data bag; login promotion via linkUser(). PR #609.
+- **FT172 — PinCode** (2026-05-27): `Nene\Xion\PinCode` — short PIN/OTP issuance with attempt limiting and expiry; SHA-256 hash storage. PR #608.
+- **FT171 — PaymentRecord** (2026-05-27): `Nene\Xion\PaymentRecord` — simple payment/transaction ledger; integer-cent amounts; pending→paid|failed, paid→refunded. PR #607.
+- **FT170 — TrustScore** (2026-05-27): `Nene\Xion\TrustScore` — append-only fraud/trust score per user; signed deltas; below() for risk queries. PR #606.
+- **FT169 — TeamMembership** (2026-05-27): `Nene\Xion\TeamMembership` — team/org membership with per-member roles; idempotent add; cross-driver upsert. PR #605.
+- **FT168 — Approval** (2026-05-27): `Nene\Xion\Approval` — single-approver request/approve/reject workflow; cannot re-decide. PR #604.
+- **FT167 — ShareLink** (2026-05-27): `Nene\Xion\ShareLink` — shareable links with optional password, view limits, and TTL expiry. PR #603.
+- **FT166 — Quota** (2026-05-27): `Nene\Xion\Quota` — plan-based resource quota management; unlimited (0), TTL windows, auto-reset. PR #602.
 - **FT165 — FileChunk** (2026-05-27): `Nene\Xion\FileChunk` — chunked file upload tracking and reassembly coordination. PR #600.
 - **FT164 — CounterMetric** (2026-05-27): `Nene\Xion\CounterMetric` — named metric counters with daily/hourly bucket aggregation. PR #599.
 - **FT163 — PushSubscription** (2026-05-27): `Nene\Xion\PushSubscription` — Web Push notification subscription registry. PR #598.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT165 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT175 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 
@@ -235,6 +235,7 @@ Completed (wave summary):
 - **FT51–FT77**: Extended social/content/identity wave. 27 trials covering i18n, pub-sub, GDPR export, leaderboard, bookmarks, TOTP, address book, and more. PRs #485–#511.
 - **FT78–FT140**: Xion helper wave. 63 trials covering social, content moderation, analytics, SaaS infrastructure, A/B testing, event sourcing, and more. PRs #512–#574.
 - **FT141–FT165**: Xion extended wave. 25 trials covering config store, cache, user groups, chat, shopping cart, cron log, export jobs, IP blocklist, content versioning, alert rules, announcements, magic links, slug registry, email queue, document locks, API usage log, OAuth tokens, user activity, email templates, batch jobs, service accounts, change logs, push subscriptions, counter metrics, and file chunk uploads. PRs #576–#600.
+- **FT166–FT175**: Xion second extended wave. 10 trials covering plan-based quota management, shareable links with password/expiry, approval workflows, team membership with roles, fraud/trust scoring, payment records, PIN/OTP codes, anonymous guest sessions, cron-style task scheduling, and admin user notes. PRs #602–#611.
 
 Future candidates:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,24 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT165 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is complete — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT175 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is complete — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-27 — FT166–FT175: Xion second extended wave (10 trials)
+
+Continuous wave of 10 field trials adding new Xion helper patterns. All PRs #602–#611.
+
+**FT166 — Quota**: `Quota` plan-based resource quota management; unlimited (0), optional TTL reset windows, auto-reset on consume(). PR #602.
+**FT167 — ShareLink**: `ShareLink` shareable links with optional password protection, view limits, and TTL expiry; password_hash omitted from resolve(). PR #603.
+**FT168 — Approval**: `Approval` single-approver request/approve/reject workflow; only pending records can be decided; cannot re-decide. PR #604.
+**FT169 — TeamMembership**: `TeamMembership` team/org membership with per-member roles; idempotent add (upserts role); cross-driver upsert. PR #605.
+**FT170 — TrustScore**: `TrustScore` append-only fraud/trust score per user; signed deltas; below() for risk queries; purgeOlderThan(). PR #606.
+**FT171 — PaymentRecord**: `PaymentRecord` payment/transaction ledger; integer-cent amounts; pending→paid|failed, paid→refunded; cannot re-decide. PR #607.
+**FT172 — PinCode**: `PinCode` short PIN/OTP (4–8 digits) with attempt limiting, expiry, and SHA-256 hash storage; one active PIN per user+purpose. PR #608.
+**FT173 — GuestSession**: `GuestSession` anonymous visitor sessions with JSON key-value data bag; login promotion via linkUser(); TTL with touch(). PR #609.
+**FT174 — ScheduledTask**: `ScheduledTask` cron-style task schedule registry; due() returns overdue tasks; complements CronLog. PR #610.
+**FT175 — UserNote**: `UserNote` admin/staff notes attached to user records; supports pinning (pinned-first ordering); CRM/support use case. PR #611.
 
 ### 2026-05-27 — FT141–FT165: Xion extended helper wave (25 trials)
 
@@ -287,7 +302,7 @@ Single-day wave of trial-driven improvements across the framework, documentation
 
 ## Next
 
-FT1–FT140 complete (FT36 deferred as ADR-class). The Xion helper wave is complete. Remaining work is trigger-based — see `docs/field-trials/candidates.md` for the 保留候補 list.
+FT1–FT175 complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61). The Xion helper wave is complete. Remaining work is trigger-based — see `docs/field-trials/candidates.md` for the 保留候補 list.
 
 ## Field Trials
 


### PR DESCRIPTION
Documentation update for the FT166–FT175 wave (10 new Xion helpers).

- **roadmap.md**: status updated to FT1–FT175 complete; FT166–FT175 wave added to completed summary
- **candidates.md**: active section updated; FT166–FT175 added to archive trail
- **todo/current.md**: Active section updated; FT166–FT175 wave block added to Recently Completed; Next section corrected from FT1–FT140 to FT1–FT175

FT166–FT175: Quota, ShareLink, Approval, TeamMembership, TrustScore, PaymentRecord, PinCode, GuestSession, ScheduledTask, UserNote. PRs #602–#611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)