### PR TITLE
feat(xion): FT214 EntityComment — flat comment list on any entity

### DIFF
--- a/class/xion/EntityComment.php
+++ b/class/xion/EntityComment.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * EntityComment — flat comment list attached to any entity.
+ *
+ * Stores user comments on arbitrary entities (posts, tasks, orders, …).
+ * Comments are flat (no threading — use CommentThread for threaded replies).
+ * Supports soft-delete and edit tracking.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ec = new EntityComment($pdo);
+ *
+ * // Add
+ * $id = $ec->add('article', '10', 'user-42', 'Great post!');
+ *
+ * // Edit / delete
+ * $ec->edit($id, 'user-42', 'Great post, thanks!');
+ * $ec->delete($id, 'user-42');
+ *
+ * // Query
+ * $comments = $ec->forEntity('article', '10');
+ * $count    = $ec->countForEntity('article', '10');
+ * $mine     = $ec->byUser('user-42');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE entity_comments (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     entity_type  VARCHAR(100) NOT NULL,
+ *     entity_id    VARCHAR(255) NOT NULL,
+ *     author_id    VARCHAR(255) NOT NULL,
+ *     body         TEXT         NOT NULL,
+ *     edited_at    DATETIME     NULL,
+ *     deleted_at   DATETIME     NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class EntityComment
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add a comment.
+     *
+     * @return int Row ID of the new comment.
+     * @throws \InvalidArgumentException on empty fields.
+     */
+    public function add(string $entityType, string $entityId, string $authorId, string $body): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $authorId = trim($authorId);
+        $body     = trim($body);
+        if ($authorId === '') {
+            throw new \InvalidArgumentException('authorId must not be empty.');
+        }
+        if ($body === '') {
+            throw new \InvalidArgumentException('body must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO entity_comments (entity_type, entity_id, author_id, body)
+             VALUES (:type, :eid, :author, :body)'
+        );
+        $stmt->execute([
+            ':type'   => $entityType,
+            ':eid'    => $entityId,
+            ':author' => $authorId,
+            ':body'   => $body,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Find a single comment by ID (including soft-deleted).
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM entity_comments WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Edit a comment body (only the author can edit; cannot edit deleted comments).
+     *
+     * @return bool True if found, author matches, and not deleted.
+     * @throws \InvalidArgumentException on empty body.
+     */
+    public function edit(int $id, string $authorId, string $body): bool
+    {
+        $body = trim($body);
+        if ($body === '') {
+            throw new \InvalidArgumentException('body must not be empty.');
+        }
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE entity_comments
+             SET body = :body, edited_at = :now
+             WHERE id = :id AND author_id = :author AND deleted_at IS NULL'
+        );
+        $stmt->execute([':body' => $body, ':now' => $now, ':id' => $id, ':author' => trim($authorId)]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Soft-delete a comment (only the author can delete).
+     *
+     * @return bool True if found, author matches, and not already deleted.
+     */
+    public function delete(int $id, string $authorId): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE entity_comments
+             SET deleted_at = :now
+             WHERE id = :id AND author_id = :author AND deleted_at IS NULL'
+        );
+        $stmt->execute([':now' => $now, ':id' => $id, ':author' => trim($authorId)]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Hard-delete a comment permanently (admin use).
+     *
+     * @return bool True if found and deleted.
+     */
+    public function purge(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM entity_comments WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List non-deleted comments for an entity (oldest first = natural conversation order).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forEntity(string $entityType, string $entityId, int $limit = 100, int $offset = 0): array
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM entity_comments
+             WHERE entity_type = :type AND entity_id = :eid AND deleted_at IS NULL
+             ORDER BY id ASC
+             LIMIT :lim OFFSET :off'
+        );
+        $stmt->bindValue(':type', $entityType);
+        $stmt->bindValue(':eid', $entityId);
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':off', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Count non-deleted comments for an entity.
+     */
+    public function countForEntity(string $entityType, string $entityId): int
+    {
+        [$entityType, $entityId] = $this->validateEntity($entityType, $entityId);
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM entity_comments
+             WHERE entity_type = :type AND entity_id = :eid AND deleted_at IS NULL'
+        );
+        $stmt->execute([':type' => $entityType, ':eid' => $entityId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * List non-deleted comments by a specific author (newest first).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function byUser(string $authorId, int $limit = 50, int $offset = 0): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM entity_comments
+             WHERE author_id = :author AND deleted_at IS NULL
+             ORDER BY id DESC
+             LIMIT :lim OFFSET :off'
+        );
+        $stmt->bindValue(':author', trim($authorId));
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':off', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function validateEntity(string $entityType, string $entityId): array
+    {
+        $entityType = trim($entityType);
+        $entityId   = trim($entityId);
+        if ($entityType === '') {
+            throw new \InvalidArgumentException('entity_type must not be empty.');
+        }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        return [$entityType, $entityId];
+    }
+}

--- a/tests/Unit/Xion/EntityCommentTest.php
+++ b/tests/Unit/Xion/EntityCommentTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\EntityComment;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class EntityCommentTest extends TestCase
+{
+    private PDO $pdo;
+    private EntityComment $ec;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE entity_comments (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type  VARCHAR(100) NOT NULL,
+                entity_id    VARCHAR(255) NOT NULL,
+                author_id    VARCHAR(255) NOT NULL,
+                body         TEXT         NOT NULL,
+                edited_at    DATETIME     NULL,
+                deleted_at   DATETIME     NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->ec = new EntityComment($this->pdo);
+    }
+
+    // ── add ───────────────────────────────────────────────────────────────────
+
+    public function testAddReturnsId(): void
+    {
+        $id = $this->ec->add('article', '1', 'user-1', 'Hello!');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testAddStoresCorrectly(): void
+    {
+        $id  = $this->ec->add('article', '1', 'user-1', 'Hello!');
+        $row = $this->ec->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('article', $row['entity_type']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('1', $row['entity_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['author_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Hello!', $row['body']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNull($row['deleted_at']);
+    }
+
+    public function testAddThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ec->add('', '1', 'user-1', 'body');
+    }
+
+    public function testAddThrowsOnEmptyEntityId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ec->add('article', '', 'user-1', 'body');
+    }
+
+    public function testAddThrowsOnEmptyAuthorId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ec->add('article', '1', '', 'body');
+    }
+
+    public function testAddThrowsOnEmptyBody(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ec->add('article', '1', 'user-1', '');
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->ec->find(9999));
+    }
+
+    // ── edit ──────────────────────────────────────────────────────────────────
+
+    public function testEditUpdatesBody(): void
+    {
+        $id     = $this->ec->add('article', '1', 'user-1', 'Original');
+        $result = $this->ec->edit($id, 'user-1', 'Updated body');
+        $this->assertTrue($result);
+
+        $row = $this->ec->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Updated body', $row['body']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['edited_at']);
+    }
+
+    public function testEditReturnsFalseForWrongAuthor(): void
+    {
+        $id = $this->ec->add('article', '1', 'user-1', 'body');
+        $this->assertFalse($this->ec->edit($id, 'user-2', 'hacked'));
+    }
+
+    public function testEditReturnsFalseForDeletedComment(): void
+    {
+        $id = $this->ec->add('article', '1', 'user-1', 'body');
+        $this->ec->delete($id, 'user-1');
+        $this->assertFalse($this->ec->edit($id, 'user-1', 'new body'));
+    }
+
+    public function testEditThrowsOnEmptyBody(): void
+    {
+        $id = $this->ec->add('article', '1', 'user-1', 'body');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ec->edit($id, 'user-1', '');
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteSoftDeletesComment(): void
+    {
+        $id     = $this->ec->add('article', '1', 'user-1', 'body');
+        $result = $this->ec->delete($id, 'user-1');
+        $this->assertTrue($result);
+
+        $row = $this->ec->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['deleted_at']);
+    }
+
+    public function testDeleteReturnsFalseForWrongAuthor(): void
+    {
+        $id = $this->ec->add('article', '1', 'user-1', 'body');
+        $this->assertFalse($this->ec->delete($id, 'user-2'));
+    }
+
+    public function testDeleteReturnsFalseWhenAlreadyDeleted(): void
+    {
+        $id = $this->ec->add('article', '1', 'user-1', 'body');
+        $this->ec->delete($id, 'user-1');
+        $this->assertFalse($this->ec->delete($id, 'user-1'));
+    }
+
+    // ── purge ─────────────────────────────────────────────────────────────────
+
+    public function testPurgeHardDeletesRow(): void
+    {
+        $id = $this->ec->add('article', '1', 'user-1', 'body');
+        $this->assertTrue($this->ec->purge($id));
+        $this->assertNull($this->ec->find($id));
+    }
+
+    public function testPurgeReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->ec->purge(9999));
+    }
+
+    // ── forEntity ─────────────────────────────────────────────────────────────
+
+    public function testForEntityReturnsOldestFirst(): void
+    {
+        $id1 = $this->ec->add('article', '1', 'user-1', 'First');
+        $id2 = $this->ec->add('article', '1', 'user-2', 'Second');
+        $list = $this->ec->forEntity('article', '1');
+        $this->assertSame($id1, (int)$list[0]['id']);
+        $this->assertSame($id2, (int)$list[1]['id']);
+    }
+
+    public function testForEntityExcludesDeleted(): void
+    {
+        $id1 = $this->ec->add('article', '1', 'user-1', 'A');
+        $id2 = $this->ec->add('article', '1', 'user-1', 'B');
+        $this->ec->delete($id1, 'user-1');
+        $list = $this->ec->forEntity('article', '1');
+        $this->assertCount(1, $list);
+        $this->assertSame($id2, (int)$list[0]['id']);
+    }
+
+    public function testForEntityIsIsolatedByEntity(): void
+    {
+        $this->ec->add('article', '1', 'user-1', 'A');
+        $this->ec->add('article', '2', 'user-1', 'B');
+        $this->assertCount(1, $this->ec->forEntity('article', '1'));
+    }
+
+    public function testForEntityReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->ec->forEntity('article', '99'));
+    }
+
+    // ── countForEntity ────────────────────────────────────────────────────────
+
+    public function testCountForEntityExcludesDeleted(): void
+    {
+        $id = $this->ec->add('article', '1', 'user-1', 'A');
+        $this->ec->add('article', '1', 'user-2', 'B');
+        $this->ec->delete($id, 'user-1');
+        $this->assertSame(1, $this->ec->countForEntity('article', '1'));
+    }
+
+    // ── byUser ────────────────────────────────────────────────────────────────
+
+    public function testByUserReturnsNonDeletedComments(): void
+    {
+        $id1 = $this->ec->add('article', '1', 'user-1', 'A');
+        $this->ec->add('article', '2', 'user-1', 'B');
+        $this->ec->delete($id1, 'user-1');
+        $list = $this->ec->byUser('user-1');
+        $this->assertCount(1, $list);
+    }
+
+    public function testByUserReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->ec->byUser('nobody'));
+    }
+}


### PR DESCRIPTION
## FT214 — EntityComment

Flat (non-threaded) comment list attached to any entity. Supports soft-delete and edit tracking. Distinct from CommentThread (parent_id tree structure).

### New files
- `class/xion/EntityComment.php`
- `tests/Unit/Xion/EntityCommentTest.php`

### Schema
```sql
CREATE TABLE entity_comments (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    entity_type  VARCHAR(100) NOT NULL,
    entity_id    VARCHAR(255) NOT NULL,
    author_id    VARCHAR(255) NOT NULL,
    body         TEXT         NOT NULL,
    edited_at    DATETIME     NULL,
    deleted_at   DATETIME     NULL,
    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

### API
- `add(entityType, entityId, authorId, body)`
- `find(id)` / `edit(id, authorId, body)` / `delete(id, authorId)` / `purge(id)`
- `forEntity(entityType, entityId, limit, offset)` — oldest first; excludes deleted
- `countForEntity(entityType, entityId)`
- `byUser(authorId, limit, offset)` — newest first; excludes deleted

### Tests
23 tests, 36 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)