### PR TITLE
feat(xion): FT209 ContentTag — flexible entity tagging with tag cloud

### DIFF
--- a/class/xion/ContentTag.php
+++ b/class/xion/ContentTag.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ContentTag — flexible tagging of arbitrary entities.
+ *
+ * Tags are normalised lowercase strings (letters, digits, hyphens). Each
+ * entity-tag pair is unique. You can attach multiple tags to an entity,
+ * search for entities by tag, and retrieve the tag cloud with usage counts.
+ *
+ * This helper intentionally avoids a separate tags master table — tag strings
+ * are stored inline. Use this when tags are ad-hoc and a canonical tag
+ * registry is not needed.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ct = new ContentTag($pdo);
+ *
+ * // Tag an entity
+ * $ct->tag('article', '10', ['php', 'testing', 'oop']);
+ *
+ * // Query
+ * $tags     = $ct->tagsFor('article', '10');
+ * $entities = $ct->entitiesWith('article', 'testing');
+ * $cloud    = $ct->cloud('article');
+ *
+ * // Remove
+ * $ct->untag('article', '10', 'oop');
+ * $ct->clearAll('article', '10');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE content_tags (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     entity_type VARCHAR(100) NOT NULL,
+ *     entity_id   VARCHAR(255) NOT NULL,
+ *     tag         VARCHAR(100) NOT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (entity_type, entity_id, tag)
+ * );
+ * ```
+ */
+final class ContentTag
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add a single tag to an entity (idempotent — ignores duplicates).
+     *
+     * @return bool True if a new row was inserted; false if already tagged.
+     * @throws \InvalidArgumentException on empty entityType/entityId/tag.
+     */
+    public function tagOne(string $entityType, string $entityId, string $tag): bool
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $tag = $this->normalise($tag);
+
+        try {
+            $stmt = $this->db()->prepare(
+                'INSERT INTO content_tags (entity_type, entity_id, tag)
+                 VALUES (:type, :eid, :tag)'
+            );
+            $stmt->execute([':type' => $entityType, ':eid' => $entityId, ':tag' => $tag]);
+            return $stmt->rowCount() > 0;
+        } catch (\PDOException) {
+            // UNIQUE violation — already tagged
+            return false;
+        }
+    }
+
+    /**
+     * Add multiple tags to an entity at once (idempotent).
+     *
+     * @param list<string> $tags
+     * @return int Number of new tags added.
+     */
+    public function tag(string $entityType, string $entityId, array $tags): int
+    {
+        $added = 0;
+        foreach ($tags as $t) {
+            if ($this->tagOne($entityType, $entityId, $t)) {
+                $added++;
+            }
+        }
+        return $added;
+    }
+
+    /**
+     * Remove a single tag from an entity.
+     *
+     * @return bool True if found and removed.
+     */
+    public function untag(string $entityType, string $entityId, string $tag): bool
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $tag = $this->normalise($tag);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM content_tags
+             WHERE entity_type = :type AND entity_id = :eid AND tag = :tag'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId, ':tag' => $tag]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Remove all tags from an entity.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function clearAll(string $entityType, string $entityId): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'DELETE FROM content_tags WHERE entity_type = :type AND entity_id = :eid'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Check whether an entity has a specific tag.
+     */
+    public function hasTag(string $entityType, string $entityId, string $tag): bool
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $tag  = $this->normalise($tag);
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM content_tags
+             WHERE entity_type = :type AND entity_id = :eid AND tag = :tag'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId, ':tag' => $tag]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * List all tags for an entity (alphabetical).
+     *
+     * @return list<string>
+     */
+    public function tagsFor(string $entityType, string $entityId): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT tag FROM content_tags
+             WHERE entity_type = :type AND entity_id = :eid
+             ORDER BY tag ASC'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * List entity IDs of a given type that have a specific tag.
+     *
+     * @return list<string>
+     */
+    public function entitiesWith(string $entityType, string $tag): array
+    {
+        $tag  = $this->normalise($tag);
+        $stmt = $this->db()->prepare(
+            'SELECT entity_id FROM content_tags
+             WHERE entity_type = :type AND tag = :tag
+             ORDER BY entity_id ASC'
+        );
+        $stmt->execute([':type' => trim($entityType), ':tag' => $tag]);
+        return $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    }
+
+    /**
+     * Return the tag cloud for an entity type — tag => count, sorted by count desc.
+     *
+     * @return array<string,int>
+     */
+    public function cloud(string $entityType): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT tag, COUNT(*) AS cnt FROM content_tags
+             WHERE entity_type = :type
+             GROUP BY tag
+             ORDER BY cnt DESC, tag ASC'
+        );
+        $stmt->execute([':type' => trim($entityType)]);
+        $rows   = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(string)$row['tag']] = (int)$row['cnt'];
+        }
+        return $result;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function validateEntity(string $entityType, string $entityId): array
+    {
+        $entityType = trim($entityType);
+        $entityId   = trim($entityId);
+        if ($entityType === '') {
+            throw new \InvalidArgumentException('entity_type must not be empty.');
+        }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        return [$entityType, $entityId];
+    }
+
+    /**
+     * Normalise a tag: trim, lowercase, collapse non-alnum/hyphen to hyphens.
+     *
+     * @throws \InvalidArgumentException on empty tag after normalisation.
+     */
+    private function normalise(string $tag): string
+    {
+        $tag = strtolower(trim($tag));
+        $tag = (string)preg_replace('/[^a-z0-9\-]+/', '-', $tag);
+        $tag = trim($tag, '-');
+        if ($tag === '') {
+            throw new \InvalidArgumentException('tag must not be empty after normalisation.');
+        }
+        return $tag;
+    }
+}

--- a/tests/Unit/Xion/ContentTagTest.php
+++ b/tests/Unit/Xion/ContentTagTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\ContentTag;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ContentTagTest extends TestCase
+{
+    private PDO $pdo;
+    private ContentTag $ct;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE content_tags (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type VARCHAR(100) NOT NULL,
+                entity_id   VARCHAR(255) NOT NULL,
+                tag         VARCHAR(100) NOT NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (entity_type, entity_id, tag)
+            )
+        ');
+        $this->ct = new ContentTag($this->pdo);
+    }
+
+    // ── tagOne ────────────────────────────────────────────────────────────────
+
+    public function testTagOneReturnsTrueOnNewTag(): void
+    {
+        $this->assertTrue($this->ct->tagOne('article', '1', 'php'));
+    }
+
+    public function testTagOneReturnsFalseOnDuplicate(): void
+    {
+        $this->ct->tagOne('article', '1', 'php');
+        $this->assertFalse($this->ct->tagOne('article', '1', 'php'));
+    }
+
+    public function testTagOneNormalisesToLowercase(): void
+    {
+        $this->ct->tagOne('article', '1', 'PHP');
+        $this->assertTrue($this->ct->hasTag('article', '1', 'php'));
+    }
+
+    public function testTagOneNormalisesSpecialChars(): void
+    {
+        $this->ct->tagOne('article', '1', 'Hello World!');
+        $this->assertTrue($this->ct->hasTag('article', '1', 'hello-world'));
+    }
+
+    public function testTagOneThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ct->tagOne('', '1', 'php');
+    }
+
+    public function testTagOneThrowsOnEmptyEntityId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ct->tagOne('article', '', 'php');
+    }
+
+    public function testTagOneThrowsOnEmptyTag(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ct->tagOne('article', '1', '!!!');
+    }
+
+    // ── tag ───────────────────────────────────────────────────────────────────
+
+    public function testTagAddsMultiple(): void
+    {
+        $added = $this->ct->tag('article', '1', ['php', 'testing', 'oop']);
+        $this->assertSame(3, $added);
+    }
+
+    public function testTagSkipsDuplicates(): void
+    {
+        $this->ct->tagOne('article', '1', 'php');
+        $added = $this->ct->tag('article', '1', ['php', 'testing']);
+        $this->assertSame(1, $added);
+    }
+
+    // ── untag ─────────────────────────────────────────────────────────────────
+
+    public function testUntagRemovesTag(): void
+    {
+        $this->ct->tagOne('article', '1', 'php');
+        $result = $this->ct->untag('article', '1', 'php');
+        $this->assertTrue($result);
+        $this->assertFalse($this->ct->hasTag('article', '1', 'php'));
+    }
+
+    public function testUntagReturnsFalseWhenTagNotPresent(): void
+    {
+        $this->assertFalse($this->ct->untag('article', '1', 'php'));
+    }
+
+    // ── clearAll ──────────────────────────────────────────────────────────────
+
+    public function testClearAllRemovesAllTagsForEntity(): void
+    {
+        $this->ct->tag('article', '1', ['a', 'b', 'c']);
+        $this->ct->tag('article', '2', ['a']);
+
+        $count = $this->ct->clearAll('article', '1');
+        $this->assertSame(3, $count);
+        $this->assertSame([], $this->ct->tagsFor('article', '1'));
+        $this->assertCount(1, $this->ct->tagsFor('article', '2'));
+    }
+
+    public function testClearAllReturnsZeroWhenNone(): void
+    {
+        $this->assertSame(0, $this->ct->clearAll('article', '99'));
+    }
+
+    // ── hasTag ────────────────────────────────────────────────────────────────
+
+    public function testHasTagReturnsTrueWhenTagged(): void
+    {
+        $this->ct->tagOne('article', '1', 'php');
+        $this->assertTrue($this->ct->hasTag('article', '1', 'php'));
+    }
+
+    public function testHasTagReturnsFalseWhenNotTagged(): void
+    {
+        $this->assertFalse($this->ct->hasTag('article', '1', 'php'));
+    }
+
+    // ── tagsFor ───────────────────────────────────────────────────────────────
+
+    public function testTagsForReturnsAlphabetical(): void
+    {
+        $this->ct->tag('article', '1', ['oop', 'php', 'abc']);
+        $tags = $this->ct->tagsFor('article', '1');
+        $this->assertSame(['abc', 'oop', 'php'], $tags);
+    }
+
+    public function testTagsForReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->ct->tagsFor('article', '99'));
+    }
+
+    public function testTagsForIsIsolatedByEntity(): void
+    {
+        $this->ct->tagOne('article', '1', 'php');
+        $this->ct->tagOne('article', '2', 'java');
+        $this->assertSame(['php'], $this->ct->tagsFor('article', '1'));
+        $this->assertSame(['java'], $this->ct->tagsFor('article', '2'));
+    }
+
+    // ── entitiesWith ─────────────────────────────────────────────────────────
+
+    public function testEntitiesWithReturnsMatchingEntityIds(): void
+    {
+        $this->ct->tagOne('article', '1', 'php');
+        $this->ct->tagOne('article', '2', 'php');
+        $this->ct->tagOne('article', '3', 'java');
+
+        $entities = $this->ct->entitiesWith('article', 'php');
+        $this->assertCount(2, $entities);
+        $this->assertContains('1', $entities);
+        $this->assertContains('2', $entities);
+    }
+
+    public function testEntitiesWithReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->ct->entitiesWith('article', 'python'));
+    }
+
+    // ── cloud ─────────────────────────────────────────────────────────────────
+
+    public function testCloudReturnsCounts(): void
+    {
+        $this->ct->tag('article', '1', ['php', 'oop']);
+        $this->ct->tagOne('article', '2', 'php');
+
+        $cloud = $this->ct->cloud('article');
+        $this->assertSame(2, $cloud['php']);
+        $this->assertSame(1, $cloud['oop']);
+    }
+
+    public function testCloudSortsByCountDescending(): void
+    {
+        $this->ct->tag('article', '1', ['b', 'a']);
+        $this->ct->tagOne('article', '2', 'a');
+
+        $keys = array_keys($this->ct->cloud('article'));
+        $this->assertSame('a', $keys[0]);
+        $this->assertSame('b', $keys[1]);
+    }
+
+    public function testCloudReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->ct->cloud('article'));
+    }
+
+    public function testCloudIsIsolatedByEntityType(): void
+    {
+        $this->ct->tagOne('article', '1', 'php');
+        $this->ct->tagOne('video', '1', 'java');
+
+        $artCloud = $this->ct->cloud('article');
+        $this->assertArrayHasKey('php', $artCloud);
+        $this->assertArrayNotHasKey('java', $artCloud);
+    }
+}


### PR DESCRIPTION
## FT209 — ContentTag

Xion helper for ad-hoc tagging of any entity type. Tags are normalised lowercase slugs stored inline (no canonical tags table).

### New files
- `class/xion/ContentTag.php`
- `tests/Unit/Xion/ContentTagTest.php`

### Schema
```sql
CREATE TABLE content_tags (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    entity_type VARCHAR(100) NOT NULL,
    entity_id   VARCHAR(255) NOT NULL,
    tag         VARCHAR(100) NOT NULL,
    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    UNIQUE (entity_type, entity_id, tag)
);
```

### API
- `tagOne(entityType, entityId, tag)` — idempotent, returns bool (new vs duplicate)
- `tag(entityType, entityId, tags[])` — batch add
- `untag(entityType, entityId, tag)` / `clearAll(entityType, entityId)`
- `hasTag(entityType, entityId, tag)`
- `tagsFor(entityType, entityId)` — alphabetical list
- `entitiesWith(entityType, tag)` — reverse lookup
- `cloud(entityType)` — tag => count sorted by frequency

### Tests
24 tests, 33 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)