### PR TITLE
docs: update candidates, todo, and roadmap to reflect FT176–FT185 completion

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -14,7 +14,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ## Active candidates
 
-The Xion helper wave (FT78–FT175) is complete as of 2026-05-27. No immediate Xion-class candidates remain. Trigger-based and structural candidates are listed in the next section.
+The Xion helper wave (FT78–FT185) is ongoing as of 2026-05-27. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -54,6 +54,16 @@ The Xion helper wave (FT78–FT175) is complete as of 2026-05-27. No immediate X
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT185 — KnowledgeBase** (2026-05-27): `Nene\Xion\KnowledgeBase` — help articles with draft→published→archived lifecycle, category filter, keyword search, view tracking. PR #622.
+- **FT184 — Reminder** (2026-05-27): `Nene\Xion\Reminder` — user-set future reminders; due() for cron-poll; markSent; purgeSent. PR #621.
+- **FT183 — ContentFilter** (2026-05-27): `Nene\Xion\ContentFilter` — DB-backed banned word list with detect/mask and optional whole-word mode; in-memory cache. PR #620.
+- **FT182 — SavedSearch** (2026-05-27): `Nene\Xion\SavedSearch` — per-user named search queries with upsert, usage tracking, and scope filtering. PR #619.
+- **FT181 — Attachment** (2026-05-27): `Nene\Xion\Attachment` — file attachment metadata linked to any entity; totalBytes; forUser. PR #618.
+- **FT180 — Watchlist** (2026-05-27): `Nene\Xion\Watchlist` — entity watch subscriptions; toggle; watcherIds; watching(userId). PR #617.
+- **FT179 — Mention** (2026-05-27): `Nene\Xion\Mention` — @-mention tracking with unread inbox, markRead, unreadCount, mentionedIn. PR #616.
+- **FT178 — Reaction** (2026-05-27): `Nene\Xion\Reaction` — emoji/symbol reactions per user; toggle; counts() grouped by type. PR #615.
+- **FT177 — Checklist** (2026-05-27): `Nene\Xion\Checklist` — ordered checklist items on any entity; check/uncheck; percent(). PR #614.
+- **FT176 — Label** (2026-05-27): `Nene\Xion\Label` — two-table colored label system; idempotent attach/detach; forEntity/entitiesWithLabel. PR #613.
 - **FT175 — UserNote** (2026-05-27): `Nene\Xion\UserNote` — admin/staff notes attached to user records with pinning. PR #611.
 - **FT174 — ScheduledTask** (2026-05-27): `Nene\Xion\ScheduledTask` — cron-style task schedule registry with last-run tracking and due() query. PR #610.
 - **FT173 — GuestSession** (2026-05-27): `Nene\Xion\GuestSession` — anonymous visitor session with key-value data bag; login promotion via linkUser(). PR #609.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT175 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT185 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 
@@ -236,6 +236,7 @@ Completed (wave summary):
 - **FT78–FT140**: Xion helper wave. 63 trials covering social, content moderation, analytics, SaaS infrastructure, A/B testing, event sourcing, and more. PRs #512–#574.
 - **FT141–FT165**: Xion extended wave. 25 trials covering config store, cache, user groups, chat, shopping cart, cron log, export jobs, IP blocklist, content versioning, alert rules, announcements, magic links, slug registry, email queue, document locks, API usage log, OAuth tokens, user activity, email templates, batch jobs, service accounts, change logs, push subscriptions, counter metrics, and file chunk uploads. PRs #576–#600.
 - **FT166–FT175**: Xion second extended wave. 10 trials covering plan-based quota management, shareable links with password/expiry, approval workflows, team membership with roles, fraud/trust scoring, payment records, PIN/OTP codes, anonymous guest sessions, cron-style task scheduling, and admin user notes. PRs #602–#611.
+- **FT176–FT185**: Xion third extended wave. 10 trials covering colored labels, ordered checklists, emoji reactions, @-mention tracking, watchlists, file attachments, saved searches, content filtering, user reminders, and knowledge base articles. PRs #613–#622.
 
 Future candidates:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,24 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT175 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is complete — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT185 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-27 — FT176–FT185: Xion third extended wave (10 trials)
+
+Continuous wave of 10 field trials adding further Xion helper patterns. All PRs #613–#622.
+
+**FT176 — Label**: `Label` two-table colored label system (labels + assignments); idempotent attach/detach; forEntity/entitiesWithLabel. PR #613.
+**FT177 — Checklist**: `Checklist` ordered checklist items on any entity; check/uncheck; percent() 0–100; pending() filter. PR #614.
+**FT178 — Reaction**: `Reaction` emoji/symbol reactions per user per entity; toggle (add/remove); counts() grouped by type. PR #615.
+**FT179 — Mention**: `Mention` @-mention tracking with unread inbox, markRead, unreadCount, mentionedIn. PR #616.
+**FT180 — Watchlist**: `Watchlist` entity watch subscriptions; toggle; watcherIds(); watching(userId) for notification routing. PR #617.
+**FT181 — Attachment**: `Attachment` file attachment metadata linked to any entity; totalBytes(); forUser(). PR #618.
+**FT182 — SavedSearch**: `SavedSearch` per-user named search queries with upsert, usage tracking, and scope filtering. PR #619.
+**FT183 — ContentFilter**: `ContentFilter` DB-backed banned word list; detect/mask with optional whole-word mode; in-memory cache. PR #620.
+**FT184 — Reminder**: `Reminder` user-set future reminders; due() for cron-poll; markSent; purgeSent. PR #621.
+**FT185 — KnowledgeBase**: `KnowledgeBase` help articles with draft→published→archived lifecycle; search; recordView. PR #622.
 
 ### 2026-05-27 — FT166–FT175: Xion second extended wave (10 trials)
 


### PR DESCRIPTION
Update documentation to record the FT176–FT185 Xion third extended wave.

## Changes
- `docs/roadmap.md`: Phase 7 status updated to FT1–FT185; wave summary added
- `docs/field-trials/candidates.md`: active section updated; FT176–FT185 entries added to archive trail
- `docs/todo/current.md`: Active section updated to FT1–FT185; FT176–FT185 wave block added to Recently Completed

## Trials covered
FT176 Label · FT177 Checklist · FT178 Reaction · FT179 Mention · FT180 Watchlist · FT181 Attachment · FT182 SavedSearch · FT183 ContentFilter · FT184 Reminder · FT185 KnowledgeBase

PRs #613–#622.

🤖 Generated with [Claude Code](https://claude.com/claude-code)