### PR TITLE
feat(xion): WorkflowInstance — persistent stateful workflow tracking (FT218)

### DIFF
--- a/class/xion/WorkflowInstance.php
+++ b/class/xion/WorkflowInstance.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * WorkflowInstance — persistent stateful workflow tracking.
+ *
+ * Stores running instances of named workflows attached to arbitrary entities.
+ * Each instance has a current state plus a transition history. The host
+ * application is responsible for defining which state transitions are valid
+ * (e.g. via WorkflowDefinition); WorkflowInstance only persists the state.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $wf = new WorkflowInstance($pdo);
+ *
+ * $id = $wf->create('order', 'order-42', 'pending', ['items' => 3]);
+ * $wf->transition($id, 'processing', 'user-7');
+ * $wf->transition($id, 'shipped',    'user-7', ['tracking' => 'TRK123']);
+ * $wf->complete($id, 'user-7');
+ *
+ * $history = $wf->history($id);
+ * $pct     = count(array_filter($history, fn($r) => $r['to_state'] === 'shipped'));
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE workflow_instances (
+ *     id            INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     type          VARCHAR(100) NOT NULL,
+ *     entity_ref    VARCHAR(255) NOT NULL,
+ *     current_state VARCHAR(100) NOT NULL,
+ *     context       TEXT         NULL,
+ *     status        VARCHAR(20)  NOT NULL DEFAULT 'active',
+ *     created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE TABLE workflow_transitions (
+ *     id              INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     instance_id     INTEGER      NOT NULL,
+ *     from_state      VARCHAR(100) NOT NULL,
+ *     to_state        VARCHAR(100) NOT NULL,
+ *     actor_id        VARCHAR(255) NULL,
+ *     metadata        TEXT         NULL,
+ *     transitioned_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class WorkflowInstance
+{
+    public const STATUS_ACTIVE    = 'active';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create a new workflow instance.
+     *
+     * @param array<string,mixed>|null $context Optional JSON-serialisable context.
+     * @return int New instance ID.
+     * @throws \InvalidArgumentException on empty type/entityRef/initialState.
+     */
+    public function create(
+        string $type,
+        string $entityRef,
+        string $initialState,
+        ?array $context = null
+    ): int {
+        $type         = trim($type);
+        $entityRef    = trim($entityRef);
+        $initialState = trim($initialState);
+        if ($type === '') {
+            throw new \InvalidArgumentException('type must not be empty.');
+        }
+        if ($entityRef === '') {
+            throw new \InvalidArgumentException('entity_ref must not be empty.');
+        }
+        if ($initialState === '') {
+            throw new \InvalidArgumentException('initial_state must not be empty.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO workflow_instances (type, entity_ref, current_state, context, status, created_at, updated_at)
+             VALUES (:type, :ref, :state, :ctx, :status, :now, :now)'
+        );
+        $stmt->execute([
+            ':type'   => $type,
+            ':ref'    => $entityRef,
+            ':state'  => $initialState,
+            ':ctx'    => $context !== null ? json_encode($context, JSON_UNESCAPED_UNICODE) : null,
+            ':status' => self::STATUS_ACTIVE,
+            ':now'    => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve a workflow instance row.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM workflow_instances WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Return the current state string, or null if the instance does not exist.
+     */
+    public function state(int $id): ?string
+    {
+        $row = $this->get($id);
+        return $row !== null ? (string)$row['current_state'] : null;
+    }
+
+    /**
+     * Record a state transition.
+     *
+     * Only transitions instances with STATUS_ACTIVE. Returns false if the
+     * instance is not found or already completed/cancelled.
+     *
+     * @param array<string,mixed>|null $metadata Optional transition metadata.
+     * @return bool True if transitioned.
+     * @throws \InvalidArgumentException on empty newState.
+     */
+    public function transition(
+        int $id,
+        string $newState,
+        ?string $actorId = null,
+        ?array $metadata = null
+    ): bool {
+        $newState = trim($newState);
+        if ($newState === '') {
+            throw new \InvalidArgumentException('new_state must not be empty.');
+        }
+
+        $row = $this->get($id);
+        if ($row === null || $row['status'] !== self::STATUS_ACTIVE) {
+            return false;
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $db   = $this->db();
+
+        // Record transition history
+        $stmt = $db->prepare(
+            'INSERT INTO workflow_transitions (instance_id, from_state, to_state, actor_id, metadata, transitioned_at)
+             VALUES (:iid, :from, :to, :actor, :meta, :now)'
+        );
+        $stmt->execute([
+            ':iid'   => $id,
+            ':from'  => $row['current_state'],
+            ':to'    => $newState,
+            ':actor' => $actorId,
+            ':meta'  => $metadata !== null ? json_encode($metadata, JSON_UNESCAPED_UNICODE) : null,
+            ':now'   => $now,
+        ]);
+
+        // Update instance state
+        $upd = $db->prepare(
+            'UPDATE workflow_instances SET current_state = :state, updated_at = :now WHERE id = :id'
+        );
+        $upd->execute([':state' => $newState, ':now' => $now, ':id' => $id]);
+        return true;
+    }
+
+    /**
+     * Mark the instance as completed.
+     *
+     * @return bool True if found and marked.
+     */
+    public function complete(int $id, ?string $actorId = null): bool
+    {
+        return $this->setTerminalStatus($id, self::STATUS_COMPLETED, $actorId);
+    }
+
+    /**
+     * Cancel the instance.
+     *
+     * @return bool True if found and cancelled.
+     */
+    public function cancel(int $id, ?string $actorId = null, ?string $reason = null): bool
+    {
+        $meta = $reason !== null ? ['reason' => $reason] : null;
+        return $this->setTerminalStatus($id, self::STATUS_CANCELLED, $actorId, $meta);
+    }
+
+    /**
+     * Return all transition records for an instance (oldest first).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function history(int $id): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, instance_id, from_state, to_state, actor_id, metadata, transitioned_at
+             FROM workflow_transitions
+             WHERE instance_id = :id
+             ORDER BY id ASC'
+        );
+        $stmt->execute([':id' => $id]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return active instances for a given entity reference.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forEntity(string $type, string $entityRef): array
+    {
+        $type      = trim($type);
+        $entityRef = trim($entityRef);
+        $stmt      = $this->db()->prepare(
+            'SELECT * FROM workflow_instances
+             WHERE type = :type AND entity_ref = :ref AND status = :status
+             ORDER BY id DESC'
+        );
+        $stmt->execute([':type' => $type, ':ref' => $entityRef, ':status' => self::STATUS_ACTIVE]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Delete an instance and its transition history (hard delete).
+     *
+     * @return bool True if found and deleted.
+     */
+    public function delete(int $id): bool
+    {
+        $db = $this->db();
+        $db->prepare('DELETE FROM workflow_transitions WHERE instance_id = :id')->execute([':id' => $id]);
+        $stmt = $db->prepare('DELETE FROM workflow_instances WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /**
+     * @param array<string,mixed>|null $meta
+     */
+    private function setTerminalStatus(
+        int $id,
+        string $status,
+        ?string $actorId,
+        ?array $meta = null
+    ): bool {
+        $row = $this->get($id);
+        if ($row === null || $row['status'] !== self::STATUS_ACTIVE) {
+            return false;
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $db   = $this->db();
+
+        // Record terminal transition
+        $stmt = $db->prepare(
+            'INSERT INTO workflow_transitions (instance_id, from_state, to_state, actor_id, metadata, transitioned_at)
+             VALUES (:iid, :from, :to, :actor, :meta, :now)'
+        );
+        $stmt->execute([
+            ':iid'   => $id,
+            ':from'  => $row['current_state'],
+            ':to'    => $status,
+            ':actor' => $actorId,
+            ':meta'  => $meta !== null ? json_encode($meta, JSON_UNESCAPED_UNICODE) : null,
+            ':now'   => $now,
+        ]);
+
+        $upd = $db->prepare(
+            'UPDATE workflow_instances SET status = :status, updated_at = :now WHERE id = :id'
+        );
+        $upd->execute([':status' => $status, ':now' => $now, ':id' => $id]);
+        return true;
+    }
+}

--- a/tests/Unit/Xion/WorkflowInstanceTest.php
+++ b/tests/Unit/Xion/WorkflowInstanceTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\WorkflowInstance;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class WorkflowInstanceTest extends TestCase
+{
+    private PDO $pdo;
+    private WorkflowInstance $wf;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE workflow_instances (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                type          VARCHAR(100) NOT NULL,
+                entity_ref    VARCHAR(255) NOT NULL,
+                current_state VARCHAR(100) NOT NULL,
+                context       TEXT         NULL,
+                status        VARCHAR(20)  NOT NULL DEFAULT \'active\',
+                created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->pdo->exec('
+            CREATE TABLE workflow_transitions (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                instance_id     INTEGER      NOT NULL,
+                from_state      VARCHAR(100) NOT NULL,
+                to_state        VARCHAR(100) NOT NULL,
+                actor_id        VARCHAR(255) NULL,
+                metadata        TEXT         NULL,
+                transitioned_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->wf = new WorkflowInstance($this->pdo);
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsId(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testCreateStoresFields(): void
+    {
+        $id  = $this->wf->create('order', 'order-1', 'pending', ['items' => 3]);
+        $row = $this->wf->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('order', $row['type']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('order-1', $row['entity_ref']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('pending', $row['current_state']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(WorkflowInstance::STATUS_ACTIVE, $row['status']);
+    }
+
+    public function testCreateStoresContext(): void
+    {
+        $id  = $this->wf->create('order', 'order-1', 'pending', ['items' => 3]);
+        $row = $this->wf->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $ctx = json_decode((string)$row['context'], true);
+        $this->assertSame(3, $ctx['items']);
+    }
+
+    public function testCreateAllowsNullContext(): void
+    {
+        $id  = $this->wf->create('order', 'order-1', 'pending');
+        $row = $this->wf->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNull($row['context']);
+    }
+
+    public function testCreateThrowsOnEmptyType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wf->create('', 'order-1', 'pending');
+    }
+
+    public function testCreateThrowsOnEmptyEntityRef(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wf->create('order', '', 'pending');
+    }
+
+    public function testCreateThrowsOnEmptyInitialState(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wf->create('order', 'order-1', '');
+    }
+
+    // ── get / state ───────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->wf->get(9999));
+    }
+
+    public function testStateReturnsCurrentState(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->assertSame('pending', $this->wf->state($id));
+    }
+
+    public function testStateReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->wf->state(9999));
+    }
+
+    // ── transition ────────────────────────────────────────────────────────────
+
+    public function testTransitionChangesCurrentState(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->assertTrue($this->wf->transition($id, 'processing', 'user-1'));
+        $this->assertSame('processing', $this->wf->state($id));
+    }
+
+    public function testTransitionRecordsHistory(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->transition($id, 'processing', 'user-1', ['note' => 'started']);
+        $history = $this->wf->history($id);
+        $this->assertCount(1, $history);
+        $this->assertSame('pending', $history[0]['from_state']);
+        $this->assertSame('processing', $history[0]['to_state']);
+        $this->assertSame('user-1', $history[0]['actor_id']);
+    }
+
+    public function testTransitionRecordsMetadata(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->transition($id, 'processing', 'user-1', ['note' => 'started']);
+        $history = $this->wf->history($id);
+        $meta    = json_decode((string)$history[0]['metadata'], true);
+        $this->assertSame('started', $meta['note']);
+    }
+
+    public function testTransitionReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->wf->transition(9999, 'processing'));
+    }
+
+    public function testTransitionReturnsFalseForCompletedInstance(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->complete($id, 'user-1');
+        $this->assertFalse($this->wf->transition($id, 'processing'));
+    }
+
+    public function testTransitionThrowsOnEmptyNewState(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wf->transition($id, '');
+    }
+
+    public function testMultipleTransitionsAreOrdered(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->transition($id, 'processing');
+        $this->wf->transition($id, 'shipped');
+        $history = $this->wf->history($id);
+        $this->assertCount(2, $history);
+        $this->assertSame('pending', $history[0]['from_state']);
+        $this->assertSame('processing', $history[1]['from_state']);
+        $this->assertSame('shipped', $history[1]['to_state']);
+    }
+
+    // ── complete ──────────────────────────────────────────────────────────────
+
+    public function testCompleteChangesStatus(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->assertTrue($this->wf->complete($id, 'user-1'));
+        $row = $this->wf->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(WorkflowInstance::STATUS_COMPLETED, $row['status']);
+    }
+
+    public function testCompleteRecordsTerminalTransition(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->complete($id, 'user-1');
+        $history = $this->wf->history($id);
+        $this->assertCount(1, $history);
+        $this->assertSame(WorkflowInstance::STATUS_COMPLETED, $history[0]['to_state']);
+    }
+
+    public function testCompleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->wf->complete(9999));
+    }
+
+    public function testCompleteReturnsFalseWhenAlreadyCompleted(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->complete($id);
+        $this->assertFalse($this->wf->complete($id));
+    }
+
+    // ── cancel ────────────────────────────────────────────────────────────────
+
+    public function testCancelChangesStatus(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->assertTrue($this->wf->cancel($id, 'user-1', 'customer request'));
+        $row = $this->wf->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(WorkflowInstance::STATUS_CANCELLED, $row['status']);
+    }
+
+    public function testCancelStoresReason(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->cancel($id, 'user-1', 'customer request');
+        $history = $this->wf->history($id);
+        $meta    = json_decode((string)$history[0]['metadata'], true);
+        $this->assertSame('customer request', $meta['reason']);
+    }
+
+    public function testCancelReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->wf->cancel(9999));
+    }
+
+    // ── forEntity ─────────────────────────────────────────────────────────────
+
+    public function testForEntityReturnsActiveInstances(): void
+    {
+        $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->create('order', 'order-1', 'pending');
+        $list = $this->wf->forEntity('order', 'order-1');
+        $this->assertCount(2, $list);
+    }
+
+    public function testForEntityExcludesCompleted(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->complete($id);
+        $this->assertCount(0, $this->wf->forEntity('order', 'order-1'));
+    }
+
+    public function testForEntityIsIsolatedByTypeAndRef(): void
+    {
+        $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->create('order', 'order-2', 'pending');
+        $this->wf->create('shipment', 'order-1', 'pending');
+        $this->assertCount(1, $this->wf->forEntity('order', 'order-1'));
+        $this->assertCount(1, $this->wf->forEntity('shipment', 'order-1'));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesInstanceAndHistory(): void
+    {
+        $id = $this->wf->create('order', 'order-1', 'pending');
+        $this->wf->transition($id, 'processing');
+        $this->assertTrue($this->wf->delete($id));
+        $this->assertNull($this->wf->get($id));
+        $this->assertSame([], $this->wf->history($id));
+    }
+
+    public function testDeleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->wf->delete(9999));
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\WorkflowInstance` — persists running workflow instances attached to arbitrary entities, with a full transition history log.

## Schema
```sql
CREATE TABLE workflow_instances (
    id            INTEGER PRIMARY KEY AUTOINCREMENT,
    type          VARCHAR(100) NOT NULL,
    entity_ref    VARCHAR(255) NOT NULL,
    current_state VARCHAR(100) NOT NULL,
    context       TEXT         NULL,
    status        VARCHAR(20)  NOT NULL DEFAULT 'active',
    created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
CREATE TABLE workflow_transitions (
    id              INTEGER PRIMARY KEY AUTOINCREMENT,
    instance_id     INTEGER      NOT NULL,
    from_state      VARCHAR(100) NOT NULL,
    to_state        VARCHAR(100) NOT NULL,
    actor_id        VARCHAR(255) NULL,
    metadata        TEXT         NULL,
    transitioned_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API
- `create(type, entityRef, initialState, context)` — new instance
- `get(id)` / `state(id)` — retrieve instance or current state
- `transition(id, newState, actorId, metadata)` — record state change with history
- `complete(id, actorId)` / `cancel(id, actorId, reason)` — terminal status
- `history(id)` — ordered transition log
- `forEntity(type, entityRef)` — active instances for an entity
- `delete(id)` — hard delete with transition history cleanup

## Constants
STATUS_ACTIVE / STATUS_COMPLETED / STATUS_CANCELLED

## Tests
29 tests, 50 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)