### PR TITLE
docs: FT201–FT210 wave summary (Xion sixth extended wave)

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -14,7 +14,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ## Active candidates
 
-The Xion helper wave (FT78–FT200) is ongoing as of 2026-05-27. Trigger-based and structural candidates are listed in the next section.
+The Xion helper wave (FT78–FT210) is ongoing as of 2026-05-27. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -54,6 +54,16 @@ The Xion helper wave (FT78–FT200) is ongoing as of 2026-05-27. Trigger-based a
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT210 — ResourceLock** (2026-05-27): `Nene\Xion\ResourceLock` — advisory entity locking with TTL; acquire() int|null; extend(); releaseExpired() cron cleanup. PR #650.
+- **FT209 — ContentTag** (2026-05-27): `Nene\Xion\ContentTag` — flexible entity tagging; tags normalised to lowercase slugs; cloud() tag→count; entitiesWith() reverse lookup. PR #649.
+- **FT208 — DeviceToken** (2026-05-27): `Nene\Xion\DeviceToken` — push notification device token management per user; register() reactivates existing; deleteInactive() cleanup. PR #648.
+- **FT207 — TaxRate** (2026-05-27): `Nene\Xion\TaxRate` — regional tax rate lookup by region+category; calculateCents()/totalWithTaxCents() integer-cent safety. PR #647.
+- **FT206 — WaitlistEntry** (2026-05-27): `Nene\Xion\WaitlistEntry` — product/feature waitlist with queue positioning; inviteNext() batch; position() 1-based rank. PR #646.
+- **FT205 — GdprRequest** (2026-05-27): `Nene\Xion\GdprRequest` — GDPR data-subject request tracking (access/rectification/erasure/portability); pending→acknowledged→completed|rejected. PR #645.
+- **FT204 — IntegrationLog** (2026-05-27): `Nene\Xion\IntegrationLog` — external API call log with service/endpoint/status/body/duration; errors() non-2xx; deleteOlderThan() TTL. PR #644.
+- **FT203 — TimeSlot** (2026-05-27): `Nene\Xion\TimeSlot` — appointment/time-slot booking with capacity; atomic UPDATE WHERE booked < capacity. PR #643.
+- **FT202 — TimeEntry** (2026-05-27): `Nene\Xion\TimeEntry` — work time tracking with start/stop timers and manual entries; totalSeconds(). PR #642.
+- **FT201 — InventoryStock** (2026-05-27): `Nene\Xion\InventoryStock` — product/SKU stock tracking with atomic three-phase reserve/release/commit; inventory_log. PR #641.
 - **FT200 — UserSegment** (2026-05-27): `Nene\Xion\UserSegment` — user cohort/segment assignment; two-table design (definitions + members); idempotent addUser; segmentsFor/usersIn. PR #639.
 - **FT199 — AppVersion** (2026-05-27): `Nene\Xion\AppVersion` — deployment/release version history per environment; current() latest; history() newest-first; environments(). PR #638.
 - **FT198 — OrderLine** (2026-05-27): `Nene\Xion\OrderLine` — e-commerce order with line items (two-table); integer-cent amounts; pending→confirmed→shipped→delivered|cancelled. PR #637.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT200 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT210 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 
@@ -239,6 +239,7 @@ Completed (wave summary):
 - **FT176–FT185**: Xion third extended wave. 10 trials covering colored labels, ordered checklists, emoji reactions, @-mention tracking, watchlists, file attachments, saved searches, content filtering, user reminders, and knowledge base articles. PRs #613–#622.
 - **FT186–FT195**: Xion fourth extended wave. 10 trials covering support ticketing, event sourcing log, daily digest accumulator, per-resource ACL, 2FA backup codes, typed global settings, ordered media gallery, entity reviews with ratings, FAQ articles, and gamification tier tracking. PRs #624–#633.
 - **FT196–FT200**: Xion fifth extended wave. 5 trials covering CSV import job tracking with per-row errors, topic-based pub/sub subscriptions, e-commerce orders with line items, deployment version history, and user cohort/segment assignment. PRs #635–#639.
+- **FT201–FT210**: Xion sixth extended wave. 10 trials covering inventory stock tracking with atomic reserve/commit, work time entries with start/stop timers, appointment time slot booking with capacity, external API call logging, GDPR data-subject request tracking, product/feature waitlist management, regional tax rate calculation, push notification device token management, flexible entity tagging with tag clouds, and advisory resource locking with TTL. PRs #641–#650.
 
 Future candidates:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,24 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT200 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT210 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-27 — FT201–FT210: Xion sixth extended wave (10 trials)
+
+Continuous wave of 10 field trials adding further Xion helper patterns. All PRs #641–#650.
+
+**FT201 — InventoryStock**: `InventoryStock` product/SKU stock tracking with atomic three-phase reserve/release/commit; inventory_log audit trail. PR #641.
+**FT202 — TimeEntry**: `TimeEntry` work time tracking with start/stop timers and manual entries; totalSeconds() per project. PR #642.
+**FT203 — TimeSlot**: `TimeSlot` appointment/time-slot booking with capacity; atomic UPDATE WHERE booked < capacity prevents overbooking. PR #643.
+**FT204 — IntegrationLog**: `IntegrationLog` external API call log with service/endpoint/status/body/duration; errors() surfaces non-2xx; deleteOlderThan() TTL. PR #644.
+**FT205 — GdprRequest**: `GdprRequest` GDPR data-subject request tracking (access/rectification/erasure/portability); pending→acknowledged→completed|rejected. PR #645.
+**FT206 — WaitlistEntry**: `WaitlistEntry` product/feature waitlist with queue positioning; inviteNext() batch; position() 1-based rank. PR #646.
+**FT207 — TaxRate**: `TaxRate` regional tax rate lookup by region+category; cross-driver upsert; calculateCents()/totalWithTaxCents() integer-cent safety. PR #647.
+**FT208 — DeviceToken**: `DeviceToken` push notification device token management per user; register() reactivates existing; deleteInactive() cleanup. PR #648.
+**FT209 — ContentTag**: `ContentTag` flexible entity tagging; tags normalised to lowercase slugs; cloud() tag→count map; entitiesWith() reverse lookup. PR #649.
+**FT210 — ResourceLock**: `ResourceLock` advisory entity locking with TTL; acquire() returns int|null; extend(); releaseExpired() cron cleanup. PR #650.
 
 ### 2026-05-27 — FT196–FT200: Xion fifth extended wave (5 trials)
 


### PR DESCRIPTION
## Docs: FT201–FT210 wave summary

Updates roadmap, todo, and candidates for the Xion sixth extended wave.

### Changes
- `docs/roadmap.md`: FT1–FT210 complete; FT201–FT210 wave summary added
- `docs/todo/current.md`: FT201–FT210 wave block (10 trials, PRs #641–#650)
- `docs/field-trials/candidates.md`: Active section updated; 10 new archive entries

### Trials covered
- FT201 InventoryStock — atomic three-phase stock; inventory_log
- FT202 TimeEntry — start/stop timers; manual entries
- FT203 TimeSlot — appointment booking with capacity
- FT204 IntegrationLog — external API call logging
- FT205 GdprRequest — GDPR data-subject request tracking
- FT206 WaitlistEntry — waitlist with queue positioning
- FT207 TaxRate — regional tax rate + integer-cent calculation
- FT208 DeviceToken — push notification token management
- FT209 ContentTag — flexible entity tagging with tag cloud
- FT210 ResourceLock — advisory entity locking with TTL

🤖 Generated with [Claude Code](https://claude.com/claude-code)