### PR TITLE
feat(xion): KnowledgeBase helper (FT185)

### DIFF
--- a/class/xion/KnowledgeBase.php
+++ b/class/xion/KnowledgeBase.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * KnowledgeBase — help articles with categories, lifecycle, and view tracking.
+ *
+ * Manages a simple help center / FAQ article store. Articles have a title,
+ * body, optional category, and a status lifecycle (draft → published →
+ * archived). Published articles can be listed by category or searched by
+ * title/body. View counts are tracked per article.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $kb = new KnowledgeBase($pdo);
+ *
+ * // Create and publish
+ * $id = $kb->create('How to reset password', $body, 'account');
+ * $kb->publish($id);
+ *
+ * // Read
+ * $kb->recordView($id);
+ * $article = $kb->find($id);
+ *
+ * // List
+ * $articles = $kb->published('account');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE kb_articles (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     title        VARCHAR(255) NOT NULL,
+ *     body         TEXT         NOT NULL DEFAULT '',
+ *     category     VARCHAR(100) NOT NULL DEFAULT '',
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'draft',
+ *     author_id    VARCHAR(255) NOT NULL DEFAULT '',
+ *     views        INTEGER      NOT NULL DEFAULT 0,
+ *     published_at DATETIME     NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class KnowledgeBase
+{
+    public const STATUS_DRAFT     = 'draft';
+    public const STATUS_PUBLISHED = 'published';
+    public const STATUS_ARCHIVED  = 'archived';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create a new article in draft status.
+     *
+     * @return int Row ID.
+     * @throws \InvalidArgumentException on empty title.
+     */
+    public function create(string $title, string $body = '', string $category = '', string $authorId = ''): int
+    {
+        $title = trim($title);
+        if ($title === '') {
+            throw new \InvalidArgumentException('title must not be empty.');
+        }
+        $stmt = $this->db()->prepare(
+            'INSERT INTO kb_articles (title, body, category, author_id)
+             VALUES (:title, :body, :cat, :author)'
+        );
+        $stmt->execute([
+            ':title'  => $title,
+            ':body'   => $body,
+            ':cat'    => trim($category),
+            ':author' => trim($authorId),
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Update the title and/or body of an article.
+     *
+     * @return bool True if found and updated.
+     * @throws \InvalidArgumentException on empty title.
+     */
+    public function update(int $id, string $title, string $body): bool
+    {
+        $title = trim($title);
+        if ($title === '') {
+            throw new \InvalidArgumentException('title must not be empty.');
+        }
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE kb_articles SET title = :title, body = :body, updated_at = :now WHERE id = :id'
+        );
+        $stmt->execute([':title' => $title, ':body' => $body, ':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Publish a draft article.
+     *
+     * @return bool True if found and transitioned.
+     */
+    public function publish(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE kb_articles SET status = :pub, published_at = :now, updated_at = :now
+             WHERE id = :id AND status = :draft'
+        );
+        $stmt->execute([
+            ':pub'   => self::STATUS_PUBLISHED,
+            ':now'   => $now,
+            ':id'    => $id,
+            ':draft' => self::STATUS_DRAFT,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Archive a published article.
+     *
+     * @return bool True if found and transitioned.
+     */
+    public function archive(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE kb_articles SET status = :arch, updated_at = :now
+             WHERE id = :id AND status = :pub'
+        );
+        $stmt->execute([
+            ':arch' => self::STATUS_ARCHIVED,
+            ':now'  => $now,
+            ':id'   => $id,
+            ':pub'  => self::STATUS_PUBLISHED,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Restore an archived article back to draft.
+     *
+     * @return bool True if found and transitioned.
+     */
+    public function restore(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE kb_articles SET status = :draft, updated_at = :now
+             WHERE id = :id AND status = :arch'
+        );
+        $stmt->execute([
+            ':draft' => self::STATUS_DRAFT,
+            ':now'   => $now,
+            ':id'    => $id,
+            ':arch'  => self::STATUS_ARCHIVED,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Find an article by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM kb_articles WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * List published articles, optionally filtered by category.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function published(?string $category = null): array
+    {
+        if ($category !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT id, title, body, category, status, author_id, views, published_at, created_at, updated_at
+                 FROM kb_articles
+                 WHERE status = :pub AND category = :cat
+                 ORDER BY published_at DESC, id DESC'
+            );
+            $stmt->execute([':pub' => self::STATUS_PUBLISHED, ':cat' => trim($category)]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT id, title, body, category, status, author_id, views, published_at, created_at, updated_at
+                 FROM kb_articles
+                 WHERE status = :pub
+                 ORDER BY published_at DESC, id DESC'
+            );
+            $stmt->execute([':pub' => self::STATUS_PUBLISHED]);
+        }
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Search published articles by keyword (title or body contains).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function search(string $keyword, int $limit = 20): array
+    {
+        $keyword = trim($keyword);
+        if ($keyword === '') {
+            return [];
+        }
+        $like = '%' . str_replace(['%', '_'], ['\%', '\_'], $keyword) . '%';
+        $stmt = $this->db()->prepare(
+            'SELECT id, title, body, category, status, author_id, views, published_at, created_at, updated_at
+             FROM kb_articles
+             WHERE status = :pub AND (title LIKE :kw OR body LIKE :kw)
+             ORDER BY views DESC, id DESC
+             LIMIT :lim'
+        );
+        $stmt->bindValue(':pub', self::STATUS_PUBLISHED);
+        $stmt->bindValue(':kw', $like);
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Increment the view count for an article.
+     *
+     * @return bool True if found and updated.
+     */
+    public function recordView(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE kb_articles SET views = views + 1 WHERE id = :id'
+        );
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete an article permanently.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM kb_articles WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/KnowledgeBaseTest.php
+++ b/tests/Unit/Xion/KnowledgeBaseTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\KnowledgeBase;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class KnowledgeBaseTest extends TestCase
+{
+    private PDO $pdo;
+    private KnowledgeBase $kb;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE kb_articles (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                title        VARCHAR(255) NOT NULL,
+                body         TEXT         NOT NULL DEFAULT \'\',
+                category     VARCHAR(100) NOT NULL DEFAULT \'\',
+                status       VARCHAR(20)  NOT NULL DEFAULT \'draft\',
+                author_id    VARCHAR(255) NOT NULL DEFAULT \'\',
+                views        INTEGER      NOT NULL DEFAULT 0,
+                published_at DATETIME     NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->kb = new KnowledgeBase($this->pdo);
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsId(): void
+    {
+        $id = $this->kb->create('How to reset password');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testCreateStoresDraftStatus(): void
+    {
+        $id  = $this->kb->create('Title', 'Body', 'account', 'author-1');
+        $row = $this->kb->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(KnowledgeBase::STATUS_DRAFT, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('account', $row['category']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('author-1', $row['author_id']);
+    }
+
+    public function testCreateThrowsOnEmptyTitle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->kb->create('');
+    }
+
+    // ── update ────────────────────────────────────────────────────────────────
+
+    public function testUpdateChangesContent(): void
+    {
+        $id = $this->kb->create('Old', 'Old body');
+        $result = $this->kb->update($id, 'New title', 'New body');
+        $this->assertTrue($result);
+
+        $row = $this->kb->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('New title', $row['title']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('New body', $row['body']);
+    }
+
+    public function testUpdateReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->kb->update(9999, 'Title', 'Body'));
+    }
+
+    public function testUpdateThrowsOnEmptyTitle(): void
+    {
+        $id = $this->kb->create('Title');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->kb->update($id, '', 'Body');
+    }
+
+    // ── publish ───────────────────────────────────────────────────────────────
+
+    public function testPublishTransitionsDraftToPublished(): void
+    {
+        $id = $this->kb->create('Title');
+        $result = $this->kb->publish($id);
+        $this->assertTrue($result);
+
+        $row = $this->kb->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(KnowledgeBase::STATUS_PUBLISHED, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['published_at']);
+    }
+
+    public function testPublishReturnsFalseForAlreadyPublished(): void
+    {
+        $id = $this->kb->create('Title');
+        $this->kb->publish($id);
+        $this->assertFalse($this->kb->publish($id));
+    }
+
+    // ── archive ───────────────────────────────────────────────────────────────
+
+    public function testArchiveTransitionsPublishedToArchived(): void
+    {
+        $id = $this->kb->create('Title');
+        $this->kb->publish($id);
+        $result = $this->kb->archive($id);
+        $this->assertTrue($result);
+
+        $row = $this->kb->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(KnowledgeBase::STATUS_ARCHIVED, $row['status']);
+    }
+
+    public function testArchiveReturnsFalseForDraft(): void
+    {
+        $id = $this->kb->create('Title');
+        $this->assertFalse($this->kb->archive($id));
+    }
+
+    // ── restore ───────────────────────────────────────────────────────────────
+
+    public function testRestoreTransitionsArchivedToDraft(): void
+    {
+        $id = $this->kb->create('Title');
+        $this->kb->publish($id);
+        $this->kb->archive($id);
+        $result = $this->kb->restore($id);
+        $this->assertTrue($result);
+
+        $row = $this->kb->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(KnowledgeBase::STATUS_DRAFT, $row['status']);
+    }
+
+    public function testRestoreReturnsFalseForPublished(): void
+    {
+        $id = $this->kb->create('Title');
+        $this->kb->publish($id);
+        $this->assertFalse($this->kb->restore($id));
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->kb->find(9999));
+    }
+
+    // ── published ─────────────────────────────────────────────────────────────
+
+    public function testPublishedReturnsOnlyPublishedArticles(): void
+    {
+        $id1 = $this->kb->create('Published');
+        $this->kb->publish($id1);
+        $this->kb->create('Draft');
+
+        $rows = $this->kb->published();
+        $this->assertCount(1, $rows);
+        $this->assertSame('Published', $rows[0]['title']);
+    }
+
+    public function testPublishedFiltersByCategory(): void
+    {
+        $id1 = $this->kb->create('A', '', 'account');
+        $id2 = $this->kb->create('B', '', 'billing');
+        $this->kb->publish($id1);
+        $this->kb->publish($id2);
+
+        $rows = $this->kb->published('account');
+        $this->assertCount(1, $rows);
+        $this->assertSame('A', $rows[0]['title']);
+    }
+
+    public function testPublishedExcludesArchived(): void
+    {
+        $id = $this->kb->create('Article');
+        $this->kb->publish($id);
+        $this->kb->archive($id);
+        $this->assertSame([], $this->kb->published());
+    }
+
+    // ── search ────────────────────────────────────────────────────────────────
+
+    public function testSearchFindsPublishedByTitle(): void
+    {
+        $id = $this->kb->create('How to reset password', 'Step 1: click reset.');
+        $this->kb->publish($id);
+
+        $results = $this->kb->search('reset');
+        $this->assertCount(1, $results);
+    }
+
+    public function testSearchFindsPublishedByBody(): void
+    {
+        $id = $this->kb->create('Account help', 'To change your email address...');
+        $this->kb->publish($id);
+
+        $results = $this->kb->search('email address');
+        $this->assertCount(1, $results);
+    }
+
+    public function testSearchExcludesDrafts(): void
+    {
+        $this->kb->create('Draft about searching');
+        $this->assertSame([], $this->kb->search('searching'));
+    }
+
+    public function testSearchReturnsEmptyForBlankKeyword(): void
+    {
+        $this->assertSame([], $this->kb->search(''));
+    }
+
+    // ── recordView ────────────────────────────────────────────────────────────
+
+    public function testRecordViewIncrementsCounter(): void
+    {
+        $id = $this->kb->create('Title');
+        $this->kb->recordView($id);
+        $this->kb->recordView($id);
+
+        $row = $this->kb->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(2, (int)$row['views']);
+    }
+
+    public function testRecordViewReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->kb->recordView(9999));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesArticle(): void
+    {
+        $id = $this->kb->create('Title');
+        $result = $this->kb->delete($id);
+        $this->assertTrue($result);
+        $this->assertNull($this->kb->find($id));
+    }
+
+    public function testDeleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->kb->delete(9999));
+    }
+}


### PR DESCRIPTION
Help articles / FAQ store with lifecycle and keyword search.

## Schema
```sql
CREATE TABLE kb_articles (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    title        VARCHAR(255) NOT NULL,
    body         TEXT         NOT NULL DEFAULT '',
    category     VARCHAR(100) NOT NULL DEFAULT '',
    status       VARCHAR(20)  NOT NULL DEFAULT 'draft',
    author_id    VARCHAR(255) NOT NULL DEFAULT '',
    views        INTEGER      NOT NULL DEFAULT 0,
    published_at DATETIME     NULL,
    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API
- `create()` — creates in draft status
- `update(id, title, body)` → bool
- `publish()` → bool (draft→published, sets published_at)
- `archive()` → bool (published→archived)
- `restore()` → bool (archived→draft)
- `find(id)` → `?array`
- `published(?category)` — list of published articles
- `search(keyword)` — LIKE search on title/body, published only
- `recordView(id)` — increments view counter
- `delete(id)` → bool

## Tests
24 unit tests, all green. CS fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)