### PR TITLE
feat(xion): FT203 TimeSlot — appointment booking with capacity

### DIFF
--- a/class/xion/TimeSlot.php
+++ b/class/xion/TimeSlot.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * TimeSlot — appointment/time slot booking with availability.
+ *
+ * Defines available time slots and manages bookings per resource.
+ * A slot is a specific (date, start_time, end_time) window for a given
+ * resource. Each slot has a capacity and tracks how many bookings exist.
+ *
+ * Distinct from EventTicket (event-centric with venue capacity).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ts = new TimeSlot($pdo);
+ *
+ * $slotId = $ts->createSlot('doctor-1', '2026-06-01', '09:00', '09:30', 1);
+ * $bookId = $ts->book($slotId, 'patient-42');
+ * $ts->cancel($bookId);
+ *
+ * $avail = $ts->availableSlots('doctor-1', '2026-06-01');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE time_slots (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     resource_ref VARCHAR(255) NOT NULL,
+ *     slot_date    DATE         NOT NULL,
+ *     start_time   VARCHAR(5)   NOT NULL,
+ *     end_time     VARCHAR(5)   NOT NULL,
+ *     capacity     INTEGER      NOT NULL DEFAULT 1,
+ *     booked       INTEGER      NOT NULL DEFAULT 0,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE time_slot_bookings (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     slot_id    INTEGER      NOT NULL,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     note       TEXT         NULL,
+ *     status     VARCHAR(20)  NOT NULL DEFAULT 'confirmed',
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class TimeSlot
+{
+    public const BOOKING_CONFIRMED = 'confirmed';
+    public const BOOKING_CANCELLED = 'cancelled';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── slot management ───────────────────────────────────────────────────────
+
+    /**
+     * Create a time slot.
+     *
+     * @return int Slot ID.
+     * @throws \InvalidArgumentException on empty resource_ref.
+     */
+    public function createSlot(
+        string $resourceRef,
+        string $slotDate,
+        string $startTime,
+        string $endTime,
+        int $capacity = 1
+    ): int {
+        $resourceRef = trim($resourceRef);
+        if ($resourceRef === '') {
+            throw new \InvalidArgumentException('resource_ref must not be empty.');
+        }
+        if ($capacity < 1) {
+            throw new \InvalidArgumentException('capacity must be at least 1.');
+        }
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO time_slots (resource_ref, slot_date, start_time, end_time, capacity, created_at)
+             VALUES (:res, :date, :start, :end, :cap, :now)'
+        );
+        $stmt->execute([
+            ':res'   => $resourceRef,
+            ':date'  => $slotDate,
+            ':start' => $startTime,
+            ':end'   => $endTime,
+            ':cap'   => $capacity,
+            ':now'   => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Return a slot by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function findSlot(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, resource_ref, slot_date, start_time, end_time, capacity, booked, created_at
+             FROM time_slots WHERE id = :id'
+        );
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * Delete a slot and all its bookings.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function deleteSlot(int $id): bool
+    {
+        $this->db()->prepare('DELETE FROM time_slot_bookings WHERE slot_id = :id')->execute([':id' => $id]);
+        $stmt = $this->db()->prepare('DELETE FROM time_slots WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Return available (not fully booked) slots for a resource on a date.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function availableSlots(string $resourceRef, string $slotDate): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, resource_ref, slot_date, start_time, end_time, capacity, booked, created_at
+             FROM time_slots
+             WHERE resource_ref = :res AND slot_date = :date AND booked < capacity
+             ORDER BY start_time ASC'
+        );
+        $stmt->execute([':res' => trim($resourceRef), ':date' => $slotDate]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    // ── booking ───────────────────────────────────────────────────────────────
+
+    /**
+     * Book a slot for a user. Returns false if the slot is full.
+     *
+     * @return int|false Booking ID on success, false if slot is full or missing.
+     * @throws \InvalidArgumentException on empty user_id.
+     */
+    public function book(int $slotId, string $userId, ?string $note = null): int|false
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+
+        // Attempt to increment booked count atomically
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE time_slots SET booked = booked + 1
+             WHERE id = :id AND booked < capacity'
+        );
+        $stmt->execute([':id' => $slotId]);
+        if ($stmt->rowCount() === 0) {
+            return false;
+        }
+
+        $bStmt = $this->db()->prepare(
+            'INSERT INTO time_slot_bookings (slot_id, user_id, note, created_at)
+             VALUES (:slot, :uid, :note, :now)'
+        );
+        $bStmt->execute([':slot' => $slotId, ':uid' => $userId, ':note' => $note, ':now' => $now]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Cancel a booking. Returns false if already cancelled or not found.
+     *
+     * @return bool True if found (confirmed) and cancelled.
+     */
+    public function cancel(int $bookingId): bool
+    {
+        // Get booking to find slot_id
+        $stmt = $this->db()->prepare(
+            "SELECT slot_id FROM time_slot_bookings WHERE id = :id AND status = 'confirmed'"
+        );
+        $stmt->execute([':id' => $bookingId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return false;
+        }
+
+        $this->db()->prepare(
+            "UPDATE time_slot_bookings SET status = 'cancelled' WHERE id = :id"
+        )->execute([':id' => $bookingId]);
+
+        // Decrement booked count on slot
+        $this->db()->prepare(
+            'UPDATE time_slots SET booked = booked - 1 WHERE id = :id AND booked > 0'
+        )->execute([':id' => $row['slot_id']]);
+
+        return true;
+    }
+
+    /**
+     * Return all bookings for a slot.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function bookingsFor(int $slotId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, slot_id, user_id, note, status, created_at
+             FROM time_slot_bookings WHERE slot_id = :sid ORDER BY id ASC'
+        );
+        $stmt->execute([':sid' => $slotId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    // ── internal helpers ──────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/TimeSlotTest.php
+++ b/tests/Unit/Xion/TimeSlotTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\TimeSlot;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class TimeSlotTest extends TestCase
+{
+    private PDO $pdo;
+    private TimeSlot $ts;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE time_slots (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                resource_ref VARCHAR(255) NOT NULL,
+                slot_date    DATE         NOT NULL,
+                start_time   VARCHAR(5)   NOT NULL,
+                end_time     VARCHAR(5)   NOT NULL,
+                capacity     INTEGER      NOT NULL DEFAULT 1,
+                booked       INTEGER      NOT NULL DEFAULT 0,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->pdo->exec('
+            CREATE TABLE time_slot_bookings (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                slot_id    INTEGER      NOT NULL,
+                user_id    VARCHAR(255) NOT NULL,
+                note       TEXT         NULL,
+                status     VARCHAR(20)  NOT NULL DEFAULT \'confirmed\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->ts = new TimeSlot($this->pdo);
+    }
+
+    // ── createSlot / findSlot ─────────────────────────────────────────────────
+
+    public function testCreateSlotReturnsId(): void
+    {
+        $id = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testCreateSlotStoresCorrectly(): void
+    {
+        $id  = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30', 2);
+        $row = $this->ts->findSlot($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('doc-1', $row['resource_ref']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(2, (int)$row['capacity']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['booked']);
+    }
+
+    public function testCreateSlotThrowsOnEmptyResource(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ts->createSlot('', '2026-06-01', '09:00', '09:30');
+    }
+
+    public function testCreateSlotThrowsOnZeroCapacity(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30', 0);
+    }
+
+    // ── deleteSlot ────────────────────────────────────────────────────────────
+
+    public function testDeleteSlotRemovesSlotAndBookings(): void
+    {
+        $id = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30');
+        $this->ts->book($id, 'u1');
+        $this->assertTrue($this->ts->deleteSlot($id));
+        $this->assertNull($this->ts->findSlot($id));
+        $this->assertCount(0, $this->ts->bookingsFor($id));
+    }
+
+    public function testDeleteSlotReturnsFalseWhenMissing(): void
+    {
+        $this->assertFalse($this->ts->deleteSlot(9999));
+    }
+
+    // ── availableSlots ────────────────────────────────────────────────────────
+
+    public function testAvailableSlotsReturnsOpenSlots(): void
+    {
+        $id1 = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30', 1);
+        $id2 = $this->ts->createSlot('doc-1', '2026-06-01', '10:00', '10:30', 1);
+        $this->ts->book($id1, 'u1'); // fills slot 1
+
+        $avail = $this->ts->availableSlots('doc-1', '2026-06-01');
+        $this->assertCount(1, $avail);
+        $this->assertSame($id2, (int)$avail[0]['id']);
+    }
+
+    public function testAvailableSlotsOrderedByStartTime(): void
+    {
+        $id2 = $this->ts->createSlot('doc-1', '2026-06-01', '14:00', '14:30');
+        $id1 = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30');
+
+        $avail = $this->ts->availableSlots('doc-1', '2026-06-01');
+        $this->assertSame($id1, (int)$avail[0]['id']);
+        $this->assertSame($id2, (int)$avail[1]['id']);
+    }
+
+    // ── book ──────────────────────────────────────────────────────────────────
+
+    public function testBookReturnsBookingId(): void
+    {
+        $slotId = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30');
+        $bid    = $this->ts->book($slotId, 'u1');
+        $this->assertIsInt($bid);
+        $this->assertGreaterThan(0, $bid);
+    }
+
+    public function testBookIncrementsBookedCount(): void
+    {
+        $slotId = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30', 2);
+        $this->ts->book($slotId, 'u1');
+
+        $row = $this->ts->findSlot($slotId);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['booked']);
+    }
+
+    public function testBookReturnsFalseWhenFull(): void
+    {
+        $slotId = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30', 1);
+        $this->ts->book($slotId, 'u1');
+        $this->assertFalse($this->ts->book($slotId, 'u2'));
+    }
+
+    public function testBookThrowsOnEmptyUserId(): void
+    {
+        $slotId = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ts->book($slotId, '');
+    }
+
+    // ── cancel ────────────────────────────────────────────────────────────────
+
+    public function testCancelFreesSlot(): void
+    {
+        $slotId = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30', 1);
+        $bid    = $this->ts->book($slotId, 'u1');
+        $this->assertIsInt($bid);
+        $this->assertTrue($this->ts->cancel($bid));
+
+        $row = $this->ts->findSlot($slotId);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['booked']);
+    }
+
+    public function testCancelReturnsFalseForAlreadyCancelled(): void
+    {
+        $slotId = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30');
+        $bid    = $this->ts->book($slotId, 'u1');
+        $this->assertIsInt($bid);
+        $this->ts->cancel($bid);
+        $this->assertFalse($this->ts->cancel($bid));
+    }
+
+    // ── bookingsFor ───────────────────────────────────────────────────────────
+
+    public function testBookingsForReturnsSlotBookings(): void
+    {
+        $slotId = $this->ts->createSlot('doc-1', '2026-06-01', '09:00', '09:30', 3);
+        $this->ts->book($slotId, 'u1');
+        $this->ts->book($slotId, 'u2');
+
+        $bookings = $this->ts->bookingsFor($slotId);
+        $this->assertCount(2, $bookings);
+    }
+}


### PR DESCRIPTION
## FT203 — TimeSlot

Xion helper for appointment/time-slot booking with capacity control.

### New files
- `class/xion/TimeSlot.php`
- `tests/Unit/Xion/TimeSlotTest.php`

### Schema
```sql
CREATE TABLE time_slots (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    resource_ref VARCHAR(255) NOT NULL,
    slot_date    DATE         NOT NULL,
    start_time   TIME         NOT NULL,
    end_time     TIME         NOT NULL,
    capacity     INTEGER      NOT NULL DEFAULT 1,
    booked       INTEGER      NOT NULL DEFAULT 0,
    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
CREATE TABLE time_slot_bookings (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    slot_id    INTEGER      NOT NULL,
    user_id    VARCHAR(255) NOT NULL,
    note       TEXT         NULL,
    status     VARCHAR(20)  NOT NULL DEFAULT 'confirmed',
    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### API
- `createSlot(resourceRef, slotDate, startTime, endTime, capacity)`
- `findSlot(id)` / `deleteSlot(id)` (cascades to bookings)
- `availableSlots(resourceRef, slotDate)` — WHERE booked < capacity
- `book(slotId, userId, note)` — atomic UPDATE WHERE booked < capacity
- `cancel(bookingId)` — decrements booked count on slot
- `bookingsFor(slotId)`

### Tests
15 tests, 28 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)