### PR TITLE
docs: update roadmap/todo/candidates for FT186-FT195 wave

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -14,7 +14,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ## Active candidates
 
-The Xion helper wave (FT78–FT185) is ongoing as of 2026-05-27. Trigger-based and structural candidates are listed in the next section.
+The Xion helper wave (FT78–FT195) is ongoing as of 2026-05-27. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -54,6 +54,16 @@ The Xion helper wave (FT78–FT185) is ongoing as of 2026-05-27. Trigger-based a
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT195 — UserTier** (2026-05-27): `Nene\Xion\UserTier` — gamification tier assignment with two-table design (current + history); hasEverHad(). PR #633.
+- **FT194 — FaqItem** (2026-05-27): `Nene\Xion\FaqItem` — FAQ articles with category, position ordering, keyword search, helpfulness voting. PR #632.
+- **FT193 — ProductReview** (2026-05-27): `Nene\Xion\ProductReview` — entity reviews with 1–5 star ratings; approval workflow; helpfulness voting; one review per user per entity. PR #631.
+- **FT192 — MediaGallery** (2026-05-27): `Nene\Xion\MediaGallery` — ordered media item gallery per entity; cover photo designation; captions; position reordering. PR #630.
+- **FT191 — SystemSetting** (2026-05-27): `Nene\Xion\SystemSetting` — typed global app settings (string/int/bool/json) with categories; cross-driver upsert; distinct from ConfigStore. PR #629.
+- **FT190 — TwoFactorBackupCode** (2026-05-27): `Nene\Xion\TwoFactorBackupCode` — one-time 2FA recovery codes; SHA-256 hash storage; generate() invalidates all previous codes. PR #628.
+- **FT189 — AccessControl** (2026-05-27): `Nene\Xion\AccessControl` — per-resource subject ACL; idempotent grant; complements global RBAC (RoleGuard). PR #627.
+- **FT188 — DailyDigest** (2026-05-27): `Nene\Xion\DailyDigest` — per-user digest item accumulator; allPending() grouped by user; batch markSent; purgeSent. PR #626.
+- **FT187 — EventLog** (2026-05-27): `Nene\Xion\EventLog` — append-only domain event log (event sourcing–lite); forAggregate/ofType/byActor queries; JSON payload. PR #625.
+- **FT186 — SupportTicket** (2026-05-27): `Nene\Xion\SupportTicket` — help-desk ticketing with support_tickets + ticket_replies; status/priority constants; addReply; countByStatus. PR #624.
 - **FT185 — KnowledgeBase** (2026-05-27): `Nene\Xion\KnowledgeBase` — help articles with draft→published→archived lifecycle, category filter, keyword search, view tracking. PR #622.
 - **FT184 — Reminder** (2026-05-27): `Nene\Xion\Reminder` — user-set future reminders; due() for cron-poll; markSent; purgeSent. PR #621.
 - **FT183 — ContentFilter** (2026-05-27): `Nene\Xion\ContentFilter` — DB-backed banned word list with detect/mask and optional whole-word mode; in-memory cache. PR #620.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT185 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT195 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 
@@ -237,6 +237,7 @@ Completed (wave summary):
 - **FT141–FT165**: Xion extended wave. 25 trials covering config store, cache, user groups, chat, shopping cart, cron log, export jobs, IP blocklist, content versioning, alert rules, announcements, magic links, slug registry, email queue, document locks, API usage log, OAuth tokens, user activity, email templates, batch jobs, service accounts, change logs, push subscriptions, counter metrics, and file chunk uploads. PRs #576–#600.
 - **FT166–FT175**: Xion second extended wave. 10 trials covering plan-based quota management, shareable links with password/expiry, approval workflows, team membership with roles, fraud/trust scoring, payment records, PIN/OTP codes, anonymous guest sessions, cron-style task scheduling, and admin user notes. PRs #602–#611.
 - **FT176–FT185**: Xion third extended wave. 10 trials covering colored labels, ordered checklists, emoji reactions, @-mention tracking, watchlists, file attachments, saved searches, content filtering, user reminders, and knowledge base articles. PRs #613–#622.
+- **FT186–FT195**: Xion fourth extended wave. 10 trials covering support ticketing, event sourcing log, daily digest accumulator, per-resource ACL, 2FA backup codes, typed global settings, ordered media gallery, entity reviews with ratings, FAQ articles, and gamification tier tracking. PRs #624–#633.
 
 Future candidates:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,24 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT185 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT195 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-27 — FT186–FT195: Xion fourth extended wave (10 trials)
+
+Continuous wave of 10 field trials adding further Xion helper patterns. All PRs #623–#633.
+
+**FT186 — SupportTicket**: `SupportTicket` help-desk ticketing with ticket + reply tables; status/priority lifecycle. PR #624.
+**FT187 — EventLog**: `EventLog` append-only domain event log (event sourcing–lite); aggregate/actor/type queries. PR #625.
+**FT188 — DailyDigest**: `DailyDigest` per-user digest item accumulator with grouping and batch markSent. PR #626.
+**FT189 — AccessControl**: `AccessControl` per-resource subject ACL; idempotent grant; complements global RBAC. PR #627.
+**FT190 — TwoFactorBackupCode**: `TwoFactorBackupCode` one-time 2FA recovery codes; SHA-256 hash storage; generate() invalidates old codes. PR #628.
+**FT191 — SystemSetting**: `SystemSetting` typed global app settings (string/int/bool/json) with categories; cross-driver upsert. PR #629.
+**FT192 — MediaGallery**: `MediaGallery` ordered media item gallery per entity; cover photo designation; distinct from Attachment. PR #630.
+**FT193 — ProductReview**: `ProductReview` entity reviews with 1–5 star ratings; approval workflow; helpfulness voting. PR #631.
+**FT194 — FaqItem**: `FaqItem` FAQ articles with category, position ordering, keyword search, helpfulness voting. PR #632.
+**FT195 — UserTier**: `UserTier` gamification tier assignment with two-table design (current + history); hasEverHad(). PR #633.
 
 ### 2026-05-27 — FT176–FT185: Xion third extended wave (10 trials)
 


### PR DESCRIPTION
## Summary

Records the Xion fourth extended wave (FT186–FT195, PRs #624–#633) in roadmap, todo, and candidates.

### Wave summary

| FT | Helper | Pattern |
|----|--------|---------|
| FT186 | SupportTicket | Two-table help-desk ticketing with status/priority lifecycle |
| FT187 | EventLog | Append-only domain event log (event sourcing–lite) |
| FT188 | DailyDigest | Per-user digest accumulator with batch delivery |
| FT189 | AccessControl | Per-resource subject ACL (complements RBAC) |
| FT190 | TwoFactorBackupCode | One-time 2FA recovery codes, SHA-256 hashed |
| FT191 | SystemSetting | Typed global app settings (string/int/bool/json) |
| FT192 | MediaGallery | Ordered media gallery with cover photo designation |
| FT193 | ProductReview | Entity reviews with ratings, approval, helpfulness voting |
| FT194 | FaqItem | FAQ articles with ordering, search, helpfulness voting |
| FT195 | UserTier | Gamification tier assignment with two-table history |

🤖 Generated with [Claude Code](https://claude.com/claude-code)