### PR TITLE
feat(xion): add MediaGallery helper (FT192)

### DIFF
--- a/class/xion/MediaGallery.php
+++ b/class/xion/MediaGallery.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * MediaGallery — ordered media item gallery attached to any entity.
+ *
+ * Manages ordered image/media galleries per entity with explicit position,
+ * captions, and a cover item designation. Physical storage is outside scope;
+ * this class records only metadata (storage key + caption + position).
+ *
+ * Distinct from Attachment (unordered, generic files). Gallery items have
+ * deliberate ordering and a single cover image per entity.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $gallery = new MediaGallery($pdo);
+ *
+ * $id1 = $gallery->addItem('post', '10', 's3://bucket/a.jpg', 'Main photo', 1);
+ * $id2 = $gallery->addItem('post', '10', 's3://bucket/b.jpg', 'Side view', 2);
+ *
+ * $gallery->setCover($id1);
+ * $cover = $gallery->getCover('post', '10');
+ * $items = $gallery->items('post', '10');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE gallery_items (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     entity_type  VARCHAR(100) NOT NULL,
+ *     entity_id    VARCHAR(255) NOT NULL,
+ *     storage_key  TEXT         NOT NULL,
+ *     caption      TEXT         NULL,
+ *     position     INTEGER      NOT NULL DEFAULT 0,
+ *     is_cover     TINYINT(1)   NOT NULL DEFAULT 0,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class MediaGallery
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add a media item to the gallery.
+     *
+     * @return int Row ID of the new item.
+     * @throws \InvalidArgumentException on empty entity type/id or storage key.
+     */
+    public function addItem(
+        string $entityType,
+        string $entityId,
+        string $storageKey,
+        ?string $caption = null,
+        int $position = 0
+    ): int {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $storageKey = trim($storageKey);
+        if ($storageKey === '') {
+            throw new \InvalidArgumentException('storage_key must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO gallery_items (entity_type, entity_id, storage_key, caption, position)
+             VALUES (:type, :eid, :key, :caption, :pos)'
+        );
+        $stmt->execute([
+            ':type'    => $entityType,
+            ':eid'     => $entityId,
+            ':key'     => $storageKey,
+            ':caption' => $caption,
+            ':pos'     => $position,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Remove a gallery item.
+     * If the removed item was the cover, no other item is auto-promoted.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function removeItem(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM gallery_items WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Set an item as the cover for its entity; clears the previous cover.
+     *
+     * @return bool True if the item was found and updated.
+     */
+    public function setCover(int $id): bool
+    {
+        $row = $this->findRow($id);
+        if ($row === null) {
+            return false;
+        }
+
+        // Clear all covers for this entity, then set the new one.
+        $clearStmt = $this->db()->prepare(
+            'UPDATE gallery_items SET is_cover = 0
+             WHERE entity_type = :type AND entity_id = :eid'
+        );
+        $clearStmt->execute([':type' => $row['entity_type'], ':eid' => $row['entity_id']]);
+
+        $setStmt = $this->db()->prepare('UPDATE gallery_items SET is_cover = 1 WHERE id = :id');
+        $setStmt->execute([':id' => $id]);
+        return $setStmt->rowCount() > 0;
+    }
+
+    /**
+     * Return the current cover item for an entity, or null if none.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function getCover(string $entityType, string $entityId): ?array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, storage_key, caption, position, is_cover, created_at
+             FROM gallery_items
+             WHERE entity_type = :type AND entity_id = :eid AND is_cover = 1
+             LIMIT 1'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * Update the caption of an item.
+     *
+     * @return bool True if found and updated.
+     */
+    public function updateCaption(int $id, ?string $caption): bool
+    {
+        $stmt = $this->db()->prepare('UPDATE gallery_items SET caption = :caption WHERE id = :id');
+        $stmt->execute([':caption' => $caption, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Change the display position of an item.
+     *
+     * @return bool True if found and updated.
+     */
+    public function reorder(int $id, int $position): bool
+    {
+        $stmt = $this->db()->prepare('UPDATE gallery_items SET position = :pos WHERE id = :id');
+        $stmt->execute([':pos' => $position, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List all gallery items for an entity, ordered by position then id.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function items(string $entityType, string $entityId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id, storage_key, caption, position, is_cover, created_at
+             FROM gallery_items
+             WHERE entity_type = :type AND entity_id = :eid
+             ORDER BY position ASC, id ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Delete all gallery items for an entity.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function clear(string $entityType, string $entityId): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM gallery_items WHERE entity_type = :type AND entity_id = :eid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Return the number of gallery items for an entity.
+     */
+    public function count(string $entityType, string $entityId): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM gallery_items WHERE entity_type = :type AND entity_id = :eid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── internal helpers ──────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function findRow(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, entity_type, entity_id FROM gallery_items WHERE id = :id'
+        );
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function validateEntity(string $entityType, string $entityId): array
+    {
+        $entityType = trim($entityType);
+        $entityId   = trim($entityId);
+        if ($entityType === '') {
+            throw new \InvalidArgumentException('entity_type must not be empty.');
+        }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        return [$entityType, $entityId];
+    }
+}

--- a/tests/Unit/Xion/MediaGalleryTest.php
+++ b/tests/Unit/Xion/MediaGalleryTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\MediaGallery;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class MediaGalleryTest extends TestCase
+{
+    private PDO $pdo;
+    private MediaGallery $gallery;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE gallery_items (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type  VARCHAR(100) NOT NULL,
+                entity_id    VARCHAR(255) NOT NULL,
+                storage_key  TEXT         NOT NULL,
+                caption      TEXT         NULL,
+                position     INTEGER      NOT NULL DEFAULT 0,
+                is_cover     TINYINT(1)   NOT NULL DEFAULT 0,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->gallery = new MediaGallery($this->pdo);
+    }
+
+    // ── addItem ───────────────────────────────────────────────────────────────
+
+    public function testAddItemReturnsId(): void
+    {
+        $id = $this->gallery->addItem('post', '1', 's3://a.jpg');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testAddItemStoresCorrectly(): void
+    {
+        $id    = $this->gallery->addItem('post', '1', 's3://a.jpg', 'My caption', 3);
+        $items = $this->gallery->items('post', '1');
+        $this->assertCount(1, $items);
+        $this->assertSame($id, (int)$items[0]['id']);
+        $this->assertSame('s3://a.jpg', $items[0]['storage_key']);
+        $this->assertSame('My caption', $items[0]['caption']);
+        $this->assertSame(3, (int)$items[0]['position']);
+        $this->assertSame(0, (int)$items[0]['is_cover']);
+    }
+
+    public function testAddItemThrowsOnEmptyStorageKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->gallery->addItem('post', '1', '');
+    }
+
+    public function testAddItemThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->gallery->addItem('', '1', 's3://a.jpg');
+    }
+
+    public function testAddItemThrowsOnEmptyEntityId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->gallery->addItem('post', '', 's3://a.jpg');
+    }
+
+    // ── removeItem ────────────────────────────────────────────────────────────
+
+    public function testRemoveItemDeletesRow(): void
+    {
+        $id = $this->gallery->addItem('post', '1', 's3://a.jpg');
+        $this->assertTrue($this->gallery->removeItem($id));
+        $this->assertCount(0, $this->gallery->items('post', '1'));
+    }
+
+    public function testRemoveItemReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->gallery->removeItem(9999));
+    }
+
+    // ── setCover / getCover ───────────────────────────────────────────────────
+
+    public function testSetCoverMarksCoverItem(): void
+    {
+        $id = $this->gallery->addItem('post', '1', 's3://a.jpg');
+        $this->assertTrue($this->gallery->setCover($id));
+
+        $items = $this->gallery->items('post', '1');
+        $this->assertSame(1, (int)$items[0]['is_cover']);
+    }
+
+    public function testSetCoverClearsPreviousCover(): void
+    {
+        $id1 = $this->gallery->addItem('post', '1', 's3://a.jpg', null, 1);
+        $id2 = $this->gallery->addItem('post', '1', 's3://b.jpg', null, 2);
+
+        $this->gallery->setCover($id1);
+        $this->gallery->setCover($id2);
+
+        $items = $this->gallery->items('post', '1');
+        $this->assertSame(0, (int)$items[0]['is_cover']); // id1 cleared
+        $this->assertSame(1, (int)$items[1]['is_cover']); // id2 set
+    }
+
+    public function testGetCoverReturnsCoverItem(): void
+    {
+        $id = $this->gallery->addItem('post', '1', 's3://a.jpg');
+        $this->gallery->setCover($id);
+
+        $cover = $this->gallery->getCover('post', '1');
+        $this->assertNotNull($cover);
+        $this->assertSame($id, (int)$cover['id']);
+    }
+
+    public function testGetCoverReturnsNullWhenNone(): void
+    {
+        $this->gallery->addItem('post', '1', 's3://a.jpg');
+        $this->assertNull($this->gallery->getCover('post', '1'));
+    }
+
+    public function testSetCoverReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->gallery->setCover(9999));
+    }
+
+    // ── updateCaption ─────────────────────────────────────────────────────────
+
+    public function testUpdateCaptionChangesCaption(): void
+    {
+        $id = $this->gallery->addItem('post', '1', 's3://a.jpg', 'Old');
+        $this->assertTrue($this->gallery->updateCaption($id, 'New'));
+
+        $items = $this->gallery->items('post', '1');
+        $this->assertSame('New', $items[0]['caption']);
+    }
+
+    public function testUpdateCaptionToNull(): void
+    {
+        $id = $this->gallery->addItem('post', '1', 's3://a.jpg', 'Old');
+        $this->gallery->updateCaption($id, null);
+
+        $items = $this->gallery->items('post', '1');
+        $this->assertNull($items[0]['caption']);
+    }
+
+    public function testUpdateCaptionReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->gallery->updateCaption(9999, 'x'));
+    }
+
+    // ── reorder ───────────────────────────────────────────────────────────────
+
+    public function testReorderChangesPosition(): void
+    {
+        $id = $this->gallery->addItem('post', '1', 's3://a.jpg', null, 1);
+        $this->assertTrue($this->gallery->reorder($id, 5));
+
+        $items = $this->gallery->items('post', '1');
+        $this->assertSame(5, (int)$items[0]['position']);
+    }
+
+    public function testReorderReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->gallery->reorder(9999, 1));
+    }
+
+    // ── items ─────────────────────────────────────────────────────────────────
+
+    public function testItemsOrdersByPositionThenId(): void
+    {
+        $id3 = $this->gallery->addItem('post', '1', 's3://c.jpg', null, 3);
+        $id1 = $this->gallery->addItem('post', '1', 's3://a.jpg', null, 1);
+        $id2 = $this->gallery->addItem('post', '1', 's3://b.jpg', null, 2);
+
+        $items = $this->gallery->items('post', '1');
+        $this->assertSame($id1, (int)$items[0]['id']);
+        $this->assertSame($id2, (int)$items[1]['id']);
+        $this->assertSame($id3, (int)$items[2]['id']);
+    }
+
+    public function testItemsIsolatedByEntity(): void
+    {
+        $this->gallery->addItem('post', '1', 's3://a.jpg');
+        $this->gallery->addItem('post', '2', 's3://b.jpg');
+
+        $this->assertCount(1, $this->gallery->items('post', '1'));
+        $this->assertCount(1, $this->gallery->items('post', '2'));
+    }
+
+    public function testItemsReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->gallery->items('post', '99'));
+    }
+
+    // ── clear ─────────────────────────────────────────────────────────────────
+
+    public function testClearDeletesAllForEntity(): void
+    {
+        $this->gallery->addItem('post', '1', 's3://a.jpg');
+        $this->gallery->addItem('post', '1', 's3://b.jpg');
+        $this->gallery->addItem('post', '2', 's3://c.jpg');
+
+        $this->assertSame(2, $this->gallery->clear('post', '1'));
+        $this->assertCount(0, $this->gallery->items('post', '1'));
+        $this->assertCount(1, $this->gallery->items('post', '2'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountReturnsCorrectNumber(): void
+    {
+        $this->gallery->addItem('post', '5', 's3://a.jpg');
+        $this->gallery->addItem('post', '5', 's3://b.jpg');
+        $this->assertSame(2, $this->gallery->count('post', '5'));
+    }
+
+    public function testCountReturnsZeroWhenNone(): void
+    {
+        $this->assertSame(0, $this->gallery->count('post', '99'));
+    }
+}

--- a/tests/Unit/Xion/MediaGalleryTest.php
+++ b/tests/Unit/Xion/MediaGalleryTest.php
@@ -115,6 +115,7 @@ final class MediaGalleryTest extends TestCase
 
         $cover = $this->gallery->getCover('post', '1');
         $this->assertNotNull($cover);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
         $this->assertSame($id, (int)$cover['id']);
     }
 


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\MediaGallery` — ordered media item gallery per entity with cover photo designation.

Distinct from `Attachment` (unordered, generic files). Gallery items have deliberate ordering, captions, and a single cover item per entity.

## Schema

```sql
CREATE TABLE gallery_items (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    entity_type  VARCHAR(100) NOT NULL,
    entity_id    VARCHAR(255) NOT NULL,
    storage_key  TEXT         NOT NULL,
    caption      TEXT         NULL,
    position     INTEGER      NOT NULL DEFAULT 0,
    is_cover     TINYINT(1)   NOT NULL DEFAULT 0,
    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API

- `addItem(entityType, entityId, storageKey, caption, position)` → int
- `removeItem(id)` → bool
- `setCover(id)` — clears previous cover, sets this one
- `getCover(entityType, entityId)` → ?array
- `updateCaption(id, caption)` → bool
- `reorder(id, position)` → bool
- `items(entityType, entityId)` — ordered by position, id
- `clear(entityType, entityId)` → int
- `count(entityType, entityId)` → int

## Tests

23 tests, 39 assertions — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)