### PR TITLE
feat(xion): add ResourceReservation helper (FT233)

### DIFF
--- a/class/xion/ResourceReservation.php
+++ b/class/xion/ResourceReservation.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ResourceReservation — time-bounded reservation of a shared resource.
+ *
+ * Manages bookings for shared physical or logical resources (meeting rooms,
+ * equipment, parking spots, demo environments, etc.). Includes overlap
+ * detection so two users cannot hold the same resource for the same period.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $rr = new ResourceReservation($pdo);
+ *
+ * // Check availability before booking
+ * if ($rr->isAvailable('room-A', '2026-06-01 10:00:00', '2026-06-01 11:00:00')) {
+ *     $id = $rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+ * }
+ *
+ * // List upcoming bookings for a resource
+ * $upcoming = $rr->upcoming('room-A');
+ *
+ * // Cancel / complete
+ * $rr->cancel($id);
+ * $rr->complete($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE resource_reservations (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     resource_id VARCHAR(255) NOT NULL,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     starts_at   DATETIME     NOT NULL,
+ *     ends_at     DATETIME     NOT NULL,
+ *     status      VARCHAR(20)  NOT NULL DEFAULT 'confirmed',
+ *     notes       TEXT         NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ResourceReservation
+{
+    public const STATUS_CONFIRMED = 'confirmed';
+    public const STATUS_CANCELLED = 'cancelled';
+    public const STATUS_COMPLETED = 'completed';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Reserve a resource for a time window.
+     *
+     * Throws \RuntimeException if the resource is already booked for the
+     * requested window (status = confirmed overlap).
+     *
+     * @return int New reservation ID.
+     * @throws \InvalidArgumentException on empty resourceId/userId or invalid window.
+     * @throws \RuntimeException if the resource is already reserved for the period.
+     */
+    public function reserve(
+        string $resourceId,
+        string $userId,
+        string $startsAt,
+        string $endsAt,
+        ?string $notes = null
+    ): int {
+        $resourceId = trim($resourceId);
+        $userId     = trim($userId);
+        if ($resourceId === '') {
+            throw new \InvalidArgumentException('resource_id must not be empty.');
+        }
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($startsAt >= $endsAt) {
+            throw new \InvalidArgumentException('starts_at must be before ends_at.');
+        }
+
+        if (!$this->isAvailable($resourceId, $startsAt, $endsAt)) {
+            throw new \RuntimeException('Resource is already reserved for the requested period.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO resource_reservations
+                 (resource_id, user_id, starts_at, ends_at, status, notes, created_at)
+             VALUES (:rid, :uid, :starts, :ends, :status, :notes, :now)'
+        );
+        $stmt->execute([
+            ':rid'    => $resourceId,
+            ':uid'    => $userId,
+            ':starts' => $startsAt,
+            ':ends'   => $endsAt,
+            ':status' => self::STATUS_CONFIRMED,
+            ':notes'  => $notes,
+            ':now'    => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve a reservation by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM resource_reservations WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Check whether a resource is free for the given window.
+     *
+     * An optional $excludeId skips one reservation row (useful for re-booking
+     * the same slot).
+     */
+    public function isAvailable(string $resourceId, string $startsAt, string $endsAt, int $excludeId = 0): bool
+    {
+        $sql = 'SELECT COUNT(*) FROM resource_reservations
+                WHERE resource_id = :rid
+                  AND status = :status
+                  AND starts_at < :ends
+                  AND ends_at   > :starts';
+        if ($excludeId > 0) {
+            $sql .= ' AND id != :excl';
+        }
+        $stmt = $this->db()->prepare($sql);
+        $params = [
+            ':rid'    => trim($resourceId),
+            ':status' => self::STATUS_CONFIRMED,
+            ':starts' => $startsAt,
+            ':ends'   => $endsAt,
+        ];
+        if ($excludeId > 0) {
+            $params[':excl'] = $excludeId;
+        }
+        $stmt->execute($params);
+        return (int)$stmt->fetchColumn() === 0;
+    }
+
+    /**
+     * Cancel a reservation.
+     *
+     * @return bool True if found and updated.
+     */
+    public function cancel(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE resource_reservations SET status = :status WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_CANCELLED, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark a reservation as completed.
+     *
+     * @return bool True if found and updated.
+     */
+    public function complete(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE resource_reservations SET status = :status WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_COMPLETED, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List confirmed reservations for a resource within a time range.
+     *
+     * Returns rows where starts_at < $to AND ends_at > $from (overlapping range).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forResource(string $resourceId, string $from, string $to): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM resource_reservations
+             WHERE resource_id = :rid
+               AND status = :status
+               AND starts_at < :to
+               AND ends_at   > :from
+             ORDER BY starts_at ASC, id ASC'
+        );
+        $stmt->execute([
+            ':rid'    => trim($resourceId),
+            ':status' => self::STATUS_CONFIRMED,
+            ':from'   => $from,
+            ':to'     => $to,
+        ]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List all reservations for a user (all statuses), newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forUser(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM resource_reservations
+             WHERE user_id = :uid
+             ORDER BY starts_at DESC, id DESC'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List upcoming confirmed reservations for a resource (starts_at >= now).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function upcoming(string $resourceId): array
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM resource_reservations
+             WHERE resource_id = :rid
+               AND status = :status
+               AND starts_at >= :now
+             ORDER BY starts_at ASC, id ASC'
+        );
+        $stmt->execute([
+            ':rid'    => trim($resourceId),
+            ':status' => self::STATUS_CONFIRMED,
+            ':now'    => $now,
+        ]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Delete cancelled/completed reservations older than $cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM resource_reservations
+             WHERE status != :confirmed AND created_at < :cutoff'
+        );
+        $stmt->execute([':confirmed' => self::STATUS_CONFIRMED, ':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/ResourceReservationTest.php
+++ b/tests/Unit/Xion/ResourceReservationTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\ResourceReservation;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ResourceReservationTest extends TestCase
+{
+    private PDO $pdo;
+    private ResourceReservation $rr;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE resource_reservations (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                resource_id VARCHAR(255) NOT NULL,
+                user_id     VARCHAR(255) NOT NULL,
+                starts_at   DATETIME     NOT NULL,
+                ends_at     DATETIME     NOT NULL,
+                status      VARCHAR(20)  NOT NULL DEFAULT \'confirmed\',
+                notes       TEXT         NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->rr = new ResourceReservation($this->pdo);
+    }
+
+    // ── reserve ───────────────────────────────────────────────────────────────
+
+    public function testReserveReturnsId(): void
+    {
+        $id = $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testReserveStoresFields(): void
+    {
+        $id  = $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00', 'Team sync');
+        $row = $this->rr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('room-A', $row['resource_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['user_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ResourceReservation::STATUS_CONFIRMED, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Team sync', $row['notes']);
+    }
+
+    public function testReserveThrowsOnEmptyResourceId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rr->reserve('', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+    }
+
+    public function testReserveThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rr->reserve('room-A', '', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+    }
+
+    public function testReserveThrowsWhenStartsAtEqualsEndsAt(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 10:00:00');
+    }
+
+    public function testReserveThrowsWhenStartsAtAfterEndsAt(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rr->reserve('room-A', 'user-1', '2026-06-01 11:00:00', '2026-06-01 10:00:00');
+    }
+
+    public function testReserveThrowsOnOverlap(): void
+    {
+        $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 12:00:00');
+        $this->expectException(\RuntimeException::class);
+        $this->rr->reserve('room-A', 'user-2', '2026-06-01 11:00:00', '2026-06-01 13:00:00');
+    }
+
+    public function testReserveAllowsAdjacentSlots(): void
+    {
+        $id1 = $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $id2 = $this->rr->reserve('room-A', 'user-2', '2026-06-01 11:00:00', '2026-06-01 12:00:00');
+        $this->assertGreaterThan(0, $id1);
+        $this->assertGreaterThan(0, $id2);
+    }
+
+    public function testReserveAllowsSameSlotDifferentResource(): void
+    {
+        $id1 = $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $id2 = $this->rr->reserve('room-B', 'user-2', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $this->assertGreaterThan(0, $id1);
+        $this->assertGreaterThan(0, $id2);
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->rr->get(9999));
+    }
+
+    // ── isAvailable ───────────────────────────────────────────────────────────
+
+    public function testIsAvailableReturnsTrueWhenFree(): void
+    {
+        $this->assertTrue($this->rr->isAvailable('room-A', '2026-06-01 10:00:00', '2026-06-01 11:00:00'));
+    }
+
+    public function testIsAvailableReturnsFalseWhenConflict(): void
+    {
+        $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 12:00:00');
+        $this->assertFalse($this->rr->isAvailable('room-A', '2026-06-01 11:00:00', '2026-06-01 13:00:00'));
+    }
+
+    public function testIsAvailableTrueAfterCancel(): void
+    {
+        $id = $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $this->rr->cancel($id);
+        $this->assertTrue($this->rr->isAvailable('room-A', '2026-06-01 10:00:00', '2026-06-01 11:00:00'));
+    }
+
+    public function testIsAvailableWithExcludeId(): void
+    {
+        $id = $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        // Same slot is available if we exclude the existing reservation
+        $this->assertTrue($this->rr->isAvailable('room-A', '2026-06-01 10:00:00', '2026-06-01 11:00:00', $id));
+    }
+
+    // ── cancel ────────────────────────────────────────────────────────────────
+
+    public function testCancelChangesStatus(): void
+    {
+        $id  = $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $this->assertTrue($this->rr->cancel($id));
+        $row = $this->rr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ResourceReservation::STATUS_CANCELLED, $row['status']);
+    }
+
+    public function testCancelReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->rr->cancel(9999));
+    }
+
+    // ── complete ──────────────────────────────────────────────────────────────
+
+    public function testCompleteChangesStatus(): void
+    {
+        $id  = $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $this->assertTrue($this->rr->complete($id));
+        $row = $this->rr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ResourceReservation::STATUS_COMPLETED, $row['status']);
+    }
+
+    public function testCompleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->rr->complete(9999));
+    }
+
+    // ── forResource ───────────────────────────────────────────────────────────
+
+    public function testForResourceReturnsOverlappingReservations(): void
+    {
+        $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        // Non-overlapping
+        $this->rr->reserve('room-A', 'user-2', '2026-06-01 14:00:00', '2026-06-01 15:00:00');
+        $list = $this->rr->forResource('room-A', '2026-06-01 09:00:00', '2026-06-01 12:00:00');
+        $this->assertCount(1, $list);
+    }
+
+    public function testForResourceExcludesCancelled(): void
+    {
+        $id = $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $this->rr->cancel($id);
+        $list = $this->rr->forResource('room-A', '2026-06-01 09:00:00', '2026-06-01 12:00:00');
+        $this->assertSame([], $list);
+    }
+
+    public function testForResourceIsIsolatedByResource(): void
+    {
+        $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $this->rr->reserve('room-B', 'user-2', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $this->assertCount(1, $this->rr->forResource('room-A', '2026-06-01 09:00:00', '2026-06-01 12:00:00'));
+        $this->assertCount(1, $this->rr->forResource('room-B', '2026-06-01 09:00:00', '2026-06-01 12:00:00'));
+    }
+
+    // ── forUser ───────────────────────────────────────────────────────────────
+
+    public function testForUserReturnsAllStatuses(): void
+    {
+        $id1 = $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $id2 = $this->rr->reserve('room-B', 'user-1', '2026-06-02 10:00:00', '2026-06-02 11:00:00');
+        $this->rr->cancel($id1);
+        $list = $this->rr->forUser('user-1');
+        $this->assertCount(2, $list);
+        unset($id2);
+    }
+
+    public function testForUserIsIsolatedByUser(): void
+    {
+        $this->rr->reserve('room-A', 'user-1', '2026-06-01 10:00:00', '2026-06-01 11:00:00');
+        $this->rr->reserve('room-A', 'user-2', '2026-06-02 10:00:00', '2026-06-02 11:00:00');
+        $this->assertCount(1, $this->rr->forUser('user-1'));
+        $this->assertCount(1, $this->rr->forUser('user-2'));
+    }
+
+    public function testForUserReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->rr->forUser('user-99'));
+    }
+
+    // ── upcoming ──────────────────────────────────────────────────────────────
+
+    public function testUpcomingReturnsConfirmedFutureReservations(): void
+    {
+        $this->rr->reserve('room-A', 'user-1', '2099-06-01 10:00:00', '2099-06-01 11:00:00');
+        $this->assertCount(1, $this->rr->upcoming('room-A'));
+    }
+
+    public function testUpcomingExcludesPastReservations(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO resource_reservations
+                 (resource_id, user_id, starts_at, ends_at, status)
+             VALUES ('room-A', 'user-1', '2020-01-01 10:00:00', '2020-01-01 11:00:00', 'confirmed')"
+        );
+        $this->assertSame([], $this->rr->upcoming('room-A'));
+    }
+
+    public function testUpcomingExcludesCancelled(): void
+    {
+        $id = $this->rr->reserve('room-A', 'user-1', '2099-06-01 10:00:00', '2099-06-01 11:00:00');
+        $this->rr->cancel($id);
+        $this->assertSame([], $this->rr->upcoming('room-A'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldNonConfirmed(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO resource_reservations
+                 (resource_id, user_id, starts_at, ends_at, status, created_at)
+             VALUES ('room-A', 'user-1', '2020-01-01 10:00:00', '2020-01-01 11:00:00', 'cancelled', '2020-01-01 00:00:00')"
+        );
+        $this->pdo->exec(
+            "INSERT INTO resource_reservations
+                 (resource_id, user_id, starts_at, ends_at, status, created_at)
+             VALUES ('room-B', 'user-2', '2020-01-02 10:00:00', '2020-01-02 11:00:00', 'completed', '2020-01-02 00:00:00')"
+        );
+        $deleted = $this->rr->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(2, $deleted);
+    }
+
+    public function testPurgeOlderThanDoesNotDeleteConfirmed(): void
+    {
+        $id = $this->rr->reserve('room-A', 'user-1', '2099-06-01 10:00:00', '2099-06-01 11:00:00');
+        $this->pdo->exec("UPDATE resource_reservations SET created_at = '2020-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->rr->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+
+    public function testPurgeOlderThanDoesNotDeleteRecent(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO resource_reservations
+                 (resource_id, user_id, starts_at, ends_at, status, created_at)
+             VALUES ('room-A', 'user-1', '2025-01-01 10:00:00', '2025-01-01 11:00:00', 'cancelled', '2025-01-01 00:00:00')"
+        );
+        $deleted = $this->rr->purgeOlderThan('2020-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\ResourceReservation` — time-bounded reservation of shared resources with overlap detection.

## What's included
- `class/xion/ResourceReservation.php` — helper class
- `tests/Unit/Xion/ResourceReservationTest.php` — 30 tests, 42 assertions

## ResourceReservation API
| Method | Description |
|---|---|
| `reserve(resourceId, userId, startsAt, endsAt, notes)` | Book a slot; throws RuntimeException on overlap |
| `get(id)` | Retrieve by ID |
| `isAvailable(resourceId, startsAt, endsAt, excludeId)` | Overlap check |
| `cancel(id)` | Set STATUS_CANCELLED |
| `complete(id)` | Set STATUS_COMPLETED |
| `forResource(resourceId, from, to)` | Confirmed overlapping reservations in range |
| `forUser(userId)` | All reservations for a user |
| `upcoming(resourceId)` | Future confirmed reservations |
| `purgeOlderThan(cutoff)` | Delete old non-confirmed rows |

## Schema
```sql
CREATE TABLE resource_reservations (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    resource_id VARCHAR(255) NOT NULL,
    user_id     VARCHAR(255) NOT NULL,
    starts_at   DATETIME     NOT NULL,
    ends_at     DATETIME     NOT NULL,
    status      VARCHAR(20)  NOT NULL DEFAULT 'confirmed',
    notes       TEXT         NULL,
    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)