### PR TITLE
feat(xion): ContentFilter helper (FT183)

### DIFF
--- a/class/xion/ContentFilter.php
+++ b/class/xion/ContentFilter.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ContentFilter — DB-backed banned word/phrase list with masking.
+ *
+ * Manages a list of banned words or phrases (stored in the database) and
+ * provides text screening and masking utilities. Words are matched
+ * case-insensitively. Whole-word matching can be enabled to avoid false
+ * positives on substrings.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cf = new ContentFilter($pdo);
+ *
+ * // Manage list
+ * $cf->addWord('badword');
+ * $cf->removeWord('badword');
+ *
+ * // Screen text
+ * if ($cf->contains('This has badword in it')) {
+ *     // reject or mask
+ * }
+ * $clean = $cf->mask('This has badword in it');   // 'This has ******* in it'
+ * $words = $cf->detect('This has badword in it'); // ['badword']
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE banned_words (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     word       VARCHAR(255) NOT NULL,
+ *     category   VARCHAR(100) NOT NULL DEFAULT '',
+ *     added_by   VARCHAR(255) NOT NULL DEFAULT '',
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (word)
+ * );
+ * ```
+ */
+final class ContentFilter
+{
+    /** @var list<string>|null */
+    private ?array $cache = null;
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── word management ───────────────────────────────────────────────────────
+
+    /**
+     * Add a banned word/phrase (idempotent).
+     *
+     * @throws \InvalidArgumentException on empty word.
+     */
+    public function addWord(string $word, string $category = '', string $addedBy = ''): void
+    {
+        $word = $this->normalise($word);
+        if ($word === '') {
+            throw new \InvalidArgumentException('word must not be empty.');
+        }
+
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $ignore = $driver === 'mysql' ? 'INSERT IGNORE' : 'INSERT OR IGNORE';
+
+        $this->db()->prepare(
+            "{$ignore} INTO banned_words (word, category, added_by)
+             VALUES (:word, :cat, :by)"
+        )->execute([':word' => $word, ':cat' => trim($category), ':by' => trim($addedBy)]);
+
+        $this->cache = null;
+    }
+
+    /**
+     * Remove a banned word/phrase.
+     *
+     * @return bool True if a row was deleted.
+     */
+    public function removeWord(string $word): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM banned_words WHERE word = :word');
+        $stmt->execute([':word' => $this->normalise($word)]);
+        $this->cache = null;
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List all banned words, optionally filtered by category.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function listWords(?string $category = null): array
+    {
+        if ($category !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT id, word, category, added_by, created_at
+                 FROM banned_words WHERE category = :cat ORDER BY word ASC'
+            );
+            $stmt->execute([':cat' => trim($category)]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT id, word, category, added_by, created_at
+                 FROM banned_words ORDER BY word ASC'
+            );
+            $stmt->execute();
+        }
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return the count of banned words.
+     */
+    public function wordCount(): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM banned_words');
+        $stmt->execute();
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── screening ─────────────────────────────────────────────────────────────
+
+    /**
+     * Return true if the text contains at least one banned word.
+     *
+     * @param bool $wholeWord When true, only match on word boundaries.
+     */
+    public function contains(string $text, bool $wholeWord = false): bool
+    {
+        return $this->detect($text, $wholeWord) !== [];
+    }
+
+    /**
+     * Return all banned words found in the text (deduplicated, ordered).
+     *
+     * @param  bool $wholeWord When true, only match on word boundaries.
+     * @return list<string>
+     */
+    public function detect(string $text, bool $wholeWord = false): array
+    {
+        $words = $this->loadCache();
+        if ($words === []) {
+            return [];
+        }
+        $lowerText = mb_strtolower($text);
+        $found     = [];
+        foreach ($words as $w) {
+            $pattern = $wholeWord ? '/\b' . preg_quote($w, '/') . '\b/iu' : null;
+            if ($pattern !== null ? (bool)preg_match($pattern, $text) : str_contains($lowerText, $w)) {
+                $found[] = $w;
+            }
+        }
+        sort($found);
+        return array_values(array_unique($found));
+    }
+
+    /**
+     * Replace each banned word in the text with asterisks.
+     *
+     * @param  string $char  Replacement character (default '*').
+     * @param  bool   $wholeWord When true, only replace on word boundaries.
+     */
+    public function mask(string $text, string $char = '*', bool $wholeWord = false): string
+    {
+        $words = $this->loadCache();
+        if ($words === []) {
+            return $text;
+        }
+        foreach ($words as $w) {
+            $replacement = str_repeat($char, mb_strlen($w));
+            if ($wholeWord) {
+                $text = preg_replace('/\b' . preg_quote($w, '/') . '\b/iu', $replacement, $text) ?? $text;
+            } else {
+                $text = str_ireplace($w, $replacement, $text);
+            }
+        }
+        return $text;
+    }
+
+    /**
+     * Flush the in-memory word cache (call after bulk changes).
+     */
+    public function flushCache(): void
+    {
+        $this->cache = null;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function normalise(string $word): string
+    {
+        return mb_strtolower(trim($word));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function loadCache(): array
+    {
+        if ($this->cache === null) {
+            $stmt = $this->db()->prepare('SELECT word FROM banned_words ORDER BY LENGTH(word) DESC');
+            $stmt->execute();
+            $this->cache = $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+        }
+        return $this->cache;
+    }
+}

--- a/tests/Unit/Xion/ContentFilterTest.php
+++ b/tests/Unit/Xion/ContentFilterTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\ContentFilter;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ContentFilterTest extends TestCase
+{
+    private PDO $pdo;
+    private ContentFilter $cf;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE banned_words (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                word       VARCHAR(255) NOT NULL,
+                category   VARCHAR(100) NOT NULL DEFAULT \'\',
+                added_by   VARCHAR(255) NOT NULL DEFAULT \'\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (word)
+            )
+        ');
+        $this->cf = new ContentFilter($this->pdo);
+    }
+
+    // ── addWord ───────────────────────────────────────────────────────────────
+
+    public function testAddWordStoresWord(): void
+    {
+        $this->cf->addWord('badword');
+        $this->assertSame(1, $this->cf->wordCount());
+    }
+
+    public function testAddWordNormalisesToLowercase(): void
+    {
+        $this->cf->addWord('BadWord');
+        $words = $this->cf->listWords();
+        $this->assertSame('badword', $words[0]['word']);
+    }
+
+    public function testAddWordIsIdempotent(): void
+    {
+        $this->cf->addWord('badword');
+        $this->cf->addWord('badword');
+        $this->assertSame(1, $this->cf->wordCount());
+    }
+
+    public function testAddWordThrowsOnEmptyWord(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cf->addWord('');
+    }
+
+    public function testAddWordStoresCategory(): void
+    {
+        $this->cf->addWord('spam', 'marketing', 'admin');
+        $words = $this->cf->listWords('marketing');
+        $this->assertCount(1, $words);
+        $this->assertSame('admin', $words[0]['added_by']);
+    }
+
+    // ── removeWord ────────────────────────────────────────────────────────────
+
+    public function testRemoveWordDeletesEntry(): void
+    {
+        $this->cf->addWord('badword');
+        $result = $this->cf->removeWord('badword');
+        $this->assertTrue($result);
+        $this->assertSame(0, $this->cf->wordCount());
+    }
+
+    public function testRemoveWordReturnsFalseWhenAbsent(): void
+    {
+        $this->assertFalse($this->cf->removeWord('nothere'));
+    }
+
+    // ── listWords ─────────────────────────────────────────────────────────────
+
+    public function testListWordsReturnsAll(): void
+    {
+        $this->cf->addWord('alpha');
+        $this->cf->addWord('beta');
+        $words = $this->cf->listWords();
+        $this->assertCount(2, $words);
+    }
+
+    public function testListWordsFiltersByCategory(): void
+    {
+        $this->cf->addWord('spam', 'marketing');
+        $this->cf->addWord('hate', 'abuse');
+        $this->assertCount(1, $this->cf->listWords('marketing'));
+        $this->assertCount(1, $this->cf->listWords('abuse'));
+    }
+
+    // ── contains ──────────────────────────────────────────────────────────────
+
+    public function testContainsReturnsTrueWhenFound(): void
+    {
+        $this->cf->addWord('badword');
+        $this->assertTrue($this->cf->contains('This has badword in it'));
+    }
+
+    public function testContainsReturnsFalseWhenClean(): void
+    {
+        $this->cf->addWord('badword');
+        $this->assertFalse($this->cf->contains('This is perfectly fine'));
+    }
+
+    public function testContainsIsCaseInsensitive(): void
+    {
+        $this->cf->addWord('badword');
+        $this->assertTrue($this->cf->contains('This has BADWORD in it'));
+    }
+
+    public function testContainsReturnsFalseWhenNoBannedWords(): void
+    {
+        $this->assertFalse($this->cf->contains('any text'));
+    }
+
+    // ── detect ────────────────────────────────────────────────────────────────
+
+    public function testDetectReturnsFoundWords(): void
+    {
+        $this->cf->addWord('foo');
+        $this->cf->addWord('bar');
+        $found = $this->cf->detect('This has foo and bar in it');
+        $this->assertSame(['bar', 'foo'], $found);
+    }
+
+    public function testDetectDeduplicates(): void
+    {
+        $this->cf->addWord('foo');
+        $found = $this->cf->detect('foo foo foo');
+        $this->assertSame(['foo'], $found);
+    }
+
+    public function testDetectReturnsEmptyWhenClean(): void
+    {
+        $this->cf->addWord('bad');
+        $this->assertSame([], $this->cf->detect('This is fine'));
+    }
+
+    public function testDetectWholeWordSkipsSubstrings(): void
+    {
+        $this->cf->addWord('ass');
+        // substring match (default)
+        $this->assertTrue($this->cf->contains('class'));
+        // whole-word match should NOT match 'class'
+        $this->assertFalse($this->cf->contains('class', true));
+        $this->assertTrue($this->cf->contains('this ass hurts', true));
+    }
+
+    // ── mask ──────────────────────────────────────────────────────────────────
+
+    public function testMaskReplacesWithAsterisks(): void
+    {
+        $this->cf->addWord('badword');
+        $result = $this->cf->mask('This has badword in it');
+        $this->assertSame('This has ******* in it', $result);
+    }
+
+    public function testMaskIsCaseInsensitive(): void
+    {
+        $this->cf->addWord('badword');
+        $result = $this->cf->mask('This has BADWORD in it');
+        $this->assertSame('This has ******* in it', $result);
+    }
+
+    public function testMaskCustomChar(): void
+    {
+        $this->cf->addWord('bad');
+        $result = $this->cf->mask('so bad', '#');
+        $this->assertSame('so ###', $result);
+    }
+
+    public function testMaskReturnsUnchangedWhenNoBannedWords(): void
+    {
+        $text = 'clean text here';
+        $this->assertSame($text, $this->cf->mask($text));
+    }
+
+    public function testMaskMultipleWords(): void
+    {
+        $this->cf->addWord('foo');
+        $this->cf->addWord('bar');
+        $result = $this->cf->mask('foo and bar');
+        $this->assertSame('*** and ***', $result);
+    }
+
+    // ── cache invalidation ────────────────────────────────────────────────────
+
+    public function testFlushCacheAllowsReload(): void
+    {
+        $this->cf->addWord('alpha');
+        $this->assertTrue($this->cf->contains('alpha'));
+        $this->cf->removeWord('alpha');
+        $this->cf->flushCache();
+        $this->assertFalse($this->cf->contains('alpha'));
+    }
+}


### PR DESCRIPTION
DB-backed banned word/phrase list with text screening and masking.

## Schema
```sql
CREATE TABLE banned_words (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    word       VARCHAR(255) NOT NULL,
    category   VARCHAR(100) NOT NULL DEFAULT '',
    added_by   VARCHAR(255) NOT NULL DEFAULT '',
    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    UNIQUE (word)
);
```

## API
- `addWord(word, category='', addedBy='')` — idempotent, normalises to lowercase
- `removeWord(word)` → bool
- `listWords(?category)` → list, `wordCount()` → int
- `contains(text, wholeWord=false)` → bool
- `detect(text, wholeWord=false)` → list of banned words found (sorted, unique)
- `mask(text, char='*', wholeWord=false)` → masked string
- `flushCache()` — invalidates in-memory word cache

## Tests
23 unit tests, all green. CS fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)