### PR TITLE
feat(xion): NotificationQueue — channel-agnostic outbox notification queue (FT217)

### DIFF
--- a/class/xion/NotificationQueue.php
+++ b/class/xion/NotificationQueue.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * NotificationQueue — channel-agnostic outbox-pattern notification queue.
+ *
+ * Queues notifications for delivery via email, SMS, push, webhook, or any
+ * channel. A dispatcher process dequeues pending items, attempts delivery,
+ * and marks them sent or failed. Failed items are retried up to a max-attempts
+ * limit before being marked permanently failed.
+ *
+ * Distinct from EmailQueue (SMTP-specific, with From/To/Subject model).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $nq = new NotificationQueue($pdo);
+ *
+ * // Enqueue
+ * $id = $nq->enqueue('user-42', 'push', 'New message', ['badge' => 1]);
+ *
+ * // Dispatcher loop
+ * $batch = $nq->dequeue(10);
+ * foreach ($batch as $item) {
+ *     // attempt delivery …
+ *     $nq->markSent($item['id']);
+ *     // or on failure:
+ *     $nq->markFailed($item['id'], 'Device unreachable');
+ * }
+ *
+ * // Housekeeping
+ * $nq->purgeSent(new \DateTimeImmutable('-7 days'));
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE notification_queue (
+ *     id            INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     recipient_id  VARCHAR(255) NOT NULL,
+ *     channel       VARCHAR(50)  NOT NULL DEFAULT 'push',
+ *     subject       VARCHAR(255) NOT NULL,
+ *     payload       TEXT         NULL,
+ *     status        VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     attempts      INTEGER      NOT NULL DEFAULT 0,
+ *     max_attempts  INTEGER      NOT NULL DEFAULT 3,
+ *     error_message TEXT         NULL,
+ *     scheduled_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     sent_at       DATETIME     NULL,
+ *     created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class NotificationQueue
+{
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_SENT    = 'sent';
+    public const STATUS_FAILED  = 'failed';
+
+    public const CHANNEL_EMAIL   = 'email';
+    public const CHANNEL_PUSH    = 'push';
+    public const CHANNEL_SMS     = 'sms';
+    public const CHANNEL_WEBHOOK = 'webhook';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Enqueue a notification.
+     *
+     * @param array<mixed>|string|null $payload Channel-specific data (array → JSON).
+     * @return int Row ID.
+     * @throws \InvalidArgumentException on empty recipientId or subject.
+     */
+    public function enqueue(
+        string $recipientId,
+        string $channel,
+        string $subject,
+        array|string|null $payload = null,
+        int $maxAttempts = 3,
+        ?\DateTimeImmutable $scheduledAt = null,
+    ): int {
+        $recipientId = trim($recipientId);
+        $subject     = trim($subject);
+        if ($recipientId === '') {
+            throw new \InvalidArgumentException('recipientId must not be empty.');
+        }
+        if ($subject === '') {
+            throw new \InvalidArgumentException('subject must not be empty.');
+        }
+
+        $scheduledStr = ($scheduledAt ?? new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $payloadStr   = is_array($payload) ? json_encode($payload) : $payload;
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO notification_queue
+                (recipient_id, channel, subject, payload, status, attempts, max_attempts, scheduled_at)
+             VALUES (:rid, :chan, :sub, :payload, :status, 0, :max, :sched)'
+        );
+        $stmt->execute([
+            ':rid'     => $recipientId,
+            ':chan'    => trim($channel) ?: self::CHANNEL_PUSH,
+            ':sub'     => $subject,
+            ':payload' => $payloadStr,
+            ':status'  => self::STATUS_PENDING,
+            ':max'     => $maxAttempts,
+            ':sched'   => $scheduledStr,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Find a single queue item by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM notification_queue WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Fetch pending items due for delivery (attempts < max_attempts, scheduled_at <= now).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function dequeue(int $limit = 50): array
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM notification_queue
+             WHERE status = :status AND attempts < max_attempts AND scheduled_at <= :now
+             ORDER BY scheduled_at ASC, id ASC
+             LIMIT :lim'
+        );
+        $stmt->bindValue(':status', self::STATUS_PENDING);
+        $stmt->bindValue(':now', $now);
+        $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Mark a notification as successfully sent.
+     *
+     * @return bool True if found and updated.
+     */
+    public function markSent(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE notification_queue
+             SET status = :status, sent_at = :now, attempts = attempts + 1
+             WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_SENT, ':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark a delivery attempt as failed (increments attempts counter).
+     * If attempts reaches max_attempts, status is set to 'failed'.
+     *
+     * @return bool True if found and updated.
+     */
+    public function markFailed(int $id, ?string $errorMessage = null): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE notification_queue
+             SET attempts = attempts + 1,
+                 error_message = :err,
+                 status = CASE WHEN attempts + 1 >= max_attempts THEN :failed ELSE :pending END
+             WHERE id = :id AND status = :pending2'
+        );
+        $stmt->execute([
+            ':err'     => $errorMessage,
+            ':failed'  => self::STATUS_FAILED,
+            ':pending' => self::STATUS_PENDING,
+            ':id'      => $id,
+            ':pending2' => self::STATUS_PENDING,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete a queue item permanently.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM notification_queue WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List pending notifications for a specific recipient.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function pendingFor(string $recipientId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM notification_queue
+             WHERE recipient_id = :rid AND status = :status
+             ORDER BY scheduled_at ASC'
+        );
+        $stmt->execute([':rid' => trim($recipientId), ':status' => self::STATUS_PENDING]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Delete all sent items older than the given cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeSent(\DateTimeImmutable $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM notification_queue WHERE status = :status AND sent_at < :cutoff'
+        );
+        $stmt->execute([':status' => self::STATUS_SENT, ':cutoff' => $cutoff->format('Y-m-d H:i:s')]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/NotificationQueueTest.php
+++ b/tests/Unit/Xion/NotificationQueueTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\NotificationQueue;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class NotificationQueueTest extends TestCase
+{
+    private PDO $pdo;
+    private NotificationQueue $nq;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE notification_queue (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                recipient_id  VARCHAR(255) NOT NULL,
+                channel       VARCHAR(50)  NOT NULL DEFAULT \'push\',
+                subject       VARCHAR(255) NOT NULL,
+                payload       TEXT         NULL,
+                status        VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                attempts      INTEGER      NOT NULL DEFAULT 0,
+                max_attempts  INTEGER      NOT NULL DEFAULT 3,
+                error_message TEXT         NULL,
+                scheduled_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                sent_at       DATETIME     NULL,
+                created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->nq = new NotificationQueue($this->pdo);
+    }
+
+    // ── enqueue ───────────────────────────────────────────────────────────────
+
+    public function testEnqueueReturnsId(): void
+    {
+        $id = $this->nq->enqueue('user-1', NotificationQueue::CHANNEL_PUSH, 'Hello');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testEnqueueStoresCorrectly(): void
+    {
+        $id  = $this->nq->enqueue('user-1', NotificationQueue::CHANNEL_PUSH, 'Hello', ['badge' => 1]);
+        $row = $this->nq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['recipient_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(NotificationQueue::CHANNEL_PUSH, $row['channel']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Hello', $row['subject']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('{"badge":1}', $row['payload']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(NotificationQueue::STATUS_PENDING, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['attempts']);
+    }
+
+    public function testEnqueueStringPayload(): void
+    {
+        $id  = $this->nq->enqueue('user-1', 'push', 'Hi', 'raw-payload');
+        $row = $this->nq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('raw-payload', $row['payload']);
+    }
+
+    public function testEnqueueThrowsOnEmptyRecipientId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->nq->enqueue('', 'push', 'Hello');
+    }
+
+    public function testEnqueueThrowsOnEmptySubject(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->nq->enqueue('user-1', 'push', '');
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->nq->find(9999));
+    }
+
+    // ── dequeue ───────────────────────────────────────────────────────────────
+
+    public function testDequeueReturnsPendingItems(): void
+    {
+        $id1 = $this->nq->enqueue('user-1', 'push', 'A');
+        $id2 = $this->nq->enqueue('user-2', 'push', 'B');
+        $this->nq->markSent($id1);
+
+        $batch = $this->nq->dequeue();
+        $this->assertCount(1, $batch);
+        $this->assertSame($id2, (int)$batch[0]['id']);
+    }
+
+    public function testDequeueExcludesExhaustedItems(): void
+    {
+        $id = $this->nq->enqueue('user-1', 'push', 'A', null, 1);
+        $this->nq->markFailed($id, 'err');
+        // After 1 attempt with max_attempts=1, should be FAILED
+        $this->assertSame([], $this->nq->dequeue());
+    }
+
+    public function testDequeueRespectsLimit(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->nq->enqueue('user-1', 'push', 'msg');
+        }
+        $this->assertCount(3, $this->nq->dequeue(3));
+    }
+
+    // ── markSent ──────────────────────────────────────────────────────────────
+
+    public function testMarkSentUpdateStatus(): void
+    {
+        $id = $this->nq->enqueue('user-1', 'push', 'Hello');
+        $this->assertTrue($this->nq->markSent($id));
+        $row = $this->nq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(NotificationQueue::STATUS_SENT, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['sent_at']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['attempts']);
+    }
+
+    public function testMarkSentReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->nq->markSent(9999));
+    }
+
+    // ── markFailed ────────────────────────────────────────────────────────────
+
+    public function testMarkFailedIncrementsAttempts(): void
+    {
+        $id = $this->nq->enqueue('user-1', 'push', 'Hello', null, 3);
+        $this->assertTrue($this->nq->markFailed($id, 'Timeout'));
+        $row = $this->nq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['attempts']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(NotificationQueue::STATUS_PENDING, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Timeout', $row['error_message']);
+    }
+
+    public function testMarkFailedSetsFailedWhenAttemptsExhausted(): void
+    {
+        $id = $this->nq->enqueue('user-1', 'push', 'Hello', null, 1);
+        $this->nq->markFailed($id, 'err1');
+        $row = $this->nq->find($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(NotificationQueue::STATUS_FAILED, $row['status']);
+    }
+
+    public function testMarkFailedReturnsFalseForNonPendingItem(): void
+    {
+        $id = $this->nq->enqueue('user-1', 'push', 'Hello');
+        $this->nq->markSent($id);
+        $this->assertFalse($this->nq->markFailed($id));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesItem(): void
+    {
+        $id = $this->nq->enqueue('user-1', 'push', 'Hello');
+        $this->assertTrue($this->nq->delete($id));
+        $this->assertNull($this->nq->find($id));
+    }
+
+    public function testDeleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->nq->delete(9999));
+    }
+
+    // ── pendingFor ────────────────────────────────────────────────────────────
+
+    public function testPendingForReturnsOnlyPendingForUser(): void
+    {
+        $id1 = $this->nq->enqueue('user-1', 'push', 'A');
+        $this->nq->enqueue('user-1', 'push', 'B');
+        $this->nq->markSent($id1);
+
+        $pending = $this->nq->pendingFor('user-1');
+        $this->assertCount(1, $pending);
+    }
+
+    public function testPendingForIsIsolatedByRecipient(): void
+    {
+        $this->nq->enqueue('user-1', 'push', 'A');
+        $this->nq->enqueue('user-2', 'push', 'B');
+        $this->assertCount(1, $this->nq->pendingFor('user-1'));
+    }
+
+    // ── purgeSent ────────────────────────────────────────────────────────────
+
+    public function testPurgeSentDeletesOldSentItems(): void
+    {
+        $id = $this->nq->enqueue('user-1', 'push', 'Old');
+        $this->nq->markSent($id);
+        // Manually backdate sent_at
+        $past = (new \DateTimeImmutable())->modify('-2 days')->format('Y-m-d H:i:s');
+        $this->pdo->exec("UPDATE notification_queue SET sent_at = '{$past}' WHERE id = {$id}");
+
+        $this->nq->enqueue('user-1', 'push', 'Recent');
+
+        $cutoff = new \DateTimeImmutable('-1 day');
+        $count  = $this->nq->purgeSent($cutoff);
+        $this->assertSame(1, $count);
+    }
+
+    public function testPurgeSentReturnsZeroWhenNone(): void
+    {
+        $cutoff = new \DateTimeImmutable('-1 day');
+        $this->assertSame(0, $this->nq->purgeSent($cutoff));
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\NotificationQueue` — a channel-agnostic outbox-pattern notification queue with retry logic.

## Schema
```sql
CREATE TABLE notification_queue (
    id            INTEGER PRIMARY KEY AUTOINCREMENT,
    recipient_id  VARCHAR(255) NOT NULL,
    channel       VARCHAR(50)  NOT NULL,
    subject       VARCHAR(500) NOT NULL,
    payload       TEXT         NULL,
    status        VARCHAR(20)  NOT NULL DEFAULT 'pending',
    attempts      INTEGER      NOT NULL DEFAULT 0,
    max_attempts  INTEGER      NOT NULL DEFAULT 3,
    error_message TEXT         NULL,
    scheduled_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    sent_at       DATETIME     NULL,
    created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API
- `enqueue(recipientId, channel, subject, payload, maxAttempts, scheduledAt)` — add to queue
- `dequeue(limit)` — pending items with attempts < max_attempts and scheduled_at <= now
- `markSent(id)` — sets status=sent, increments attempts
- `markFailed(id, errorMessage)` — increments attempts; sets FAILED when exhausted (CASE WHEN)
- `pendingFor(recipientId)` — all pending items for a recipient
- `purgeSent(cutoff)` — cleanup old sent items

## Constants
- STATUS_PENDING / STATUS_SENT / STATUS_FAILED
- CHANNEL_EMAIL / CHANNEL_PUSH / CHANNEL_SMS / CHANNEL_WEBHOOK

## Tests
20 tests, 38 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)