### PR TITLE
feat(xion): Reaction helper (FT178)

### DIFF
--- a/class/xion/Reaction.php
+++ b/class/xion/Reaction.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Reaction — emoji / symbol reactions on any entity.
+ *
+ * Tracks per-user reactions (like, love, thumbs-up, etc.) on arbitrary
+ * resources. Each user may have at most one reaction of a given type on
+ * a given entity; toggling the same reaction removes it.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $r = new Reaction($pdo);
+ *
+ * // Toggle reactions
+ * $r->toggle('post', '42', 'user-1', '👍');  // adds
+ * $r->toggle('post', '42', 'user-1', '👍');  // removes (returns false)
+ *
+ * // Query
+ * $counts = $r->counts('post', '42');          // ['👍' => 3, '❤️' => 1]
+ * $mine   = $r->byUser('post', '42', 'user-1');// ['👍']
+ * $all    = $r->forEntity('post', '42');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE reactions (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     entity_type VARCHAR(100) NOT NULL,
+ *     entity_id   VARCHAR(255) NOT NULL,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     reaction    VARCHAR(64)  NOT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (entity_type, entity_id, user_id, reaction)
+ * );
+ * ```
+ */
+final class Reaction
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Toggle a reaction for a user on an entity.
+     *
+     * If the reaction does not exist it is added and true is returned.
+     * If it already exists it is removed and false is returned.
+     *
+     * @throws \InvalidArgumentException on empty fields.
+     */
+    public function toggle(
+        string $entityType,
+        string $entityId,
+        string $userId,
+        string $reaction
+    ): bool {
+        [$entityType, $entityId, $userId, $reaction] = $this->validate($entityType, $entityId, $userId, $reaction);
+
+        if ($this->has($entityType, $entityId, $userId, $reaction)) {
+            $this->db()->prepare(
+                'DELETE FROM reactions
+                 WHERE entity_type = :type AND entity_id = :eid
+                   AND user_id = :uid AND reaction = :r'
+            )->execute([':type' => $entityType, ':eid' => $entityId, ':uid' => $userId, ':r' => $reaction]);
+            return false;
+        }
+
+        $this->db()->prepare(
+            'INSERT INTO reactions (entity_type, entity_id, user_id, reaction)
+             VALUES (:type, :eid, :uid, :r)'
+        )->execute([':type' => $entityType, ':eid' => $entityId, ':uid' => $userId, ':r' => $reaction]);
+        return true;
+    }
+
+    /**
+     * Add a reaction without toggling (idempotent — no error if already present).
+     */
+    public function add(string $entityType, string $entityId, string $userId, string $reaction): void
+    {
+        [$entityType, $entityId, $userId, $reaction] = $this->validate($entityType, $entityId, $userId, $reaction);
+
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'mysql') {
+            $sql = 'INSERT IGNORE INTO reactions (entity_type, entity_id, user_id, reaction)
+                    VALUES (:type, :eid, :uid, :r)';
+        } else {
+            $sql = 'INSERT OR IGNORE INTO reactions (entity_type, entity_id, user_id, reaction)
+                    VALUES (:type, :eid, :uid, :r)';
+        }
+        $this->db()->prepare($sql)->execute([
+            ':type' => $entityType,
+            ':eid'  => $entityId,
+            ':uid'  => $userId,
+            ':r'    => $reaction,
+        ]);
+    }
+
+    /**
+     * Remove a specific reaction from a user on an entity.
+     *
+     * @return bool True if a row was deleted.
+     */
+    public function remove(string $entityType, string $entityId, string $userId, string $reaction): bool
+    {
+        [$entityType, $entityId, $userId, $reaction] = $this->validate($entityType, $entityId, $userId, $reaction);
+
+        $stmt = $this->db()->prepare(
+            'DELETE FROM reactions
+             WHERE entity_type = :type AND entity_id = :eid
+               AND user_id = :uid AND reaction = :r'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId, ':uid' => $userId, ':r' => $reaction]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Check whether a user has a specific reaction on an entity.
+     */
+    public function has(string $entityType, string $entityId, string $userId, string $reaction): bool
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM reactions
+             WHERE entity_type = :type AND entity_id = :eid
+               AND user_id = :uid AND reaction = :r'
+        );
+        $stmt->execute([
+            ':type' => $entityType,
+            ':eid'  => $entityId,
+            ':uid'  => $userId,
+            ':r'    => $reaction,
+        ]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Get reaction counts grouped by reaction type for an entity.
+     *
+     * @return array<string, int>  e.g. ['👍' => 3, '❤️' => 1]
+     */
+    public function counts(string $entityType, string $entityId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT reaction, COUNT(*) AS cnt
+             FROM reactions
+             WHERE entity_type = :type AND entity_id = :eid
+             GROUP BY reaction
+             ORDER BY cnt DESC, reaction ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        if (!$rows) {
+            return [];
+        }
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(string)$row['reaction']] = (int)$row['cnt'];
+        }
+        return $result;
+    }
+
+    /**
+     * Get the list of reaction types a specific user has on an entity.
+     *
+     * @return list<string>
+     */
+    public function byUser(string $entityType, string $entityId, string $userId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare(
+            'SELECT reaction FROM reactions
+             WHERE entity_type = :type AND entity_id = :eid AND user_id = :uid
+             ORDER BY reaction ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId, ':uid' => $userId]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Get all reaction rows for an entity.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forEntity(string $entityType, string $entityId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, user_id, reaction, created_at
+             FROM reactions
+             WHERE entity_type = :type AND entity_id = :eid
+             ORDER BY created_at ASC, id ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Remove all reactions from all users on an entity.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function clearEntity(string $entityType, string $entityId): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM reactions WHERE entity_type = :type AND entity_id = :eid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Remove all reactions by a user across all entities.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function clearUser(string $userId): int
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare('DELETE FROM reactions WHERE user_id = :uid');
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function validateEntity(string $entityType, string $entityId): array
+    {
+        $entityType = trim($entityType);
+        $entityId   = trim($entityId);
+        if ($entityType === '') {
+            throw new \InvalidArgumentException('entity_type must not be empty.');
+        }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        return [$entityType, $entityId];
+    }
+
+    /**
+     * @return array{string, string, string, string}
+     */
+    private function validate(string $entityType, string $entityId, string $userId, string $reaction): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $userId   = trim($userId);
+        $reaction = trim($reaction);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($reaction === '') {
+            throw new \InvalidArgumentException('reaction must not be empty.');
+        }
+        return [$entityType, $entityId, $userId, $reaction];
+    }
+}

--- a/tests/Unit/Xion/ReactionTest.php
+++ b/tests/Unit/Xion/ReactionTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\Reaction;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ReactionTest extends TestCase
+{
+    private PDO $pdo;
+    private Reaction $r;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE reactions (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type VARCHAR(100) NOT NULL,
+                entity_id   VARCHAR(255) NOT NULL,
+                user_id     VARCHAR(255) NOT NULL,
+                reaction    VARCHAR(64)  NOT NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (entity_type, entity_id, user_id, reaction)
+            )
+        ');
+        $this->r = new Reaction($this->pdo);
+    }
+
+    // ── toggle ────────────────────────────────────────────────────────────────
+
+    public function testToggleAddsReaction(): void
+    {
+        $added = $this->r->toggle('post', '1', 'user-1', '👍');
+        $this->assertTrue($added);
+        $this->assertTrue($this->r->has('post', '1', 'user-1', '👍'));
+    }
+
+    public function testToggleRemovesExistingReaction(): void
+    {
+        $this->r->toggle('post', '1', 'user-1', '👍');
+        $added = $this->r->toggle('post', '1', 'user-1', '👍');
+        $this->assertFalse($added);
+        $this->assertFalse($this->r->has('post', '1', 'user-1', '👍'));
+    }
+
+    public function testToggleDifferentReactionsCoexist(): void
+    {
+        $this->r->toggle('post', '1', 'user-1', '👍');
+        $this->r->toggle('post', '1', 'user-1', '❤️');
+        $this->assertTrue($this->r->has('post', '1', 'user-1', '👍'));
+        $this->assertTrue($this->r->has('post', '1', 'user-1', '❤️'));
+    }
+
+    // ── add ───────────────────────────────────────────────────────────────────
+
+    public function testAddIsIdempotent(): void
+    {
+        $this->r->add('post', '1', 'user-1', '👍');
+        $this->r->add('post', '1', 'user-1', '👍');
+        $counts = $this->r->counts('post', '1');
+        $this->assertSame(1, $counts['👍']);
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesReaction(): void
+    {
+        $this->r->add('post', '1', 'user-1', '👍');
+        $result = $this->r->remove('post', '1', 'user-1', '👍');
+        $this->assertTrue($result);
+        $this->assertFalse($this->r->has('post', '1', 'user-1', '👍'));
+    }
+
+    public function testRemoveReturnsFalseWhenNotFound(): void
+    {
+        $this->assertFalse($this->r->remove('post', '1', 'user-1', '👍'));
+    }
+
+    // ── has ───────────────────────────────────────────────────────────────────
+
+    public function testHasReturnsFalseWhenAbsent(): void
+    {
+        $this->assertFalse($this->r->has('post', '1', 'user-1', '👍'));
+    }
+
+    // ── counts ────────────────────────────────────────────────────────────────
+
+    public function testCountsGroupsByReaction(): void
+    {
+        $this->r->add('post', '1', 'user-1', '👍');
+        $this->r->add('post', '1', 'user-2', '👍');
+        $this->r->add('post', '1', 'user-3', '❤️');
+
+        $counts = $this->r->counts('post', '1');
+        $this->assertSame(2, $counts['👍']);
+        $this->assertSame(1, $counts['❤️']);
+    }
+
+    public function testCountsReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->r->counts('post', '99'));
+    }
+
+    public function testCountsIsolatedByEntity(): void
+    {
+        $this->r->add('post', '1', 'user-1', '👍');
+        $this->r->add('post', '2', 'user-1', '👍');
+
+        $counts1 = $this->r->counts('post', '1');
+        $counts2 = $this->r->counts('post', '2');
+        $this->assertSame(1, $counts1['👍']);
+        $this->assertSame(1, $counts2['👍']);
+    }
+
+    // ── byUser ────────────────────────────────────────────────────────────────
+
+    public function testByUserReturnsUserReactions(): void
+    {
+        $this->r->add('post', '1', 'user-1', '👍');
+        $this->r->add('post', '1', 'user-1', '❤️');
+        $this->r->add('post', '1', 'user-2', '👍');
+
+        $mine = $this->r->byUser('post', '1', 'user-1');
+        sort($mine);
+        $this->assertCount(2, $mine);
+        $this->assertContains('👍', $mine);
+        $this->assertContains('❤️', $mine);
+    }
+
+    public function testByUserReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->r->byUser('post', '1', 'user-99'));
+    }
+
+    // ── forEntity ─────────────────────────────────────────────────────────────
+
+    public function testForEntityReturnsAllRows(): void
+    {
+        $this->r->add('post', '1', 'user-1', '👍');
+        $this->r->add('post', '1', 'user-2', '❤️');
+
+        $rows = $this->r->forEntity('post', '1');
+        $this->assertCount(2, $rows);
+        $this->assertArrayHasKey('user_id', $rows[0]);
+        $this->assertArrayHasKey('reaction', $rows[0]);
+    }
+
+    public function testForEntityReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->r->forEntity('post', '99'));
+    }
+
+    // ── clearEntity ───────────────────────────────────────────────────────────
+
+    public function testClearEntityDeletesAllForEntity(): void
+    {
+        $this->r->add('post', '1', 'user-1', '👍');
+        $this->r->add('post', '1', 'user-2', '👍');
+        $this->r->add('post', '2', 'user-1', '👍');
+
+        $deleted = $this->r->clearEntity('post', '1');
+        $this->assertSame(2, $deleted);
+        $this->assertSame([], $this->r->counts('post', '1'));
+        $this->assertNotEmpty($this->r->counts('post', '2'));
+    }
+
+    public function testClearEntityReturnsZeroWhenNone(): void
+    {
+        $this->assertSame(0, $this->r->clearEntity('post', '99'));
+    }
+
+    // ── clearUser ─────────────────────────────────────────────────────────────
+
+    public function testClearUserDeletesAllForUser(): void
+    {
+        $this->r->add('post', '1', 'user-1', '👍');
+        $this->r->add('post', '2', 'user-1', '❤️');
+        $this->r->add('post', '1', 'user-2', '👍');
+
+        $deleted = $this->r->clearUser('user-1');
+        $this->assertSame(2, $deleted);
+        $this->assertSame([], $this->r->byUser('post', '1', 'user-1'));
+        $this->assertNotEmpty($this->r->byUser('post', '1', 'user-2'));
+    }
+
+    // ── validation ────────────────────────────────────────────────────────────
+
+    public function testToggleThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->toggle('', '1', 'user-1', '👍');
+    }
+
+    public function testToggleThrowsOnEmptyEntityId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->toggle('post', '', 'user-1', '👍');
+    }
+
+    public function testToggleThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->toggle('post', '1', '', '👍');
+    }
+
+    public function testToggleThrowsOnEmptyReaction(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->toggle('post', '1', 'user-1', '');
+    }
+
+    public function testByUserThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->byUser('post', '1', '');
+    }
+
+    public function testClearUserThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->clearUser('');
+    }
+}


### PR DESCRIPTION
Emoji/symbol reactions on any entity.

## Schema
```sql
CREATE TABLE reactions (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    entity_type VARCHAR(100) NOT NULL,
    entity_id   VARCHAR(255) NOT NULL,
    user_id     VARCHAR(255) NOT NULL,
    reaction    VARCHAR(64)  NOT NULL,
    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    UNIQUE (entity_type, entity_id, user_id, reaction)
);
```

## API
- `toggle()` — adds reaction if absent, removes if present
- `add()` — idempotent via INSERT OR IGNORE / INSERT IGNORE
- `remove()` / `has()` → bool
- `counts()` → `array<string, int>` grouped by reaction type
- `byUser()` → `list<string>`
- `forEntity()` → all rows
- `clearEntity()` / `clearUser()` → int rows deleted

## Tests
23 unit tests, all green. CS fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)