### PR TITLE
feat(xion): FT213 PointBalance — loyalty/reward points ledger

### DIFF
--- a/class/xion/PointBalance.php
+++ b/class/xion/PointBalance.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * PointBalance — user loyalty/reward points with append-only ledger.
+ *
+ * Tracks earned, spent, and expired point transactions per user. The running
+ * balance is derived by summing all signed deltas. Points are non-negative
+ * integers. Spending is guarded to prevent going below zero.
+ *
+ * Distinct from `CreditLedger` (financial credits, arbitrary amounts, balance
+ * guard is configurable) — PointBalance is specifically for loyalty/reward
+ * programmes where points are earned through actions and spent on rewards.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $pb = new PointBalance($pdo);
+ *
+ * // Earn / spend / expire
+ * $pb->earn('user-1', 100, 'purchase', 'order-42');
+ * $pb->spend('user-1', 50,  'redeem',   'reward-7');
+ * $pb->expire('user-1', 20, 'monthly-expiry');
+ *
+ * // Query
+ * $balance = $pb->balance('user-1');       // 30
+ * $history = $pb->history('user-1', 20, 0);
+ * $earned  = $pb->totalEarned('user-1');   // 100
+ * $spent   = $pb->totalSpent('user-1');    // 50
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE point_ledger (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     delta       INTEGER      NOT NULL,
+ *     reason      VARCHAR(100) NOT NULL,
+ *     reference   VARCHAR(255) NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class PointBalance
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Credit points to a user (positive delta).
+     *
+     * @return int Row ID.
+     * @throws \InvalidArgumentException on invalid userId/reason or non-positive amount.
+     */
+    public function earn(string $userId, int $points, string $reason, ?string $reference = null): int
+    {
+        if ($points <= 0) {
+            throw new \InvalidArgumentException('points must be > 0.');
+        }
+        return $this->append($userId, $points, $reason, $reference);
+    }
+
+    /**
+     * Debit points from a user (negative delta). Guards against going below zero.
+     *
+     * @return int Row ID.
+     * @throws \InvalidArgumentException on invalid arguments.
+     * @throws \RuntimeException if insufficient balance.
+     */
+    public function spend(string $userId, int $points, string $reason, ?string $reference = null): int
+    {
+        if ($points <= 0) {
+            throw new \InvalidArgumentException('points must be > 0.');
+        }
+        if ($this->balance($userId) < $points) {
+            throw new \RuntimeException("Insufficient points for user {$userId}.");
+        }
+        return $this->append($userId, -$points, $reason, $reference);
+    }
+
+    /**
+     * Expire points (negative delta) — does NOT guard against going below zero.
+     * Used by batch expiry jobs where balance could go negative due to timing.
+     *
+     * @return int Row ID.
+     * @throws \InvalidArgumentException on invalid arguments.
+     */
+    public function expire(string $userId, int $points, string $reason, ?string $reference = null): int
+    {
+        if ($points <= 0) {
+            throw new \InvalidArgumentException('points must be > 0.');
+        }
+        return $this->append($userId, -$points, $reason, $reference);
+    }
+
+    /**
+     * Return the current point balance (sum of all deltas). Returns 0 if no entries.
+     */
+    public function balance(string $userId): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COALESCE(SUM(delta), 0) FROM point_ledger WHERE user_id = :uid'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Return total points ever earned (sum of positive deltas).
+     */
+    public function totalEarned(string $userId): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COALESCE(SUM(delta), 0) FROM point_ledger WHERE user_id = :uid AND delta > 0'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Return total points ever spent (absolute sum of negative deltas).
+     */
+    public function totalSpent(string $userId): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COALESCE(SUM(delta), 0) FROM point_ledger WHERE user_id = :uid AND delta < 0'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return abs((int)$stmt->fetchColumn());
+    }
+
+    /**
+     * List ledger entries for a user (newest first).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function history(string $userId, int $limit = 50, int $offset = 0): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM point_ledger
+             WHERE user_id = :uid
+             ORDER BY id DESC
+             LIMIT :lim OFFSET :off'
+        );
+        $stmt->bindValue(':uid', trim($userId));
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':off', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Find a single ledger entry by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM point_ledger WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function append(string $userId, int $delta, string $reason, ?string $reference): int
+    {
+        $userId = trim($userId);
+        $reason = trim($reason);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('userId must not be empty.');
+        }
+        if ($reason === '') {
+            throw new \InvalidArgumentException('reason must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO point_ledger (user_id, delta, reason, reference)
+             VALUES (:uid, :delta, :reason, :ref)'
+        );
+        $stmt->execute([
+            ':uid'    => $userId,
+            ':delta'  => $delta,
+            ':reason' => $reason,
+            ':ref'    => $reference,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+}

--- a/tests/Unit/Xion/PointBalanceTest.php
+++ b/tests/Unit/Xion/PointBalanceTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\PointBalance;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class PointBalanceTest extends TestCase
+{
+    private PDO $pdo;
+    private PointBalance $pb;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE point_ledger (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL,
+                delta      INTEGER      NOT NULL,
+                reason     VARCHAR(100) NOT NULL,
+                reference  VARCHAR(255) NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->pb = new PointBalance($this->pdo);
+    }
+
+    // ── earn ──────────────────────────────────────────────────────────────────
+
+    public function testEarnReturnsId(): void
+    {
+        $id = $this->pb->earn('user-1', 100, 'purchase');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testEarnStoresCorrectDelta(): void
+    {
+        $id  = $this->pb->earn('user-1', 100, 'purchase', 'order-42');
+        $row = $this->pb->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(100, (int)$row['delta']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('purchase', $row['reason']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('order-42', $row['reference']);
+    }
+
+    public function testEarnThrowsOnZeroPoints(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pb->earn('user-1', 0, 'purchase');
+    }
+
+    public function testEarnThrowsOnNegativePoints(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pb->earn('user-1', -10, 'purchase');
+    }
+
+    public function testEarnThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pb->earn('', 10, 'purchase');
+    }
+
+    public function testEarnThrowsOnEmptyReason(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pb->earn('user-1', 10, '');
+    }
+
+    // ── spend ─────────────────────────────────────────────────────────────────
+
+    public function testSpendReducesBalance(): void
+    {
+        $this->pb->earn('user-1', 100, 'purchase');
+        $id = $this->pb->spend('user-1', 30, 'redeem');
+        $this->assertGreaterThan(0, $id);
+        $this->assertSame(70, $this->pb->balance('user-1'));
+    }
+
+    public function testSpendThrowsWhenInsufficientBalance(): void
+    {
+        $this->pb->earn('user-1', 50, 'purchase');
+        $this->expectException(\RuntimeException::class);
+        $this->pb->spend('user-1', 100, 'redeem');
+    }
+
+    public function testSpendThrowsOnZeroPoints(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pb->spend('user-1', 0, 'redeem');
+    }
+
+    // ── expire ────────────────────────────────────────────────────────────────
+
+    public function testExpireReducesBalance(): void
+    {
+        $this->pb->earn('user-1', 100, 'purchase');
+        $this->pb->expire('user-1', 20, 'monthly-expiry');
+        $this->assertSame(80, $this->pb->balance('user-1'));
+    }
+
+    public function testExpireDoesNotGuardAgainstNegative(): void
+    {
+        // No balance — expire does not throw
+        $this->pb->expire('user-1', 50, 'batch-expiry');
+        $this->assertSame(-50, $this->pb->balance('user-1'));
+    }
+
+    // ── balance ───────────────────────────────────────────────────────────────
+
+    public function testBalanceReturnsZeroWithNoEntries(): void
+    {
+        $this->assertSame(0, $this->pb->balance('nobody'));
+    }
+
+    public function testBalanceSumsAllDeltas(): void
+    {
+        $this->pb->earn('user-1', 100, 'a');
+        $this->pb->earn('user-1', 50, 'b');
+        $this->pb->spend('user-1', 30, 'c');
+        $this->assertSame(120, $this->pb->balance('user-1'));
+    }
+
+    public function testBalanceIsIsolatedByUser(): void
+    {
+        $this->pb->earn('user-1', 100, 'purchase');
+        $this->pb->earn('user-2', 200, 'purchase');
+        $this->assertSame(100, $this->pb->balance('user-1'));
+        $this->assertSame(200, $this->pb->balance('user-2'));
+    }
+
+    // ── totalEarned / totalSpent ──────────────────────────────────────────────
+
+    public function testTotalEarned(): void
+    {
+        $this->pb->earn('user-1', 100, 'a');
+        $this->pb->earn('user-1', 50, 'b');
+        $this->pb->spend('user-1', 30, 'c');
+        $this->assertSame(150, $this->pb->totalEarned('user-1'));
+    }
+
+    public function testTotalSpent(): void
+    {
+        $this->pb->earn('user-1', 200, 'a');
+        $this->pb->spend('user-1', 30, 'b');
+        $this->pb->spend('user-1', 20, 'c');
+        $this->assertSame(50, $this->pb->totalSpent('user-1'));
+    }
+
+    public function testTotalEarnedReturnsZeroWhenNone(): void
+    {
+        $this->assertSame(0, $this->pb->totalEarned('nobody'));
+    }
+
+    public function testTotalSpentReturnsZeroWhenNone(): void
+    {
+        $this->assertSame(0, $this->pb->totalSpent('nobody'));
+    }
+
+    // ── history ───────────────────────────────────────────────────────────────
+
+    public function testHistoryReturnsNewestFirst(): void
+    {
+        $id1 = $this->pb->earn('user-1', 100, 'a');
+        $id2 = $this->pb->earn('user-1', 50, 'b');
+        $list = $this->pb->history('user-1');
+        $this->assertSame($id2, (int)$list[0]['id']);
+        $this->assertSame($id1, (int)$list[1]['id']);
+    }
+
+    public function testHistoryReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->pb->history('nobody'));
+    }
+
+    public function testHistoryRespectsLimitOffset(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->pb->earn('user-1', 10, 'purchase');
+        }
+        $page1 = $this->pb->history('user-1', 3, 0);
+        $page2 = $this->pb->history('user-1', 3, 3);
+        $this->assertCount(3, $page1);
+        $this->assertCount(2, $page2);
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->pb->find(9999));
+    }
+}


### PR DESCRIPTION
## FT213 — PointBalance

Xion helper for user loyalty/reward points with append-only ledger. Distinct from CreditLedger (financial credits).

### New files
- `class/xion/PointBalance.php`
- `tests/Unit/Xion/PointBalanceTest.php`

### Schema
```sql
CREATE TABLE point_ledger (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id    VARCHAR(255) NOT NULL,
    delta      INTEGER      NOT NULL,
    reason     VARCHAR(100) NOT NULL,
    reference  VARCHAR(255) NULL,
    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### API
- `earn(userId, points, reason, reference)` — positive delta
- `spend(userId, points, reason, reference)` — guarded negative delta (RuntimeException if insufficient)
- `expire(userId, points, reason, reference)` — unguarded negative delta for batch expiry
- `balance(userId)` — current balance (SUM of deltas)
- `totalEarned(userId)` / `totalSpent(userId)`
- `history(userId, limit, offset)` — newest first
- `find(id)`

### Tests
22 tests, 29 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)