### PR TITLE
feat(xion): add FaqItem helper (FT194)

### DIFF
--- a/class/xion/FaqItem.php
+++ b/class/xion/FaqItem.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * FaqItem — FAQ articles with categories, ordering, and helpfulness voting.
+ *
+ * Stores structured FAQ items with category grouping, explicit display
+ * ordering, publish/unpublish control, and per-item helpfulness tracking.
+ * Supports keyword search across question and answer text.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $faq = new FaqItem($pdo);
+ *
+ * $id = $faq->add('billing', 'How do I cancel?', 'Go to Settings > Account.', 1);
+ * $faq->publish($id);
+ *
+ * $items  = $faq->forCategory('billing');
+ * $found  = $faq->search('cancel');
+ * $cats   = $faq->allCategories();
+ *
+ * $faq->voteHelpful($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE faq_items (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     category    VARCHAR(100) NOT NULL DEFAULT 'general',
+ *     question    TEXT         NOT NULL,
+ *     answer      TEXT         NOT NULL,
+ *     position    INTEGER      NOT NULL DEFAULT 0,
+ *     published   TINYINT(1)   NOT NULL DEFAULT 1,
+ *     helpful     INTEGER      NOT NULL DEFAULT 0,
+ *     not_helpful INTEGER      NOT NULL DEFAULT 0,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class FaqItem
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add a FAQ item. New items are published by default.
+     *
+     * @return int Row ID of the new item.
+     * @throws \InvalidArgumentException on empty question or answer.
+     */
+    public function add(string $category, string $question, string $answer, int $position = 0): int
+    {
+        $category = trim($category) === '' ? 'general' : trim($category);
+        $question = trim($question);
+        $answer   = trim($answer);
+        if ($question === '') {
+            throw new \InvalidArgumentException('question must not be empty.');
+        }
+        if ($answer === '') {
+            throw new \InvalidArgumentException('answer must not be empty.');
+        }
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO faq_items (category, question, answer, position, created_at, updated_at)
+             VALUES (:cat, :q, :a, :pos, :now, :now)'
+        );
+        $stmt->execute([
+            ':cat' => $category,
+            ':q'   => $question,
+            ':a'   => $answer,
+            ':pos' => $position,
+            ':now' => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Update question and answer text.
+     *
+     * @return bool True if found and updated.
+     * @throws \InvalidArgumentException on empty question or answer.
+     */
+    public function update(int $id, string $question, string $answer): bool
+    {
+        $question = trim($question);
+        $answer   = trim($answer);
+        if ($question === '') {
+            throw new \InvalidArgumentException('question must not be empty.');
+        }
+        if ($answer === '') {
+            throw new \InvalidArgumentException('answer must not be empty.');
+        }
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE faq_items SET question = :q, answer = :a, updated_at = :now WHERE id = :id'
+        );
+        $stmt->execute([':q' => $question, ':a' => $answer, ':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Publish a FAQ item (make visible).
+     *
+     * @return bool True if found and updated.
+     */
+    public function publish(int $id): bool
+    {
+        $stmt = $this->db()->prepare('UPDATE faq_items SET published = 1 WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Unpublish a FAQ item (hide from public).
+     *
+     * @return bool True if found and updated.
+     */
+    public function unpublish(int $id): bool
+    {
+        $stmt = $this->db()->prepare('UPDATE faq_items SET published = 0 WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete a FAQ item.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM faq_items WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Find a FAQ item by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, category, question, answer, position, published,
+                    helpful, not_helpful, created_at, updated_at
+             FROM faq_items WHERE id = :id'
+        );
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * List FAQ items for a category, ordered by position then id.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forCategory(string $category, bool $publishedOnly = true): array
+    {
+        $category = trim($category) === '' ? 'general' : trim($category);
+        $sql      = 'SELECT id, category, question, answer, position, published,
+                            helpful, not_helpful, created_at, updated_at
+                     FROM faq_items WHERE category = :cat';
+        if ($publishedOnly) {
+            $sql .= ' AND published = 1';
+        }
+        $sql .= ' ORDER BY position ASC, id ASC';
+        $stmt = $this->db()->prepare($sql);
+        $stmt->execute([':cat' => $category]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return distinct category names ordered alphabetically.
+     *
+     * @return list<string>
+     */
+    public function allCategories(): array
+    {
+        $stmt = $this->db()->query(
+            'SELECT DISTINCT category FROM faq_items ORDER BY category ASC'
+        );
+        if ($stmt === false) {
+            return [];
+        }
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Search FAQ items by keyword (question and answer), published only.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function search(string $keyword): array
+    {
+        $like = '%' . str_replace(['%', '_'], ['\\%', '\\_'], trim($keyword)) . '%';
+        $stmt = $this->db()->prepare(
+            'SELECT id, category, question, answer, position, published,
+                    helpful, not_helpful, created_at, updated_at
+             FROM faq_items
+             WHERE published = 1 AND (question LIKE :kw OR answer LIKE :kw)
+             ORDER BY position ASC, id ASC'
+        );
+        $stmt->execute([':kw' => $like]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Change display position of a FAQ item.
+     *
+     * @return bool True if found and updated.
+     */
+    public function reorder(int $id, int $position): bool
+    {
+        $stmt = $this->db()->prepare('UPDATE faq_items SET position = :pos WHERE id = :id');
+        $stmt->execute([':pos' => $position, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Increment the helpful vote counter.
+     *
+     * @return bool True if found and updated.
+     */
+    public function voteHelpful(int $id): bool
+    {
+        $stmt = $this->db()->prepare('UPDATE faq_items SET helpful = helpful + 1 WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Increment the not-helpful vote counter.
+     *
+     * @return bool True if found and updated.
+     */
+    public function voteNotHelpful(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE faq_items SET not_helpful = not_helpful + 1 WHERE id = :id'
+        );
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ──────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/FaqItemTest.php
+++ b/tests/Unit/Xion/FaqItemTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\FaqItem;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class FaqItemTest extends TestCase
+{
+    private PDO $pdo;
+    private FaqItem $faq;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE faq_items (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                category    VARCHAR(100) NOT NULL DEFAULT \'general\',
+                question    TEXT         NOT NULL,
+                answer      TEXT         NOT NULL,
+                position    INTEGER      NOT NULL DEFAULT 0,
+                published   TINYINT(1)   NOT NULL DEFAULT 1,
+                helpful     INTEGER      NOT NULL DEFAULT 0,
+                not_helpful INTEGER      NOT NULL DEFAULT 0,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->faq = new FaqItem($this->pdo);
+    }
+
+    // ── add ───────────────────────────────────────────────────────────────────
+
+    public function testAddReturnsId(): void
+    {
+        $id = $this->faq->add('billing', 'How to cancel?', 'Go to Settings.');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testAddStoresCorrectly(): void
+    {
+        $id  = $this->faq->add('billing', 'How to cancel?', 'Go to Settings.', 2);
+        $row = $this->faq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('billing', $row['category']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('How to cancel?', $row['question']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(2, (int)$row['position']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['published']); // published by default
+    }
+
+    public function testAddUsesGeneralCategoryByDefault(): void
+    {
+        $id  = $this->faq->add('', 'Q?', 'A.');
+        $row = $this->faq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('general', $row['category']);
+    }
+
+    public function testAddThrowsOnEmptyQuestion(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->faq->add('cat', '', 'Answer.');
+    }
+
+    public function testAddThrowsOnEmptyAnswer(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->faq->add('cat', 'Question?', '');
+    }
+
+    // ── update ────────────────────────────────────────────────────────────────
+
+    public function testUpdateChangesQuestionAndAnswer(): void
+    {
+        $id = $this->faq->add('cat', 'Old?', 'Old answer.');
+        $this->assertTrue($this->faq->update($id, 'New?', 'New answer.'));
+
+        $row = $this->faq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('New?', $row['question']);
+    }
+
+    public function testUpdateReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->faq->update(9999, 'Q?', 'A.'));
+    }
+
+    // ── publish / unpublish ───────────────────────────────────────────────────
+
+    public function testUnpublishHidesItem(): void
+    {
+        $id = $this->faq->add('cat', 'Q?', 'A.');
+        $this->faq->unpublish($id);
+        $items = $this->faq->forCategory('cat');
+        $this->assertCount(0, $items);
+    }
+
+    public function testPublishRestoresItem(): void
+    {
+        $id = $this->faq->add('cat', 'Q?', 'A.');
+        $this->faq->unpublish($id);
+        $this->faq->publish($id);
+        $items = $this->faq->forCategory('cat');
+        $this->assertCount(1, $items);
+    }
+
+    public function testPublishReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->faq->publish(9999));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesItem(): void
+    {
+        $id = $this->faq->add('cat', 'Q?', 'A.');
+        $this->assertTrue($this->faq->delete($id));
+        $this->assertNull($this->faq->find($id));
+    }
+
+    public function testDeleteReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->faq->delete(9999));
+    }
+
+    // ── forCategory ───────────────────────────────────────────────────────────
+
+    public function testForCategoryOrdersByPositionThenId(): void
+    {
+        $id3 = $this->faq->add('cat', 'C', 'c', 3);
+        $id1 = $this->faq->add('cat', 'A', 'a', 1);
+        $id2 = $this->faq->add('cat', 'B', 'b', 2);
+
+        $items = $this->faq->forCategory('cat');
+        $this->assertSame($id1, (int)$items[0]['id']);
+        $this->assertSame($id2, (int)$items[1]['id']);
+        $this->assertSame($id3, (int)$items[2]['id']);
+    }
+
+    public function testForCategoryWithPublishedOnlyFalse(): void
+    {
+        $id = $this->faq->add('cat', 'Q?', 'A.');
+        $this->faq->unpublish($id);
+        $items = $this->faq->forCategory('cat', false);
+        $this->assertCount(1, $items);
+    }
+
+    public function testForCategoryReturnsEmptyForUnknownCategory(): void
+    {
+        $this->assertSame([], $this->faq->forCategory('unknown'));
+    }
+
+    // ── allCategories ─────────────────────────────────────────────────────────
+
+    public function testAllCategoriesReturnsSortedDistinctList(): void
+    {
+        $this->faq->add('billing', 'Q?', 'A.');
+        $this->faq->add('billing', 'R?', 'B.');
+        $this->faq->add('account', 'S?', 'C.');
+
+        $cats = $this->faq->allCategories();
+        $this->assertSame(['account', 'billing'], $cats);
+    }
+
+    // ── search ────────────────────────────────────────────────────────────────
+
+    public function testSearchFindsInQuestion(): void
+    {
+        $id = $this->faq->add('cat', 'How to reset password?', 'Click forgot password.');
+        $rows = $this->faq->search('reset');
+        $this->assertCount(1, $rows);
+        $this->assertSame($id, (int)$rows[0]['id']);
+    }
+
+    public function testSearchFindsInAnswer(): void
+    {
+        $id = $this->faq->add('cat', 'Login problem?', 'Contact support via email.');
+        $rows = $this->faq->search('support');
+        $this->assertCount(1, $rows);
+    }
+
+    public function testSearchDoesNotReturnUnpublished(): void
+    {
+        $id = $this->faq->add('cat', 'Hidden FAQ?', 'Hidden answer.');
+        $this->faq->unpublish($id);
+        $rows = $this->faq->search('Hidden');
+        $this->assertCount(0, $rows);
+    }
+
+    public function testSearchReturnsEmptyWhenNoMatch(): void
+    {
+        $this->faq->add('cat', 'Q?', 'A.');
+        $this->assertSame([], $this->faq->search('zzz_no_match'));
+    }
+
+    // ── reorder ───────────────────────────────────────────────────────────────
+
+    public function testReorderChangesPosition(): void
+    {
+        $id = $this->faq->add('cat', 'Q?', 'A.', 1);
+        $this->assertTrue($this->faq->reorder($id, 10));
+
+        $row = $this->faq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(10, (int)$row['position']);
+    }
+
+    // ── voteHelpful / voteNotHelpful ──────────────────────────────────────────
+
+    public function testVoteHelpfulIncrementsCounter(): void
+    {
+        $id = $this->faq->add('cat', 'Q?', 'A.');
+        $this->faq->voteHelpful($id);
+        $this->faq->voteHelpful($id);
+
+        $row = $this->faq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(2, (int)$row['helpful']);
+    }
+
+    public function testVoteNotHelpfulIncrementsCounter(): void
+    {
+        $id = $this->faq->add('cat', 'Q?', 'A.');
+        $this->faq->voteNotHelpful($id);
+
+        $row = $this->faq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['not_helpful']);
+    }
+
+    public function testVoteHelpfulReturnsFalseForMissing(): void
+    {
+        $this->assertFalse($this->faq->voteHelpful(9999));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\FaqItem` — FAQ articles with categories, ordering, helpfulness voting, and keyword search.

## Schema

```sql
CREATE TABLE faq_items (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    category    VARCHAR(100) NOT NULL DEFAULT 'general',
    question    TEXT         NOT NULL,
    answer      TEXT         NOT NULL,
    position    INTEGER      NOT NULL DEFAULT 0,
    published   TINYINT(1)   NOT NULL DEFAULT 1,
    helpful     INTEGER      NOT NULL DEFAULT 0,
    not_helpful INTEGER      NOT NULL DEFAULT 0,
    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API

- `add(category, question, answer, position)` → int
- `update(id, question, answer)` → bool
- `publish(id)` / `unpublish(id)` → bool
- `delete(id)` → bool
- `find(id)` → ?array
- `forCategory(category, publishedOnly=true)` — ordered by position, id
- `allCategories()` → list of distinct category names
- `search(keyword)` — matches question or answer text (published only)
- `reorder(id, position)` → bool
- `voteHelpful(id)` / `voteNotHelpful(id)` → bool

## Tests

24 tests, 39 assertions — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)