### PR TITLE
docs: FT211–FT228 wave summary (Xion seventh extended wave)

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -14,7 +14,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ## Active candidates
 
-The Xion helper wave (FT78–FT210) is ongoing as of 2026-05-27. Trigger-based and structural candidates are listed in the next section.
+The Xion helper wave (FT78–FT228) is ongoing as of 2026-05-28. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -226,6 +226,24 @@ When a candidate becomes a trial, move it to this section briefly so we can see 
 - **FT41 — Account lockout** (2026-05-27): `Nene\Xion\LoginAttemptTracker` — DB-backed failure counter; locks at threshold; reset on success; ACCOUNT-LOCKED (423). PR #473.
 - **FT40 — Batch operations** (2026-05-27): `Nene\Xion\BatchResult` — addSuccess/addFailure/httpStatus/toArray; 200/207/422 based on partial success. PR #472.
 - **FT39 — API versioning + deprecation headers** (2026-05-27): `Nene\Xion\ApiDeprecation` — RFC 8594 Deprecation/Sunset/Link headers; ADR-0013 URI prefix versioning. PR #471.
+- **FT228 — AccessGrant** (2026-05-28): `Nene\Xion\AccessGrant` — time-bounded delegated access; hasAccess() checks active+non-expired; myGrants()/grantsIGave() for both sides; purge(). PR #669.
+- **FT227 — ContactMessage** (2026-05-28): `Nene\Xion\ContactMessage` — contact form inbox; STATUS_UNREAD→READ→REPLIED/ARCHIVED; unreadCount(); ORDER BY submitted_at DESC, id DESC. PR #668.
+- **FT226 — PageView** (2026-05-28): `Nene\Xion\PageView` — page view analytics; count()/uniqueCount() with period prefix; topUrls()/dailyCounts(); purgeOlderThan(). PR #667.
+- **FT225 — HealthCheck** (2026-05-28): `Nene\Xion\HealthCheck` — service health monitoring; latestAll() MAX(id) subquery; avgResponseTime()/failureRate() over last N; STATUS_OK/DEGRADED/FAIL. PR #666.
+- **FT224 — MultiLangContent** (2026-05-28): `Nene\Xion\MultiLangContent` — DB-backed multilingual content; UNIQUE (content_key, locale); get() with fallback; cross-driver upsert. PR #665.
+- **FT223 — ContentBlock** (2026-05-28): `Nene\Xion\ContentBlock` — ordered page builder blocks; JSON content payload; reorder()/deactivate()/activate()/clear(). PR #664.
+- **FT222 — UserSession** (2026-05-28): `Nene\Xion\UserSession` — multi-device session management; SHA-256 token hash; findByToken() auto-marks expired; invalidateAll() force-logout. PR #663.
+- **FT221 — EntityAlias** (2026-05-28): `Nene\Xion\EntityAlias` — multiple identifier aliases; UNIQUE (entity_type, alias); idempotent register(); transfer() atomic reassignment; setPrimary(). PR #662.
+- **FT220 — BillingUsage** (2026-05-28): `Nene\Xion\BillingUsage` — metered usage tracking; sum()/summary()/overage(); period defaults to current month; reset()/purgeOlderThan(). PR #661.
+- **FT219 — SearchSuggestion** (2026-05-28): `Nene\Xion\SearchSuggestion` — type-ahead suggestions; record() cross-driver upsert; suggest() (weight+frequency) DESC; boost(); purge() TTL. PR #660.
+- **FT218 — WorkflowInstance** (2026-05-28): `Nene\Xion\WorkflowInstance` — persistent workflow tracking; two-table (instances+transitions); transition()/complete()/cancel(); forEntity(). PR #659.
+- **FT217 — NotificationQueue** (2026-05-28): `Nene\Xion\NotificationQueue` — channel-agnostic outbox queue; dequeue() respects scheduled_at+max_attempts; markFailed() CASE WHEN exhaustion. PR #658.
+- **FT216 — ProductBundle** (2026-05-28): `Nene\Xion\ProductBundle` — two-table bundle catalog; UNIQUE (bundle_key); addItem() upserts quantity; allActive(). PR #657.
+- **FT215 — SurveyResponse** (2026-05-28): `Nene\Xion\SurveyResponse` — two-table survey responses; answers(responseId); answerFrequency() analysis; forSurvey() pagination. PR #656.
+- **FT214 — EntityComment** (2026-05-28): `Nene\Xion\EntityComment` — flat comments with soft-delete; edit() blocked on deleted; author-only guards; purge() admin hard-delete. PR #655.
+- **FT213 — PointBalance** (2026-05-28): `Nene\Xion\PointBalance` — loyalty point ledger; earn()/spend() (guarded)/expire(); balance() = COALESCE(SUM(delta),0). PR #654.
+- **FT212 — AuditLog** (2026-05-28): `Nene\Xion\AuditLog` — compliance append-only entity change tracking; before/after JSON snapshots; forEntity()/byActor()/ofAction()/purgeOlderThan(). PR #653.
+- **FT211 — PriceList** (2026-05-28): `Nene\Xion\PriceList` — product price catalog with retail/wholesale/member tiers; effective/expiry windows; integer-cent; cross-driver upsert. PR #652.
 - **FT38 — Full-text search helper** (2026-05-27): `Nene\Func\SearchQuery` — escapeLike/likePattern/sanitizeFts/normalize; FTS5 patterns doc. PR #470.
 - **FT37 — Idempotency keys** (2026-05-27): `Nene\Xion\IdempotencyStore` — DB-backed get/put/hash; INSERT IGNORE/INSERT OR IGNORE; X-Idempotency-Key / X-Idempotent-Replayed. PR #469.
 - **FT35 — Feature flags** (2026-05-27): `Nene\Func\FeatureFlagService` — DB-backed; 3-tier priority (user override → global → rollout%); deterministic crc32 bucket. PR #468.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT210 complete as of 2026-05-27 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT228 complete as of 2026-05-28 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 
