### PR TITLE
feat(xion): add UserTier helper (FT195)

### DIFF
--- a/class/xion/UserTier.php
+++ b/class/xion/UserTier.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * UserTier — gamification tier/membership level assignment with history.
+ *
+ * Tracks each user's current tier (e.g. bronze, silver, gold, platinum)
+ * and maintains a full assignment history. The current tier is stored in
+ * a separate table with a UNIQUE constraint so lookups are O(1).
+ *
+ * Tier names are arbitrary strings; the class imposes no fixed tier list.
+ * You can define constants for your tier names in the caller.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $t = new UserTier($pdo);
+ *
+ * $t->assign('user-1', 'bronze');
+ * $t->assign('user-1', 'silver', 'Reached 1000 points');
+ *
+ * echo $t->current('user-1');  // 'silver'
+ * $t->usersInTier('silver');   // ['user-1', ...]
+ * $t->history('user-1');       // all past assignments
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE user_tiers (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     tier        VARCHAR(50)  NOT NULL,
+ *     assigned_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     reason      TEXT         NULL,
+ *     UNIQUE (user_id)
+ * );
+ *
+ * CREATE TABLE user_tier_history (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     tier        VARCHAR(50)  NOT NULL,
+ *     assigned_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     reason      TEXT         NULL
+ * );
+ * ```
+ */
+final class UserTier
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Assign (or re-assign) a tier to a user.
+     * Overwrites the current tier and appends an entry to history.
+     *
+     * @throws \InvalidArgumentException on empty user_id or tier.
+     */
+    public function assign(string $userId, string $tier, ?string $reason = null): void
+    {
+        $userId = trim($userId);
+        $tier   = trim($tier);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($tier === '') {
+            throw new \InvalidArgumentException('tier must not be empty.');
+        }
+        $now    = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $upsert = 'INSERT INTO user_tiers (user_id, tier, assigned_at, reason)
+                       VALUES (:uid, :tier, :now, :reason)
+                       ON CONFLICT (user_id) DO UPDATE SET
+                           tier = excluded.tier,
+                           assigned_at = excluded.assigned_at,
+                           reason = excluded.reason';
+        } else {
+            $upsert = 'INSERT INTO user_tiers (user_id, tier, assigned_at, reason)
+                       VALUES (:uid, :tier, :now, :reason)
+                       ON DUPLICATE KEY UPDATE
+                           tier = VALUES(tier),
+                           assigned_at = VALUES(assigned_at),
+                           reason = VALUES(reason)';
+        }
+        $stmt = $this->db()->prepare($upsert);
+        $stmt->execute([':uid' => $userId, ':tier' => $tier, ':now' => $now, ':reason' => $reason]);
+
+        $hist = $this->db()->prepare(
+            'INSERT INTO user_tier_history (user_id, tier, assigned_at, reason)
+             VALUES (:uid, :tier, :now, :reason)'
+        );
+        $hist->execute([':uid' => $userId, ':tier' => $tier, ':now' => $now, ':reason' => $reason]);
+    }
+
+    /**
+     * Return the current tier name for a user, or null if none assigned.
+     */
+    public function current(string $userId): ?string
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT tier FROM user_tiers WHERE user_id = :uid'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        $val = $stmt->fetchColumn();
+        return $val === false ? null : (string)$val;
+    }
+
+    /**
+     * Return the full tier assignment history for a user, most recent first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function history(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, tier, assigned_at, reason
+             FROM user_tier_history WHERE user_id = :uid ORDER BY id DESC'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return user IDs currently in a given tier.
+     *
+     * @return list<string>
+     */
+    public function usersInTier(string $tier): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT user_id FROM user_tiers WHERE tier = :tier ORDER BY user_id ASC'
+        );
+        $stmt->execute([':tier' => trim($tier)]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Return tier → count map for all currently assigned tiers.
+     *
+     * @return array<string,int>
+     */
+    public function countByTier(): array
+    {
+        $stmt = $this->db()->query(
+            'SELECT tier, COUNT(*) AS cnt FROM user_tiers GROUP BY tier ORDER BY tier ASC'
+        );
+        if ($stmt === false) {
+            return [];
+        }
+        $result = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $result[(string)$row['tier']] = (int)$row['cnt'];
+        }
+        return $result;
+    }
+
+    /**
+     * Return true if a user has ever been assigned the given tier.
+     */
+    public function hasEverHad(string $userId, string $tier): bool
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM user_tier_history WHERE user_id = :uid AND tier = :tier'
+        );
+        $stmt->execute([':uid' => trim($userId), ':tier' => trim($tier)]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Remove the current tier assignment for a user (keeps history).
+     *
+     * @return bool True if an assignment existed and was removed.
+     */
+    public function remove(string $userId): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM user_tiers WHERE user_id = :uid');
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ──────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/UserTierTest.php
+++ b/tests/Unit/Xion/UserTierTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\UserTier;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class UserTierTest extends TestCase
+{
+    private PDO $pdo;
+    private UserTier $t;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE user_tiers (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     VARCHAR(255) NOT NULL,
+                tier        VARCHAR(50)  NOT NULL,
+                assigned_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                reason      TEXT         NULL,
+                UNIQUE (user_id)
+            )
+        ');
+        $this->pdo->exec('
+            CREATE TABLE user_tier_history (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     VARCHAR(255) NOT NULL,
+                tier        VARCHAR(50)  NOT NULL,
+                assigned_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                reason      TEXT         NULL
+            )
+        ');
+        $this->t = new UserTier($this->pdo);
+    }
+
+    // ── assign ────────────────────────────────────────────────────────────────
+
+    public function testAssignSetsCurrent(): void
+    {
+        $this->t->assign('u1', 'bronze');
+        $this->assertSame('bronze', $this->t->current('u1'));
+    }
+
+    public function testAssignOverwritesCurrent(): void
+    {
+        $this->t->assign('u1', 'bronze');
+        $this->t->assign('u1', 'silver', 'Reached threshold');
+        $this->assertSame('silver', $this->t->current('u1'));
+    }
+
+    public function testAssignOnlyOneCurrentRowPerUser(): void
+    {
+        $this->t->assign('u1', 'bronze');
+        $this->t->assign('u1', 'silver');
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM user_tiers WHERE user_id = 'u1'");
+        $this->assertSame(1, (int)$stmt->fetchColumn());
+    }
+
+    public function testAssignAppendsToHistory(): void
+    {
+        $this->t->assign('u1', 'bronze');
+        $this->t->assign('u1', 'silver');
+        $history = $this->t->history('u1');
+        $this->assertCount(2, $history);
+    }
+
+    public function testAssignThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->t->assign('', 'bronze');
+    }
+
+    public function testAssignThrowsOnEmptyTier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->t->assign('u1', '');
+    }
+
+    // ── current ───────────────────────────────────────────────────────────────
+
+    public function testCurrentReturnsNullWhenNotAssigned(): void
+    {
+        $this->assertNull($this->t->current('u999'));
+    }
+
+    // ── history ───────────────────────────────────────────────────────────────
+
+    public function testHistoryReturnsMostRecentFirst(): void
+    {
+        $this->t->assign('u1', 'bronze');
+        $this->t->assign('u1', 'silver');
+        $this->t->assign('u1', 'gold');
+
+        $history = $this->t->history('u1');
+        $this->assertSame('gold', $history[0]['tier']);
+        $this->assertSame('silver', $history[1]['tier']);
+        $this->assertSame('bronze', $history[2]['tier']);
+    }
+
+    public function testHistoryStoresReason(): void
+    {
+        $this->t->assign('u1', 'gold', 'Loyalty milestone');
+        $history = $this->t->history('u1');
+        $this->assertSame('Loyalty milestone', $history[0]['reason']);
+    }
+
+    public function testHistoryReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->t->history('u999'));
+    }
+
+    // ── usersInTier ───────────────────────────────────────────────────────────
+
+    public function testUsersInTierReturnsMatchingUsers(): void
+    {
+        $this->t->assign('u1', 'silver');
+        $this->t->assign('u2', 'silver');
+        $this->t->assign('u3', 'gold');
+
+        $users = $this->t->usersInTier('silver');
+        $this->assertCount(2, $users);
+        $this->assertContains('u1', $users);
+        $this->assertContains('u2', $users);
+    }
+
+    public function testUsersInTierReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->t->usersInTier('platinum'));
+    }
+
+    // ── countByTier ───────────────────────────────────────────────────────────
+
+    public function testCountByTierGroupsCorrectly(): void
+    {
+        $this->t->assign('u1', 'bronze');
+        $this->t->assign('u2', 'bronze');
+        $this->t->assign('u3', 'gold');
+
+        $counts = $this->t->countByTier();
+        $this->assertSame(2, $counts['bronze']);
+        $this->assertSame(1, $counts['gold']);
+    }
+
+    public function testCountByTierReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->t->countByTier());
+    }
+
+    // ── hasEverHad ────────────────────────────────────────────────────────────
+
+    public function testHasEverHadReturnsTrueForPastTier(): void
+    {
+        $this->t->assign('u1', 'bronze');
+        $this->t->assign('u1', 'silver');
+        $this->assertTrue($this->t->hasEverHad('u1', 'bronze'));
+    }
+
+    public function testHasEverHadReturnsFalseForNeverHeld(): void
+    {
+        $this->t->assign('u1', 'silver');
+        $this->assertFalse($this->t->hasEverHad('u1', 'platinum'));
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesCurrentTier(): void
+    {
+        $this->t->assign('u1', 'bronze');
+        $this->assertTrue($this->t->remove('u1'));
+        $this->assertNull($this->t->current('u1'));
+    }
+
+    public function testRemoveKeepsHistory(): void
+    {
+        $this->t->assign('u1', 'bronze');
+        $this->t->remove('u1');
+        $history = $this->t->history('u1');
+        $this->assertCount(1, $history);
+    }
+
+    public function testRemoveReturnsFalseWhenNotAssigned(): void
+    {
+        $this->assertFalse($this->t->remove('u999'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\UserTier` — gamification tier/membership level assignment with history tracking.

Two-table design: current tier (UNIQUE per user, fast lookup) + history (append-only). Tier names are arbitrary strings.

## Schema

```sql
CREATE TABLE user_tiers (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id     VARCHAR(255) NOT NULL,
    tier        VARCHAR(50)  NOT NULL,
    assigned_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    reason      TEXT         NULL,
    UNIQUE (user_id)
);

CREATE TABLE user_tier_history (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id     VARCHAR(255) NOT NULL,
    tier        VARCHAR(50)  NOT NULL,
    assigned_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    reason      TEXT         NULL
);
```

## API

- `assign(userId, tier, reason)` — upsert current + append history
- `current(userId)` → ?string
- `history(userId)` — most recent first
- `usersInTier(tier)` → list of user IDs
- `countByTier()` → [tier => count]
- `hasEverHad(userId, tier)` → bool
- `remove(userId)` — delete current tier, keep history

## Tests

19 tests, 25 assertions — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)