### PR TITLE
feat(xion): Watchlist helper (FT180)

### DIFF
--- a/class/xion/Watchlist.php
+++ b/class/xion/Watchlist.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Watchlist — users subscribe to watch entities for updates.
+ *
+ * Tracks which users are watching which resources (issues, pull requests,
+ * documents, threads, etc.). Useful for notification routing: "notify all
+ * watchers when this entity changes."
+ *
+ * ## Usage
+ *
+ * ```php
+ * $wl = new Watchlist($pdo);
+ *
+ * // Subscribe / unsubscribe
+ * $wl->watch('issue', '42', 'user-1');
+ * $wl->unwatch('issue', '42', 'user-1');
+ *
+ * // Toggle
+ * $watching = $wl->toggle('issue', '42', 'user-2'); // true = now watching
+ *
+ * // Query
+ * $watching = $wl->isWatching('issue', '42', 'user-1'); // false
+ * $watchers = $wl->watchers('issue', '42');
+ * $count    = $wl->watcherCount('issue', '42');
+ * $items    = $wl->watching('user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE watchlist (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     entity_type VARCHAR(100) NOT NULL,
+ *     entity_id   VARCHAR(255) NOT NULL,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     watched_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (entity_type, entity_id, user_id)
+ * );
+ * ```
+ */
+final class Watchlist
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Subscribe a user to watch an entity (idempotent).
+     *
+     * @throws \InvalidArgumentException on empty fields.
+     */
+    public function watch(string $entityType, string $entityId, string $userId): void
+    {
+        [$entityType, $entityId, $userId] = $this->validateAll($entityType, $entityId, $userId);
+
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $ignore = $driver === 'mysql' ? 'INSERT IGNORE' : 'INSERT OR IGNORE';
+
+        $this->db()->prepare(
+            "{$ignore} INTO watchlist (entity_type, entity_id, user_id)
+             VALUES (:type, :eid, :uid)"
+        )->execute([':type' => $entityType, ':eid' => $entityId, ':uid' => $userId]);
+    }
+
+    /**
+     * Unsubscribe a user from watching an entity.
+     *
+     * @return bool True if a row was deleted.
+     */
+    public function unwatch(string $entityType, string $entityId, string $userId): bool
+    {
+        [$entityType, $entityId, $userId] = $this->validateAll($entityType, $entityId, $userId);
+
+        $stmt = $this->db()->prepare(
+            'DELETE FROM watchlist
+             WHERE entity_type = :type AND entity_id = :eid AND user_id = :uid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId, ':uid' => $userId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Toggle watch state for a user on an entity.
+     *
+     * @return bool True if the user is now watching, false if they stopped watching.
+     */
+    public function toggle(string $entityType, string $entityId, string $userId): bool
+    {
+        if ($this->isWatching($entityType, $entityId, $userId)) {
+            $this->unwatch($entityType, $entityId, $userId);
+            return false;
+        }
+        $this->watch($entityType, $entityId, $userId);
+        return true;
+    }
+
+    /**
+     * Check whether a user is watching an entity.
+     */
+    public function isWatching(string $entityType, string $entityId, string $userId): bool
+    {
+        [$entityType, $entityId, $userId] = $this->validateAll($entityType, $entityId, $userId);
+
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM watchlist
+             WHERE entity_type = :type AND entity_id = :eid AND user_id = :uid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId, ':uid' => $userId]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * List all watchers of an entity.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function watchers(string $entityType, string $entityId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, user_id, watched_at
+             FROM watchlist
+             WHERE entity_type = :type AND entity_id = :eid
+             ORDER BY watched_at ASC, id ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Count watchers for an entity.
+     */
+    public function watcherCount(string $entityType, string $entityId): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM watchlist
+             WHERE entity_type = :type AND entity_id = :eid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * List all entities a user is watching.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function watching(string $userId): array
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, user_id, watched_at
+             FROM watchlist
+             WHERE user_id = :uid
+             ORDER BY watched_at DESC, id DESC'
+        );
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List only the user IDs watching an entity.
+     *
+     * @return list<string>
+     */
+    public function watcherIds(string $entityType, string $entityId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT user_id FROM watchlist
+             WHERE entity_type = :type AND entity_id = :eid
+             ORDER BY watched_at ASC, id ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Remove all watchers from an entity (e.g. when the entity is deleted).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function clearEntity(string $entityType, string $entityId): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM watchlist WHERE entity_type = :type AND entity_id = :eid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Remove all watches for a user (e.g. on account deletion).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function clearUser(string $userId): int
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare('DELETE FROM watchlist WHERE user_id = :uid');
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function validateEntity(string $entityType, string $entityId): array
+    {
+        $entityType = trim($entityType);
+        $entityId   = trim($entityId);
+        if ($entityType === '') {
+            throw new \InvalidArgumentException('entity_type must not be empty.');
+        }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        return [$entityType, $entityId];
+    }
+
+    /**
+     * @return array{string, string, string}
+     */
+    private function validateAll(string $entityType, string $entityId, string $userId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        return [$entityType, $entityId, $userId];
+    }
+}

--- a/tests/Unit/Xion/WatchlistTest.php
+++ b/tests/Unit/Xion/WatchlistTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\Watchlist;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class WatchlistTest extends TestCase
+{
+    private PDO $pdo;
+    private Watchlist $wl;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE watchlist (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type VARCHAR(100) NOT NULL,
+                entity_id   VARCHAR(255) NOT NULL,
+                user_id     VARCHAR(255) NOT NULL,
+                watched_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (entity_type, entity_id, user_id)
+            )
+        ');
+        $this->wl = new Watchlist($this->pdo);
+    }
+
+    // ── watch ─────────────────────────────────────────────────────────────────
+
+    public function testWatchSubscribesUser(): void
+    {
+        $this->wl->watch('issue', '42', 'user-1');
+        $this->assertTrue($this->wl->isWatching('issue', '42', 'user-1'));
+    }
+
+    public function testWatchIsIdempotent(): void
+    {
+        $this->wl->watch('issue', '42', 'user-1');
+        $this->wl->watch('issue', '42', 'user-1');
+        $this->assertSame(1, $this->wl->watcherCount('issue', '42'));
+    }
+
+    public function testWatchThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wl->watch('', '1', 'user-1');
+    }
+
+    public function testWatchThrowsOnEmptyEntityId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wl->watch('issue', '', 'user-1');
+    }
+
+    public function testWatchThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wl->watch('issue', '1', '');
+    }
+
+    // ── unwatch ───────────────────────────────────────────────────────────────
+
+    public function testUnwatchRemovesSubscription(): void
+    {
+        $this->wl->watch('issue', '42', 'user-1');
+        $result = $this->wl->unwatch('issue', '42', 'user-1');
+        $this->assertTrue($result);
+        $this->assertFalse($this->wl->isWatching('issue', '42', 'user-1'));
+    }
+
+    public function testUnwatchReturnsFalseWhenNotWatching(): void
+    {
+        $this->assertFalse($this->wl->unwatch('issue', '42', 'user-1'));
+    }
+
+    // ── toggle ────────────────────────────────────────────────────────────────
+
+    public function testToggleAddsWatch(): void
+    {
+        $watching = $this->wl->toggle('issue', '1', 'user-1');
+        $this->assertTrue($watching);
+        $this->assertTrue($this->wl->isWatching('issue', '1', 'user-1'));
+    }
+
+    public function testToggleRemovesWatch(): void
+    {
+        $this->wl->watch('issue', '1', 'user-1');
+        $watching = $this->wl->toggle('issue', '1', 'user-1');
+        $this->assertFalse($watching);
+        $this->assertFalse($this->wl->isWatching('issue', '1', 'user-1'));
+    }
+
+    // ── isWatching ────────────────────────────────────────────────────────────
+
+    public function testIsWatchingReturnsFalseWhenAbsent(): void
+    {
+        $this->assertFalse($this->wl->isWatching('issue', '1', 'user-1'));
+    }
+
+    // ── watchers ──────────────────────────────────────────────────────────────
+
+    public function testWatchersReturnsAllRows(): void
+    {
+        $this->wl->watch('issue', '1', 'user-1');
+        $this->wl->watch('issue', '1', 'user-2');
+
+        $watchers = $this->wl->watchers('issue', '1');
+        $this->assertCount(2, $watchers);
+        $this->assertArrayHasKey('user_id', $watchers[0]);
+    }
+
+    public function testWatchersReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->wl->watchers('issue', '99'));
+    }
+
+    public function testWatchersIsolatedByEntity(): void
+    {
+        $this->wl->watch('issue', '1', 'user-1');
+        $this->wl->watch('issue', '2', 'user-2');
+
+        $this->assertCount(1, $this->wl->watchers('issue', '1'));
+        $this->assertCount(1, $this->wl->watchers('issue', '2'));
+    }
+
+    // ── watcherCount ─────────────────────────────────────────────────────────
+
+    public function testWatcherCountReturnsCorrectNumber(): void
+    {
+        $this->assertSame(0, $this->wl->watcherCount('issue', '1'));
+        $this->wl->watch('issue', '1', 'user-1');
+        $this->assertSame(1, $this->wl->watcherCount('issue', '1'));
+        $this->wl->watch('issue', '1', 'user-2');
+        $this->assertSame(2, $this->wl->watcherCount('issue', '1'));
+    }
+
+    // ── watching ──────────────────────────────────────────────────────────────
+
+    public function testWatchingReturnsUserSubscriptions(): void
+    {
+        $this->wl->watch('issue', '1', 'user-1');
+        $this->wl->watch('issue', '2', 'user-1');
+        $this->wl->watch('issue', '1', 'user-2');
+
+        $items = $this->wl->watching('user-1');
+        $this->assertCount(2, $items);
+    }
+
+    public function testWatchingReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->wl->watching('user-99'));
+    }
+
+    public function testWatchingThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wl->watching('');
+    }
+
+    // ── watcherIds ────────────────────────────────────────────────────────────
+
+    public function testWatcherIdsReturnsUserIdList(): void
+    {
+        $this->wl->watch('issue', '1', 'user-1');
+        $this->wl->watch('issue', '1', 'user-2');
+
+        $ids = $this->wl->watcherIds('issue', '1');
+        sort($ids);
+        $this->assertSame(['user-1', 'user-2'], $ids);
+    }
+
+    // ── clearEntity ───────────────────────────────────────────────────────────
+
+    public function testClearEntityRemovesAllWatchers(): void
+    {
+        $this->wl->watch('issue', '1', 'user-1');
+        $this->wl->watch('issue', '1', 'user-2');
+        $this->wl->watch('issue', '2', 'user-1');
+
+        $n = $this->wl->clearEntity('issue', '1');
+        $this->assertSame(2, $n);
+        $this->assertSame(0, $this->wl->watcherCount('issue', '1'));
+        $this->assertSame(1, $this->wl->watcherCount('issue', '2'));
+    }
+
+    // ── clearUser ─────────────────────────────────────────────────────────────
+
+    public function testClearUserRemovesAllUserWatches(): void
+    {
+        $this->wl->watch('issue', '1', 'user-1');
+        $this->wl->watch('issue', '2', 'user-1');
+        $this->wl->watch('issue', '1', 'user-2');
+
+        $n = $this->wl->clearUser('user-1');
+        $this->assertSame(2, $n);
+        $this->assertSame([], $this->wl->watching('user-1'));
+        $this->assertCount(1, $this->wl->watching('user-2'));
+    }
+
+    public function testClearUserThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wl->clearUser('');
+    }
+}


### PR DESCRIPTION
Users subscribe to watch entities for update notifications.

## Schema
```sql
CREATE TABLE watchlist (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    entity_type VARCHAR(100) NOT NULL,
    entity_id   VARCHAR(255) NOT NULL,
    user_id     VARCHAR(255) NOT NULL,
    watched_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    UNIQUE (entity_type, entity_id, user_id)
);
```

## API
- `watch()` — idempotent subscribe
- `unwatch()` → bool
- `toggle()` → bool (true=now watching)
- `isWatching()` → bool
- `watchers()` / `watcherIds()` / `watcherCount()`
- `watching(userId)` — all entities a user watches
- `clearEntity()` / `clearUser()` → int

## Tests
21 unit tests, all green. CS fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)