@@ -240,6 +240,7 @@ Completed (wave summary):
 - **FT186–FT195**: Xion fourth extended wave. 10 trials covering support ticketing, event sourcing log, daily digest accumulator, per-resource ACL, 2FA backup codes, typed global settings, ordered media gallery, entity reviews with ratings, FAQ articles, and gamification tier tracking. PRs #624–#633.
 - **FT196–FT200**: Xion fifth extended wave. 5 trials covering CSV import job tracking with per-row errors, topic-based pub/sub subscriptions, e-commerce orders with line items, deployment version history, and user cohort/segment assignment. PRs #635–#639.
 - **FT201–FT210**: Xion sixth extended wave. 10 trials covering inventory stock tracking with atomic reserve/commit, work time entries with start/stop timers, appointment time slot booking with capacity, external API call logging, GDPR data-subject request tracking, product/feature waitlist management, regional tax rate calculation, push notification device token management, flexible entity tagging with tag clouds, and advisory resource locking with TTL. PRs #641–#650.
+- **FT211–FT228**: Xion seventh extended wave. 18 trials covering product price catalog with tiers, compliance audit log with before/after snapshots, loyalty point ledger, flat entity comments, survey/form response collection, product bundle catalog, channel-agnostic notification queue, persistent stateful workflow instances, type-ahead search suggestion management, metered billing usage tracking, multiple entity identifier aliases, multi-device session management, ordered page builder content blocks, database-backed multilingual content, service health monitoring, page/resource view analytics, contact form inbox management, and time-bounded access delegation. PRs #652–#669.
 
 Future candidates:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,32 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-27: all non-promotion Issues are closed; FT1–FT210 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-28: all non-promotion Issues are closed; FT1–FT228 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-28 — FT211–FT228: Xion seventh extended wave (18 trials)
