### PR TITLE
feat(xion): Mention helper (FT179)

### DIFF
--- a/class/xion/Mention.php
+++ b/class/xion/Mention.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Mention — track @-mentions of users within content items.
+ *
+ * Records which users are mentioned in a given piece of content (post,
+ * comment, document). Supports listing unread mentions per user and
+ * bulk-marking as read.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $m = new Mention($pdo);
+ *
+ * // When saving a comment, record mentions
+ * $m->record('comment', '99', 'author-1', ['user-2', 'user-3']);
+ *
+ * // User inbox
+ * $unread = $m->unreadFor('user-2');
+ * $m->markRead('user-2', array_column($unread, 'id'));
+ *
+ * // Content mentions
+ * $who = $m->mentionedIn('comment', '99');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE mentions (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     entity_type  VARCHAR(100) NOT NULL,
+ *     entity_id    VARCHAR(255) NOT NULL,
+ *     author_id    VARCHAR(255) NOT NULL,
+ *     mentioned_id VARCHAR(255) NOT NULL,
+ *     read_at      DATETIME     NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (entity_type, entity_id, mentioned_id)
+ * );
+ * ```
+ */
+final class Mention
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record mentions for a piece of content.
+     *
+     * Idempotent: re-recording the same mention for an existing (entity, user)
+     * pair is silently ignored so callers can re-save content safely.
+     *
+     * @param  list<string> $mentionedIds  User IDs that were @-mentioned.
+     * @return int Number of new mention rows inserted.
+     * @throws \InvalidArgumentException on empty fields.
+     */
+    public function record(
+        string $entityType,
+        string $entityId,
+        string $authorId,
+        array $mentionedIds
+    ): int {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $authorId = trim($authorId);
+        if ($authorId === '') {
+            throw new \InvalidArgumentException('author_id must not be empty.');
+        }
+        if ($mentionedIds === []) {
+            return 0;
+        }
+
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $ignore = $driver === 'mysql' ? 'INSERT IGNORE' : 'INSERT OR IGNORE';
+
+        $stmt = $this->db()->prepare(
+            "{$ignore} INTO mentions (entity_type, entity_id, author_id, mentioned_id)
+             VALUES (:type, :eid, :author, :mid)"
+        );
+
+        $inserted = 0;
+        foreach ($mentionedIds as $mid) {
+            $mid = trim((string)$mid);
+            if ($mid === '') {
+                continue;
+            }
+            $stmt->execute([
+                ':type'   => $entityType,
+                ':eid'    => $entityId,
+                ':author' => $authorId,
+                ':mid'    => $mid,
+            ]);
+            $inserted += $stmt->rowCount();
+        }
+        return $inserted;
+    }
+
+    /**
+     * List all unread mentions for a user, newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function unreadFor(string $userId, int $limit = 50): array
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, author_id, mentioned_id, read_at, created_at
+             FROM mentions
+             WHERE mentioned_id = :uid AND read_at IS NULL
+             ORDER BY id DESC
+             LIMIT :lim'
+        );
+        $stmt->bindValue(':uid', $userId);
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List all mentions for a user (read and unread), newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function allFor(string $userId, int $limit = 50): array
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, author_id, mentioned_id, read_at, created_at
+             FROM mentions
+             WHERE mentioned_id = :uid
+             ORDER BY id DESC
+             LIMIT :lim'
+        );
+        $stmt->bindValue(':uid', $userId);
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Mark a list of mention IDs as read for a user.
+     *
+     * Only marks rows that belong to the given user.
+     *
+     * @param  list<int> $ids
+     * @return int Number of rows updated.
+     */
+    public function markRead(string $userId, array $ids): int
+    {
+        $userId = trim($userId);
+        if ($userId === '' || $ids === []) {
+            return 0;
+        }
+        $now         = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $stmt        = $this->db()->prepare(
+            "UPDATE mentions SET read_at = ?
+             WHERE mentioned_id = ? AND read_at IS NULL AND id IN ({$placeholders})"
+        );
+        $stmt->execute(array_merge([$now, $userId], array_values($ids)));
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Mark all unread mentions for a user as read.
+     *
+     * @return int Number of rows updated.
+     */
+    public function markAllRead(string $userId): int
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE mentions SET read_at = :now
+             WHERE mentioned_id = :uid AND read_at IS NULL'
+        );
+        $stmt->execute([':now' => $now, ':uid' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Count unread mentions for a user.
+     */
+    public function unreadCount(string $userId): int
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM mentions WHERE mentioned_id = :uid AND read_at IS NULL'
+        );
+        $stmt->execute([':uid' => $userId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * List user IDs mentioned in a piece of content.
+     *
+     * @return list<string>
+     */
+    public function mentionedIn(string $entityType, string $entityId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT mentioned_id FROM mentions
+             WHERE entity_type = :type AND entity_id = :eid
+             ORDER BY id ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Delete all mentions for a piece of content (e.g. when the content is deleted).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function deleteForEntity(string $entityType, string $entityId): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM mentions WHERE entity_type = :type AND entity_id = :eid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function validateEntity(string $entityType, string $entityId): array
+    {
+        $entityType = trim($entityType);
+        $entityId   = trim($entityId);
+        if ($entityType === '') {
+            throw new \InvalidArgumentException('entity_type must not be empty.');
+        }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        return [$entityType, $entityId];
+    }
+}

--- a/tests/Unit/Xion/MentionTest.php
+++ b/tests/Unit/Xion/MentionTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\Mention;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class MentionTest extends TestCase
+{
+    private PDO $pdo;
+    private Mention $m;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE mentions (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type  VARCHAR(100) NOT NULL,
+                entity_id    VARCHAR(255) NOT NULL,
+                author_id    VARCHAR(255) NOT NULL,
+                mentioned_id VARCHAR(255) NOT NULL,
+                read_at      DATETIME     NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (entity_type, entity_id, mentioned_id)
+            )
+        ');
+        $this->m = new Mention($this->pdo);
+    }
+
+    // ── record ────────────────────────────────────────────────────────────────
+
+    public function testRecordInsertsRows(): void
+    {
+        $n = $this->m->record('post', '1', 'author-1', ['user-2', 'user-3']);
+        $this->assertSame(2, $n);
+    }
+
+    public function testRecordIsIdempotent(): void
+    {
+        $this->m->record('post', '1', 'author-1', ['user-2']);
+        $n = $this->m->record('post', '1', 'author-1', ['user-2']);
+        $this->assertSame(0, $n);
+    }
+
+    public function testRecordReturnsZeroForEmptyList(): void
+    {
+        $this->assertSame(0, $this->m->record('post', '1', 'author-1', []));
+    }
+
+    public function testRecordSkipsBlankMentionedIds(): void
+    {
+        $n = $this->m->record('post', '1', 'author-1', ['user-2', '  ', 'user-3']);
+        $this->assertSame(2, $n);
+    }
+
+    public function testRecordThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->m->record('', '1', 'author-1', ['user-2']);
+    }
+
+    public function testRecordThrowsOnEmptyEntityId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->m->record('post', '', 'author-1', ['user-2']);
+    }
+
+    public function testRecordThrowsOnEmptyAuthorId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->m->record('post', '1', '', ['user-2']);
+    }
+
+    // ── unreadFor ─────────────────────────────────────────────────────────────
+
+    public function testUnreadForReturnsNewMentions(): void
+    {
+        $this->m->record('post', '1', 'author-1', ['user-2']);
+        $unread = $this->m->unreadFor('user-2');
+        $this->assertCount(1, $unread);
+        $this->assertNull($unread[0]['read_at']);
+    }
+
+    public function testUnreadForExcludesReadMentions(): void
+    {
+        $this->m->record('post', '1', 'author-1', ['user-2']);
+        $this->m->markAllRead('user-2');
+        $this->assertSame([], $this->m->unreadFor('user-2'));
+    }
+
+    public function testUnreadForReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->m->unreadFor('user-99'));
+    }
+
+    // ── allFor ────────────────────────────────────────────────────────────────
+
+    public function testAllForReturnsBothReadAndUnread(): void
+    {
+        $this->m->record('post', '1', 'author-1', ['user-2']);
+        $this->m->record('post', '2', 'author-1', ['user-2']);
+        $this->m->markAllRead('user-2');
+        $this->m->record('post', '3', 'author-1', ['user-2']);
+
+        $all = $this->m->allFor('user-2');
+        $this->assertCount(3, $all);
+    }
+
+    // ── markRead ──────────────────────────────────────────────────────────────
+
+    public function testMarkReadSetsReadAt(): void
+    {
+        $this->m->record('post', '1', 'author-1', ['user-2']);
+        $unread = $this->m->unreadFor('user-2');
+        $ids    = array_column($unread, 'id');
+
+        $n = $this->m->markRead('user-2', $ids);
+        $this->assertSame(1, $n);
+        $this->assertSame([], $this->m->unreadFor('user-2'));
+    }
+
+    public function testMarkReadOnlyAffectsGivenUser(): void
+    {
+        $this->m->record('post', '1', 'author-1', ['user-2', 'user-3']);
+        $all    = $this->m->unreadFor('user-2');
+        $ids    = array_column($all, 'id');
+
+        $this->m->markRead('user-2', $ids);
+        $this->assertSame(1, $this->m->unreadCount('user-3'));
+    }
+
+    public function testMarkReadReturnsZeroForEmptyIds(): void
+    {
+        $this->assertSame(0, $this->m->markRead('user-2', []));
+    }
+
+    // ── markAllRead ───────────────────────────────────────────────────────────
+
+    public function testMarkAllReadClearsInbox(): void
+    {
+        $this->m->record('post', '1', 'author-1', ['user-2']);
+        $this->m->record('post', '2', 'author-1', ['user-2']);
+        $n = $this->m->markAllRead('user-2');
+        $this->assertSame(2, $n);
+        $this->assertSame(0, $this->m->unreadCount('user-2'));
+    }
+
+    // ── unreadCount ───────────────────────────────────────────────────────────
+
+    public function testUnreadCountIncreasesOnRecord(): void
+    {
+        $this->assertSame(0, $this->m->unreadCount('user-2'));
+        $this->m->record('post', '1', 'author-1', ['user-2']);
+        $this->assertSame(1, $this->m->unreadCount('user-2'));
+        $this->m->record('post', '2', 'author-1', ['user-2']);
+        $this->assertSame(2, $this->m->unreadCount('user-2'));
+    }
+
+    // ── mentionedIn ───────────────────────────────────────────────────────────
+
+    public function testMentionedInListsUsers(): void
+    {
+        $this->m->record('comment', '5', 'author-1', ['user-2', 'user-3']);
+        $who = $this->m->mentionedIn('comment', '5');
+        sort($who);
+        $this->assertSame(['user-2', 'user-3'], $who);
+    }
+
+    public function testMentionedInReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->m->mentionedIn('comment', '99'));
+    }
+
+    // ── deleteForEntity ───────────────────────────────────────────────────────
+
+    public function testDeleteForEntityRemovesRows(): void
+    {
+        $this->m->record('post', '1', 'author-1', ['user-2', 'user-3']);
+        $this->m->record('post', '2', 'author-1', ['user-2']);
+
+        $n = $this->m->deleteForEntity('post', '1');
+        $this->assertSame(2, $n);
+        $this->assertSame([], $this->m->mentionedIn('post', '1'));
+        $this->assertCount(1, $this->m->mentionedIn('post', '2'));
+    }
+
+    public function testDeleteForEntityReturnsZeroWhenNone(): void
+    {
+        $this->assertSame(0, $this->m->deleteForEntity('post', '99'));
+    }
+
+    // ── validation ────────────────────────────────────────────────────────────
+
+    public function testUnreadForThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->m->unreadFor('');
+    }
+
+    public function testUnreadCountThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->m->unreadCount('');
+    }
+
+    public function testMarkAllReadThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->m->markAllRead('');
+    }
+}


### PR DESCRIPTION
Track @-mentions of users within content items.

## Schema
```sql
CREATE TABLE mentions (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    entity_type  VARCHAR(100) NOT NULL,
    entity_id    VARCHAR(255) NOT NULL,
    author_id    VARCHAR(255) NOT NULL,
    mentioned_id VARCHAR(255) NOT NULL,
    read_at      DATETIME     NULL,
    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    UNIQUE (entity_type, entity_id, mentioned_id)
);
```

## API
- `record()` — idempotent via INSERT OR IGNORE / INSERT IGNORE
- `unreadFor()` / `allFor()` — user inbox
- `markRead(ids[])` / `markAllRead()` — mark as read
- `unreadCount()` → int
- `mentionedIn()` → list of mentioned user IDs
- `deleteForEntity()` — cascade when content is deleted

## Tests
23 unit tests, all green. CS fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)