### PR TITLE
feat(xion): ContactMessage — contact form inbox management (FT227)

### DIFF
--- a/class/xion/ContactMessage.php
+++ b/class/xion/ContactMessage.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ContactMessage — customer contact form inbox management.
+ *
+ * Stores inbound contact form submissions and manages their lifecycle through
+ * an inbox workflow: unread → read → replied / archived. Provides an inbox
+ * view and bulk archive for cleared messages.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cm = new ContactMessage($pdo);
+ *
+ * $id = $cm->submit('Alice', 'alice@example.com', 'Help!', 'I cannot log in.');
+ *
+ * $inbox = $cm->inbox(20, 0);
+ * $cm->markRead($id);
+ * $cm->markReplied($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE contact_messages (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     name        VARCHAR(255) NOT NULL,
+ *     email       VARCHAR(255) NOT NULL,
+ *     subject     VARCHAR(500) NOT NULL,
+ *     body        TEXT         NOT NULL,
+ *     status      VARCHAR(20)  NOT NULL DEFAULT 'unread',
+ *     ip_address  VARCHAR(45)  NULL,
+ *     replied_at  DATETIME     NULL,
+ *     submitted_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ContactMessage
+{
+    public const STATUS_UNREAD   = 'unread';
+    public const STATUS_READ     = 'read';
+    public const STATUS_REPLIED  = 'replied';
+    public const STATUS_ARCHIVED = 'archived';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Submit a new contact message.
+     *
+     * @return int Row ID of the new message.
+     * @throws \InvalidArgumentException on empty name/email/subject/body.
+     */
+    public function submit(
+        string $name,
+        string $email,
+        string $subject,
+        string $body,
+        ?string $ipAddress = null
+    ): int {
+        $name    = trim($name);
+        $email   = trim($email);
+        $subject = trim($subject);
+        $body    = trim($body);
+        if ($name === '') {
+            throw new \InvalidArgumentException('name must not be empty.');
+        }
+        if ($email === '') {
+            throw new \InvalidArgumentException('email must not be empty.');
+        }
+        if ($subject === '') {
+            throw new \InvalidArgumentException('subject must not be empty.');
+        }
+        if ($body === '') {
+            throw new \InvalidArgumentException('body must not be empty.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO contact_messages (name, email, subject, body, status, ip_address, submitted_at)
+             VALUES (:name, :email, :subject, :body, :status, :ip, :now)'
+        );
+        $stmt->execute([
+            ':name'    => $name,
+            ':email'   => $email,
+            ':subject' => $subject,
+            ':body'    => $body,
+            ':status'  => self::STATUS_UNREAD,
+            ':ip'      => $ipAddress,
+            ':now'     => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve a message by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM contact_messages WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Return inbox messages (non-archived), newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function inbox(int $limit = 20, int $offset = 0): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, name, email, subject, status, submitted_at
+             FROM contact_messages
+             WHERE status != :archived
+             ORDER BY submitted_at DESC, id DESC
+             LIMIT :limit OFFSET :offset'
+        );
+        $stmt->bindValue(':archived', self::STATUS_ARCHIVED, PDO::PARAM_STR);
+        $stmt->bindValue(':limit', max(1, $limit), PDO::PARAM_INT);
+        $stmt->bindValue(':offset', max(0, $offset), PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return unread message count.
+     */
+    public function unreadCount(): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) AS cnt FROM contact_messages WHERE status = :status'
+        );
+        $stmt->execute([':status' => self::STATUS_UNREAD]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return (int)($row !== false ? $row['cnt'] : 0);
+    }
+
+    /**
+     * Mark a message as read.
+     *
+     * @return bool True if found and updated.
+     */
+    public function markRead(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE contact_messages SET status = :status WHERE id = :id AND status = :unread'
+        );
+        $stmt->execute([
+            ':status' => self::STATUS_READ,
+            ':id'     => $id,
+            ':unread' => self::STATUS_UNREAD,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark a message as replied.
+     *
+     * @return bool True if found and updated.
+     */
+    public function markReplied(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE contact_messages SET status = :status, replied_at = :now WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_REPLIED, ':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Archive a message.
+     *
+     * @return bool True if found and archived.
+     */
+    public function archive(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE contact_messages SET status = :status WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_ARCHIVED, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete a message (hard delete).
+     *
+     * @return bool True if found and deleted.
+     */
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM contact_messages WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete archived messages older than $cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeArchived(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM contact_messages WHERE status = :status AND submitted_at < :cutoff'
+        );
+        $stmt->execute([':status' => self::STATUS_ARCHIVED, ':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/ContactMessageTest.php
+++ b/tests/Unit/Xion/ContactMessageTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\ContactMessage;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ContactMessageTest extends TestCase
+{
+    private PDO $pdo;
+    private ContactMessage $cm;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE contact_messages (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                name         VARCHAR(255) NOT NULL,
+                email        VARCHAR(255) NOT NULL,
+                subject      VARCHAR(500) NOT NULL,
+                body         TEXT         NOT NULL,
+                status       VARCHAR(20)  NOT NULL DEFAULT \'unread\',
+                ip_address   VARCHAR(45)  NULL,
+                replied_at   DATETIME     NULL,
+                submitted_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->cm = new ContactMessage($this->pdo);
+    }
+
+    // ── submit ────────────────────────────────────────────────────────────────
+
+    public function testSubmitReturnsId(): void
+    {
+        $id = $this->cm->submit('Alice', 'alice@example.com', 'Help!', 'I cannot log in.');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testSubmitStoresFields(): void
+    {
+        $id  = $this->cm->submit('Alice', 'alice@example.com', 'Help!', 'I cannot log in.', '1.2.3.4');
+        $row = $this->cm->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Alice', $row['name']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('alice@example.com', $row['email']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ContactMessage::STATUS_UNREAD, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('1.2.3.4', $row['ip_address']);
+    }
+
+    public function testSubmitThrowsOnEmptyName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cm->submit('', 'alice@example.com', 'Help!', 'Body');
+    }
+
+    public function testSubmitThrowsOnEmptyEmail(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cm->submit('Alice', '', 'Help!', 'Body');
+    }
+
+    public function testSubmitThrowsOnEmptySubject(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cm->submit('Alice', 'alice@example.com', '', 'Body');
+    }
+
+    public function testSubmitThrowsOnEmptyBody(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cm->submit('Alice', 'alice@example.com', 'Help!', '');
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->cm->get(9999));
+    }
+
+    // ── inbox ─────────────────────────────────────────────────────────────────
+
+    public function testInboxReturnsNonArchivedMessages(): void
+    {
+        $id1 = $this->cm->submit('Alice', 'a@x.com', 'Q1', 'Body1');
+        $id2 = $this->cm->submit('Bob', 'b@x.com', 'Q2', 'Body2');
+        $this->cm->archive($id1);
+        $inbox = $this->cm->inbox();
+        $this->assertCount(1, $inbox);
+        $this->assertSame((string)$id2, (string)$inbox[0]['id']);
+    }
+
+    public function testInboxReturnsNewestFirst(): void
+    {
+        $id1 = $this->cm->submit('Alice', 'a@x.com', 'Q1', 'Body1');
+        $id2 = $this->cm->submit('Bob', 'b@x.com', 'Q2', 'Body2');
+        $inbox = $this->cm->inbox();
+        $this->assertSame((string)$id2, (string)$inbox[0]['id']);
+    }
+
+    public function testInboxRespectsLimitOffset(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->cm->submit('User' . $i, "u{$i}@x.com", "Q{$i}", "Body{$i}");
+        }
+        $page1 = $this->cm->inbox(3, 0);
+        $page2 = $this->cm->inbox(3, 3);
+        $this->assertCount(3, $page1);
+        $this->assertCount(2, $page2);
+    }
+
+    // ── unreadCount ───────────────────────────────────────────────────────────
+
+    public function testUnreadCountReturnsCorrectCount(): void
+    {
+        $id1 = $this->cm->submit('Alice', 'a@x.com', 'Q1', 'Body1');
+        $this->cm->submit('Bob', 'b@x.com', 'Q2', 'Body2');
+        $this->cm->markRead($id1);
+        $this->assertSame(1, $this->cm->unreadCount());
+    }
+
+    // ── markRead ──────────────────────────────────────────────────────────────
+
+    public function testMarkReadChangesStatus(): void
+    {
+        $id = $this->cm->submit('Alice', 'a@x.com', 'Q', 'Body');
+        $this->assertTrue($this->cm->markRead($id));
+        $row = $this->cm->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ContactMessage::STATUS_READ, $row['status']);
+    }
+
+    public function testMarkReadReturnsFalseWhenAlreadyRead(): void
+    {
+        $id = $this->cm->submit('Alice', 'a@x.com', 'Q', 'Body');
+        $this->cm->markRead($id);
+        $this->assertFalse($this->cm->markRead($id));
+    }
+
+    // ── markReplied ───────────────────────────────────────────────────────────
+
+    public function testMarkRepliedChangesStatus(): void
+    {
+        $id = $this->cm->submit('Alice', 'a@x.com', 'Q', 'Body');
+        $this->assertTrue($this->cm->markReplied($id));
+        $row = $this->cm->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ContactMessage::STATUS_REPLIED, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['replied_at']);
+    }
+
+    // ── archive ───────────────────────────────────────────────────────────────
+
+    public function testArchiveChangesStatus(): void
+    {
+        $id = $this->cm->submit('Alice', 'a@x.com', 'Q', 'Body');
+        $this->assertTrue($this->cm->archive($id));
+        $row = $this->cm->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ContactMessage::STATUS_ARCHIVED, $row['status']);
+    }
+
+    public function testArchiveReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->cm->archive(9999));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesMessage(): void
+    {
+        $id = $this->cm->submit('Alice', 'a@x.com', 'Q', 'Body');
+        $this->assertTrue($this->cm->delete($id));
+        $this->assertNull($this->cm->get($id));
+    }
+
+    // ── purgeArchived ─────────────────────────────────────────────────────────
+
+    public function testPurgeArchivedDeletesOldArchivedMessages(): void
+    {
+        $id = $this->cm->submit('Alice', 'a@x.com', 'Q', 'Body');
+        $this->cm->archive($id);
+        $this->pdo->exec("UPDATE contact_messages SET submitted_at = '2020-01-01 00:00:00' WHERE id = {$id}");
+        $this->cm->submit('Bob', 'b@x.com', 'Q2', 'Body2');
+        $deleted = $this->cm->purgeArchived('2025-01-01 00:00:00');
+        $this->assertSame(1, $deleted);
+        $this->assertCount(1, $this->cm->inbox());
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\ContactMessage` — stores inbound contact form submissions and manages their lifecycle through an inbox workflow.

## Schema
```sql
CREATE TABLE contact_messages (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    name         VARCHAR(255) NOT NULL,
    email        VARCHAR(255) NOT NULL,
    subject      VARCHAR(500) NOT NULL,
    body         TEXT         NOT NULL,
    status       VARCHAR(20)  NOT NULL DEFAULT 'unread',
    ip_address   VARCHAR(45)  NULL,
    replied_at   DATETIME     NULL,
    submitted_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## API
- `submit(name, email, subject, body, ipAddress)` — store inbound message
- `get(id)` — single message lookup
- `inbox(limit, offset)` — non-archived messages, newest first (submitted_at DESC, id DESC)
- `unreadCount()` — count of unread messages
- `markRead(id)` — transitions unread → read
- `markReplied(id)` — sets replied_at timestamp
- `archive(id)` — hide from inbox
- `delete(id)` — hard delete
- `purgeArchived(cutoff)` — cleanup old archived messages

## Constants
STATUS_UNREAD / STATUS_READ / STATUS_REPLIED / STATUS_ARCHIVED

## Tests
18 tests, 33 assertions — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)