### PR TITLE
feat(xion): add ScoreBoard helper (FT234)

### DIFF
--- a/class/xion/ScoreBoard.php
+++ b/class/xion/ScoreBoard.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ScoreBoard — high-score table with personal-best and period tracking.
+ *
+ * Records every score submission and derives high-score tables from the raw
+ * events. Supports multiple categories (game modes, difficulty levels, etc.)
+ * and period-scoped queries (all-time, daily, weekly, monthly).
+ *
+ * Personal bests are derived on-the-fly from MAX(score), so no denormalised
+ * cache is needed. The leaderboard query returns each player's single best
+ * score per category, ranked descending.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $sb = new ScoreBoard($pdo);
+ *
+ * // Submit a score
+ * $sb->submit('user-1', 'arcade', 15000);
+ *
+ * // Top 10 for a category
+ * $top = $sb->top('arcade', 10);
+ *
+ * // Personal best
+ * $best = $sb->personalBest('user-1', 'arcade');
+ *
+ * // Top scores this week
+ * $weekly = $sb->top('arcade', 10, date('Y-W'));
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE score_board (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     category   VARCHAR(100) NOT NULL,
+ *     score      INTEGER      NOT NULL,
+ *     period     VARCHAR(20)  NOT NULL DEFAULT '',
+ *     meta       TEXT         NULL,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ScoreBoard
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Submit a score for a player in a category.
+     *
+     * @param array<string,mixed>|null $meta Optional extra data (level, duration, etc.).
+     * @return int New row ID.
+     * @throws \InvalidArgumentException on empty userId/category.
+     */
+    public function submit(string $userId, string $category, int $score, string $period = '', ?array $meta = null): int
+    {
+        $userId   = trim($userId);
+        $category = trim($category);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($category === '') {
+            throw new \InvalidArgumentException('category must not be empty.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO score_board (user_id, category, score, period, meta, created_at)
+             VALUES (:uid, :cat, :score, :period, :meta, :now)'
+        );
+        $stmt->execute([
+            ':uid'    => $userId,
+            ':cat'    => $category,
+            ':score'  => $score,
+            ':period' => $period,
+            ':meta'   => $meta !== null ? json_encode($meta, JSON_UNESCAPED_UNICODE) : null,
+            ':now'    => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Return the top-N leaderboard for a category.
+     *
+     * Each player appears at most once (their personal best for that category
+     * and period). Results are ordered best score descending.
+     *
+     * @return list<array<string,mixed>>  Each row: user_id, category, best_score, period.
+     */
+    public function top(string $category, int $limit = 10, string $period = ''): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT user_id, category, MAX(score) AS best_score, period
+             FROM score_board
+             WHERE category = :cat AND period = :period
+             GROUP BY user_id
+             ORDER BY best_score DESC, MIN(id) ASC
+             LIMIT :lim'
+        );
+        $stmt->bindValue(':cat', trim($category));
+        $stmt->bindValue(':period', $period);
+        $stmt->bindValue(':lim', max(1, $limit), PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return a player's personal best score for a category (and optional period).
+     *
+     * Returns null if no scores have been submitted.
+     */
+    public function personalBest(string $userId, string $category, string $period = ''): ?int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT MAX(score) FROM score_board
+             WHERE user_id = :uid AND category = :cat AND period = :period'
+        );
+        $stmt->execute([':uid' => trim($userId), ':cat' => trim($category), ':period' => $period]);
+        $val = $stmt->fetchColumn();
+        return $val !== null && $val !== false ? (int)$val : null;
+    }
+
+    /**
+     * Return all score submissions for a player in a category, newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function history(string $userId, string $category, int $limit = 50): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM score_board
+             WHERE user_id = :uid AND category = :cat
+             ORDER BY created_at DESC, id DESC
+             LIMIT :lim'
+        );
+        $stmt->bindValue(':uid', trim($userId));
+        $stmt->bindValue(':cat', trim($category));
+        $stmt->bindValue(':lim', max(1, $limit), PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return a player's rank (1-based) for a category.
+     *
+     * Rank is determined by how many distinct players have a higher best score.
+     * Returns null if the player has no scores.
+     */
+    public function rank(string $userId, string $category, string $period = ''): ?int
+    {
+        $best = $this->personalBest($userId, $category, $period);
+        if ($best === null) {
+            return null;
+        }
+
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(DISTINCT user_id) FROM score_board
+             WHERE category = :cat AND period = :period AND score > :best'
+        );
+        $stmt->execute([':cat' => trim($category), ':period' => $period, ':best' => $best]);
+        return (int)$stmt->fetchColumn() + 1;
+    }
+
+    /**
+     * Return the total number of score submissions for a category.
+     */
+    public function count(string $category, string $period = ''): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM score_board WHERE category = :cat AND period = :period'
+        );
+        $stmt->execute([':cat' => trim($category), ':period' => $period]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Delete all scores for a player in a category (and optional period).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function reset(string $userId, string $category, string $period = ''): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM score_board WHERE user_id = :uid AND category = :cat AND period = :period'
+        );
+        $stmt->execute([':uid' => trim($userId), ':cat' => trim($category), ':period' => $period]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Delete score rows older than $cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM score_board WHERE created_at < :cutoff');
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/ScoreBoardTest.php
+++ b/tests/Unit/Xion/ScoreBoardTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\ScoreBoard;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ScoreBoardTest extends TestCase
+{
+    private PDO $pdo;
+    private ScoreBoard $sb;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE score_board (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL,
+                category   VARCHAR(100) NOT NULL,
+                score      INTEGER      NOT NULL,
+                period     VARCHAR(20)  NOT NULL DEFAULT \'\',
+                meta       TEXT         NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->sb = new ScoreBoard($this->pdo);
+    }
+
+    // ── submit ────────────────────────────────────────────────────────────────
+
+    public function testSubmitReturnsId(): void
+    {
+        $id = $this->sb->submit('user-1', 'arcade', 5000);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testSubmitThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sb->submit('', 'arcade', 5000);
+    }
+
+    public function testSubmitThrowsOnEmptyCategory(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sb->submit('user-1', '', 5000);
+    }
+
+    public function testSubmitStoresMeta(): void
+    {
+        $id  = $this->sb->submit('user-1', 'arcade', 5000, '', ['level' => 3]);
+        $row = $this->pdo->query("SELECT meta FROM score_board WHERE id = {$id}")->fetch(PDO::FETCH_ASSOC);
+        $this->assertIsArray($row);
+        $this->assertStringContainsString('level', $row['meta']);
+    }
+
+    // ── top ───────────────────────────────────────────────────────────────────
+
+    public function testTopReturnsPersonalBestPerPlayer(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 5000);
+        $this->sb->submit('user-1', 'arcade', 8000);
+        $this->sb->submit('user-2', 'arcade', 6000);
+
+        $top = $this->sb->top('arcade');
+        $this->assertCount(2, $top);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(8000, (int)$top[0]['best_score']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $top[0]['user_id']);
+    }
+
+    public function testTopRespectsLimit(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 9000);
+        $this->sb->submit('user-2', 'arcade', 8000);
+        $this->sb->submit('user-3', 'arcade', 7000);
+
+        $top = $this->sb->top('arcade', 2);
+        $this->assertCount(2, $top);
+    }
+
+    public function testTopIsIsolatedByCategory(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 9000);
+        $this->sb->submit('user-1', 'puzzle', 3000);
+
+        $this->assertCount(1, $this->sb->top('arcade'));
+        $this->assertCount(1, $this->sb->top('puzzle'));
+    }
+
+    public function testTopIsIsolatedByPeriod(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 9000, '2026-W01');
+        $this->sb->submit('user-1', 'arcade', 7000, '2026-W02');
+
+        $this->assertCount(1, $this->sb->top('arcade', 10, '2026-W01'));
+        $this->assertCount(0, $this->sb->top('arcade', 10, '2026-W03'));
+    }
+
+    public function testTopReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->sb->top('unknown'));
+    }
+
+    // ── personalBest ──────────────────────────────────────────────────────────
+
+    public function testPersonalBestReturnsHighest(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 5000);
+        $this->sb->submit('user-1', 'arcade', 9000);
+        $this->sb->submit('user-1', 'arcade', 7000);
+        $this->assertSame(9000, $this->sb->personalBest('user-1', 'arcade'));
+    }
+
+    public function testPersonalBestReturnsNullWhenNone(): void
+    {
+        $this->assertNull($this->sb->personalBest('user-1', 'arcade'));
+    }
+
+    public function testPersonalBestIsIsolatedByPeriod(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 9000, '2026-W01');
+        $this->assertNull($this->sb->personalBest('user-1', 'arcade', '2026-W02'));
+    }
+
+    // ── history ───────────────────────────────────────────────────────────────
+
+    public function testHistoryReturnsNewestFirst(): void
+    {
+        $id1 = $this->sb->submit('user-1', 'arcade', 5000);
+        $id2 = $this->sb->submit('user-1', 'arcade', 8000);
+        $list = $this->sb->history('user-1', 'arcade');
+        $this->assertCount(2, $list);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame($id2, (int)$list[0]['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame($id1, (int)$list[1]['id']);
+    }
+
+    public function testHistoryRespectsLimit(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->sb->submit('user-1', 'arcade', $i * 1000);
+        }
+        $this->assertCount(3, $this->sb->history('user-1', 'arcade', 3));
+    }
+
+    public function testHistoryIsIsolatedByUser(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 5000);
+        $this->sb->submit('user-2', 'arcade', 6000);
+        $this->assertCount(1, $this->sb->history('user-1', 'arcade'));
+    }
+
+    public function testHistoryReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->sb->history('user-1', 'arcade'));
+    }
+
+    // ── rank ──────────────────────────────────────────────────────────────────
+
+    public function testRankReturnsOneForTopPlayer(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 9000);
+        $this->sb->submit('user-2', 'arcade', 7000);
+        $this->assertSame(1, $this->sb->rank('user-1', 'arcade'));
+    }
+
+    public function testRankReturnsTwoForSecondPlayer(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 9000);
+        $this->sb->submit('user-2', 'arcade', 7000);
+        $this->assertSame(2, $this->sb->rank('user-2', 'arcade'));
+    }
+
+    public function testRankReturnsNullWhenNoScores(): void
+    {
+        $this->assertNull($this->sb->rank('user-1', 'arcade'));
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    public function testCountReturnsSubmissionCount(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 5000);
+        $this->sb->submit('user-1', 'arcade', 8000);
+        $this->sb->submit('user-2', 'arcade', 6000);
+        $this->assertSame(3, $this->sb->count('arcade'));
+    }
+
+    public function testCountIsIsolatedByPeriod(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 5000, '2026-W01');
+        $this->sb->submit('user-1', 'arcade', 8000, '2026-W02');
+        $this->assertSame(1, $this->sb->count('arcade', '2026-W01'));
+        $this->assertSame(0, $this->sb->count('arcade', '2026-W03'));
+    }
+
+    // ── reset ─────────────────────────────────────────────────────────────────
+
+    public function testResetDeletesPlayerScores(): void
+    {
+        $this->sb->submit('user-1', 'arcade', 5000);
+        $this->sb->submit('user-1', 'arcade', 8000);
+        $this->sb->submit('user-2', 'arcade', 6000);
+        $deleted = $this->sb->reset('user-1', 'arcade');
+        $this->assertSame(2, $deleted);
+        $this->assertNull($this->sb->personalBest('user-1', 'arcade'));
+        $this->assertNotNull($this->sb->personalBest('user-2', 'arcade'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldRows(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO score_board (user_id, category, score, period, created_at)
+             VALUES ('user-1', 'arcade', 5000, '', '2020-01-01 00:00:00')"
+        );
+        $this->pdo->exec(
+            "INSERT INTO score_board (user_id, category, score, period, created_at)
+             VALUES ('user-2', 'arcade', 6000, '', '2025-01-01 00:00:00')"
+        );
+        $deleted = $this->sb->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(1, $deleted);
+        $this->assertSame(1, $this->sb->count('arcade'));
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\ScoreBoard` — high-score table with personal-best and period-scoped leaderboard queries.

## What's included
- `class/xion/ScoreBoard.php` — helper class
- `tests/Unit/Xion/ScoreBoardTest.php` — 23 tests, 34 assertions

## ScoreBoard API
| Method | Description |
|---|---|
| `submit(userId, category, score, period, meta)` | Record a score submission |
| `top(category, limit, period)` | Top-N leaderboard (personal best per player) |
| `personalBest(userId, category, period)` | Player's best score |
| `history(userId, category, limit)` | All submissions for a player |
| `rank(userId, category, period)` | 1-based rank by best score |
| `count(category, period)` | Total submission count |
| `reset(userId, category, period)` | Delete a player's scores |
| `purgeOlderThan(cutoff)` | Delete old score rows |

## Schema
```sql
CREATE TABLE score_board (
    id         INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id    VARCHAR(255) NOT NULL,
    category   VARCHAR(100) NOT NULL,
    score      INTEGER      NOT NULL,
    period     VARCHAR(20)  NOT NULL DEFAULT '',
    meta       TEXT         NULL,
    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)