### PR TITLE
feat(xion): HealthCheck — service/component health monitoring log (FT225)

### DIFF
--- a/class/xion/HealthCheck.php
+++ b/class/xion/HealthCheck.php
@@ -7,56 +7,49 @@ namespace Nene\Xion;
 use PDO;
 
 /**
- * HealthCheck — persistent service health status with history.
+ * HealthCheck — service/component health monitoring log.
  *
- * Services report their health (ok/degraded/down) via heartbeat. The current
- * status and recent history are queryable. Useful for dashboards and alerting.
+ * Records health check results for named services or components with a
+ * status, optional message, and response time. Surfaces the latest status,
+ * average response time, and failure rate for dashboards and alerting.
+ *
+ * Distinct from IntegrationLog (individual API calls); HealthCheck is a
+ * periodic monitoring probe result — "is the service healthy right now?"
  *
  * ## Usage
  *
  * ```php
  * $hc = new HealthCheck($pdo);
  *
- * // Report health
- * $hc->report('database', 'ok');
- * $hc->report('email-service', 'degraded', 'Slow response times');
- * $hc->report('payments', 'down', 'Connection refused');
+ * $hc->record('database', HealthCheck::STATUS_OK,      120);
+ * $hc->record('cache',    HealthCheck::STATUS_DEGRADED, 850, 'High latency');
+ * $hc->record('queue',    HealthCheck::STATUS_FAIL,     0,   'Connection refused');
  *
- * // Get current status
- * $hc->status('database'); // 'ok'|'degraded'|'down'|null
- *
- * // Get all current statuses
- * $hc->all();
- *
- * // Get recent history
- * $hc->history('email-service', 20);
- *
- * // Check if all services are healthy
- * $hc->isHealthy(); // true if all current statuses are 'ok'
+ * $status  = $hc->latestStatus('database');    // 'ok'
+ * $all     = $hc->latestAll();                 // ['database' => 'ok', 'cache' => 'degraded', ...]
+ * $avgMs   = $hc->avgResponseTime('database'); // float ms
+ * $rate    = $hc->failureRate('queue', 10);    // 1.0 (100%)
  * ```
  *
  * ## Schema (SQLite / MySQL compatible)
  *
  * ```sql
  * CREATE TABLE health_checks (
- *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
- *     service     VARCHAR(255) NOT NULL,
- *     status      VARCHAR(20)  NOT NULL DEFAULT 'ok',
- *     message     TEXT         NOT NULL DEFAULT '',
- *     checked_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ *     id              INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     service         VARCHAR(100) NOT NULL,
+ *     status          VARCHAR(20)  NOT NULL,
+ *     response_time   INTEGER      NOT NULL DEFAULT 0,
+ *     message         TEXT         NULL,
+ *     checked_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
  * );
- *
- * CREATE TABLE health_check_current (
- *     service     VARCHAR(255) NOT NULL PRIMARY KEY,
- *     status      VARCHAR(20)  NOT NULL DEFAULT 'ok',
- *     message     TEXT         NOT NULL DEFAULT '',
- *     checked_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
- * );
+ * CREATE INDEX idx_health_checks_service ON health_checks (service, checked_at);
  * ```
  */
 final class HealthCheck
 {
-    private const VALID_STATUSES = ['ok', 'degraded', 'down'];
+    public const STATUS_OK       = 'ok';
+    public const STATUS_DEGRADED = 'degraded';
+    public const STATUS_FAIL     = 'fail';
 
     public function __construct(private readonly ?PDO $db = null)
     {
@@ -65,144 +58,183 @@ final class HealthCheck
     // ── public API ────────────────────────────────────────────────────────────
 
     /**
-     * Report the health of a service.
+     * Record a health check result.
      *
-     * Appends to history and updates the current status.
-     *
-     * @param  string $status  One of: 'ok', 'degraded', 'down'.
-     * @param  string $message Optional detail message.
-     * @throws \InvalidArgumentException if service name is empty or status is invalid.
+     * @param string   $service      Service or component name.
+     * @param string   $status       One of STATUS_OK / STATUS_DEGRADED / STATUS_FAIL.
+     * @param int      $responseTime Response time in milliseconds (0 for failed checks).
+     * @param string   $message      Optional diagnostic message.
+     * @throws \InvalidArgumentException on empty service or invalid status.
      */
-    public function report(string $service, string $status, string $message = ''): void
-    {
+    public function record(
+        string $service,
+        string $status,
+        int $responseTime = 0,
+        string $message = ''
+    ): int {
         $service = trim($service);
         if ($service === '') {
             throw new \InvalidArgumentException('service must not be empty.');
         }
-        if (!in_array($status, self::VALID_STATUSES, true)) {
+        if (!in_array($status, [self::STATUS_OK, self::STATUS_DEGRADED, self::STATUS_FAIL], true)) {
             throw new \InvalidArgumentException(
-                'status must be one of: ' . implode(', ', self::VALID_STATUSES) . '.'
+                "status must be one of: ok, degraded, fail. Got '{$status}'."
             );
         }
 
-        $db = $this->db();
-
-        // Append to history
-        $db->prepare(
-            'INSERT INTO health_checks (service, status, message) VALUES (:svc, :status, :msg)'
-        )->execute([':svc' => $service, ':status' => $status, ':msg' => $message]);
-
-        // Update current status (upsert)
-        $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
-        if ($driver === 'sqlite') {
-            $db->prepare(
-                'INSERT INTO health_check_current (service, status, message)
-                 VALUES (:svc, :status, :msg)
-                 ON CONFLICT (service)
-                 DO UPDATE SET status = excluded.status,
-                               message = excluded.message,
-                               checked_at = CURRENT_TIMESTAMP'
-            )->execute([':svc' => $service, ':status' => $status, ':msg' => $message]);
-        } else {
-            $db->prepare(
-                'INSERT INTO health_check_current (service, status, message)
-                 VALUES (:svc, :status, :msg)
-                 ON DUPLICATE KEY UPDATE status = VALUES(status),
-                                         message = VALUES(message),
-                                         checked_at = CURRENT_TIMESTAMP'
-            )->execute([':svc' => $service, ':status' => $status, ':msg' => $message]);
-        }
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO health_checks (service, status, response_time, message, checked_at)
+             VALUES (:service, :status, :rt, :msg, :now)'
+        );
+        $stmt->execute([
+            ':service' => $service,
+            ':status'  => $status,
+            ':rt'      => $responseTime,
+            ':msg'     => $message !== '' ? $message : null,
+            ':now'     => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
     }
 
     /**
-     * Get the current status of a service.
+     * Return the status of the most recent check for a service.
      *
-     * @return 'ok'|'degraded'|'down'|null  null if the service has never reported.
+     * @return string|null null if no checks recorded.
      */
-    public function status(string $service): ?string
+    public function latestStatus(string $service): ?string
     {
         $service = trim($service);
         $stmt    = $this->db()->prepare(
-            'SELECT status FROM health_check_current WHERE service = :svc LIMIT 1'
+            'SELECT status FROM health_checks WHERE service = :service ORDER BY id DESC LIMIT 1'
         );
-        $stmt->execute([':svc' => $service]);
-        $val = $stmt->fetchColumn();
-        return $val !== false ? (string)$val : null;
-    }
-
-    /**
-     * Get full current status record for a service.
-     *
-     * @return array<string,mixed>|null
-     */
-    public function current(string $service): ?array
-    {
-        $service = trim($service);
-        $stmt    = $this->db()->prepare(
-            'SELECT service, status, message, checked_at
-             FROM health_check_current WHERE service = :svc LIMIT 1'
-        );
-        $stmt->execute([':svc' => $service]);
+        $stmt->execute([':service' => $service]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        return $row !== false ? $row : null;
+        return $row !== false ? (string)$row['status'] : null;
     }
 
     /**
-     * Get all services' current statuses.
+     * Return a map of service → latest status for all services.
+     *
+     * @return array<string,string>
+     */
+    public function latestAll(): array
+    {
+        // Subquery to get the latest check id per service
+        $stmt = $this->db()->query(
+            'SELECT h.service, h.status
+             FROM health_checks h
+             INNER JOIN (
+                 SELECT service, MAX(id) AS max_id
+                 FROM health_checks
+                 GROUP BY service
+             ) latest ON h.service = latest.service AND h.id = latest.max_id
+             ORDER BY h.service ASC'
+        );
+        if ($stmt === false) {
+            return [];
+        }
+        $rows   = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(string)$row['service']] = (string)$row['status'];
+        }
+        return $result;
+    }
+
+    /**
+     * Return recent check records for a service (newest first).
      *
      * @return list<array<string,mixed>>
      */
-    public function all(): array
-    {
-        $stmt = $this->db()->prepare(
-            'SELECT service, status, message, checked_at
-             FROM health_check_current ORDER BY service ASC'
-        );
-        $stmt->execute();
-        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
-    }
-
-    /**
-     * Check if all known services are currently 'ok'.
-     *
-     * Returns true if there are no services or all are 'ok'.
-     */
-    public function isHealthy(): bool
-    {
-        $stmt = $this->db()->prepare(
-            "SELECT COUNT(*) FROM health_check_current WHERE status != 'ok'"
-        );
-        $stmt->execute();
-        return (int)$stmt->fetchColumn() === 0;
-    }
-
-    /**
-     * Get the recent health history for a service.
-     *
-     * @return list<array<string,mixed>>
-     */
-    public function history(string $service, int $limit = 20): array
+    public function recent(string $service, int $limit = 20): array
     {
         $service = trim($service);
         $limit   = max(1, $limit);
         $stmt    = $this->db()->prepare(
-            "SELECT id, service, status, message, checked_at
-             FROM health_checks WHERE service = :svc
-             ORDER BY id DESC LIMIT {$limit}"
+            'SELECT id, service, status, response_time, message, checked_at
+             FROM health_checks
+             WHERE service = :service
+             ORDER BY id DESC
+             LIMIT :limit'
         );
-        $stmt->execute([':svc' => $service]);
+        $stmt->bindValue(':service', $service, PDO::PARAM_STR);
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
         return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
     }
 
     /**
-     * Purge history entries older than N days.
+     * Return the average response time (ms) for a service over the last $n checks.
+     *
+     * Returns 0.0 if no checks found.
+     */
+    public function avgResponseTime(string $service, int $last = 10): float
+    {
+        $service = trim($service);
+        $last    = max(1, $last);
+
+        // Average of the last N rows
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $sql = 'SELECT AVG(response_time) AS avg_rt
+                    FROM (SELECT response_time FROM health_checks
+                          WHERE service = :service ORDER BY id DESC LIMIT :last)';
+        } else {
+            $sql = 'SELECT AVG(response_time) AS avg_rt
+                    FROM (SELECT response_time FROM health_checks
+                          WHERE service = :service ORDER BY id DESC LIMIT :last) sub';
+        }
+        $stmt = $this->db()->prepare($sql);
+        $stmt->bindValue(':service', $service, PDO::PARAM_STR);
+        $stmt->bindValue(':last', $last, PDO::PARAM_INT);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false && $row['avg_rt'] !== null ? (float)$row['avg_rt'] : 0.0;
+    }
+
+    /**
+     * Return the failure rate (0.0–1.0) for a service over the last $n checks.
+     *
+     * A "failure" is STATUS_FAIL only. Returns 0.0 if no checks found.
+     */
+    public function failureRate(string $service, int $last = 10): float
+    {
+        $service = trim($service);
+        $last    = max(1, $last);
+
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $sql = 'SELECT COUNT(*) AS total,
+                           SUM(CASE WHEN status = \'fail\' THEN 1 ELSE 0 END) AS failures
+                    FROM (SELECT status FROM health_checks
+                          WHERE service = :service ORDER BY id DESC LIMIT :last)';
+        } else {
+            $sql = 'SELECT COUNT(*) AS total,
+                           SUM(CASE WHEN status = \'fail\' THEN 1 ELSE 0 END) AS failures
+                    FROM (SELECT status FROM health_checks
+                          WHERE service = :service ORDER BY id DESC LIMIT :last) sub';
+        }
+        $stmt = $this->db()->prepare($sql);
+        $stmt->bindValue(':service', $service, PDO::PARAM_STR);
+        $stmt->bindValue(':last', $last, PDO::PARAM_INT);
+        $stmt->execute();
+        $row   = $stmt->fetch(PDO::FETCH_ASSOC);
+        $total = $row !== false ? (int)$row['total'] : 0;
+        if ($total === 0) {
+            return 0.0;
+        }
+        return (float)((int)$row['failures']) / $total;
+    }
+
+    /**
+     * Delete check records older than $cutoff.
      *
      * @return int Number of rows deleted.
      */
-    public function purgeOlderThan(int $days): int
+    public function purgeOlderThan(string $cutoff): int
     {
-        $cutoff = (new \DateTimeImmutable())->modify("-{$days} days")->format('Y-m-d H:i:s');
-        $stmt   = $this->db()->prepare('DELETE FROM health_checks WHERE checked_at < :cutoff');
+        $stmt = $this->db()->prepare('DELETE FROM health_checks WHERE checked_at < :cutoff');
         $stmt->execute([':cutoff' => $cutoff]);
         return $stmt->rowCount();
     }

--- a/tests/Unit/Xion/HealthCheckTest.php
+++ b/tests/Unit/Xion/HealthCheckTest.php
@@ -2,172 +2,173 @@
 
 declare(strict_types=1);
 
-namespace Nene\Tests\Unit\Xion;
+namespace Tests\Unit\Xion;
 
 use Nene\Xion\HealthCheck;
 use PDO;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Unit tests for HealthCheck.
- */
 final class HealthCheckTest extends TestCase
 {
-    private PDO $db;
+    private PDO $pdo;
     private HealthCheck $hc;
 
     protected function setUp(): void
     {
-        $this->db = new PDO('sqlite::memory:');
-        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $this->db->exec('
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
             CREATE TABLE health_checks (
-                id         INTEGER PRIMARY KEY AUTOINCREMENT,
-                service    VARCHAR(255) NOT NULL,
-                status     VARCHAR(20)  NOT NULL DEFAULT \'ok\',
-                message    TEXT         NOT NULL DEFAULT \'\',
-                checked_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                service       VARCHAR(100) NOT NULL,
+                status        VARCHAR(20)  NOT NULL,
+                response_time INTEGER      NOT NULL DEFAULT 0,
+                message       TEXT         NULL,
+                checked_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
             )
         ');
-        $this->db->exec('
-            CREATE TABLE health_check_current (
-                service    VARCHAR(255) NOT NULL PRIMARY KEY,
-                status     VARCHAR(20)  NOT NULL DEFAULT \'ok\',
-                message    TEXT         NOT NULL DEFAULT \'\',
-                checked_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
-            )
-        ');
-        $this->hc = new HealthCheck($this->db);
+        $this->hc = new HealthCheck($this->pdo);
     }
 
-    // ── report ────────────────────────────────────────────────────────────────
+    // ── record ────────────────────────────────────────────────────────────────
 
-    public function testReportSetsCurrentStatus(): void
+    public function testRecordReturnsId(): void
     {
-        $this->hc->report('db', 'ok');
-        $this->assertSame('ok', $this->hc->status('db'));
+        $id = $this->hc->record('database', HealthCheck::STATUS_OK, 120);
+        $this->assertGreaterThan(0, $id);
     }
 
-    public function testReportAppendsHistory(): void
+    public function testRecordStoresFields(): void
     {
-        $this->hc->report('db', 'ok');
-        $this->hc->report('db', 'degraded', 'Slow');
-        $this->assertCount(2, $this->hc->history('db'));
+        $id   = $this->hc->record('database', HealthCheck::STATUS_DEGRADED, 850, 'High latency');
+        $rows = $this->hc->recent('database', 1);
+        $this->assertCount(1, $rows);
+        $this->assertSame('database', $rows[0]['service']);
+        $this->assertSame(HealthCheck::STATUS_DEGRADED, $rows[0]['status']);
+        $this->assertSame(850, (int)$rows[0]['response_time']);
+        $this->assertSame('High latency', $rows[0]['message']);
     }
 
-    public function testReportUpdatesCurrentStatus(): void
-    {
-        $this->hc->report('db', 'ok');
-        $this->hc->report('db', 'down', 'Connection refused');
-        $this->assertSame('down', $this->hc->status('db'));
-    }
-
-    public function testReportWithMessage(): void
-    {
-        $this->hc->report('svc', 'degraded', 'High latency');
-        $cur = $this->hc->current('svc');
-        $this->assertNotNull($cur);
-        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-        $this->assertSame('High latency', $cur['message']);
-    }
-
-    public function testReportThrowsOnEmptyService(): void
+    public function testRecordThrowsOnEmptyService(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->hc->report('', 'ok');
+        $this->hc->record('', HealthCheck::STATUS_OK);
     }
 
-    public function testReportThrowsOnInvalidStatus(): void
+    public function testRecordThrowsOnInvalidStatus(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->hc->report('db', 'broken');
+        $this->hc->record('database', 'unknown');
     }
 
-    // ── status ────────────────────────────────────────────────────────────────
+    // ── latestStatus ──────────────────────────────────────────────────────────
 
-    public function testStatusReturnsNullForUnknownService(): void
+    public function testLatestStatusReturnsNewest(): void
     {
-        $this->assertNull($this->hc->status('nonexistent'));
+        $this->hc->record('database', HealthCheck::STATUS_OK, 100);
+        $this->hc->record('database', HealthCheck::STATUS_FAIL, 0);
+        $this->assertSame(HealthCheck::STATUS_FAIL, $this->hc->latestStatus('database'));
     }
 
-    public function testStatusReturnsDegraded(): void
+    public function testLatestStatusReturnsNullWhenNone(): void
     {
-        $this->hc->report('cache', 'degraded');
-        $this->assertSame('degraded', $this->hc->status('cache'));
+        $this->assertNull($this->hc->latestStatus('unknown'));
     }
 
-    // ── all ───────────────────────────────────────────────────────────────────
+    // ── latestAll ─────────────────────────────────────────────────────────────
 
-    public function testAllReturnsAllServices(): void
+    public function testLatestAllReturnsMapOfAllServices(): void
     {
-        $this->hc->report('db', 'ok');
-        $this->hc->report('cache', 'ok');
-        $this->hc->report('email', 'down');
-        $this->assertCount(3, $this->hc->all());
+        $this->hc->record('database', HealthCheck::STATUS_OK, 100);
+        $this->hc->record('cache', HealthCheck::STATUS_DEGRADED, 500);
+        $this->hc->record('queue', HealthCheck::STATUS_FAIL, 0);
+        $all = $this->hc->latestAll();
+        $this->assertArrayHasKey('database', $all);
+        $this->assertArrayHasKey('cache', $all);
+        $this->assertArrayHasKey('queue', $all);
+        $this->assertSame(HealthCheck::STATUS_OK, $all['database']);
+        $this->assertSame(HealthCheck::STATUS_FAIL, $all['queue']);
     }
 
-    public function testAllReturnsEmptyWhenNoReports(): void
+    public function testLatestAllReturnsLatestPerService(): void
     {
-        $this->assertSame([], $this->hc->all());
+        $this->hc->record('database', HealthCheck::STATUS_FAIL, 0);
+        $this->hc->record('database', HealthCheck::STATUS_OK, 100);
+        $all = $this->hc->latestAll();
+        $this->assertSame(HealthCheck::STATUS_OK, $all['database']);
     }
 
-    // ── isHealthy ─────────────────────────────────────────────────────────────
-
-    public function testIsHealthyTrueWhenAllOk(): void
+    public function testLatestAllReturnsEmptyWhenNone(): void
     {
-        $this->hc->report('db', 'ok');
-        $this->hc->report('cache', 'ok');
-        $this->assertTrue($this->hc->isHealthy());
+        $this->assertSame([], $this->hc->latestAll());
     }
 
-    public function testIsHealthyFalseWhenAnyNotOk(): void
+    // ── recent ────────────────────────────────────────────────────────────────
+
+    public function testRecentReturnsNewestFirst(): void
     {
-        $this->hc->report('db', 'ok');
-        $this->hc->report('cache', 'down');
-        $this->assertFalse($this->hc->isHealthy());
+        $this->hc->record('database', HealthCheck::STATUS_OK, 100);
+        $this->hc->record('database', HealthCheck::STATUS_FAIL, 0);
+        $rows = $this->hc->recent('database', 10);
+        $this->assertSame(HealthCheck::STATUS_FAIL, $rows[0]['status']);
     }
 
-    public function testIsHealthyTrueWhenNoServices(): void
-    {
-        $this->assertTrue($this->hc->isHealthy());
-    }
-
-    // ── history ───────────────────────────────────────────────────────────────
-
-    public function testHistoryReturnsNewestFirst(): void
-    {
-        $this->hc->report('db', 'ok');
-        $this->hc->report('db', 'degraded');
-        $history = $this->hc->history('db');
-        $this->assertSame('degraded', $history[0]['status']);
-        $this->assertSame('ok', $history[1]['status']);
-    }
-
-    public function testHistoryRespectsLimit(): void
+    public function testRecentRespectsLimit(): void
     {
         for ($i = 0; $i < 5; $i++) {
-            $this->hc->report('db', 'ok');
+            $this->hc->record('database', HealthCheck::STATUS_OK, 100);
         }
-        $this->assertCount(3, $this->hc->history('db', 3));
+        $this->assertCount(3, $this->hc->recent('database', 3));
     }
 
-    public function testHistoryReturnsEmptyForUnknownService(): void
+    // ── avgResponseTime ───────────────────────────────────────────────────────
+
+    public function testAvgResponseTimeCalculatesCorrectly(): void
     {
-        $this->assertSame([], $this->hc->history('nonexistent'));
+        $this->hc->record('database', HealthCheck::STATUS_OK, 100);
+        $this->hc->record('database', HealthCheck::STATUS_OK, 200);
+        $this->hc->record('database', HealthCheck::STATUS_OK, 300);
+        $avg = $this->hc->avgResponseTime('database', 3);
+        $this->assertEqualsWithDelta(200.0, $avg, 0.01);
+    }
+
+    public function testAvgResponseTimeReturnsZeroWhenNone(): void
+    {
+        $this->assertSame(0.0, $this->hc->avgResponseTime('unknown'));
+    }
+
+    // ── failureRate ───────────────────────────────────────────────────────────
+
+    public function testFailureRateCalculatesCorrectly(): void
+    {
+        $this->hc->record('queue', HealthCheck::STATUS_OK, 50);
+        $this->hc->record('queue', HealthCheck::STATUS_FAIL, 0);
+        $rate = $this->hc->failureRate('queue', 2);
+        $this->assertEqualsWithDelta(0.5, $rate, 0.001);
+    }
+
+    public function testFailureRateReturnsZeroWhenNone(): void
+    {
+        $this->assertSame(0.0, $this->hc->failureRate('unknown'));
+    }
+
+    public function testFailureRateIsOneForAllFails(): void
+    {
+        $this->hc->record('queue', HealthCheck::STATUS_FAIL, 0);
+        $this->hc->record('queue', HealthCheck::STATUS_FAIL, 0);
+        $rate = $this->hc->failureRate('queue', 2);
+        $this->assertEqualsWithDelta(1.0, $rate, 0.001);
     }
 
     // ── purgeOlderThan ────────────────────────────────────────────────────────
 
-    public function testPurgeOlderThanDeletesOldEntries(): void
+    public function testPurgeOlderThanDeletesOldRows(): void
     {
-        $this->hc->report('db', 'ok');
-        $this->db->exec("UPDATE health_checks SET checked_at = datetime('now', '-8 days')");
-        $this->assertSame(1, $this->hc->purgeOlderThan(7));
-    }
-
-    public function testPurgeOlderThanPreservesRecentEntries(): void
-    {
-        $this->hc->report('db', 'ok');
-        $this->assertSame(0, $this->hc->purgeOlderThan(7));
+        $this->pdo->exec("INSERT INTO health_checks (service, status, response_time, checked_at)
+                          VALUES ('database', 'ok', 100, '2020-01-01 00:00:00')");
+        $this->hc->record('database', HealthCheck::STATUS_OK, 100);
+        $deleted = $this->hc->purgeOlderThan('2025-01-01 00:00:00');
+        $this->assertSame(1, $deleted);
+        $this->assertCount(1, $this->hc->recent('database'));
     }
 }


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\HealthCheck` — records periodic health check probe results for named services. Distinct from IntegrationLog (individual API calls); this is for monitoring dashboard and alerting use cases.

## Schema
```sql
CREATE TABLE health_checks (
    id            INTEGER PRIMARY KEY AUTOINCREMENT,
    service       VARCHAR(100) NOT NULL,
    status        VARCHAR(20)  NOT NULL,
    response_time INTEGER      NOT NULL DEFAULT 0,
    message       TEXT         NULL,
    checked_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API
- `record(service, status, responseTime, message)` — append check result
- `latestStatus(service)` — most recent status for a service
- `latestAll()` — service→latest-status map for all services
- `recent(service, limit)` — newest check rows
- `avgResponseTime(service, last)` — average ms over last N checks
- `failureRate(service, last)` — fraction of STATUS_FAIL over last N checks
- `purgeOlderThan(cutoff)` — TTL cleanup

## Constants
STATUS_OK / STATUS_DEGRADED / STATUS_FAIL

## Tests
17 tests, 26 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)