### PR TITLE
feat(xion): add StockAlert helper (FT232)

### DIFF
--- a/class/xion/StockAlert.php
+++ b/class/xion/StockAlert.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * StockAlert — user-defined stock/availability alert registrations.
+ *
+ * Allows users to register an alert to be notified when a product/item
+ * becomes available or drops below/above a quantity threshold. A cron job
+ * calls pendingTriggers() to find alerts that should fire, then calls
+ * markTriggered() after sending the notification.
+ *
+ * Alerts can be dismissed (kept but silenced) or deleted when no longer
+ * wanted.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $sa = new StockAlert($pdo);
+ *
+ * // Register an alert when SKU-1 comes back in stock (qty >= 1)
+ * $id = $sa->create('user-1', 'sku-1', 1);
+ *
+ * // Cron: check which alerts should fire
+ * $stock = ['sku-1' => 5, 'sku-2' => 0];
+ * foreach ($sa->pendingTriggers() as $alert) {
+ *     if ($stock[$alert['sku']] >= $alert['threshold']) {
+ *         sendNotification($alert);
+ *         $sa->markTriggered($alert['id']);
+ *     }
+ * }
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE stock_alerts (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id      VARCHAR(255) NOT NULL,
+ *     sku          VARCHAR(255) NOT NULL,
+ *     threshold    INTEGER      NOT NULL DEFAULT 1,
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'active',
+ *     triggered_at DATETIME     NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class StockAlert
+{
+    public const STATUS_ACTIVE    = 'active';
+    public const STATUS_TRIGGERED = 'triggered';
+    public const STATUS_DISMISSED = 'dismissed';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create a stock alert.
+     *
+     * @param int $threshold Minimum quantity that should trigger the alert (>= 1).
+     * @return int New alert ID.
+     * @throws \InvalidArgumentException on empty userId/sku or threshold < 1.
+     */
+    public function create(string $userId, string $sku, int $threshold = 1): int
+    {
+        $userId = trim($userId);
+        $sku    = trim($sku);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($sku === '') {
+            throw new \InvalidArgumentException('sku must not be empty.');
+        }
+        if ($threshold < 1) {
+            throw new \InvalidArgumentException('threshold must be >= 1.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO stock_alerts (user_id, sku, threshold, status, created_at)
+             VALUES (:uid, :sku, :threshold, :status, :now)'
+        );
+        $stmt->execute([
+            ':uid'       => $userId,
+            ':sku'       => $sku,
+            ':threshold' => $threshold,
+            ':status'    => self::STATUS_ACTIVE,
+            ':now'       => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve an alert by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM stock_alerts WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Return all active alerts for a user.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function activeFor(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM stock_alerts WHERE user_id = :uid AND status = :status ORDER BY created_at ASC'
+        );
+        $stmt->execute([':uid' => trim($userId), ':status' => self::STATUS_ACTIVE]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return all active alerts for a specific SKU (for cron processing).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function pendingForSku(string $sku): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM stock_alerts WHERE sku = :sku AND status = :status ORDER BY created_at ASC'
+        );
+        $stmt->execute([':sku' => trim($sku), ':status' => self::STATUS_ACTIVE]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return all active alerts across all SKUs (for cron batch processing).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function pendingTriggers(): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM stock_alerts WHERE status = :status ORDER BY sku ASC, created_at ASC'
+        );
+        $stmt->execute([':status' => self::STATUS_ACTIVE]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Mark an alert as triggered (notification sent).
+     *
+     * @return bool True if found and updated.
+     */
+    public function markTriggered(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE stock_alerts SET status = :status, triggered_at = :now WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_TRIGGERED, ':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Dismiss an alert (silence without deleting).
+     *
+     * @return bool True if found and dismissed.
+     */
+    public function dismiss(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE stock_alerts SET status = :status WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_DISMISSED, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete an alert.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM stock_alerts WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete triggered/dismissed alerts older than $cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purge(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM stock_alerts WHERE status != :active AND created_at < :cutoff'
+        );
+        $stmt->execute([':active' => self::STATUS_ACTIVE, ':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/StockAlertTest.php
+++ b/tests/Unit/Xion/StockAlertTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\StockAlert;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class StockAlertTest extends TestCase
+{
+    private PDO $pdo;
+    private StockAlert $sa;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE stock_alerts (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id      VARCHAR(255) NOT NULL,
+                sku          VARCHAR(255) NOT NULL,
+                threshold    INTEGER      NOT NULL DEFAULT 1,
+                status       VARCHAR(20)  NOT NULL DEFAULT \'active\',
+                triggered_at DATETIME     NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->sa = new StockAlert($this->pdo);
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsId(): void
+    {
+        $id = $this->sa->create('user-1', 'sku-1');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testCreateStoresFields(): void
+    {
+        $id  = $this->sa->create('user-1', 'sku-1', 3);
+        $row = $this->sa->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['user_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('sku-1', $row['sku']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(3, (int)$row['threshold']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(StockAlert::STATUS_ACTIVE, $row['status']);
+    }
+
+    public function testCreateDefaultThresholdIsOne(): void
+    {
+        $id  = $this->sa->create('user-1', 'sku-1');
+        $row = $this->sa->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['threshold']);
+    }
+
+    public function testCreateThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sa->create('', 'sku-1');
+    }
+
+    public function testCreateThrowsOnEmptySku(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sa->create('user-1', '');
+    }
+
+    public function testCreateThrowsOnZeroThreshold(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sa->create('user-1', 'sku-1', 0);
+    }
+
+    public function testCreateThrowsOnNegativeThreshold(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sa->create('user-1', 'sku-1', -1);
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->sa->get(9999));
+    }
+
+    // ── activeFor ─────────────────────────────────────────────────────────────
+
+    public function testActiveForReturnsActiveAlerts(): void
+    {
+        $this->sa->create('user-1', 'sku-1');
+        $this->sa->create('user-1', 'sku-2');
+        $this->assertCount(2, $this->sa->activeFor('user-1'));
+    }
+
+    public function testActiveForExcludesTriggered(): void
+    {
+        $id = $this->sa->create('user-1', 'sku-1');
+        $this->sa->markTriggered($id);
+        $this->assertSame([], $this->sa->activeFor('user-1'));
+    }
+
+    public function testActiveForExcludesDismissed(): void
+    {
+        $id = $this->sa->create('user-1', 'sku-1');
+        $this->sa->dismiss($id);
+        $this->assertSame([], $this->sa->activeFor('user-1'));
+    }
+
+    public function testActiveForIsIsolatedByUser(): void
+    {
+        $this->sa->create('user-1', 'sku-1');
+        $this->sa->create('user-2', 'sku-1');
+        $this->assertCount(1, $this->sa->activeFor('user-1'));
+        $this->assertCount(1, $this->sa->activeFor('user-2'));
+    }
+
+    public function testActiveForReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->sa->activeFor('user-99'));
+    }
+
+    // ── pendingForSku ─────────────────────────────────────────────────────────
+
+    public function testPendingForSkuReturnsActiveAlerts(): void
+    {
+        $this->sa->create('user-1', 'sku-1');
+        $this->sa->create('user-2', 'sku-1');
+        $this->assertCount(2, $this->sa->pendingForSku('sku-1'));
+    }
+
+    public function testPendingForSkuExcludesTriggered(): void
+    {
+        $id = $this->sa->create('user-1', 'sku-1');
+        $this->sa->markTriggered($id);
+        $this->assertSame([], $this->sa->pendingForSku('sku-1'));
+    }
+
+    public function testPendingForSkuIsIsolatedBySku(): void
+    {
+        $this->sa->create('user-1', 'sku-1');
+        $this->sa->create('user-1', 'sku-2');
+        $this->assertCount(1, $this->sa->pendingForSku('sku-1'));
+        $this->assertCount(1, $this->sa->pendingForSku('sku-2'));
+    }
+
+    public function testPendingForSkuReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->sa->pendingForSku('sku-unknown'));
+    }
+
+    // ── pendingTriggers ───────────────────────────────────────────────────────
+
+    public function testPendingTriggersReturnsAllActive(): void
+    {
+        $this->sa->create('user-1', 'sku-1');
+        $this->sa->create('user-2', 'sku-2');
+        $this->assertCount(2, $this->sa->pendingTriggers());
+    }
+
+    public function testPendingTriggersExcludesNonActive(): void
+    {
+        $id1 = $this->sa->create('user-1', 'sku-1');
+        $id2 = $this->sa->create('user-2', 'sku-2');
+        $this->sa->markTriggered($id1);
+        $this->sa->dismiss($id2);
+        $this->assertSame([], $this->sa->pendingTriggers());
+    }
+
+    public function testPendingTriggersReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->sa->pendingTriggers());
+    }
+
+    // ── markTriggered ─────────────────────────────────────────────────────────
+
+    public function testMarkTriggeredChangesStatus(): void
+    {
+        $id  = $this->sa->create('user-1', 'sku-1');
+        $this->assertTrue($this->sa->markTriggered($id));
+        $row = $this->sa->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(StockAlert::STATUS_TRIGGERED, $row['status']);
+    }
+
+    public function testMarkTriggeredSetsTriggeredAt(): void
+    {
+        $id  = $this->sa->create('user-1', 'sku-1');
+        $this->sa->markTriggered($id);
+        $row = $this->sa->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['triggered_at']);
+    }
+
+    public function testMarkTriggeredReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->sa->markTriggered(9999));
+    }
+
+    // ── dismiss ───────────────────────────────────────────────────────────────
+
+    public function testDismissChangesStatus(): void
+    {
+        $id  = $this->sa->create('user-1', 'sku-1');
+        $this->assertTrue($this->sa->dismiss($id));
+        $row = $this->sa->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(StockAlert::STATUS_DISMISSED, $row['status']);
+    }
+
+    public function testDismissReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->sa->dismiss(9999));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesRow(): void
+    {
+        $id = $this->sa->create('user-1', 'sku-1');
+        $this->assertTrue($this->sa->delete($id));
+        $this->assertNull($this->sa->get($id));
+    }
+
+    public function testDeleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->sa->delete(9999));
+    }
+
+    // ── purge ─────────────────────────────────────────────────────────────────
+
+    public function testPurgeDeletesOldNonActiveRows(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO stock_alerts (user_id, sku, threshold, status, created_at)
+             VALUES ('user-1', 'sku-1', 1, 'triggered', '2020-01-01 00:00:00')"
+        );
+        $this->pdo->exec(
+            "INSERT INTO stock_alerts (user_id, sku, threshold, status, created_at)
+             VALUES ('user-2', 'sku-2', 1, 'dismissed', '2020-01-01 00:00:00')"
+        );
+        $deleted = $this->sa->purge('2020-06-01 00:00:00');
+        $this->assertSame(2, $deleted);
+    }
+
+    public function testPurgeDoesNotDeleteActiveAlerts(): void
+    {
+        $id = $this->sa->create('user-1', 'sku-1');
+        // Even if created_at is old, active alerts must not be purged
+        $this->pdo->exec("UPDATE stock_alerts SET created_at = '2020-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->sa->purge('2020-06-01 00:00:00');
+        $this->assertSame(0, $deleted);
+        $this->assertNotNull($this->sa->get($id));
+    }
+
+    public function testPurgeDoesNotDeleteRecentRows(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO stock_alerts (user_id, sku, threshold, status, created_at)
+             VALUES ('user-1', 'sku-1', 1, 'triggered', '2025-01-01 00:00:00')"
+        );
+        $deleted = $this->sa->purge('2020-06-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\StockAlert` — user-defined stock/availability alert registrations.

## What's included
- `class/xion/StockAlert.php` — helper class
- `tests/Unit/Xion/StockAlertTest.php` — 30 tests, 44 assertions

## StockAlert API
| Method | Description |
|---|---|
| `create(userId, sku, threshold)` | Register an alert; threshold >= 1 |
| `get(id)` | Retrieve by ID |
| `activeFor(userId)` | Active alerts for a user |
| `pendingForSku(sku)` | Active alerts for a specific SKU |
| `pendingTriggers()` | All active alerts (cron batch) |
| `markTriggered(id)` | Set STATUS_TRIGGERED + triggered_at |
| `dismiss(id)` | Set STATUS_DISMISSED (silence without delete) |
| `delete(id)` | Hard delete |
| `purge(cutoff)` | Delete old non-active rows |

## Schema
```sql
CREATE TABLE stock_alerts (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id      VARCHAR(255) NOT NULL,
    sku          VARCHAR(255) NOT NULL,
    threshold    INTEGER      NOT NULL DEFAULT 1,
    status       VARCHAR(20)  NOT NULL DEFAULT 'active',
    triggered_at DATETIME     NULL,
    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)