+
+Continuous wave of 18 field trials adding further Xion helper patterns. All PRs #652–#669.
+
+**FT211 — PriceList**: `PriceList` product price catalog with retail/wholesale/member tiers; integer-cent amounts; effective/expiry date windows; cross-driver upsert. PR #652.
+**FT212 — AuditLog**: `AuditLog` compliance-grade append-only entity change tracking; before/after JSON snapshots; forEntity()/byActor()/ofAction()/purgeOlderThan(). PR #653.
+**FT213 — PointBalance**: `PointBalance` loyalty/reward point ledger; earn()/spend() (guarded against negative)/expire(); balance() = COALESCE(SUM(delta),0). PR #654.
+**FT214 — EntityComment**: `EntityComment` flat (non-threaded) comments on any entity; soft-delete; edit tracking; author-only guards; purge() for admin hard-delete. PR #655.
+**FT215 — SurveyResponse**: `SurveyResponse` two-table form/survey response collection; per-response answers; answerFrequency() for analysis. PR #656.
+**FT216 — ProductBundle**: `ProductBundle` two-table product bundle catalog; inactive by default; addItem() upserts quantity; allActive(). PR #657.
+**FT217 — NotificationQueue**: `NotificationQueue` channel-agnostic outbox-pattern queue; dequeue() respects scheduled_at and max_attempts; markFailed() CASE WHEN exhaustion. PR #658.
+**FT218 — WorkflowInstance**: `WorkflowInstance` persistent stateful workflow tracking; two-table (instances + transitions); complete()/cancel() terminal states. PR #659.
+**FT219 — SearchSuggestion**: `SearchSuggestion` type-ahead suggestion management; record() cross-driver upsert; suggest() by (weight+frequency) desc; boost(); purge(). PR #660.
+**FT220 — BillingUsage**: `BillingUsage` metered usage tracking for billing; sum()/summary()/overage(); period defaults to current month; reset()/purgeOlderThan(). PR #661.
+**FT221 — EntityAlias**: `EntityAlias` multiple identifier aliases per entity; UNIQUE (entity_type, alias); idempotent register(); transfer() atomic reassignment. PR #662.
+**FT222 — UserSession**: `UserSession` multi-device session management; SHA-256 token hash storage; findByToken() auto-marks expired; invalidateAll() force-logout. PR #663.
+**FT223 — ContentBlock**: `ContentBlock` ordered page builder content blocks; JSON content payload; reorder()/deactivate()/activate(); clear() entity bulk-delete. PR #664.
+**FT224 — MultiLangContent**: `MultiLangContent` DB-backed multilingual content; UNIQUE (content_key, locale); get() with fallback locale; cross-driver upsert. PR #665.
+**FT225 — HealthCheck**: `HealthCheck` service health monitoring log; latestAll() MAX(id) subquery; avgResponseTime()/failureRate() over last N checks. PR #666.
+**FT226 — PageView**: `PageView` page view analytics; count()/uniqueCount() with period prefix filter; topUrls()/dailyCounts(); purgeOlderThan(). PR #667.
+**FT227 — ContactMessage**: `ContactMessage` contact form inbox; STATUS_UNREAD→READ→REPLIED/ARCHIVED lifecycle; unreadCount(); purgeArchived() TTL. PR #668.
+**FT228 — AccessGrant**: `AccessGrant` time-bounded access delegation; hasAccess() checks active+non-expired; myGrants()/grantsIGave() for both sides. PR #669.
 
 ### 2026-05-27 — FT201–FT210: Xion sixth extended wave (10 trials)
 


### PR DESCRIPTION
## Summary
Updates roadmap, todo, and candidates for the FT211–FT228 Xion seventh extended wave (18 trials, PRs #652–#669).

## Changes
- `docs/roadmap.md`: FT1–FT228 complete; wave summary added
- `docs/todo/current.md`: status and per-FT details for FT211–FT228
- `docs/field-trials/candidates.md`: active section updated to FT78–FT228; 18 archive entries added

## Wave contents
PriceList, AuditLog, PointBalance, EntityComment, SurveyResponse, ProductBundle, NotificationQueue, WorkflowInstance, SearchSuggestion, BillingUsage, EntityAlias, UserSession, ContentBlock, MultiLangContent, HealthCheck, PageView, ContactMessage, AccessGrant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)