### PR TITLE
feat(xion): FT205 GdprRequest — GDPR data-subject request tracking

### DIFF
--- a/class/xion/GdprRequest.php
+++ b/class/xion/GdprRequest.php
@@ -233,9 +233,9 @@ final class GdprRequest
     }
 
     /**
-     * Count requests grouped by type.
+     * Count requests of a given type.
      *
-     * @return array<string,int>  e.g. ['erasure' => 12, 'access' => 5]
+     * @return int
      */
     public function countByType(string $type): int
     {

--- a/class/xion/GdprRequest.php
+++ b/class/xion/GdprRequest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * GdprRequest — GDPR data-subject request tracking.
+ *
+ * Tracks Article 15 (access), Article 16 (rectification), Article 17 (erasure /
+ * right-to-be-forgotten), and Article 20 (portability) requests submitted by
+ * users. Each request moves through a defined lifecycle with timestamped
+ * transitions.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $gdpr = new GdprRequest($pdo);
+ *
+ * // Submit a request
+ * $id = $gdpr->submit('user-42', GdprRequest::TYPE_ERASURE, 'Please delete my account');
+ *
+ * // Workflow
+ * $gdpr->acknowledge($id);
+ * $gdpr->complete($id, 'All data removed from production');
+ * // or $gdpr->reject($id, 'Cannot process — ongoing contract');
+ *
+ * // Query
+ * $req    = $gdpr->find($id);
+ * $list   = $gdpr->forUser('user-42');
+ * $open   = $gdpr->pending(50, 0);
+ * $count  = $gdpr->countByType(GdprRequest::TYPE_ERASURE);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE gdpr_requests (
+ *     id             INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id        VARCHAR(255) NOT NULL,
+ *     type           VARCHAR(30)  NOT NULL,
+ *     status         VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     notes          TEXT         NULL,
+ *     response_notes TEXT         NULL,
+ *     submitted_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     acknowledged_at DATETIME    NULL,
+ *     completed_at   DATETIME     NULL
+ * );
+ * ```
+ */
+final class GdprRequest
+{
+    public const TYPE_ACCESS        = 'access';
+    public const TYPE_RECTIFICATION = 'rectification';
+    public const TYPE_ERASURE       = 'erasure';
+    public const TYPE_PORTABILITY   = 'portability';
+
+    public const STATUS_PENDING    = 'pending';
+    public const STATUS_ACKNOWLEDGED = 'acknowledged';
+    public const STATUS_COMPLETED  = 'completed';
+    public const STATUS_REJECTED   = 'rejected';
+
+    private const VALID_TYPES = [
+        self::TYPE_ACCESS,
+        self::TYPE_RECTIFICATION,
+        self::TYPE_ERASURE,
+        self::TYPE_PORTABILITY,
+    ];
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Submit a new GDPR request.
+     *
+     * @return int Row ID of the new request.
+     * @throws \InvalidArgumentException on invalid userId or type.
+     */
+    public function submit(string $userId, string $type, ?string $notes = null): int
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('userId must not be empty.');
+        }
+        if (!in_array($type, self::VALID_TYPES, true)) {
+            throw new \InvalidArgumentException("Invalid request type: {$type}.");
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO gdpr_requests (user_id, type, status, notes)
+             VALUES (:uid, :type, :status, :notes)'
+        );
+        $stmt->execute([
+            ':uid'    => $userId,
+            ':type'   => $type,
+            ':status' => self::STATUS_PENDING,
+            ':notes'  => $notes,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Find a single request by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM gdpr_requests WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Acknowledge a pending request (confirm receipt; start processing).
+     *
+     * @return bool True if found in pending state and updated.
+     */
+    public function acknowledge(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE gdpr_requests
+             SET status = :status, acknowledged_at = :now
+             WHERE id = :id AND status = :pending'
+        );
+        $stmt->execute([
+            ':status'  => self::STATUS_ACKNOWLEDGED,
+            ':now'     => $now,
+            ':id'      => $id,
+            ':pending' => self::STATUS_PENDING,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Complete a request.
+     *
+     * @return bool True if found in pending|acknowledged state and updated.
+     */
+    public function complete(int $id, ?string $responseNotes = null): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE gdpr_requests
+             SET status = :status, completed_at = :now, response_notes = :notes
+             WHERE id = :id AND status IN (:pending, :ack)'
+        );
+        $stmt->execute([
+            ':status'  => self::STATUS_COMPLETED,
+            ':now'     => $now,
+            ':notes'   => $responseNotes,
+            ':id'      => $id,
+            ':pending' => self::STATUS_PENDING,
+            ':ack'     => self::STATUS_ACKNOWLEDGED,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Reject a request.
+     *
+     * @return bool True if found in pending|acknowledged state and updated.
+     */
+    public function reject(int $id, ?string $responseNotes = null): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE gdpr_requests
+             SET status = :status, response_notes = :notes
+             WHERE id = :id AND status IN (:pending, :ack)'
+        );
+        $stmt->execute([
+            ':status'  => self::STATUS_REJECTED,
+            ':notes'   => $responseNotes,
+            ':id'      => $id,
+            ':pending' => self::STATUS_PENDING,
+            ':ack'     => self::STATUS_ACKNOWLEDGED,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete a request record permanently.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM gdpr_requests WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List all requests for a user (newest first).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forUser(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM gdpr_requests WHERE user_id = :uid ORDER BY id DESC'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List pending and acknowledged requests (oldest first — FIFO processing).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function pending(int $limit = 50, int $offset = 0): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM gdpr_requests
+             WHERE status IN (:pending, :ack)
+             ORDER BY id ASC
+             LIMIT :lim OFFSET :off'
+        );
+        $stmt->bindValue(':pending', self::STATUS_PENDING);
+        $stmt->bindValue(':ack', self::STATUS_ACKNOWLEDGED);
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':off', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Count requests grouped by type.
+     *
+     * @return array<string,int>  e.g. ['erasure' => 12, 'access' => 5]
+     */
+    public function countByType(string $type): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM gdpr_requests WHERE type = :type'
+        );
+        $stmt->execute([':type' => $type]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Count requests by status.
+     */
+    public function countByStatus(string $status): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM gdpr_requests WHERE status = :status'
+        );
+        $stmt->execute([':status' => $status]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/GdprRequestTest.php
+++ b/tests/Unit/Xion/GdprRequestTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\GdprRequest;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class GdprRequestTest extends TestCase
+{
+    private PDO $pdo;
+    private GdprRequest $gdpr;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE gdpr_requests (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id         VARCHAR(255) NOT NULL,
+                type            VARCHAR(30)  NOT NULL,
+                status          VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                notes           TEXT         NULL,
+                response_notes  TEXT         NULL,
+                submitted_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                acknowledged_at DATETIME     NULL,
+                completed_at    DATETIME     NULL
+            )
+        ');
+        $this->gdpr = new GdprRequest($this->pdo);
+    }
+
+    // ── submit ────────────────────────────────────────────────────────────────
+
+    public function testSubmitReturnsId(): void
+    {
+        $id = $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testSubmitStoresCorrectly(): void
+    {
+        $id  = $this->gdpr->submit('user-1', GdprRequest::TYPE_ACCESS, 'Need my data');
+        $req = $this->gdpr->find($id);
+        $this->assertNotNull($req);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $req['user_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(GdprRequest::TYPE_ACCESS, $req['type']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(GdprRequest::STATUS_PENDING, $req['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Need my data', $req['notes']);
+    }
+
+    public function testSubmitAllTypes(): void
+    {
+        $types = [
+            GdprRequest::TYPE_ACCESS,
+            GdprRequest::TYPE_RECTIFICATION,
+            GdprRequest::TYPE_ERASURE,
+            GdprRequest::TYPE_PORTABILITY,
+        ];
+        foreach ($types as $type) {
+            $id = $this->gdpr->submit('user-1', $type);
+            $this->assertGreaterThan(0, $id);
+        }
+    }
+
+    public function testSubmitThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->gdpr->submit('', GdprRequest::TYPE_ERASURE);
+    }
+
+    public function testSubmitThrowsOnInvalidType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->gdpr->submit('user-1', 'invalid-type');
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->gdpr->find(9999));
+    }
+
+    // ── acknowledge ───────────────────────────────────────────────────────────
+
+    public function testAcknowledgeChangesPendingToAcknowledged(): void
+    {
+        $id     = $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $result = $this->gdpr->acknowledge($id);
+        $this->assertTrue($result);
+
+        $req = $this->gdpr->find($id);
+        $this->assertNotNull($req);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(GdprRequest::STATUS_ACKNOWLEDGED, $req['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($req['acknowledged_at']);
+    }
+
+    public function testAcknowledgeReturnsFalseWhenAlreadyCompleted(): void
+    {
+        $id = $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $this->gdpr->complete($id);
+        $this->assertFalse($this->gdpr->acknowledge($id));
+    }
+
+    public function testAcknowledgeReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->gdpr->acknowledge(9999));
+    }
+
+    // ── complete ──────────────────────────────────────────────────────────────
+
+    public function testCompleteFromPendingState(): void
+    {
+        $id     = $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $result = $this->gdpr->complete($id, 'All data removed');
+        $this->assertTrue($result);
+
+        $req = $this->gdpr->find($id);
+        $this->assertNotNull($req);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(GdprRequest::STATUS_COMPLETED, $req['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('All data removed', $req['response_notes']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($req['completed_at']);
+    }
+
+    public function testCompleteFromAcknowledgedState(): void
+    {
+        $id = $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $this->gdpr->acknowledge($id);
+        $this->assertTrue($this->gdpr->complete($id));
+    }
+
+    public function testCompleteReturnsFalseWhenAlreadyCompleted(): void
+    {
+        $id = $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $this->gdpr->complete($id);
+        $this->assertFalse($this->gdpr->complete($id));
+    }
+
+    public function testCompleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->gdpr->complete(9999));
+    }
+
+    // ── reject ────────────────────────────────────────────────────────────────
+
+    public function testRejectFromPendingState(): void
+    {
+        $id     = $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $result = $this->gdpr->reject($id, 'Active contract prevents erasure');
+        $this->assertTrue($result);
+
+        $req = $this->gdpr->find($id);
+        $this->assertNotNull($req);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(GdprRequest::STATUS_REJECTED, $req['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Active contract prevents erasure', $req['response_notes']);
+    }
+
+    public function testRejectFromAcknowledgedState(): void
+    {
+        $id = $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $this->gdpr->acknowledge($id);
+        $this->assertTrue($this->gdpr->reject($id));
+    }
+
+    public function testRejectReturnsFalseWhenAlreadyCompleted(): void
+    {
+        $id = $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $this->gdpr->complete($id);
+        $this->assertFalse($this->gdpr->reject($id));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesRequest(): void
+    {
+        $id = $this->gdpr->submit('user-1', GdprRequest::TYPE_ACCESS);
+        $this->assertTrue($this->gdpr->delete($id));
+        $this->assertNull($this->gdpr->find($id));
+    }
+
+    public function testDeleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->gdpr->delete(9999));
+    }
+
+    // ── forUser ───────────────────────────────────────────────────────────────
+
+    public function testForUserReturnsAllRequestsForUser(): void
+    {
+        $this->gdpr->submit('user-1', GdprRequest::TYPE_ACCESS);
+        $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $this->gdpr->submit('user-2', GdprRequest::TYPE_PORTABILITY);
+
+        $this->assertCount(2, $this->gdpr->forUser('user-1'));
+        $this->assertCount(1, $this->gdpr->forUser('user-2'));
+    }
+
+    public function testForUserReturnsNewestFirst(): void
+    {
+        $id1 = $this->gdpr->submit('user-1', GdprRequest::TYPE_ACCESS);
+        $id2 = $this->gdpr->submit('user-1', GdprRequest::TYPE_ERASURE);
+        $list = $this->gdpr->forUser('user-1');
+        $this->assertSame($id2, (int)$list[0]['id']);
+        $this->assertSame($id1, (int)$list[1]['id']);
+    }
+
+    public function testForUserReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->gdpr->forUser('nobody'));
+    }
+
+    // ── pending ───────────────────────────────────────────────────────────────
+
+    public function testPendingReturnsPendingAndAcknowledged(): void
+    {
+        $id1 = $this->gdpr->submit('user-1', GdprRequest::TYPE_ACCESS);
+        $id2 = $this->gdpr->submit('user-2', GdprRequest::TYPE_ERASURE);
+        $this->gdpr->acknowledge($id2);
+        $id3 = $this->gdpr->submit('user-3', GdprRequest::TYPE_PORTABILITY);
+        $this->gdpr->complete($id3);
+
+        $open = $this->gdpr->pending();
+        $this->assertCount(2, $open);
+        $openIds = array_map('intval', array_column($open, 'id'));
+        $this->assertContains($id1, $openIds);
+        $this->assertContains($id2, $openIds);
+    }
+
+    public function testPendingOrdersOldestFirst(): void
+    {
+        $id1 = $this->gdpr->submit('user-1', GdprRequest::TYPE_ACCESS);
+        $id2 = $this->gdpr->submit('user-2', GdprRequest::TYPE_ERASURE);
+        $list = $this->gdpr->pending();
+        $this->assertSame($id1, (int)$list[0]['id']);
+        $this->assertSame($id2, (int)$list[1]['id']);
+    }
+
+    public function testPendingRespectsLimitOffset(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->gdpr->submit('user-' . $i, GdprRequest::TYPE_ERASURE);
+        }
+        $page1 = $this->gdpr->pending(3, 0);
+        $page2 = $this->gdpr->pending(3, 3);
+        $this->assertCount(3, $page1);
+        $this->assertCount(2, $page2);
+    }
+
+    // ── countByType / countByStatus ───────────────────────────────────────────
+
+    public function testCountByType(): void
+    {
+        $this->gdpr->submit('u1', GdprRequest::TYPE_ERASURE);
+        $this->gdpr->submit('u2', GdprRequest::TYPE_ERASURE);
+        $this->gdpr->submit('u3', GdprRequest::TYPE_ACCESS);
+        $this->assertSame(2, $this->gdpr->countByType(GdprRequest::TYPE_ERASURE));
+        $this->assertSame(1, $this->gdpr->countByType(GdprRequest::TYPE_ACCESS));
+        $this->assertSame(0, $this->gdpr->countByType(GdprRequest::TYPE_PORTABILITY));
+    }
+
+    public function testCountByStatus(): void
+    {
+        $id1 = $this->gdpr->submit('u1', GdprRequest::TYPE_ERASURE);
+        $this->gdpr->submit('u2', GdprRequest::TYPE_ACCESS);
+        $this->gdpr->complete($id1);
+        $this->assertSame(1, $this->gdpr->countByStatus(GdprRequest::STATUS_PENDING));
+        $this->assertSame(1, $this->gdpr->countByStatus(GdprRequest::STATUS_COMPLETED));
+        $this->assertSame(0, $this->gdpr->countByStatus(GdprRequest::STATUS_REJECTED));
+    }
+}


### PR DESCRIPTION
## FT205 — GdprRequest

Xion helper for tracking GDPR Article 15/16/17/20 data-subject requests with lifecycle state machine.

### New files
- `class/xion/GdprRequest.php`
- `tests/Unit/Xion/GdprRequestTest.php`

### Schema
```sql
CREATE TABLE gdpr_requests (
    id              INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id         VARCHAR(255) NOT NULL,
    type            VARCHAR(30)  NOT NULL,
    status          VARCHAR(20)  NOT NULL DEFAULT 'pending',
    notes           TEXT         NULL,
    response_notes  TEXT         NULL,
    submitted_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    acknowledged_at DATETIME     NULL,
    completed_at    DATETIME     NULL
);
```

### API
- `submit(userId, type, notes)` — types: access / rectification / erasure / portability
- `find(id)` / `delete(id)`
- `acknowledge(id)` — pending → acknowledged
- `complete(id, responseNotes)` — pending|acknowledged → completed
- `reject(id, responseNotes)` — pending|acknowledged → rejected
- `forUser(userId)` — newest-first
- `pending(limit, offset)` — FIFO queue of open requests
- `countByType(type)` / `countByStatus(status)`

### Tests
26 tests, 54 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)