### PR TITLE
feat(xion): add UserSegment helper (FT200)

### DIFF
--- a/class/xion/UserSegment.php
+++ b/class/xion/UserSegment.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * UserSegment — user cohort/segment assignment for targeting and analytics.
+ *
+ * Assigns users to named segments (e.g. "power-users", "trial-expired",
+ * "beta-testers"). Segments can have an optional description. The
+ * membership table uses a UNIQUE constraint so each user is in each
+ * segment at most once.
+ *
+ * Use cases: A/B test cohorts, feature rollout groups, marketing targeting,
+ * retention cohorts, risk classification.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $seg = new UserSegment($pdo);
+ *
+ * $seg->createSegment('beta-testers', 'Users enrolled in the beta program');
+ * $seg->addUser('beta-testers', 'user-1');
+ * $seg->addUser('beta-testers', 'user-2');
+ *
+ * $users = $seg->usersIn('beta-testers');
+ * $segs  = $seg->segmentsFor('user-1');
+ * $seg->removeUser('beta-testers', 'user-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE user_segments (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     name        VARCHAR(100) NOT NULL UNIQUE,
+ *     description TEXT         NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE user_segment_members (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     segment    VARCHAR(100) NOT NULL,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     added_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (segment, user_id)
+ * );
+ * ```
+ */
+final class UserSegment
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── segment management ────────────────────────────────────────────────────
+
+    /**
+     * Create a new segment. Idempotent (duplicate names are ignored).
+     *
+     * @throws \InvalidArgumentException on empty name.
+     */
+    public function createSegment(string $name, ?string $description = null): void
+    {
+        $name = trim($name);
+        if ($name === '') {
+            throw new \InvalidArgumentException('segment name must not be empty.');
+        }
+        $now    = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $sql = 'INSERT OR IGNORE INTO user_segments (name, description, created_at)
+                    VALUES (:name, :desc, :now)';
+        } else {
+            $sql = 'INSERT IGNORE INTO user_segments (name, description, created_at)
+                    VALUES (:name, :desc, :now)';
+        }
+        $this->db()->prepare($sql)->execute([':name' => $name, ':desc' => $description, ':now' => $now]);
+    }
+
+    /**
+     * Delete a segment and all its memberships.
+     *
+     * @return bool True if the segment existed and was removed.
+     */
+    public function deleteSegment(string $name): bool
+    {
+        $name = trim($name);
+        $this->db()->prepare(
+            'DELETE FROM user_segment_members WHERE segment = :name'
+        )->execute([':name' => $name]);
+        $stmt = $this->db()->prepare('DELETE FROM user_segments WHERE name = :name');
+        $stmt->execute([':name' => $name]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Return all defined segments ordered by name.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function allSegments(): array
+    {
+        $stmt = $this->db()->query(
+            'SELECT id, name, description, created_at FROM user_segments ORDER BY name ASC'
+        );
+        if ($stmt === false) {
+            return [];
+        }
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    // ── membership ────────────────────────────────────────────────────────────
+
+    /**
+     * Add a user to a segment (idempotent).
+     *
+     * @throws \InvalidArgumentException on empty segment or user_id.
+     */
+    public function addUser(string $segment, string $userId): void
+    {
+        [$segment, $userId] = $this->validate($segment, $userId);
+        $now    = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $sql = 'INSERT OR IGNORE INTO user_segment_members (segment, user_id, added_at)
+                    VALUES (:seg, :uid, :now)';
+        } else {
+            $sql = 'INSERT IGNORE INTO user_segment_members (segment, user_id, added_at)
+                    VALUES (:seg, :uid, :now)';
+        }
+        $this->db()->prepare($sql)->execute([':seg' => $segment, ':uid' => $userId, ':now' => $now]);
+    }
+
+    /**
+     * Remove a user from a segment.
+     *
+     * @return bool True if the membership existed and was removed.
+     */
+    public function removeUser(string $segment, string $userId): bool
+    {
+        [$segment, $userId] = $this->validate($segment, $userId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM user_segment_members WHERE segment = :seg AND user_id = :uid'
+        );
+        $stmt->execute([':seg' => $segment, ':uid' => $userId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Return true if the user is a member of the segment.
+     */
+    public function isMember(string $segment, string $userId): bool
+    {
+        [$segment, $userId] = $this->validate($segment, $userId);
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM user_segment_members WHERE segment = :seg AND user_id = :uid'
+        );
+        $stmt->execute([':seg' => $segment, ':uid' => $userId]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Return all user IDs in a segment, ordered alphabetically.
+     *
+     * @return list<string>
+     */
+    public function usersIn(string $segment): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT user_id FROM user_segment_members WHERE segment = :seg ORDER BY user_id ASC'
+        );
+        $stmt->execute([':seg' => trim($segment)]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Return the count of members in a segment.
+     */
+    public function memberCount(string $segment): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM user_segment_members WHERE segment = :seg'
+        );
+        $stmt->execute([':seg' => trim($segment)]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Return all segment names a user belongs to, alphabetically.
+     *
+     * @return list<string>
+     */
+    public function segmentsFor(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT segment FROM user_segment_members WHERE user_id = :uid ORDER BY segment ASC'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Remove a user from all segments.
+     *
+     * @return int Number of memberships removed.
+     */
+    public function removeFromAll(string $userId): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM user_segment_members WHERE user_id = :uid'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ──────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function validate(string $segment, string $userId): array
+    {
+        $segment = trim($segment);
+        $userId  = trim($userId);
+        if ($segment === '') {
+            throw new \InvalidArgumentException('segment must not be empty.');
+        }
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        return [$segment, $userId];
+    }
+}

--- a/tests/Unit/Xion/UserSegmentTest.php
+++ b/tests/Unit/Xion/UserSegmentTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\UserSegment;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class UserSegmentTest extends TestCase
+{
+    private PDO $pdo;
+    private UserSegment $seg;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE user_segments (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                name        VARCHAR(100) NOT NULL UNIQUE,
+                description TEXT         NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->pdo->exec('
+            CREATE TABLE user_segment_members (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                segment  VARCHAR(100) NOT NULL,
+                user_id  VARCHAR(255) NOT NULL,
+                added_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (segment, user_id)
+            )
+        ');
+        $this->seg = new UserSegment($this->pdo);
+    }
+
+    // ── createSegment ─────────────────────────────────────────────────────────
+
+    public function testCreateSegmentAddsToList(): void
+    {
+        $this->seg->createSegment('beta-testers', 'Beta program');
+        $segments = $this->seg->allSegments();
+        $this->assertCount(1, $segments);
+        $this->assertSame('beta-testers', $segments[0]['name']);
+        $this->assertSame('Beta program', $segments[0]['description']);
+    }
+
+    public function testCreateSegmentIsIdempotent(): void
+    {
+        $this->seg->createSegment('beta');
+        $this->seg->createSegment('beta');
+        $this->assertCount(1, $this->seg->allSegments());
+    }
+
+    public function testCreateSegmentThrowsOnEmptyName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->seg->createSegment('');
+    }
+
+    // ── deleteSegment ─────────────────────────────────────────────────────────
+
+    public function testDeleteSegmentRemovesSegmentAndMembers(): void
+    {
+        $this->seg->createSegment('old');
+        $this->seg->addUser('old', 'u1');
+        $this->assertTrue($this->seg->deleteSegment('old'));
+        $this->assertCount(0, $this->seg->allSegments());
+        $this->assertSame([], $this->seg->usersIn('old'));
+    }
+
+    public function testDeleteSegmentReturnsFalseWhenMissing(): void
+    {
+        $this->assertFalse($this->seg->deleteSegment('nonexistent'));
+    }
+
+    // ── allSegments ───────────────────────────────────────────────────────────
+
+    public function testAllSegmentsReturnsAlphabeticList(): void
+    {
+        $this->seg->createSegment('z-seg');
+        $this->seg->createSegment('a-seg');
+        $segments = $this->seg->allSegments();
+        $this->assertSame('a-seg', $segments[0]['name']);
+        $this->assertSame('z-seg', $segments[1]['name']);
+    }
+
+    // ── addUser / isMember ────────────────────────────────────────────────────
+
+    public function testAddUserMakesUserMember(): void
+    {
+        $this->seg->addUser('beta', 'u1');
+        $this->assertTrue($this->seg->isMember('beta', 'u1'));
+    }
+
+    public function testAddUserIsIdempotent(): void
+    {
+        $this->seg->addUser('beta', 'u1');
+        $this->seg->addUser('beta', 'u1');
+        $this->assertSame(1, $this->seg->memberCount('beta'));
+    }
+
+    public function testIsMemberReturnsFalseWhenNot(): void
+    {
+        $this->assertFalse($this->seg->isMember('beta', 'u99'));
+    }
+
+    public function testAddUserThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->seg->addUser('seg', '');
+    }
+
+    // ── removeUser ────────────────────────────────────────────────────────────
+
+    public function testRemoveUserRemovesMembership(): void
+    {
+        $this->seg->addUser('beta', 'u1');
+        $this->assertTrue($this->seg->removeUser('beta', 'u1'));
+        $this->assertFalse($this->seg->isMember('beta', 'u1'));
+    }
+
+    public function testRemoveUserReturnsFalseWhenNotMember(): void
+    {
+        $this->assertFalse($this->seg->removeUser('beta', 'u99'));
+    }
+
+    // ── usersIn / memberCount ─────────────────────────────────────────────────
+
+    public function testUsersInReturnsAlphabeticList(): void
+    {
+        $this->seg->addUser('seg', 'u3');
+        $this->seg->addUser('seg', 'u1');
+        $this->seg->addUser('seg', 'u2');
+
+        $users = $this->seg->usersIn('seg');
+        $this->assertSame(['u1', 'u2', 'u3'], $users);
+    }
+
+    public function testMemberCountIsCorrect(): void
+    {
+        $this->seg->addUser('seg', 'u1');
+        $this->seg->addUser('seg', 'u2');
+        $this->assertSame(2, $this->seg->memberCount('seg'));
+    }
+
+    // ── segmentsFor ───────────────────────────────────────────────────────────
+
+    public function testSegmentsForReturnsUsersSegments(): void
+    {
+        $this->seg->addUser('b-seg', 'u1');
+        $this->seg->addUser('a-seg', 'u1');
+        $this->seg->addUser('b-seg', 'u2');
+
+        $segs = $this->seg->segmentsFor('u1');
+        $this->assertSame(['a-seg', 'b-seg'], $segs);
+    }
+
+    public function testSegmentsForReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->seg->segmentsFor('u99'));
+    }
+
+    // ── removeFromAll ─────────────────────────────────────────────────────────
+
+    public function testRemoveFromAllRemovesAllMemberships(): void
+    {
+        $this->seg->addUser('seg1', 'u1');
+        $this->seg->addUser('seg2', 'u1');
+        $this->seg->addUser('seg1', 'u2');
+
+        $count = $this->seg->removeFromAll('u1');
+        $this->assertSame(2, $count);
+        $this->assertSame([], $this->seg->segmentsFor('u1'));
+        $this->assertCount(1, $this->seg->usersIn('seg1')); // u2 still in
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Nene\Xion\UserSegment` — user cohort/segment assignment for targeting and analytics.

Two-table design with segment definitions and idempotent membership. Use cases: A/B test cohorts, feature rollout groups, marketing targeting, retention cohorts.

## Schema

```sql
CREATE TABLE user_segments (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    name        VARCHAR(100) NOT NULL UNIQUE,
    description TEXT         NULL,
    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);

CREATE TABLE user_segment_members (
    id       INTEGER PRIMARY KEY AUTOINCREMENT,
    segment  VARCHAR(100) NOT NULL,
    user_id  VARCHAR(255) NOT NULL,
    added_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    UNIQUE (segment, user_id)
);
```

## API

- `createSegment(name, description)` — idempotent
- `deleteSegment(name)` — removes segment + all memberships
- `allSegments()` — alphabetically ordered
- `addUser(segment, userId)` — idempotent
- `removeUser(segment, userId)` → bool
- `isMember(segment, userId)` → bool
- `usersIn(segment)` → alphabetic list
- `memberCount(segment)` → int
- `segmentsFor(userId)` → alphabetic list
- `removeFromAll(userId)` → int

## Tests

17 tests, 25 assertions — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)