### PR TITLE
feat(xion): add SystemSetting helper (FT191)

### DIFF
--- a/class/xion/SystemSetting.php
+++ b/class/xion/SystemSetting.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * SystemSetting — typed global application settings store.
+ *
+ * Stores admin-controlled application-wide key-value settings with optional
+ * type casting (string, int, bool, json) and category grouping.
+ * Distinct from ConfigStore (entity-scoped) and UserPreference (user-scoped).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ss = new SystemSetting($pdo);
+ *
+ * $ss->set('site.name', 'My App');
+ * $ss->set('max_upload_mb', '50', 'int', 'upload');
+ * $ss->set('maintenance', '0', 'bool');
+ * $ss->set('allowed_mimes', '["image/png","image/jpeg"]', 'json', 'upload');
+ *
+ * echo $ss->getString('site.name');   // 'My App'
+ * echo $ss->getInt('max_upload_mb'); // 50
+ * echo $ss->getBool('maintenance') ? 'down' : 'up';
+ * print_r($ss->getJson('allowed_mimes'));
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE system_settings (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     key        VARCHAR(100) NOT NULL UNIQUE,
+ *     value      TEXT         NULL,
+ *     type       VARCHAR(10)  NOT NULL DEFAULT 'string',
+ *     category   VARCHAR(100) NOT NULL DEFAULT 'general',
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class SystemSetting
+{
+    public const TYPE_STRING = 'string';
+    public const TYPE_INT    = 'int';
+    public const TYPE_BOOL   = 'bool';
+    public const TYPE_JSON   = 'json';
+
+    private const ALLOWED_TYPES = [self::TYPE_STRING, self::TYPE_INT, self::TYPE_BOOL, self::TYPE_JSON];
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create or update a setting.
+     *
+     * @throws \InvalidArgumentException on empty key or unknown type.
+     */
+    public function set(string $key, ?string $value, string $type = self::TYPE_STRING, string $category = 'general'): void
+    {
+        $key = trim($key);
+        if ($key === '') {
+            throw new \InvalidArgumentException('key must not be empty.');
+        }
+        if (!in_array($type, self::ALLOWED_TYPES, true)) {
+            throw new \InvalidArgumentException("Unknown type '{$type}'. Must be one of: " . implode(', ', self::ALLOWED_TYPES));
+        }
+        $category = trim($category) === '' ? 'general' : trim($category);
+        $now      = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $sql = 'INSERT INTO system_settings (key, value, type, category, updated_at)
+                    VALUES (:key, :val, :type, :cat, :now)
+                    ON CONFLICT (key) DO UPDATE SET value = excluded.value,
+                        type = excluded.type, category = excluded.category, updated_at = excluded.updated_at';
+        } else {
+            $sql = 'INSERT INTO system_settings (key, value, type, category, updated_at)
+                    VALUES (:key, :val, :type, :cat, :now)
+                    ON DUPLICATE KEY UPDATE value = VALUES(value),
+                        type = VALUES(type), category = VALUES(category), updated_at = VALUES(updated_at)';
+        }
+        $stmt = $this->db()->prepare($sql);
+        $stmt->execute([':key' => $key, ':val' => $value, ':type' => $type, ':cat' => $category, ':now' => $now]);
+    }
+
+    /**
+     * Get the raw stored value, cast by type; returns default when missing.
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $row = $this->findRow($key);
+        if ($row === null) {
+            return $default;
+        }
+        return $this->cast((string)$row['value'], (string)$row['type']);
+    }
+
+    /**
+     * Get as string.
+     */
+    public function getString(string $key, string $default = ''): string
+    {
+        $row = $this->findRow($key);
+        if ($row === null || $row['value'] === null) {
+            return $default;
+        }
+        return (string)$row['value'];
+    }
+
+    /**
+     * Get as int.
+     */
+    public function getInt(string $key, int $default = 0): int
+    {
+        $row = $this->findRow($key);
+        if ($row === null || $row['value'] === null) {
+            return $default;
+        }
+        return (int)$row['value'];
+    }
+
+    /**
+     * Get as bool. Truthy: "1", "true", "yes", "on" (case-insensitive).
+     */
+    public function getBool(string $key, bool $default = false): bool
+    {
+        $row = $this->findRow($key);
+        if ($row === null || $row['value'] === null) {
+            return $default;
+        }
+        return $this->parseBool((string)$row['value']);
+    }
+
+    /**
+     * Get as decoded JSON array (empty array on missing or null).
+     *
+     * @return array<mixed>
+     */
+    public function getJson(string $key, array $default = []): array
+    {
+        $row = $this->findRow($key);
+        if ($row === null || $row['value'] === null) {
+            return $default;
+        }
+        $decoded = json_decode((string)$row['value'], true);
+        return is_array($decoded) ? $decoded : $default;
+    }
+
+    /**
+     * Delete a setting. Returns true if found and removed.
+     */
+    public function delete(string $key): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM system_settings WHERE key = :key');
+        $stmt->execute([':key' => trim($key)]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Return all settings for a given category, ordered by key.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function allForCategory(string $category): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, key, value, type, category, updated_at
+             FROM system_settings WHERE category = :cat ORDER BY key ASC'
+        );
+        $stmt->execute([':cat' => $category]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return all settings ordered by category, then key.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function all(): array
+    {
+        $stmt = $this->db()->query(
+            'SELECT id, key, value, type, category, updated_at
+             FROM system_settings ORDER BY category ASC, key ASC'
+        );
+        if ($stmt === false) {
+            return [];
+        }
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    // ── internal helpers ──────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function findRow(string $key): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT value, type FROM system_settings WHERE key = :key'
+        );
+        $stmt->execute([':key' => trim($key)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row === false ? null : $row;
+    }
+
+    private function cast(string $value, string $type): mixed
+    {
+        return match ($type) {
+            self::TYPE_INT  => (int)$value,
+            self::TYPE_BOOL => $this->parseBool($value),
+            self::TYPE_JSON => is_array($decoded = json_decode($value, true)) ? $decoded : [],
+            default         => $value,
+        };
+    }
+
+    private function parseBool(string $value): bool
+    {
+        return in_array(strtolower($value), ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/tests/Unit/Xion/SystemSettingTest.php
+++ b/tests/Unit/Xion/SystemSettingTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\SystemSetting;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class SystemSettingTest extends TestCase
+{
+    private PDO $pdo;
+    private SystemSetting $ss;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE system_settings (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                key        VARCHAR(100) NOT NULL UNIQUE,
+                value      TEXT         NULL,
+                type       VARCHAR(10)  NOT NULL DEFAULT \'string\',
+                category   VARCHAR(100) NOT NULL DEFAULT \'general\',
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->ss = new SystemSetting($this->pdo);
+    }
+
+    // ── set / get ─────────────────────────────────────────────────────────────
+
+    public function testSetAndGetString(): void
+    {
+        $this->ss->set('site.name', 'My App');
+        $this->assertSame('My App', $this->ss->getString('site.name'));
+    }
+
+    public function testSetAndGetInt(): void
+    {
+        $this->ss->set('max_upload', '50', 'int');
+        $this->assertSame(50, $this->ss->getInt('max_upload'));
+    }
+
+    public function testSetAndGetBoolTrue(): void
+    {
+        foreach (['1', 'true', 'yes', 'on', 'TRUE', 'YES'] as $v) {
+            $this->ss->set('flag', $v, 'bool');
+            $this->assertTrue($this->ss->getBool('flag'), "Expected true for value '{$v}'");
+        }
+    }
+
+    public function testSetAndGetBoolFalse(): void
+    {
+        foreach (['0', 'false', 'no', 'off'] as $v) {
+            $this->ss->set('flag', $v, 'bool');
+            $this->assertFalse($this->ss->getBool('flag'), "Expected false for value '{$v}'");
+        }
+    }
+
+    public function testSetAndGetJson(): void
+    {
+        $this->ss->set('mimes', '["image/png","image/jpeg"]', 'json');
+        $this->assertSame(['image/png', 'image/jpeg'], $this->ss->getJson('mimes'));
+    }
+
+    public function testGetReturnsNullDefaultForMissing(): void
+    {
+        $this->assertNull($this->ss->get('missing'));
+    }
+
+    public function testGetStringReturnsDefaultForMissing(): void
+    {
+        $this->assertSame('default', $this->ss->getString('missing', 'default'));
+    }
+
+    public function testGetIntReturnsDefaultForMissing(): void
+    {
+        $this->assertSame(42, $this->ss->getInt('missing', 42));
+    }
+
+    public function testGetBoolReturnsDefaultForMissing(): void
+    {
+        $this->assertTrue($this->ss->getBool('missing', true));
+    }
+
+    public function testGetJsonReturnsDefaultForMissing(): void
+    {
+        $this->assertSame(['fallback'], $this->ss->getJson('missing', ['fallback']));
+    }
+
+    // ── upsert ────────────────────────────────────────────────────────────────
+
+    public function testSetIsIdempotentUpsert(): void
+    {
+        $this->ss->set('key', 'first');
+        $this->ss->set('key', 'second');
+        $this->assertSame('second', $this->ss->getString('key'));
+
+        $rows = $this->ss->all();
+        $this->assertCount(1, $rows);
+    }
+
+    public function testSetUpdatesTypeOnUpsert(): void
+    {
+        $this->ss->set('count', '5', 'string');
+        $this->ss->set('count', '10', 'int');
+        $this->assertSame(10, $this->ss->getInt('count'));
+    }
+
+    // ── validation ────────────────────────────────────────────────────────────
+
+    public function testSetThrowsOnEmptyKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ss->set('', 'value');
+    }
+
+    public function testSetThrowsOnUnknownType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ss->set('key', 'value', 'float');
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesSetting(): void
+    {
+        $this->ss->set('temp', 'x');
+        $result = $this->ss->delete('temp');
+        $this->assertTrue($result);
+        $this->assertSame('', $this->ss->getString('temp'));
+    }
+
+    public function testDeleteReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->ss->delete('missing'));
+    }
+
+    // ── allForCategory ────────────────────────────────────────────────────────
+
+    public function testAllForCategoryFiltersCorrectly(): void
+    {
+        $this->ss->set('upload.max', '50', 'int', 'upload');
+        $this->ss->set('upload.types', '["png"]', 'json', 'upload');
+        $this->ss->set('site.name', 'App', 'string', 'general');
+
+        $rows = $this->ss->allForCategory('upload');
+        $this->assertCount(2, $rows);
+    }
+
+    public function testAllForCategoryReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->ss->allForCategory('nonexistent'));
+    }
+
+    // ── all ───────────────────────────────────────────────────────────────────
+
+    public function testAllReturnsAllSettings(): void
+    {
+        $this->ss->set('a', '1', 'string', 'cat1');
+        $this->ss->set('b', '2', 'string', 'cat2');
+        $this->ss->set('c', '3', 'string', 'cat1');
+
+        $rows = $this->ss->all();
+        $this->assertCount(3, $rows);
+    }
+
+    public function testAllReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->ss->all());
+    }
+
+    // ── get() cast dispatch ───────────────────────────────────────────────────
+
+    public function testGetCastsIntType(): void
+    {
+        $this->ss->set('n', '7', 'int');
+        $result = $this->ss->get('n');
+        $this->assertSame(7, $result);
+    }
+
+    public function testGetCastsBoolType(): void
+    {
+        $this->ss->set('b', '1', 'bool');
+        $this->assertTrue($this->ss->get('b'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\SystemSetting` — typed global application settings store with categories.

Distinct from `ConfigStore` (entity-scoped) and `UserPreference` (user-scoped). This is admin-controlled application-wide settings with type casting.

## Schema

```sql
CREATE TABLE system_settings (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    key        VARCHAR(100) NOT NULL UNIQUE,
    value      TEXT         NULL,
    type       VARCHAR(10)  NOT NULL DEFAULT 'string',
    category   VARCHAR(100) NOT NULL DEFAULT 'general',
    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API

- `set(key, value, type, category)` — upsert (cross-driver)
- `get(key, default)` — returns cast value by stored type
- `getString/getInt/getBool/getJson` — typed getters with defaults
- `delete(key)` — remove setting
- `allForCategory(category)` — filter by category
- `all()` — all settings ordered by category, key

## Tests

22 tests, 32 assertions — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)