### PR TITLE
feat(xion): SearchSuggestion — type-ahead suggestion management with frequency weighting (FT219)

### DIFF
--- a/class/xion/SearchSuggestion.php
+++ b/class/xion/SearchSuggestion.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * SearchSuggestion — type-ahead suggestion management with frequency weighting.
+ *
+ * Records user search queries and surfaces normalised suggestions ordered by
+ * frequency. Supports manual weight boosts for editorial pinning. Suggestions
+ * are normalised to lowercase with collapsed whitespace before storage.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ss = new SearchSuggestion($pdo);
+ *
+ * // Record user queries
+ * $ss->record('PHP framework');
+ * $ss->record('PHP framework');
+ * $ss->record('php tutorial');
+ *
+ * // Type-ahead
+ * $results = $ss->suggest('php', 5);
+ * // → [['term' => 'php framework', 'frequency' => 2, 'weight' => 0], ...]
+ *
+ * // Editorial boost
+ * $ss->boost('php tutorial', 10);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE search_suggestions (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     term       VARCHAR(500) NOT NULL UNIQUE,
+ *     frequency  INTEGER      NOT NULL DEFAULT 0,
+ *     weight     INTEGER      NOT NULL DEFAULT 0,
+ *     last_seen  DATETIME     NULL
+ * );
+ * ```
+ */
+final class SearchSuggestion
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record a search query, incrementing frequency.
+     *
+     * The term is normalised (lowercase, collapsed whitespace) before storage.
+     * If the term already exists the frequency is incremented; otherwise a new
+     * row is inserted.
+     *
+     * @throws \InvalidArgumentException on empty term after normalisation.
+     */
+    public function record(string $term): void
+    {
+        $term = $this->normalise($term);
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $sql = 'INSERT INTO search_suggestions (term, frequency, last_seen)
+                    VALUES (:term, 1, :now)
+                    ON CONFLICT (term) DO UPDATE SET frequency = frequency + 1, last_seen = :now2';
+            $this->db()->prepare($sql)->execute([':term' => $term, ':now' => $now, ':now2' => $now]);
+        } else {
+            $sql = 'INSERT INTO search_suggestions (term, frequency, last_seen)
+                    VALUES (:term, 1, :now)
+                    ON DUPLICATE KEY UPDATE frequency = frequency + 1, last_seen = :now2';
+            $this->db()->prepare($sql)->execute([':term' => $term, ':now' => $now, ':now2' => $now]);
+        }
+    }
+
+    /**
+     * Return suggestions matching a prefix (case-insensitive), ordered by
+     * (weight + frequency) descending.
+     *
+     * @return list<array<string,mixed>>
+     * @throws \InvalidArgumentException on empty prefix after normalisation.
+     */
+    public function suggest(string $prefix, int $limit = 10): array
+    {
+        $prefix = $this->normalise($prefix);
+        $limit  = max(1, $limit);
+        $stmt   = $this->db()->prepare(
+            'SELECT term, frequency, weight
+             FROM search_suggestions
+             WHERE term LIKE :prefix
+             ORDER BY (weight + frequency) DESC, term ASC
+             LIMIT :limit'
+        );
+        $stmt->bindValue(':prefix', $prefix . '%', PDO::PARAM_STR);
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Set a manual weight boost for a term.
+     *
+     * @return bool True if the term exists and was updated.
+     * @throws \InvalidArgumentException on empty term or negative weight.
+     */
+    public function boost(string $term, int $weight): bool
+    {
+        $term = $this->normalise($term);
+        if ($weight < 0) {
+            throw new \InvalidArgumentException('weight must be >= 0.');
+        }
+        $stmt = $this->db()->prepare('UPDATE search_suggestions SET weight = :w WHERE term = :term');
+        $stmt->execute([':w' => $weight, ':term' => $term]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Remove a single suggestion term.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function remove(string $term): bool
+    {
+        $term = $this->normalise($term);
+        $stmt = $this->db()->prepare('DELETE FROM search_suggestions WHERE term = :term');
+        $stmt->execute([':term' => $term]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete suggestions not seen since $cutoff (for TTL cleanup).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purge(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM search_suggestions WHERE last_seen < :cutoff OR last_seen IS NULL'
+        );
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Return the stored frequency for a term (0 if not found).
+     */
+    public function frequency(string $term): int
+    {
+        $term = $this->normalise($term);
+        $stmt = $this->db()->prepare('SELECT frequency FROM search_suggestions WHERE term = :term');
+        $stmt->execute([':term' => $term]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? (int)$row['frequency'] : 0;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    private function normalise(string $term): string
+    {
+        $term = mb_strtolower(trim($term));
+        $term = (string)preg_replace('/\s+/', ' ', $term);
+        if ($term === '') {
+            throw new \InvalidArgumentException('term must not be empty.');
+        }
+        return $term;
+    }
+}

--- a/tests/Unit/Xion/SearchSuggestionTest.php
+++ b/tests/Unit/Xion/SearchSuggestionTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\SearchSuggestion;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class SearchSuggestionTest extends TestCase
+{
+    private PDO $pdo;
+    private SearchSuggestion $ss;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE search_suggestions (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                term      VARCHAR(500) NOT NULL UNIQUE,
+                frequency INTEGER      NOT NULL DEFAULT 0,
+                weight    INTEGER      NOT NULL DEFAULT 0,
+                last_seen DATETIME     NULL
+            )
+        ');
+        $this->ss = new SearchSuggestion($this->pdo);
+    }
+
+    // ── record ────────────────────────────────────────────────────────────────
+
+    public function testRecordIncreasesFrequency(): void
+    {
+        $this->ss->record('PHP framework');
+        $this->ss->record('PHP framework');
+        $this->assertSame(2, $this->ss->frequency('php framework'));
+    }
+
+    public function testRecordNormalisesToLowercase(): void
+    {
+        $this->ss->record('PHP Framework');
+        $this->ss->record('php framework');
+        $this->assertSame(2, $this->ss->frequency('php framework'));
+    }
+
+    public function testRecordCollapseWhitespace(): void
+    {
+        $this->ss->record('php  framework');
+        $this->assertSame(1, $this->ss->frequency('php framework'));
+    }
+
+    public function testRecordThrowsOnEmptyTerm(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ss->record('');
+    }
+
+    public function testRecordThrowsOnWhitespaceTerm(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ss->record('   ');
+    }
+
+    // ── suggest ───────────────────────────────────────────────────────────────
+
+    public function testSuggestReturnsPrefixMatches(): void
+    {
+        $this->ss->record('php framework');
+        $this->ss->record('php tutorial');
+        $this->ss->record('python guide');
+        $results = $this->ss->suggest('php');
+        $terms   = array_column($results, 'term');
+        $this->assertContains('php framework', $terms);
+        $this->assertContains('php tutorial', $terms);
+        $this->assertNotContains('python guide', $terms);
+    }
+
+    public function testSuggestOrdersByFrequencyDesc(): void
+    {
+        $this->ss->record('php tutorial');
+        $this->ss->record('php framework');
+        $this->ss->record('php framework');
+        $results = $this->ss->suggest('php');
+        $this->assertSame('php framework', $results[0]['term']);
+    }
+
+    public function testSuggestRespectsLimit(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->ss->record('php term' . $i);
+        }
+        $results = $this->ss->suggest('php', 3);
+        $this->assertCount(3, $results);
+    }
+
+    public function testSuggestReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->ss->suggest('xyz'));
+    }
+
+    public function testSuggestIsCaseInsensitive(): void
+    {
+        $this->ss->record('PHP framework');
+        $results = $this->ss->suggest('PHP');
+        $this->assertCount(1, $results);
+        $this->assertSame('php framework', $results[0]['term']);
+    }
+
+    // ── boost ─────────────────────────────────────────────────────────────────
+
+    public function testBoostUpdatesWeight(): void
+    {
+        $this->ss->record('php tutorial');
+        $this->assertTrue($this->ss->boost('php tutorial', 10));
+        $results = $this->ss->suggest('php');
+        $this->assertSame(10, (int)$results[0]['weight']);
+    }
+
+    public function testBoostElevatesSuggestionOrder(): void
+    {
+        $this->ss->record('php framework');
+        $this->ss->record('php framework');
+        $this->ss->record('php tutorial');
+        $this->ss->boost('php tutorial', 5);
+        $results = $this->ss->suggest('php');
+        $this->assertSame('php tutorial', $results[0]['term']);
+    }
+
+    public function testBoostReturnsFalseForMissingTerm(): void
+    {
+        $this->assertFalse($this->ss->boost('unknown', 5));
+    }
+
+    public function testBoostThrowsOnNegativeWeight(): void
+    {
+        $this->ss->record('php tutorial');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ss->boost('php tutorial', -1);
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesTerm(): void
+    {
+        $this->ss->record('php framework');
+        $this->assertTrue($this->ss->remove('php framework'));
+        $this->assertSame(0, $this->ss->frequency('php framework'));
+        $this->assertSame([], $this->ss->suggest('php'));
+    }
+
+    public function testRemoveReturnsFalseForMissingTerm(): void
+    {
+        $this->assertFalse($this->ss->remove('nonexistent'));
+    }
+
+    // ── purge ─────────────────────────────────────────────────────────────────
+
+    public function testPurgeRemovesOldEntries(): void
+    {
+        // Insert a stale entry directly
+        $this->pdo->exec("INSERT INTO search_suggestions (term, frequency, last_seen)
+                          VALUES ('stale term', 1, '2020-01-01 00:00:00')");
+        $this->ss->record('recent term');
+        $deleted = $this->ss->purge('2025-01-01 00:00:00');
+        $this->assertSame(1, $deleted);
+        $this->assertSame(0, $this->ss->frequency('stale term'));
+        $this->assertSame(1, $this->ss->frequency('recent term'));
+    }
+
+    // ── frequency ─────────────────────────────────────────────────────────────
+
+    public function testFrequencyReturnsZeroForUnknownTerm(): void
+    {
+        $this->assertSame(0, $this->ss->frequency('unknown'));
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\SearchSuggestion` — records user search queries and surfaces normalised suggestions ordered by frequency, with manual weight boosts.

## Schema
```sql
CREATE TABLE search_suggestions (
    id        INTEGER PRIMARY KEY AUTOINCREMENT,
    term      VARCHAR(500) NOT NULL UNIQUE,
    frequency INTEGER      NOT NULL DEFAULT 0,
    weight    INTEGER      NOT NULL DEFAULT 0,
    last_seen DATETIME     NULL
);
```

## API
- `record(term)` — normalises and increments frequency (cross-driver upsert)
- `suggest(prefix, limit)` — prefix-match ordered by (weight + frequency) DESC
- `boost(term, weight)` — editorial weight override for manual pinning
- `remove(term)` — delete a single suggestion
- `purge(cutoff)` — TTL cleanup of stale suggestions
- `frequency(term)` — raw frequency lookup

## Normalisation
Terms are lowercased and whitespace-collapsed before storage/lookup.

## Tests
18 tests, 26 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)