### PR TITLE
feat(xion): FT204 IntegrationLog — external API call logging

### DIFF
--- a/class/xion/IntegrationLog.php
+++ b/class/xion/IntegrationLog.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * IntegrationLog — outbound/inbound API call log with request and response data.
+ *
+ * Records every external HTTP/API call your application makes (or receives from
+ * partners) for debugging, auditing, and replay purposes. Each log entry stores
+ * the service name, endpoint, method, request/response bodies, HTTP status, and
+ * duration.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $log = new IntegrationLog($pdo);
+ *
+ * // Record a call
+ * $id = $log->record('stripe', '/v1/charges', 'POST', ['amount' => 500], 200, '{"id":"ch_1"}', 230);
+ *
+ * // Query
+ * $entry   = $log->find($id);
+ * $entries = $log->forService('stripe', 50, 0);
+ * $errors  = $log->errors('stripe', 50, 0);
+ * $count   = $log->countErrors('stripe');
+ * $log->deleteOlderThan(new \DateTimeImmutable('-30 days'));
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE integration_logs (
+ *     id             INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     service        VARCHAR(100) NOT NULL,
+ *     endpoint       TEXT         NOT NULL,
+ *     method         VARCHAR(10)  NOT NULL DEFAULT 'GET',
+ *     request_body   TEXT         NULL,
+ *     http_status    INTEGER      NULL,
+ *     response_body  TEXT         NULL,
+ *     duration_ms    INTEGER      NULL,
+ *     error_message  TEXT         NULL,
+ *     created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class IntegrationLog
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record an API call.
+     *
+     * @param string               $service      Logical service name (e.g. "stripe").
+     * @param string               $endpoint     URL path or identifier.
+     * @param string               $method       HTTP method (GET, POST, …).
+     * @param array<mixed>|string|null $requestBody  Request payload — array is JSON-encoded.
+     * @param int|null             $httpStatus   HTTP response status code.
+     * @param string|null          $responseBody Response body string.
+     * @param int|null             $durationMs   Round-trip duration in milliseconds.
+     * @param string|null          $errorMessage Error description if the call failed.
+     * @return int Row ID of the new log entry.
+     * @throws \InvalidArgumentException on empty service or endpoint.
+     */
+    public function record(
+        string $service,
+        string $endpoint,
+        string $method = 'GET',
+        array|string|null $requestBody = null,
+        ?int $httpStatus = null,
+        ?string $responseBody = null,
+        ?int $durationMs = null,
+        ?string $errorMessage = null,
+    ): int {
+        $service  = trim($service);
+        $endpoint = trim($endpoint);
+        if ($service === '') {
+            throw new \InvalidArgumentException('service must not be empty.');
+        }
+        if ($endpoint === '') {
+            throw new \InvalidArgumentException('endpoint must not be empty.');
+        }
+
+        $reqBody = is_array($requestBody) ? json_encode($requestBody) : $requestBody;
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO integration_logs
+                (service, endpoint, method, request_body, http_status, response_body, duration_ms, error_message)
+             VALUES
+                (:service, :endpoint, :method, :req, :status, :resp, :dur, :err)'
+        );
+        $stmt->execute([
+            ':service'  => $service,
+            ':endpoint' => $endpoint,
+            ':method'   => strtoupper(trim($method)) ?: 'GET',
+            ':req'      => $reqBody,
+            ':status'   => $httpStatus,
+            ':resp'     => $responseBody,
+            ':dur'      => $durationMs,
+            ':err'      => $errorMessage,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Find a single log entry by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM integration_logs WHERE id = :id'
+        );
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Delete a single log entry.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM integration_logs WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List log entries for a specific service (newest first).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forService(string $service, int $limit = 100, int $offset = 0): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM integration_logs
+             WHERE service = :service
+             ORDER BY id DESC
+             LIMIT :lim OFFSET :off'
+        );
+        $stmt->bindValue(':service', trim($service));
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':off', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List entries that have an error_message or non-2xx HTTP status (newest first).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function errors(string $service, int $limit = 100, int $offset = 0): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM integration_logs
+             WHERE service = :service
+               AND (error_message IS NOT NULL OR (http_status IS NOT NULL AND (http_status < 200 OR http_status >= 300)))
+             ORDER BY id DESC
+             LIMIT :lim OFFSET :off'
+        );
+        $stmt->bindValue(':service', trim($service));
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':off', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Count error entries for a service.
+     */
+    public function countErrors(string $service): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM integration_logs
+             WHERE service = :service
+               AND (error_message IS NOT NULL OR (http_status IS NOT NULL AND (http_status < 200 OR http_status >= 300)))'
+        );
+        $stmt->execute([':service' => trim($service)]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * List all distinct service names recorded.
+     *
+     * @return list<string>
+     */
+    public function services(): array
+    {
+        $stmt = $this->db()->query(
+            'SELECT DISTINCT service FROM integration_logs ORDER BY service ASC'
+        );
+        return $stmt !== false ? $stmt->fetchAll(PDO::FETCH_COLUMN) : [];
+    }
+
+    /**
+     * Delete all log entries older than the given cutoff datetime.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function deleteOlderThan(\DateTimeImmutable $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM integration_logs WHERE created_at < :cutoff'
+        );
+        $stmt->execute([':cutoff' => $cutoff->format('Y-m-d H:i:s')]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/IntegrationLogTest.php
+++ b/tests/Unit/Xion/IntegrationLogTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\IntegrationLog;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class IntegrationLogTest extends TestCase
+{
+    private PDO $pdo;
+    private IntegrationLog $log;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE integration_logs (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                service        VARCHAR(100) NOT NULL,
+                endpoint       TEXT         NOT NULL,
+                method         VARCHAR(10)  NOT NULL DEFAULT \'GET\',
+                request_body   TEXT         NULL,
+                http_status    INTEGER      NULL,
+                response_body  TEXT         NULL,
+                duration_ms    INTEGER      NULL,
+                error_message  TEXT         NULL,
+                created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->log = new IntegrationLog($this->pdo);
+    }
+
+    // ── record ────────────────────────────────────────────────────────────────
+
+    public function testRecordReturnsId(): void
+    {
+        $id = $this->log->record('stripe', '/v1/charges', 'POST');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testRecordStoresAllFields(): void
+    {
+        $id = $this->log->record('stripe', '/v1/charges', 'POST', ['amount' => 500], 200, '{"id":"ch_1"}', 230);
+        $entry = $this->log->find($id);
+        $this->assertNotNull($entry);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('stripe', $entry['service']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('/v1/charges', $entry['endpoint']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('POST', $entry['method']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(200, (int)$entry['http_status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('{"id":"ch_1"}', $entry['response_body']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(230, (int)$entry['duration_ms']);
+    }
+
+    public function testRecordArrayRequestBodyEncodedAsJson(): void
+    {
+        $id = $this->log->record('svc', '/ep', 'POST', ['key' => 'val']);
+        $entry = $this->log->find($id);
+        $this->assertNotNull($entry);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('{"key":"val"}', $entry['request_body']);
+    }
+
+    public function testRecordStringRequestBody(): void
+    {
+        $id = $this->log->record('svc', '/ep', 'POST', 'raw-body');
+        $entry = $this->log->find($id);
+        $this->assertNotNull($entry);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('raw-body', $entry['request_body']);
+    }
+
+    public function testRecordUppercasesMethod(): void
+    {
+        $id = $this->log->record('svc', '/ep', 'post');
+        $entry = $this->log->find($id);
+        $this->assertNotNull($entry);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('POST', $entry['method']);
+    }
+
+    public function testRecordWithErrorMessage(): void
+    {
+        $id = $this->log->record('svc', '/ep', 'GET', null, null, null, null, 'Connection refused');
+        $entry = $this->log->find($id);
+        $this->assertNotNull($entry);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Connection refused', $entry['error_message']);
+    }
+
+    public function testRecordThrowsOnEmptyService(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->log->record('', '/ep');
+    }
+
+    public function testRecordThrowsOnEmptyEndpoint(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->log->record('svc', '');
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->log->find(9999));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesEntry(): void
+    {
+        $id = $this->log->record('svc', '/ep');
+        $this->assertTrue($this->log->delete($id));
+        $this->assertNull($this->log->find($id));
+    }
+
+    public function testDeleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->log->delete(9999));
+    }
+
+    // ── forService ────────────────────────────────────────────────────────────
+
+    public function testForServiceReturnsNewestFirst(): void
+    {
+        $id1 = $this->log->record('stripe', '/a');
+        $id2 = $this->log->record('stripe', '/b');
+        $entries = $this->log->forService('stripe');
+        $this->assertCount(2, $entries);
+        $this->assertSame($id2, (int)$entries[0]['id']);
+        $this->assertSame($id1, (int)$entries[1]['id']);
+    }
+
+    public function testForServiceIsIsolatedByService(): void
+    {
+        $this->log->record('stripe', '/a');
+        $this->log->record('twilio', '/b');
+        $this->assertCount(1, $this->log->forService('stripe'));
+        $this->assertCount(1, $this->log->forService('twilio'));
+    }
+
+    public function testForServiceReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->log->forService('unknown'));
+    }
+
+    public function testForServiceRespectsLimitOffset(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->log->record('svc', '/ep');
+        }
+        $page1 = $this->log->forService('svc', 3, 0);
+        $page2 = $this->log->forService('svc', 3, 3);
+        $this->assertCount(3, $page1);
+        $this->assertCount(2, $page2);
+    }
+
+    // ── errors ────────────────────────────────────────────────────────────────
+
+    public function testErrorsReturnsEntriesWithErrorMessage(): void
+    {
+        $this->log->record('svc', '/ok', 'GET', null, 200);
+        $errId = $this->log->record('svc', '/fail', 'GET', null, null, null, null, 'Timeout');
+        $errors = $this->log->errors('svc');
+        $this->assertCount(1, $errors);
+        $this->assertSame($errId, (int)$errors[0]['id']);
+    }
+
+    public function testErrorsReturnsEntriesWithNon2xxStatus(): void
+    {
+        $this->log->record('svc', '/ok', 'GET', null, 200);
+        $e404 = $this->log->record('svc', '/missing', 'GET', null, 404);
+        $e500 = $this->log->record('svc', '/broken', 'GET', null, 500);
+        $errors = $this->log->errors('svc');
+        $this->assertCount(2, $errors);
+        $ids = array_map('intval', array_column($errors, 'id'));
+        $this->assertContains($e404, $ids);
+        $this->assertContains($e500, $ids);
+    }
+
+    public function testErrorsReturnsEmptyWhenAllSuccessful(): void
+    {
+        $this->log->record('svc', '/a', 'GET', null, 200);
+        $this->log->record('svc', '/b', 'POST', null, 201);
+        $this->assertSame([], $this->log->errors('svc'));
+    }
+
+    // ── countErrors ───────────────────────────────────────────────────────────
+
+    public function testCountErrors(): void
+    {
+        $this->log->record('svc', '/ok', 'GET', null, 200);
+        $this->log->record('svc', '/fail', 'GET', null, 500);
+        $this->log->record('svc', '/err', 'GET', null, null, null, null, 'Timeout');
+        $this->assertSame(2, $this->log->countErrors('svc'));
+    }
+
+    public function testCountErrorsReturnsZeroWhenNone(): void
+    {
+        $this->assertSame(0, $this->log->countErrors('svc'));
+    }
+
+    // ── services ─────────────────────────────────────────────────────────────
+
+    public function testServicesReturnsDistinctNames(): void
+    {
+        $this->log->record('stripe', '/a');
+        $this->log->record('stripe', '/b');
+        $this->log->record('twilio', '/c');
+        $services = $this->log->services();
+        $this->assertCount(2, $services);
+        $this->assertContains('stripe', $services);
+        $this->assertContains('twilio', $services);
+    }
+
+    public function testServicesReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->log->services());
+    }
+
+    // ── deleteOlderThan ───────────────────────────────────────────────────────
+
+    public function testDeleteOlderThan(): void
+    {
+        // Insert with explicit old timestamp
+        $this->pdo->exec("INSERT INTO integration_logs (service, endpoint, created_at) VALUES ('svc', '/old', '2020-01-01 00:00:00')");
+        $this->log->record('svc', '/new');
+
+        $cutoff = new \DateTimeImmutable('2021-01-01 00:00:00');
+        $count = $this->log->deleteOlderThan($cutoff);
+        $this->assertSame(1, $count);
+        $this->assertCount(1, $this->log->forService('svc'));
+    }
+
+    public function testDeleteOlderThanReturnsZeroWhenNone(): void
+    {
+        $cutoff = new \DateTimeImmutable('2000-01-01 00:00:00');
+        $this->assertSame(0, $this->log->deleteOlderThan($cutoff));
+    }
+}


### PR DESCRIPTION
## FT204 — IntegrationLog

Xion helper for logging outbound/inbound API calls with request, response, and error data.

### New files
- `class/xion/IntegrationLog.php`
- `tests/Unit/Xion/IntegrationLogTest.php`

### Schema
```sql
CREATE TABLE integration_logs (
    id             INTEGER PRIMARY KEY AUTOINCREMENT,
    service        VARCHAR(100) NOT NULL,
    endpoint       TEXT         NOT NULL,
    method         VARCHAR(10)  NOT NULL DEFAULT 'GET',
    request_body   TEXT         NULL,
    http_status    INTEGER      NULL,
    response_body  TEXT         NULL,
    duration_ms    INTEGER      NULL,
    error_message  TEXT         NULL,
    created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### API
- `record(service, endpoint, method, requestBody, httpStatus, responseBody, durationMs, errorMessage)`
- `find(id)` / `delete(id)`
- `forService(service, limit, offset)` — newest first
- `errors(service, limit, offset)` — non-2xx or error_message entries
- `countErrors(service)`
- `services()` — distinct service names
- `deleteOlderThan(DateTimeImmutable)` — TTL pruning

### Tests
24 tests, 45 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)