### PR TITLE
feat(xion): Reminder helper (FT184)

### DIFF
--- a/class/xion/Reminder.php
+++ b/class/xion/Reminder.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Reminder — user-set future reminders.
+ *
+ * Stores reminders for users to be triggered at a specified datetime.
+ * Reminders can be attached to an optional target entity (task, event,
+ * issue). The delivery mechanism (email, push, in-app) is outside scope;
+ * this class manages the schedule and sent state.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $rm = new Reminder($pdo);
+ *
+ * // Set a reminder
+ * $id = $rm->set('user-1', 'Review PR #42', '2026-06-01 09:00:00', 'pr', '42');
+ *
+ * // Poll due reminders (e.g. from a cron job)
+ * $due = $rm->due();
+ * foreach ($due as $r) {
+ *     // deliver notification…
+ *     $rm->markSent($r['id']);
+ * }
+ *
+ * // User management
+ * $list = $rm->forUser('user-1');
+ * $rm->cancel($id, 'user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE reminders (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     message     TEXT         NOT NULL,
+ *     remind_at   DATETIME     NOT NULL,
+ *     entity_type VARCHAR(100) NOT NULL DEFAULT '',
+ *     entity_id   VARCHAR(255) NOT NULL DEFAULT '',
+ *     sent        TINYINT(1)   NOT NULL DEFAULT 0,
+ *     sent_at     DATETIME     NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class Reminder
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create a reminder for a user.
+     *
+     * @param  string $remindAt  ISO 8601 datetime string: 'Y-m-d H:i:s'.
+     * @param  string $entityType  Optional: entity type the reminder relates to.
+     * @param  string $entityId    Optional: entity ID the reminder relates to.
+     * @return int Row ID of the new reminder.
+     * @throws \InvalidArgumentException on empty fields.
+     */
+    public function set(
+        string $userId,
+        string $message,
+        string $remindAt,
+        string $entityType = '',
+        string $entityId = ''
+    ): int {
+        $userId  = trim($userId);
+        $message = trim($message);
+        $remindAt = trim($remindAt);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($message === '') {
+            throw new \InvalidArgumentException('message must not be empty.');
+        }
+        if ($remindAt === '') {
+            throw new \InvalidArgumentException('remind_at must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO reminders (user_id, message, remind_at, entity_type, entity_id)
+             VALUES (:uid, :msg, :at, :etype, :eid)'
+        );
+        $stmt->execute([
+            ':uid'   => $userId,
+            ':msg'   => $message,
+            ':at'    => $remindAt,
+            ':etype' => trim($entityType),
+            ':eid'   => trim($entityId),
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Find a reminder by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM reminders WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * List all reminders for a user (unsent first, then by remind_at ASC).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forUser(string $userId, bool $unsentOnly = false): array
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+
+        if ($unsentOnly) {
+            $stmt = $this->db()->prepare(
+                'SELECT id, user_id, message, remind_at, entity_type, entity_id, sent, sent_at, created_at
+                 FROM reminders
+                 WHERE user_id = :uid AND sent = 0
+                 ORDER BY remind_at ASC, id ASC'
+            );
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT id, user_id, message, remind_at, entity_type, entity_id, sent, sent_at, created_at
+                 FROM reminders
+                 WHERE user_id = :uid
+                 ORDER BY sent ASC, remind_at ASC, id ASC'
+            );
+        }
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return all unsent reminders whose remind_at is ≤ now.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function due(?string $asOf = null): array
+    {
+        $now  = $asOf ?? (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, message, remind_at, entity_type, entity_id, sent, sent_at, created_at
+             FROM reminders
+             WHERE sent = 0 AND remind_at <= :now
+             ORDER BY remind_at ASC, id ASC'
+        );
+        $stmt->execute([':now' => $now]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Mark a reminder as sent.
+     *
+     * @return bool True if found and updated.
+     */
+    public function markSent(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE reminders SET sent = 1, sent_at = :now WHERE id = :id AND sent = 0'
+        );
+        $stmt->execute([':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Cancel (delete) a reminder (ownership-enforced).
+     *
+     * @return bool True if found and deleted.
+     */
+    public function cancel(int $id, string $userId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM reminders WHERE id = :id AND user_id = :uid'
+        );
+        $stmt->execute([':id' => $id, ':uid' => trim($userId)]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Cancel all reminders for a user.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function cancelAll(string $userId): int
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        $stmt = $this->db()->prepare('DELETE FROM reminders WHERE user_id = :uid');
+        $stmt->execute([':uid' => $userId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Delete sent reminders older than a given number of days (maintenance).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeSent(int $days): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'DELETE FROM reminders WHERE sent = 1 AND sent_at <= :cutoff'
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/ReminderTest.php
+++ b/tests/Unit/Xion/ReminderTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\Reminder;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ReminderTest extends TestCase
+{
+    private PDO $pdo;
+    private Reminder $rm;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE reminders (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     VARCHAR(255) NOT NULL,
+                message     TEXT         NOT NULL,
+                remind_at   DATETIME     NOT NULL,
+                entity_type VARCHAR(100) NOT NULL DEFAULT \'\',
+                entity_id   VARCHAR(255) NOT NULL DEFAULT \'\',
+                sent        TINYINT(1)   NOT NULL DEFAULT 0,
+                sent_at     DATETIME     NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->rm = new Reminder($this->pdo);
+    }
+
+    private const FUTURE = '2099-12-31 12:00:00';
+    private const PAST   = '2000-01-01 12:00:00';
+
+    // ── set ───────────────────────────────────────────────────────────────────
+
+    public function testSetReturnsId(): void
+    {
+        $id = $this->rm->set('user-1', 'Review PR', self::FUTURE);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testSetStoresFields(): void
+    {
+        $id  = $this->rm->set('user-1', 'Check in', self::FUTURE, 'issue', '42');
+        $row = $this->rm->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['user_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Check in', $row['message']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(self::FUTURE, $row['remind_at']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('issue', $row['entity_type']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('42', $row['entity_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['sent']);
+    }
+
+    public function testSetThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rm->set('', 'msg', self::FUTURE);
+    }
+
+    public function testSetThrowsOnEmptyMessage(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rm->set('user-1', '', self::FUTURE);
+    }
+
+    public function testSetThrowsOnEmptyRemindAt(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rm->set('user-1', 'msg', '');
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->rm->find(9999));
+    }
+
+    // ── forUser ───────────────────────────────────────────────────────────────
+
+    public function testForUserReturnsAllForUser(): void
+    {
+        $this->rm->set('user-1', 'A', self::FUTURE);
+        $this->rm->set('user-1', 'B', self::FUTURE);
+        $this->rm->set('user-2', 'C', self::FUTURE);
+
+        $rows = $this->rm->forUser('user-1');
+        $this->assertCount(2, $rows);
+    }
+
+    public function testForUserUnsentOnlyExcludesSent(): void
+    {
+        $id1 = $this->rm->set('user-1', 'A', self::PAST);
+        $this->rm->set('user-1', 'B', self::FUTURE);
+        $this->rm->markSent($id1);
+
+        $rows = $this->rm->forUser('user-1', true);
+        $this->assertCount(1, $rows);
+        $this->assertSame('B', $rows[0]['message']);
+    }
+
+    public function testForUserThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rm->forUser('');
+    }
+
+    // ── due ───────────────────────────────────────────────────────────────────
+
+    public function testDueReturnsPastUnsentReminders(): void
+    {
+        $this->rm->set('user-1', 'Old', self::PAST);
+        $this->rm->set('user-1', 'Future', self::FUTURE);
+
+        $due = $this->rm->due();
+        $this->assertCount(1, $due);
+        $this->assertSame('Old', $due[0]['message']);
+    }
+
+    public function testDueExcludesSentReminders(): void
+    {
+        $id = $this->rm->set('user-1', 'Old', self::PAST);
+        $this->rm->markSent($id);
+
+        $this->assertSame([], $this->rm->due());
+    }
+
+    public function testDueUsesCustomAsOf(): void
+    {
+        $this->rm->set('user-1', 'In 2026', '2026-06-01 00:00:00');
+        $this->rm->set('user-1', 'In 2030', '2030-01-01 00:00:00');
+
+        $due = $this->rm->due('2027-01-01 00:00:00');
+        $this->assertCount(1, $due);
+        $this->assertSame('In 2026', $due[0]['message']);
+    }
+
+    // ── markSent ──────────────────────────────────────────────────────────────
+
+    public function testMarkSentSetsSentFlag(): void
+    {
+        $id = $this->rm->set('user-1', 'Check', self::PAST);
+        $result = $this->rm->markSent($id);
+        $this->assertTrue($result);
+
+        $row = $this->rm->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['sent']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['sent_at']);
+    }
+
+    public function testMarkSentReturnsFalseForAlreadySent(): void
+    {
+        $id = $this->rm->set('user-1', 'Check', self::PAST);
+        $this->rm->markSent($id);
+        $this->assertFalse($this->rm->markSent($id));
+    }
+
+    public function testMarkSentReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->rm->markSent(9999));
+    }
+
+    // ── cancel ────────────────────────────────────────────────────────────────
+
+    public function testCancelDeletesReminder(): void
+    {
+        $id = $this->rm->set('user-1', 'Cancel me', self::FUTURE);
+        $result = $this->rm->cancel($id, 'user-1');
+        $this->assertTrue($result);
+        $this->assertNull($this->rm->find($id));
+    }
+
+    public function testCancelReturnsFalseForWrongOwner(): void
+    {
+        $id = $this->rm->set('user-1', 'Mine', self::FUTURE);
+        $this->assertFalse($this->rm->cancel($id, 'user-2'));
+    }
+
+    // ── cancelAll ─────────────────────────────────────────────────────────────
+
+    public function testCancelAllRemovesAllForUser(): void
+    {
+        $this->rm->set('user-1', 'A', self::FUTURE);
+        $this->rm->set('user-1', 'B', self::FUTURE);
+        $this->rm->set('user-2', 'C', self::FUTURE);
+
+        $n = $this->rm->cancelAll('user-1');
+        $this->assertSame(2, $n);
+        $this->assertSame([], $this->rm->forUser('user-1'));
+        $this->assertCount(1, $this->rm->forUser('user-2'));
+    }
+
+    public function testCancelAllThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rm->cancelAll('');
+    }
+
+    // ── purgeSent ─────────────────────────────────────────────────────────────
+
+    public function testPurgeSentDeletesOldSentRows(): void
+    {
+        $id = $this->rm->set('user-1', 'Old', self::PAST);
+        $this->rm->markSent($id);
+
+        // purgeSent(0) treats any sent reminder as old enough
+        $n = $this->rm->purgeSent(0);
+        $this->assertGreaterThanOrEqual(1, $n);
+        $this->assertNull($this->rm->find($id));
+    }
+
+    public function testPurgeSentKeepsUnsentRows(): void
+    {
+        $this->rm->set('user-1', 'Unsent', self::FUTURE);
+        $this->rm->purgeSent(0);
+        $this->assertCount(1, $this->rm->forUser('user-1'));
+    }
+}


### PR DESCRIPTION
User-set future reminders with entity attachment and cron-poll support.

## Schema
```sql
CREATE TABLE reminders (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id     VARCHAR(255) NOT NULL,
    message     TEXT         NOT NULL,
    remind_at   DATETIME     NOT NULL,
    entity_type VARCHAR(100) NOT NULL DEFAULT '',
    entity_id   VARCHAR(255) NOT NULL DEFAULT '',
    sent        TINYINT(1)   NOT NULL DEFAULT 0,
    sent_at     DATETIME     NULL,
    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API
- `set(userId, message, remindAt, entityType='', entityId='')` → int
- `find(id)` → `?array`
- `forUser(userId, unsentOnly=false)`
- `due(?asOf)` — unsent reminders ≤ now (cron-poll friendly)
- `markSent(id)` — idempotent guard (WHERE sent=0)
- `cancel(id, userId)` — ownership-enforced
- `cancelAll(userId)` → int
- `purgeSent(days)` → int

## Tests
21 unit tests, all green. CS fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)