### PR TITLE
docs: update roadmap/todo/candidates for FT196-FT200 wave

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -14,7 +14,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ## Active candidates
 
-The Xion helper wave (FT78–FT195) is ongoing as of 2026-05-27. Trigger-based and structural candidates are listed in the next section.
+The Xion helper wave (FT78–FT200) is ongoing as of 2026-05-27. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -54,6 +54,11 @@ The Xion helper wave (FT78–FT195) is ongoing as of 2026-05-27. Trigger-based a
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT200 — UserSegment** (2026-05-27): `Nene\Xion\UserSegment` — user cohort/segment assignment; two-table design (definitions + members); idempotent addUser; segmentsFor/usersIn. PR #639.
+- **FT199 — AppVersion** (2026-05-27): `Nene\Xion\AppVersion` — deployment/release version history per environment; current() latest; history() newest-first; environments(). PR #638.
+- **FT198 — OrderLine** (2026-05-27): `Nene\Xion\OrderLine` — e-commerce order with line items (two-table); integer-cent amounts; pending→confirmed→shipped→delivered|cancelled. PR #637.
+- **FT197 — TopicSubscription** (2026-05-27): `Nene\Xion\TopicSubscription` — user subscriptions to named topics; idempotent subscribe; subscribersOf() fanout; distinct from NewsletterSubscription. PR #636.
+- **FT196 — DataImportJob** (2026-05-27): `Nene\Xion\DataImportJob` — two-table CSV import job tracking with per-row errors; pending→validating→processing→done|failed; error_count. PR #635.
 - **FT195 — UserTier** (2026-05-27): `Nene\Xion\UserTier` — gamification tier assignment with two-table design (current + history); hasEverHad(). PR #633.
 - **FT194 — FaqItem** (2026-05-27): `Nene\Xion\FaqItem` — FAQ articles with category, position ordering, keyword search, helpfulness voting. PR #632.
 - **FT193 — ProductReview** (2026-05-27): `Nene\Xion\ProductReview` — entity reviews with 1–5 star ratings; approval workflow; helpfulness voting; one review per user per entity. PR #631.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT195 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT200 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 
@@ -238,6 +238,7 @@ Completed (wave summary):
 - **FT166–FT175**: Xion second extended wave. 10 trials covering plan-based quota management, shareable links with password/expiry, approval workflows, team membership with roles, fraud/trust scoring, payment records, PIN/OTP codes, anonymous guest sessions, cron-style task scheduling, and admin user notes. PRs #602–#611.
 - **FT176–FT185**: Xion third extended wave. 10 trials covering colored labels, ordered checklists, emoji reactions, @-mention tracking, watchlists, file attachments, saved searches, content filtering, user reminders, and knowledge base articles. PRs #613–#622.
 - **FT186–FT195**: Xion fourth extended wave. 10 trials covering support ticketing, event sourcing log, daily digest accumulator, per-resource ACL, 2FA backup codes, typed global settings, ordered media gallery, entity reviews with ratings, FAQ articles, and gamification tier tracking. PRs #624–#633.
+- **FT196–FT200**: Xion fifth extended wave. 5 trials covering CSV import job tracking with per-row errors, topic-based pub/sub subscriptions, e-commerce orders with line items, deployment version history, and user cohort/segment assignment. PRs #635–#639.
 
 Future candidates:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,19 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT195 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT200 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-27 — FT196–FT200: Xion fifth extended wave (5 trials)
+
+Continuous wave of 5 field trials adding further Xion helper patterns. All PRs #635–#639.
+
+**FT196 — DataImportJob**: `DataImportJob` two-table CSV/data import job tracking; per-row error recording; pending→validating→processing→done|failed. PR #635.
+**FT197 — TopicSubscription**: `TopicSubscription` user subscriptions to named topics for notification routing; subscribersOf() fanout; distinct from NewsletterSubscription. PR #636.
+**FT198 — OrderLine**: `OrderLine` e-commerce order with line items (two-table); integer-cent amounts; pending→confirmed→shipped→delivered|cancelled. PR #637.
+**FT199 — AppVersion**: `AppVersion` deployment/release version history per environment; current() latest; history() paginated newest-first. PR #638.
+**FT200 — UserSegment**: `UserSegment` user cohort/segment assignment (two-table); idempotent addUser; segmentsFor/usersIn for targeting. PR #639.
 
 ### 2026-05-27 — FT186–FT195: Xion fourth extended wave (10 trials)
 


### PR DESCRIPTION
## Summary

Records the Xion fifth extended wave (FT196–FT200, PRs #635–#639) in roadmap, todo, and candidates. **FT200 milestone reached.**

| FT | Helper | Pattern |
|----|--------|---------|
| FT196 | DataImportJob | Two-table CSV import job with per-row error tracking |
| FT197 | TopicSubscription | Topic-based pub/sub subscription routing |
| FT198 | OrderLine | E-commerce order with line items (two-table) |
| FT199 | AppVersion | Deployment/release version history per environment |
| FT200 | UserSegment | User cohort/segment assignment (two-table) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)