### PR TITLE
feat(xion): add AppVersion helper (FT199)

### DIFF
--- a/class/xion/AppVersion.php
+++ b/class/xion/AppVersion.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * AppVersion — deployment/release version history tracking.
+ *
+ * Records when each version of the application was deployed, to which
+ * environment, by whom, and with which git hash. Useful for audit trails,
+ * rollback decisions, and release dashboards.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $av = new AppVersion($pdo);
+ *
+ * $id = $av->record('1.4.2', 'production', 'a3f9c12', 'deploy-bot');
+ * $current = $av->current('production');  // latest for env
+ * $history = $av->history('production', 5);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE app_versions (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     version     VARCHAR(50)  NOT NULL,
+ *     environment VARCHAR(50)  NOT NULL DEFAULT 'production',
+ *     git_hash    VARCHAR(40)  NULL,
+ *     deployed_by VARCHAR(255) NULL,
+ *     note        TEXT         NULL,
+ *     deployed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class AppVersion
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record a new deployment.
+     *
+     * @return int Row ID.
+     * @throws \InvalidArgumentException on empty version.
+     */
+    public function record(
+        string $version,
+        string $environment = 'production',
+        ?string $gitHash = null,
+        ?string $deployedBy = null,
+        ?string $note = null
+    ): int {
+        $version     = trim($version);
+        $environment = trim($environment) === '' ? 'production' : trim($environment);
+        if ($version === '') {
+            throw new \InvalidArgumentException('version must not be empty.');
+        }
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO app_versions (version, environment, git_hash, deployed_by, note, deployed_at)
+             VALUES (:ver, :env, :hash, :by, :note, :now)'
+        );
+        $stmt->execute([
+            ':ver'  => $version,
+            ':env'  => $environment,
+            ':hash' => $gitHash,
+            ':by'   => $deployedBy,
+            ':note' => $note,
+            ':now'  => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Find a specific version record by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, version, environment, git_hash, deployed_by, note, deployed_at
+             FROM app_versions WHERE id = :id'
+        );
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * Return the most recently recorded version for an environment.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function current(string $environment = 'production'): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, version, environment, git_hash, deployed_by, note, deployed_at
+             FROM app_versions WHERE environment = :env ORDER BY id DESC LIMIT 1'
+        );
+        $stmt->execute([':env' => trim($environment)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * Return the deployment history for an environment, newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function history(string $environment = 'production', int $limit = 20): array
+    {
+        $limit = max(1, $limit);
+        $stmt  = $this->db()->prepare(
+            'SELECT id, version, environment, git_hash, deployed_by, note, deployed_at
+             FROM app_versions WHERE environment = :env ORDER BY id DESC LIMIT :lim'
+        );
+        $stmt->bindValue(':env', trim($environment), PDO::PARAM_STR);
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return all distinct environments that have been recorded.
+     *
+     * @return list<string>
+     */
+    public function environments(): array
+    {
+        $stmt = $this->db()->query(
+            'SELECT DISTINCT environment FROM app_versions ORDER BY environment ASC'
+        );
+        if ($stmt === false) {
+            return [];
+        }
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Delete all version records for an environment.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function clearEnvironment(string $environment): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM app_versions WHERE environment = :env');
+        $stmt->execute([':env' => trim($environment)]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ──────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/AppVersionTest.php
+++ b/tests/Unit/Xion/AppVersionTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\AppVersion;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class AppVersionTest extends TestCase
+{
+    private PDO $pdo;
+    private AppVersion $av;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE app_versions (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                version     VARCHAR(50)  NOT NULL,
+                environment VARCHAR(50)  NOT NULL DEFAULT \'production\',
+                git_hash    VARCHAR(40)  NULL,
+                deployed_by VARCHAR(255) NULL,
+                note        TEXT         NULL,
+                deployed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->av = new AppVersion($this->pdo);
+    }
+
+    // ── record / find ─────────────────────────────────────────────────────────
+
+    public function testRecordReturnsId(): void
+    {
+        $id = $this->av->record('1.0.0');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testRecordStoresAllFields(): void
+    {
+        $id  = $this->av->record('1.2.3', 'staging', 'abc123', 'ci-bot', 'Hotfix');
+        $row = $this->av->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('1.2.3', $row['version']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('staging', $row['environment']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('abc123', $row['git_hash']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('ci-bot', $row['deployed_by']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Hotfix', $row['note']);
+    }
+
+    public function testRecordUsesProductionAsDefaultEnv(): void
+    {
+        $id  = $this->av->record('1.0.0');
+        $row = $this->av->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('production', $row['environment']);
+    }
+
+    public function testRecordThrowsOnEmptyVersion(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->av->record('');
+    }
+
+    // ── current ───────────────────────────────────────────────────────────────
+
+    public function testCurrentReturnsLatestForEnvironment(): void
+    {
+        $id1 = $this->av->record('1.0.0', 'production');
+        $id2 = $this->av->record('1.1.0', 'production');
+        $this->av->record('2.0.0', 'staging');
+
+        $row = $this->av->current('production');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame($id2, (int)$row['id']);
+    }
+
+    public function testCurrentReturnsNullWhenNoRecords(): void
+    {
+        $this->assertNull($this->av->current('production'));
+    }
+
+    // ── history ───────────────────────────────────────────────────────────────
+
+    public function testHistoryReturnsNewestFirst(): void
+    {
+        $id1 = $this->av->record('1.0', 'prod');
+        $id2 = $this->av->record('1.1', 'prod');
+        $id3 = $this->av->record('1.2', 'prod');
+
+        $history = $this->av->history('prod');
+        $this->assertSame($id3, (int)$history[0]['id']);
+        $this->assertSame($id2, (int)$history[1]['id']);
+        $this->assertSame($id1, (int)$history[2]['id']);
+    }
+
+    public function testHistoryRespectsLimit(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->av->record("1.{$i}", 'prod');
+        }
+        $history = $this->av->history('prod', 3);
+        $this->assertCount(3, $history);
+    }
+
+    public function testHistoryIsolatedByEnvironment(): void
+    {
+        $this->av->record('1.0', 'prod');
+        $this->av->record('2.0', 'staging');
+
+        $this->assertCount(1, $this->av->history('prod'));
+        $this->assertCount(1, $this->av->history('staging'));
+    }
+
+    // ── environments ─────────────────────────────────────────────────────────
+
+    public function testEnvironmentsReturnsSortedDistinctList(): void
+    {
+        $this->av->record('1.0', 'staging');
+        $this->av->record('1.0', 'production');
+        $this->av->record('1.1', 'production');
+
+        $envs = $this->av->environments();
+        $this->assertSame(['production', 'staging'], $envs);
+    }
+
+    public function testEnvironmentsReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->av->environments());
+    }
+
+    // ── clearEnvironment ──────────────────────────────────────────────────────
+
+    public function testClearEnvironmentDeletesRecords(): void
+    {
+        $this->av->record('1.0', 'prod');
+        $this->av->record('1.1', 'prod');
+        $this->av->record('2.0', 'staging');
+
+        $count = $this->av->clearEnvironment('prod');
+        $this->assertSame(2, $count);
+        $this->assertSame([], $this->av->history('prod'));
+        $this->assertCount(1, $this->av->history('staging'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\AppVersion` — deployment/release version history tracking per environment.

## Schema

```sql
CREATE TABLE app_versions (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    version     VARCHAR(50)  NOT NULL,
    environment VARCHAR(50)  NOT NULL DEFAULT 'production',
    git_hash    VARCHAR(40)  NULL,
    deployed_by VARCHAR(255) NULL,
    note        TEXT         NULL,
    deployed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API

- `record(version, environment, gitHash, deployedBy, note)` → int
- `find(id)` → ?array
- `current(environment)` → ?array (latest for env)
- `history(environment, limit=20)` — newest first
- `environments()` → distinct sorted list
- `clearEnvironment(environment)` → int

## Tests

12 tests, 24 assertions — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)