### PR TITLE
feat(xion): add DataImportJob helper (FT196)

### DIFF
--- a/class/xion/DataImportJob.php
+++ b/class/xion/DataImportJob.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * DataImportJob — CSV/data import job tracking with per-row error recording.
+ *
+ * Two-table design: `data_import_jobs` for the overall job lifecycle and
+ * `data_import_errors` for per-row validation/processing errors.
+ *
+ * Distinct from BatchJob (generic progress tracking) and ExportJob (outbound).
+ * This class records the full import lifecycle: pending → validating →
+ * processing → done | failed.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $imp = new DataImportJob($pdo);
+ *
+ * $jobId = $imp->create('users-2026-05.csv', 'csv', 'user-admin');
+ * $imp->startValidation($jobId);
+ * $imp->addError($jobId, 12, 'email', 'Invalid email format');
+ * $imp->startProcessing($jobId, 500);
+ * $imp->finish($jobId, 490);  // 10 rows skipped/errored
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE data_import_jobs (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     filename     TEXT         NOT NULL,
+ *     format       VARCHAR(20)  NOT NULL DEFAULT 'csv',
+ *     uploaded_by  VARCHAR(255) NOT NULL,
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     total_rows   INTEGER      NULL,
+ *     done_rows    INTEGER      NOT NULL DEFAULT 0,
+ *     error_count  INTEGER      NOT NULL DEFAULT 0,
+ *     started_at   DATETIME     NULL,
+ *     finished_at  DATETIME     NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE data_import_errors (
+ *     id       INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     job_id   INTEGER      NOT NULL,
+ *     row_num  INTEGER      NOT NULL,
+ *     field    VARCHAR(100) NULL,
+ *     message  TEXT         NOT NULL,
+ *     created_at DATETIME   NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class DataImportJob
+{
+    public const STATUS_PENDING    = 'pending';
+    public const STATUS_VALIDATING = 'validating';
+    public const STATUS_PROCESSING = 'processing';
+    public const STATUS_DONE       = 'done';
+    public const STATUS_FAILED     = 'failed';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create a new import job.
+     *
+     * @return int Job ID.
+     * @throws \InvalidArgumentException on empty filename or uploadedBy.
+     */
+    public function create(string $filename, string $format, string $uploadedBy): int
+    {
+        $filename   = trim($filename);
+        $uploadedBy = trim($uploadedBy);
+        if ($filename === '') {
+            throw new \InvalidArgumentException('filename must not be empty.');
+        }
+        if ($uploadedBy === '') {
+            throw new \InvalidArgumentException('uploaded_by must not be empty.');
+        }
+        $format = trim($format) === '' ? 'csv' : trim($format);
+        $now    = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO data_import_jobs (filename, format, uploaded_by, created_at)
+             VALUES (:file, :fmt, :uid, :now)'
+        );
+        $stmt->execute([':file' => $filename, ':fmt' => $format, ':uid' => $uploadedBy, ':now' => $now]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Find a job by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, filename, format, uploaded_by, status,
+                    total_rows, done_rows, error_count, started_at, finished_at, created_at
+             FROM data_import_jobs WHERE id = :id'
+        );
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * Transition job to validating status.
+     *
+     * @return bool True if found and updated.
+     */
+    public function startValidation(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            "UPDATE data_import_jobs SET status = 'validating', started_at = :now
+             WHERE id = :id AND status = 'pending'"
+        );
+        $stmt->execute([':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Transition job to processing status and record total row count.
+     *
+     * @return bool True if found and updated.
+     */
+    public function startProcessing(int $id, int $totalRows): bool
+    {
+        $stmt = $this->db()->prepare(
+            "UPDATE data_import_jobs SET status = 'processing', total_rows = :total
+             WHERE id = :id AND status IN ('pending', 'validating')"
+        );
+        $stmt->execute([':total' => $totalRows, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark job as done and record successfully processed row count.
+     *
+     * @return bool True if found and updated.
+     */
+    public function finish(int $id, int $doneRows): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            "UPDATE data_import_jobs SET status = 'done', done_rows = :done, finished_at = :now
+             WHERE id = :id AND status = 'processing'"
+        );
+        $stmt->execute([':done' => $doneRows, ':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark job as failed with an optional reason message.
+     *
+     * @return bool True if found and updated.
+     */
+    public function fail(int $id, ?string $reason = null): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            "UPDATE data_import_jobs
+             SET status = 'failed', finished_at = :now
+             WHERE id = :id AND status NOT IN ('done', 'failed')"
+        );
+        $stmt->execute([':now' => $now, ':id' => $id]);
+        if ($stmt->rowCount() === 0) {
+            return false;
+        }
+        if ($reason !== null) {
+            $this->addError($id, 0, null, $reason);
+        }
+        return true;
+    }
+
+    /**
+     * Record a per-row validation/processing error.
+     *
+     * @return int Error row ID.
+     */
+    public function addError(int $jobId, int $rowNum, ?string $field, string $message): int
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO data_import_errors (job_id, row_num, field, message, created_at)
+             VALUES (:job, :row, :field, :msg, :now)'
+        );
+        $stmt->execute([
+            ':job'   => $jobId,
+            ':row'   => $rowNum,
+            ':field' => $field,
+            ':msg'   => $message,
+            ':now'   => $now,
+        ]);
+        // Increment error_count on job
+        $this->db()->prepare(
+            'UPDATE data_import_jobs SET error_count = error_count + 1 WHERE id = :id'
+        )->execute([':id' => $jobId]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Return all errors for a job, ordered by row number.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function errors(int $jobId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, job_id, row_num, field, message, created_at
+             FROM data_import_errors WHERE job_id = :job ORDER BY row_num ASC, id ASC'
+        );
+        $stmt->execute([':job' => $jobId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return jobs for a user, newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forUser(string $uploadedBy): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, filename, format, uploaded_by, status,
+                    total_rows, done_rows, error_count, started_at, finished_at, created_at
+             FROM data_import_jobs WHERE uploaded_by = :uid ORDER BY id DESC'
+        );
+        $stmt->execute([':uid' => trim($uploadedBy)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    // ── internal helpers ──────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/DataImportJobTest.php
+++ b/tests/Unit/Xion/DataImportJobTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\DataImportJob;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class DataImportJobTest extends TestCase
+{
+    private PDO $pdo;
+    private DataImportJob $imp;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE data_import_jobs (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename     TEXT         NOT NULL,
+                format       VARCHAR(20)  NOT NULL DEFAULT \'csv\',
+                uploaded_by  VARCHAR(255) NOT NULL,
+                status       VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                total_rows   INTEGER      NULL,
+                done_rows    INTEGER      NOT NULL DEFAULT 0,
+                error_count  INTEGER      NOT NULL DEFAULT 0,
+                started_at   DATETIME     NULL,
+                finished_at  DATETIME     NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->pdo->exec('
+            CREATE TABLE data_import_errors (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_id     INTEGER      NOT NULL,
+                row_num    INTEGER      NOT NULL,
+                field      VARCHAR(100) NULL,
+                message    TEXT         NOT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->imp = new DataImportJob($this->pdo);
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsId(): void
+    {
+        $id = $this->imp->create('users.csv', 'csv', 'admin');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testCreateStoresCorrectly(): void
+    {
+        $id  = $this->imp->create('data.csv', 'csv', 'admin');
+        $row = $this->imp->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('data.csv', $row['filename']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('pending', $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['error_count']);
+    }
+
+    public function testCreateThrowsOnEmptyFilename(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->imp->create('', 'csv', 'admin');
+    }
+
+    public function testCreateThrowsOnEmptyUploadedBy(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->imp->create('file.csv', 'csv', '');
+    }
+
+    // ── startValidation ───────────────────────────────────────────────────────
+
+    public function testStartValidationSetsStatus(): void
+    {
+        $id = $this->imp->create('f.csv', 'csv', 'u1');
+        $this->assertTrue($this->imp->startValidation($id));
+
+        $row = $this->imp->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('validating', $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['started_at']);
+    }
+
+    public function testStartValidationOnlyFromPending(): void
+    {
+        $id = $this->imp->create('f.csv', 'csv', 'u1');
+        $this->imp->startValidation($id);
+        $this->assertFalse($this->imp->startValidation($id)); // already validating
+    }
+
+    // ── startProcessing ───────────────────────────────────────────────────────
+
+    public function testStartProcessingSetsStatusAndTotal(): void
+    {
+        $id = $this->imp->create('f.csv', 'csv', 'u1');
+        $this->imp->startValidation($id);
+        $this->assertTrue($this->imp->startProcessing($id, 100));
+
+        $row = $this->imp->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('processing', $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(100, (int)$row['total_rows']);
+    }
+
+    // ── finish ────────────────────────────────────────────────────────────────
+
+    public function testFinishSetsDoneStatus(): void
+    {
+        $id = $this->imp->create('f.csv', 'csv', 'u1');
+        $this->imp->startProcessing($id, 50);
+        $this->assertTrue($this->imp->finish($id, 48));
+
+        $row = $this->imp->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('done', $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(48, (int)$row['done_rows']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['finished_at']);
+    }
+
+    public function testFinishReturnsFalseWhenNotProcessing(): void
+    {
+        $id = $this->imp->create('f.csv', 'csv', 'u1');
+        $this->assertFalse($this->imp->finish($id, 0)); // still pending
+    }
+
+    // ── fail ─────────────────────────────────────────────────────────────────
+
+    public function testFailSetsFailedStatus(): void
+    {
+        $id = $this->imp->create('f.csv', 'csv', 'u1');
+        $this->imp->startValidation($id);
+        $this->assertTrue($this->imp->fail($id, 'File format error'));
+
+        $row = $this->imp->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('failed', $row['status']);
+    }
+
+    public function testFailAddsReasonAsError(): void
+    {
+        $id = $this->imp->create('f.csv', 'csv', 'u1');
+        $this->imp->fail($id, 'Reason text');
+
+        $errors = $this->imp->errors($id);
+        $this->assertCount(1, $errors);
+        $this->assertSame('Reason text', $errors[0]['message']);
+    }
+
+    public function testFailReturnsFalseIfAlreadyDone(): void
+    {
+        $id = $this->imp->create('f.csv', 'csv', 'u1');
+        $this->imp->startProcessing($id, 10);
+        $this->imp->finish($id, 10);
+        $this->assertFalse($this->imp->fail($id));
+    }
+
+    // ── addError / errors ─────────────────────────────────────────────────────
+
+    public function testAddErrorStoresError(): void
+    {
+        $id  = $this->imp->create('f.csv', 'csv', 'u1');
+        $eid = $this->imp->addError($id, 5, 'email', 'Invalid format');
+        $this->assertGreaterThan(0, $eid);
+
+        $errors = $this->imp->errors($id);
+        $this->assertCount(1, $errors);
+        $this->assertSame(5, (int)$errors[0]['row_num']);
+        $this->assertSame('email', $errors[0]['field']);
+        $this->assertSame('Invalid format', $errors[0]['message']);
+    }
+
+    public function testAddErrorIncrementsErrorCount(): void
+    {
+        $id = $this->imp->create('f.csv', 'csv', 'u1');
+        $this->imp->addError($id, 1, null, 'E1');
+        $this->imp->addError($id, 2, null, 'E2');
+
+        $row = $this->imp->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(2, (int)$row['error_count']);
+    }
+
+    public function testErrorsOrderedByRowNum(): void
+    {
+        $id = $this->imp->create('f.csv', 'csv', 'u1');
+        $this->imp->addError($id, 10, null, 'E10');
+        $this->imp->addError($id, 3, null, 'E3');
+        $this->imp->addError($id, 7, null, 'E7');
+
+        $errors = $this->imp->errors($id);
+        $this->assertSame(3, (int)$errors[0]['row_num']);
+        $this->assertSame(7, (int)$errors[1]['row_num']);
+        $this->assertSame(10, (int)$errors[2]['row_num']);
+    }
+
+    // ── forUser ───────────────────────────────────────────────────────────────
+
+    public function testForUserReturnsUsersJobs(): void
+    {
+        $this->imp->create('a.csv', 'csv', 'u1');
+        $this->imp->create('b.csv', 'csv', 'u1');
+        $this->imp->create('c.csv', 'csv', 'u2');
+
+        $jobs = $this->imp->forUser('u1');
+        $this->assertCount(2, $jobs);
+    }
+
+    public function testForUserReturnsNewestFirst(): void
+    {
+        $id1 = $this->imp->create('a.csv', 'csv', 'u1');
+        $id2 = $this->imp->create('b.csv', 'csv', 'u1');
+
+        $jobs = $this->imp->forUser('u1');
+        $this->assertSame($id2, (int)$jobs[0]['id']);
+        $this->assertSame($id1, (int)$jobs[1]['id']);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\DataImportJob` — two-table CSV/data import job tracking with per-row error recording.

Distinct from `BatchJob` (generic progress tracking) and `ExportJob` (outbound). Tracks the full import lifecycle with per-row validation errors.

## Schema

```sql
CREATE TABLE data_import_jobs (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    filename     TEXT         NOT NULL,
    format       VARCHAR(20)  NOT NULL DEFAULT 'csv',
    uploaded_by  VARCHAR(255) NOT NULL,
    status       VARCHAR(20)  NOT NULL DEFAULT 'pending',
    total_rows   INTEGER      NULL,
    done_rows    INTEGER      NOT NULL DEFAULT 0,
    error_count  INTEGER      NOT NULL DEFAULT 0,
    started_at   DATETIME     NULL,
    finished_at  DATETIME     NULL,
    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);

CREATE TABLE data_import_errors (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    job_id     INTEGER      NOT NULL,
    row_num    INTEGER      NOT NULL,
    field      VARCHAR(100) NULL,
    message    TEXT         NOT NULL,
    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API

- `create(filename, format, uploadedBy)` → int
- `find(id)` → ?array
- `startValidation(id)` / `startProcessing(id, total)` / `finish(id, done)` / `fail(id, reason)`
- `addError(jobId, rowNum, field, message)` → int (increments error_count)
- `errors(jobId)` — ordered by row number
- `forUser(uploadedBy)` — newest first

## Tests

17 tests, 41 assertions — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)