### PR TITLE
feat(xion): FT207 TaxRate — regional tax rate lookup and calculation

### DIFF
--- a/class/xion/TaxRate.php
+++ b/class/xion/TaxRate.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * TaxRate — tax rate lookup and amount calculation by region and category.
+ *
+ * Stores configurable tax rates keyed by region (e.g. country code, state,
+ * postal zone) and product category. Rates are stored as percentage values
+ * (e.g. 10.00 for 10%). Amount calculations return integer cents to avoid
+ * floating-point rounding errors.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $tax = new TaxRate($pdo);
+ *
+ * // Set rates
+ * $id = $tax->set('JP', 'default', 10.00);
+ * $tax->set('JP', 'food', 8.00);
+ * $tax->set('US-CA', 'default', 8.25);
+ *
+ * // Calculate
+ * $rate       = $tax->getRate('JP', 'default');           // 10.00
+ * $taxCents   = $tax->calculateCents(1000, 'JP', 'default'); // 100
+ * $totalCents = $tax->totalWithTaxCents(1000, 'JP', 'default'); // 1100
+ *
+ * // Manage
+ * $all = $tax->forRegion('JP');
+ * $tax->delete($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE tax_rates (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     region     VARCHAR(50)    NOT NULL,
+ *     category   VARCHAR(50)    NOT NULL DEFAULT 'default',
+ *     rate       DECIMAL(8,4)   NOT NULL,
+ *     created_at DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (region, category)
+ * );
+ * ```
+ */
+final class TaxRate
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set (upsert) a tax rate for a region + category pair.
+     *
+     * @param float $rate Percentage value (e.g. 10.00 for 10%).
+     * @return int Row ID.
+     * @throws \InvalidArgumentException on empty region, or negative rate.
+     */
+    public function set(string $region, string $category, float $rate): int
+    {
+        $region   = trim($region);
+        $category = trim($category) ?: 'default';
+        if ($region === '') {
+            throw new \InvalidArgumentException('region must not be empty.');
+        }
+        if ($rate < 0) {
+            throw new \InvalidArgumentException('rate must be >= 0.');
+        }
+
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        // SQLite upsert
+        $stmt = $this->db()->prepare(
+            'INSERT INTO tax_rates (region, category, rate, created_at, updated_at)
+             VALUES (:region, :cat, :rate, :now, :now)
+             ON CONFLICT (region, category) DO UPDATE SET rate = :rate2, updated_at = :now2'
+        );
+        try {
+            $stmt->execute([
+                ':region' => $region,
+                ':cat'    => $category,
+                ':rate'   => $rate,
+                ':now'    => $now,
+                ':rate2'  => $rate,
+                ':now2'   => $now,
+            ]);
+            return (int)$this->db()->lastInsertId();
+        } catch (\PDOException) {
+            // MySQL fallback: ON DUPLICATE KEY UPDATE
+            $stmt2 = $this->db()->prepare(
+                'INSERT INTO tax_rates (region, category, rate, created_at, updated_at)
+                 VALUES (:region, :cat, :rate, :now, :now)
+                 ON DUPLICATE KEY UPDATE rate = :rate2, updated_at = :now2'
+            );
+            $stmt2->execute([
+                ':region' => $region,
+                ':cat'    => $category,
+                ':rate'   => $rate,
+                ':now'    => $now,
+                ':rate2'  => $rate,
+                ':now2'   => $now,
+            ]);
+            return (int)$this->db()->lastInsertId();
+        }
+    }
+
+    /**
+     * Find a single rate record by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM tax_rates WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Get the percentage rate for a region + category.
+     * Returns null if not configured.
+     */
+    public function getRate(string $region, string $category = 'default'): ?float
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT rate FROM tax_rates WHERE region = :region AND category = :cat'
+        );
+        $stmt->execute([':region' => trim($region), ':cat' => trim($category) ?: 'default']);
+        $val = $stmt->fetchColumn();
+        return $val !== false ? (float)$val : null;
+    }
+
+    /**
+     * Delete a rate record.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM tax_rates WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List all rate records for a region.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forRegion(string $region): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM tax_rates WHERE region = :region ORDER BY category ASC'
+        );
+        $stmt->execute([':region' => trim($region)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List all configured regions (distinct).
+     *
+     * @return list<string>
+     */
+    public function regions(): array
+    {
+        $stmt = $this->db()->query('SELECT DISTINCT region FROM tax_rates ORDER BY region ASC');
+        return $stmt !== false ? $stmt->fetchAll(PDO::FETCH_COLUMN) : [];
+    }
+
+    /**
+     * Calculate tax amount in integer cents.
+     *
+     * @param int $amountCents Pre-tax amount in cents.
+     * @return int Tax amount in cents (rounded to nearest cent).
+     * @throws \RuntimeException if no rate is configured.
+     */
+    public function calculateCents(int $amountCents, string $region, string $category = 'default'): int
+    {
+        $rate = $this->getRate($region, $category);
+        if ($rate === null) {
+            throw new \RuntimeException("No tax rate configured for region={$region} category={$category}.");
+        }
+        return (int)round($amountCents * $rate / 100);
+    }
+
+    /**
+     * Return the total (amount + tax) in integer cents.
+     *
+     * @throws \RuntimeException if no rate is configured.
+     */
+    public function totalWithTaxCents(int $amountCents, string $region, string $category = 'default'): int
+    {
+        return $amountCents + $this->calculateCents($amountCents, $region, $category);
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/TaxRateTest.php
+++ b/tests/Unit/Xion/TaxRateTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\TaxRate;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class TaxRateTest extends TestCase
+{
+    private PDO $pdo;
+    private TaxRate $tax;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE tax_rates (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                region     VARCHAR(50)  NOT NULL,
+                category   VARCHAR(50)  NOT NULL DEFAULT \'default\',
+                rate       DECIMAL(8,4) NOT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (region, category)
+            )
+        ');
+        $this->tax = new TaxRate($this->pdo);
+    }
+
+    // ── set ───────────────────────────────────────────────────────────────────
+
+    public function testSetReturnsId(): void
+    {
+        $id = $this->tax->set('JP', 'default', 10.00);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testSetStoresCorrectly(): void
+    {
+        $id  = $this->tax->set('JP', 'default', 10.00);
+        $row = $this->tax->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('JP', $row['region']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('default', $row['category']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertEqualsWithDelta(10.00, (float)$row['rate'], 0.0001);
+    }
+
+    public function testSetUpsertUpdatesExistingRate(): void
+    {
+        $this->tax->set('JP', 'default', 8.00);
+        $this->tax->set('JP', 'default', 10.00);
+        $rate = $this->tax->getRate('JP', 'default');
+        $this->assertEqualsWithDelta(10.00, $rate, 0.0001);
+    }
+
+    public function testSetDefaultsCategoryToDefault(): void
+    {
+        $this->tax->set('JP', '', 10.00);
+        $rate = $this->tax->getRate('JP', 'default');
+        $this->assertNotNull($rate);
+    }
+
+    public function testSetThrowsOnEmptyRegion(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->tax->set('', 'default', 10.00);
+    }
+
+    public function testSetThrowsOnNegativeRate(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->tax->set('JP', 'default', -1.0);
+    }
+
+    public function testSetAllowsZeroRate(): void
+    {
+        $id = $this->tax->set('XX', 'default', 0.0);
+        $this->assertGreaterThan(0, $id);
+        $this->assertEqualsWithDelta(0.0, $this->tax->getRate('XX', 'default'), 0.0001);
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->tax->find(9999));
+    }
+
+    // ── getRate ───────────────────────────────────────────────────────────────
+
+    public function testGetRateReturnsNullWhenNotConfigured(): void
+    {
+        $this->assertNull($this->tax->getRate('US', 'default'));
+    }
+
+    public function testGetRateReturnsCorrectValue(): void
+    {
+        $this->tax->set('JP', 'food', 8.00);
+        $this->assertEqualsWithDelta(8.00, $this->tax->getRate('JP', 'food'), 0.0001);
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesRecord(): void
+    {
+        $id = $this->tax->set('JP', 'default', 10.00);
+        $this->assertTrue($this->tax->delete($id));
+        $this->assertNull($this->tax->find($id));
+    }
+
+    public function testDeleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->tax->delete(9999));
+    }
+
+    // ── forRegion ─────────────────────────────────────────────────────────────
+
+    public function testForRegionReturnsAllCategoriesForRegion(): void
+    {
+        $this->tax->set('JP', 'default', 10.00);
+        $this->tax->set('JP', 'food', 8.00);
+        $this->tax->set('US', 'default', 7.50);
+
+        $list = $this->tax->forRegion('JP');
+        $this->assertCount(2, $list);
+    }
+
+    public function testForRegionReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->tax->forRegion('XX'));
+    }
+
+    // ── regions ───────────────────────────────────────────────────────────────
+
+    public function testRegionsReturnsDistinctRegions(): void
+    {
+        $this->tax->set('JP', 'default', 10.00);
+        $this->tax->set('JP', 'food', 8.00);
+        $this->tax->set('US', 'default', 7.50);
+
+        $regions = $this->tax->regions();
+        $this->assertCount(2, $regions);
+        $this->assertContains('JP', $regions);
+        $this->assertContains('US', $regions);
+    }
+
+    public function testRegionsReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->tax->regions());
+    }
+
+    // ── calculateCents ────────────────────────────────────────────────────────
+
+    public function testCalculateCentsReturnsCorrectTax(): void
+    {
+        $this->tax->set('JP', 'default', 10.00);
+        // 1000 cents at 10% = 100 cents
+        $this->assertSame(100, $this->tax->calculateCents(1000, 'JP', 'default'));
+    }
+
+    public function testCalculateCentsRoundsCorrectly(): void
+    {
+        $this->tax->set('JP', 'default', 8.00);
+        // 125 cents at 8% = 10.0 cents
+        $this->assertSame(10, $this->tax->calculateCents(125, 'JP', 'default'));
+        // 126 cents at 8% = 10.08 → 10 cents
+        $this->assertSame(10, $this->tax->calculateCents(126, 'JP', 'default'));
+        // 119 cents at 8% = 9.52 → 10 cents
+        $this->assertSame(10, $this->tax->calculateCents(119, 'JP', 'default'));
+    }
+
+    public function testCalculateCentsThrowsWhenNoRateConfigured(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->tax->calculateCents(1000, 'XX', 'default');
+    }
+
+    public function testCalculateCentsZeroRate(): void
+    {
+        $this->tax->set('XX', 'default', 0.0);
+        $this->assertSame(0, $this->tax->calculateCents(1000, 'XX', 'default'));
+    }
+
+    // ── totalWithTaxCents ─────────────────────────────────────────────────────
+
+    public function testTotalWithTaxCents(): void
+    {
+        $this->tax->set('JP', 'default', 10.00);
+        // 1000 + 100 = 1100
+        $this->assertSame(1100, $this->tax->totalWithTaxCents(1000, 'JP', 'default'));
+    }
+
+    public function testTotalWithTaxCentsZeroRate(): void
+    {
+        $this->tax->set('XX', 'default', 0.0);
+        $this->assertSame(500, $this->tax->totalWithTaxCents(500, 'XX', 'default'));
+    }
+
+    public function testTotalWithTaxCentsThrowsWhenNoRateConfigured(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->tax->totalWithTaxCents(1000, 'XX', 'default');
+    }
+}


### PR DESCRIPTION
## FT207 — TaxRate

Xion helper for configurable tax rates by region and product category with integer-cent calculations.

### New files
- `class/xion/TaxRate.php`
- `tests/Unit/Xion/TaxRateTest.php`

### Schema
```sql
CREATE TABLE tax_rates (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    region     VARCHAR(50)    NOT NULL,
    category   VARCHAR(50)    NOT NULL DEFAULT 'default',
    rate       DECIMAL(8,4)   NOT NULL,
    created_at DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP,
    UNIQUE (region, category)
);
```

### API
- `set(region, category, rate)` — upsert (cross-driver ON CONFLICT / ON DUPLICATE KEY)
- `find(id)` / `getRate(region, category)` / `delete(id)`
- `forRegion(region)` / `regions()`
- `calculateCents(amountCents, region, category)` — integer-cent tax amount
- `totalWithTaxCents(amountCents, region, category)` — pre-tax + tax

### Tests
23 tests, 32 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)