### PR TITLE
feat(xion): Checklist helper (FT177)

### DIFF
--- a/class/xion/Checklist.php
+++ b/class/xion/Checklist.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Checklist — ordered checklist items attached to any entity.
+ *
+ * Stores ordered checklist items (e.g. onboarding steps, review checklist,
+ * deployment checklist) attached to an arbitrary resource. Items have an
+ * explicit position (order) and a completion state. The overall completion
+ * percentage is derived from the item states.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cl = new Checklist($pdo);
+ *
+ * // Add items
+ * $id1 = $cl->addItem('issue', '42', 'Write unit tests', 1);
+ * $id2 = $cl->addItem('issue', '42', 'Update documentation', 2);
+ *
+ * // Mark done / undone
+ * $cl->check($id1);
+ * $cl->uncheck($id2);
+ *
+ * // Query
+ * $items   = $cl->items('issue', '42');
+ * $pct     = $cl->percent('issue', '42');  // 50
+ * $pending = $cl->pending('issue', '42');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE checklist_items (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     entity_type  VARCHAR(100) NOT NULL,
+ *     entity_id    VARCHAR(255) NOT NULL,
+ *     label        TEXT         NOT NULL,
+ *     position     INTEGER      NOT NULL DEFAULT 0,
+ *     completed    TINYINT(1)   NOT NULL DEFAULT 0,
+ *     completed_at DATETIME     NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class Checklist
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add an item to the checklist for an entity.
+     *
+     * @return int Row ID of the new item.
+     * @throws \InvalidArgumentException on empty label/entityType/entityId.
+     */
+    public function addItem(string $entityType, string $entityId, string $label, int $position = 0): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $label = trim($label);
+        if ($label === '') {
+            throw new \InvalidArgumentException('label must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO checklist_items (entity_type, entity_id, label, position)
+             VALUES (:type, :eid, :label, :pos)'
+        );
+        $stmt->execute([
+            ':type'  => $entityType,
+            ':eid'   => $entityId,
+            ':label' => $label,
+            ':pos'   => $position,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Mark an item as completed.
+     *
+     * @return bool True if found and updated.
+     */
+    public function check(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE checklist_items SET completed = 1, completed_at = :now WHERE id = :id'
+        );
+        $stmt->execute([':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark an item as not completed.
+     *
+     * @return bool True if found and updated.
+     */
+    public function uncheck(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE checklist_items SET completed = 0, completed_at = NULL WHERE id = :id'
+        );
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Update the label text of an item.
+     *
+     * @return bool True if found and updated.
+     */
+    public function updateLabel(int $id, string $label): bool
+    {
+        $label = trim($label);
+        if ($label === '') {
+            throw new \InvalidArgumentException('label must not be empty.');
+        }
+        $stmt = $this->db()->prepare('UPDATE checklist_items SET label = :label WHERE id = :id');
+        $stmt->execute([':label' => $label, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete a checklist item.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function removeItem(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM checklist_items WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete all checklist items for an entity.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function clear(string $entityType, string $entityId): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM checklist_items WHERE entity_type = :type AND entity_id = :eid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * List all checklist items for an entity (ordered by position, then id).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function items(string $entityType, string $entityId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, label, position, completed, completed_at, created_at
+             FROM checklist_items
+             WHERE entity_type = :type AND entity_id = :eid
+             ORDER BY position ASC, id ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List only uncompleted items for an entity.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function pending(string $entityType, string $entityId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, label, position, completed, completed_at, created_at
+             FROM checklist_items
+             WHERE entity_type = :type AND entity_id = :eid AND completed = 0
+             ORDER BY position ASC, id ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return completion percentage (0–100). Returns 0 if no items.
+     */
+    public function percent(string $entityType, string $entityId): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) AS total, SUM(completed) AS done
+             FROM checklist_items
+             WHERE entity_type = :type AND entity_id = :eid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false || (int)$row['total'] === 0) {
+            return 0;
+        }
+        return (int)round((int)$row['done'] / (int)$row['total'] * 100);
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function validateEntity(string $entityType, string $entityId): array
+    {
+        $entityType = trim($entityType);
+        $entityId   = trim($entityId);
+        if ($entityType === '') {
+            throw new \InvalidArgumentException('entity_type must not be empty.');
+        }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        return [$entityType, $entityId];
+    }
+}

--- a/tests/Unit/Xion/ChecklistTest.php
+++ b/tests/Unit/Xion/ChecklistTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\Checklist;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ChecklistTest extends TestCase
+{
+    private PDO $pdo;
+    private Checklist $cl;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE checklist_items (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type  VARCHAR(100) NOT NULL,
+                entity_id    VARCHAR(255) NOT NULL,
+                label        TEXT         NOT NULL,
+                position     INTEGER      NOT NULL DEFAULT 0,
+                completed    TINYINT(1)   NOT NULL DEFAULT 0,
+                completed_at DATETIME     NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->cl = new Checklist($this->pdo);
+    }
+
+    // ── addItem ───────────────────────────────────────────────────────────────
+
+    public function testAddItemReturnsId(): void
+    {
+        $id = $this->cl->addItem('issue', '42', 'Write tests', 1);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testAddItemStoresCorrectly(): void
+    {
+        $id    = $this->cl->addItem('issue', '42', 'Write tests', 1);
+        $items = $this->cl->items('issue', '42');
+        $this->assertCount(1, $items);
+        $this->assertSame($id, (int)$items[0]['id']);
+        $this->assertSame('Write tests', $items[0]['label']);
+        $this->assertSame(1, (int)$items[0]['position']);
+        $this->assertSame(0, (int)$items[0]['completed']);
+    }
+
+    public function testAddItemTrimsEntityTypeAndId(): void
+    {
+        $this->cl->addItem('  issue  ', '  42  ', 'Label');
+        $items = $this->cl->items('issue', '42');
+        $this->assertCount(1, $items);
+    }
+
+    public function testAddItemThrowsOnEmptyLabel(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cl->addItem('issue', '1', '   ');
+    }
+
+    public function testAddItemThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cl->addItem('', '1', 'Label');
+    }
+
+    public function testAddItemThrowsOnEmptyEntityId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cl->addItem('issue', '', 'Label');
+    }
+
+    // ── check / uncheck ───────────────────────────────────────────────────────
+
+    public function testCheckMarksCompleted(): void
+    {
+        $id = $this->cl->addItem('issue', '42', 'Step 1');
+        $result = $this->cl->check($id);
+        $this->assertTrue($result);
+
+        $items = $this->cl->items('issue', '42');
+        $this->assertSame(1, (int)$items[0]['completed']);
+        $this->assertNotNull($items[0]['completed_at']);
+    }
+
+    public function testUncheckClearsCompleted(): void
+    {
+        $id = $this->cl->addItem('issue', '42', 'Step 1');
+        $this->cl->check($id);
+        $result = $this->cl->uncheck($id);
+        $this->assertTrue($result);
+
+        $items = $this->cl->items('issue', '42');
+        $this->assertSame(0, (int)$items[0]['completed']);
+        $this->assertNull($items[0]['completed_at']);
+    }
+
+    public function testCheckReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->cl->check(9999));
+    }
+
+    public function testUncheckReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->cl->uncheck(9999));
+    }
+
+    // ── updateLabel ───────────────────────────────────────────────────────────
+
+    public function testUpdateLabelChangesLabel(): void
+    {
+        $id = $this->cl->addItem('issue', '1', 'Old label');
+        $result = $this->cl->updateLabel($id, 'New label');
+        $this->assertTrue($result);
+
+        $items = $this->cl->items('issue', '1');
+        $this->assertSame('New label', $items[0]['label']);
+    }
+
+    public function testUpdateLabelThrowsOnEmptyLabel(): void
+    {
+        $id = $this->cl->addItem('issue', '1', 'Label');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cl->updateLabel($id, '');
+    }
+
+    public function testUpdateLabelReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->cl->updateLabel(9999, 'Label'));
+    }
+
+    // ── removeItem ────────────────────────────────────────────────────────────
+
+    public function testRemoveItemDeletesRow(): void
+    {
+        $id = $this->cl->addItem('issue', '1', 'Label');
+        $result = $this->cl->removeItem($id);
+        $this->assertTrue($result);
+        $this->assertCount(0, $this->cl->items('issue', '1'));
+    }
+
+    public function testRemoveItemReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->cl->removeItem(9999));
+    }
+
+    // ── clear ─────────────────────────────────────────────────────────────────
+
+    public function testClearDeletesAllForEntity(): void
+    {
+        $this->cl->addItem('issue', '5', 'A', 1);
+        $this->cl->addItem('issue', '5', 'B', 2);
+        $this->cl->addItem('issue', '6', 'C', 1);
+
+        $count = $this->cl->clear('issue', '5');
+        $this->assertSame(2, $count);
+        $this->assertCount(0, $this->cl->items('issue', '5'));
+        $this->assertCount(1, $this->cl->items('issue', '6'));
+    }
+
+    public function testClearReturnsZeroWhenNoItems(): void
+    {
+        $this->assertSame(0, $this->cl->clear('issue', '99'));
+    }
+
+    // ── items ─────────────────────────────────────────────────────────────────
+
+    public function testItemsOrdersByPositionThenId(): void
+    {
+        $id3 = $this->cl->addItem('task', '1', 'Third', 3);
+        $id1 = $this->cl->addItem('task', '1', 'First', 1);
+        $id2 = $this->cl->addItem('task', '1', 'Second', 2);
+
+        $items = $this->cl->items('task', '1');
+        $this->assertCount(3, $items);
+        $this->assertSame($id1, (int)$items[0]['id']);
+        $this->assertSame($id2, (int)$items[1]['id']);
+        $this->assertSame($id3, (int)$items[2]['id']);
+    }
+
+    public function testItemsReturnsEmptyArrayWhenNone(): void
+    {
+        $this->assertSame([], $this->cl->items('issue', '999'));
+    }
+
+    public function testItemsIsolatedByEntity(): void
+    {
+        $this->cl->addItem('issue', '1', 'A');
+        $this->cl->addItem('issue', '2', 'B');
+
+        $this->assertCount(1, $this->cl->items('issue', '1'));
+        $this->assertCount(1, $this->cl->items('issue', '2'));
+    }
+
+    // ── pending ───────────────────────────────────────────────────────────────
+
+    public function testPendingReturnsOnlyUncompleted(): void
+    {
+        $id1 = $this->cl->addItem('issue', '10', 'Done', 1);
+        $id2 = $this->cl->addItem('issue', '10', 'Todo', 2);
+        $this->cl->check($id1);
+
+        $pending = $this->cl->pending('issue', '10');
+        $this->assertCount(1, $pending);
+        $this->assertSame($id2, (int)$pending[0]['id']);
+    }
+
+    public function testPendingReturnsEmptyWhenAllDone(): void
+    {
+        $id = $this->cl->addItem('issue', '10', 'Done');
+        $this->cl->check($id);
+        $this->assertSame([], $this->cl->pending('issue', '10'));
+    }
+
+    // ── percent ───────────────────────────────────────────────────────────────
+
+    public function testPercentReturnsZeroWhenNoItems(): void
+    {
+        $this->assertSame(0, $this->cl->percent('issue', '99'));
+    }
+
+    public function testPercentAllUncompleted(): void
+    {
+        $this->cl->addItem('issue', '20', 'A');
+        $this->cl->addItem('issue', '20', 'B');
+        $this->assertSame(0, $this->cl->percent('issue', '20'));
+    }
+
+    public function testPercentAllCompleted(): void
+    {
+        $id1 = $this->cl->addItem('issue', '20', 'A');
+        $id2 = $this->cl->addItem('issue', '20', 'B');
+        $this->cl->check($id1);
+        $this->cl->check($id2);
+        $this->assertSame(100, $this->cl->percent('issue', '20'));
+    }
+
+    public function testPercentHalf(): void
+    {
+        $id1 = $this->cl->addItem('issue', '30', 'A');
+        $this->cl->addItem('issue', '30', 'B');
+        $this->cl->check($id1);
+        $this->assertSame(50, $this->cl->percent('issue', '30'));
+    }
+
+    public function testPercentRoundsCorrectly(): void
+    {
+        $id1 = $this->cl->addItem('issue', '40', 'A');
+        $this->cl->addItem('issue', '40', 'B');
+        $this->cl->addItem('issue', '40', 'C');
+        $this->cl->check($id1);
+        // 1/3 = 33.33% → rounds to 33
+        $this->assertSame(33, $this->cl->percent('issue', '40'));
+    }
+}


### PR DESCRIPTION
Ordered checklist items attached to any entity.

## Schema
```sql
CREATE TABLE checklist_items (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    entity_type  VARCHAR(100) NOT NULL,
    entity_id    VARCHAR(255) NOT NULL,
    label        TEXT         NOT NULL,
    position     INTEGER      NOT NULL DEFAULT 0,
    completed    TINYINT(1)   NOT NULL DEFAULT 0,
    completed_at DATETIME     NULL,
    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API
- `addItem(entityType, entityId, label, position=0)` → int
- `check(id)` / `uncheck(id)` → bool
- `updateLabel(id, label)` → bool
- `removeItem(id)` / `clear(entityType, entityId)` → int
- `items()` / `pending()` ordered by position ASC, id ASC
- `percent()` 0–100 rounded

## Tests
27 unit tests, all green. Phan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)