### PR TITLE
feat(xion): add CreditNote helper (FT235)

### DIFF
--- a/class/xion/CreditNote.php
+++ b/class/xion/CreditNote.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * CreditNote — financial credit notes / refund adjustments.
+ *
+ * Tracks credit notes issued against an entity (order, invoice, account, etc.).
+ * Amount is stored in the smallest currency unit (cents / yen) to avoid
+ * floating-point rounding. A credit note starts as PENDING, transitions to
+ * APPLIED when the credit has been consumed, or VOIDED if it is cancelled.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cn = new CreditNote($pdo);
+ *
+ * // Issue a credit note for 10 USD against an order
+ * $id = $cn->issue('order', 'ord-1', 1000, 'Damaged item refund');
+ *
+ * // Apply when the credit is consumed
+ * $cn->apply($id);
+ *
+ * // Query
+ * $pending = $cn->pendingTotal('order', 'ord-1');  // sum of pending cents
+ * $notes   = $cn->forEntity('order', 'ord-1');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE credit_notes (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     reference   VARCHAR(100) NOT NULL DEFAULT '',
+ *     entity_type VARCHAR(100) NOT NULL,
+ *     entity_id   VARCHAR(255) NOT NULL,
+ *     amount      INTEGER      NOT NULL,
+ *     reason      TEXT         NULL,
+ *     status      VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     issued_at   DATETIME     NOT NULL,
+ *     applied_at  DATETIME     NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class CreditNote
+{
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_APPLIED = 'applied';
+    public const STATUS_VOIDED  = 'voided';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Issue a credit note against an entity.
+     *
+     * @param int    $amountCents Amount in smallest currency unit (must be > 0).
+     * @param string $reference   Optional external reference number.
+     * @return int New credit note ID.
+     * @throws \InvalidArgumentException on empty entityType/entityId or amount <= 0.
+     */
+    public function issue(
+        string $entityType,
+        string $entityId,
+        int $amountCents,
+        ?string $reason = null,
+        string $reference = ''
+    ): int {
+        $entityType = trim($entityType);
+        $entityId   = trim($entityId);
+        if ($entityType === '') {
+            throw new \InvalidArgumentException('entity_type must not be empty.');
+        }
+        if ($entityId === '') {
+            throw new \InvalidArgumentException('entity_id must not be empty.');
+        }
+        if ($amountCents <= 0) {
+            throw new \InvalidArgumentException('amount must be > 0.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO credit_notes
+                 (reference, entity_type, entity_id, amount, reason, status, issued_at, created_at)
+             VALUES (:ref, :etype, :eid, :amount, :reason, :status, :now, :now2)'
+        );
+        $stmt->execute([
+            ':ref'    => $reference,
+            ':etype'  => $entityType,
+            ':eid'    => $entityId,
+            ':amount' => $amountCents,
+            ':reason' => $reason,
+            ':status' => self::STATUS_PENDING,
+            ':now'    => $now,
+            ':now2'   => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve a credit note by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM credit_notes WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Mark a credit note as applied (credit consumed).
+     *
+     * @return bool True if found and updated.
+     */
+    public function apply(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE credit_notes SET status = :status, applied_at = :now WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_APPLIED, ':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Void a credit note (cancel without applying).
+     *
+     * @return bool True if found and updated.
+     */
+    public function void(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE credit_notes SET status = :status WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_VOIDED, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List all credit notes for an entity (newest first).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forEntity(string $entityType, string $entityId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM credit_notes
+             WHERE entity_type = :etype AND entity_id = :eid
+             ORDER BY issued_at DESC, id DESC'
+        );
+        $stmt->execute([':etype' => trim($entityType), ':eid' => trim($entityId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Sum of all credit notes in a given status for an entity.
+     *
+     * Returns 0 if none exist.
+     */
+    public function total(string $entityType, string $entityId, string $status = self::STATUS_PENDING): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COALESCE(SUM(amount), 0) FROM credit_notes
+             WHERE entity_type = :etype AND entity_id = :eid AND status = :status'
+        );
+        $stmt->execute([':etype' => trim($entityType), ':eid' => trim($entityId), ':status' => $status]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Sum of pending credit notes for an entity (convenience wrapper).
+     */
+    public function pendingTotal(string $entityType, string $entityId): int
+    {
+        return $this->total($entityType, $entityId, self::STATUS_PENDING);
+    }
+
+    /**
+     * Delete voided/applied credit notes older than $cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM credit_notes WHERE status != :pending AND created_at < :cutoff'
+        );
+        $stmt->execute([':pending' => self::STATUS_PENDING, ':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/CreditNoteTest.php
+++ b/tests/Unit/Xion/CreditNoteTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\CreditNote;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class CreditNoteTest extends TestCase
+{
+    private PDO $pdo;
+    private CreditNote $cn;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE credit_notes (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                reference   VARCHAR(100) NOT NULL DEFAULT \'\',
+                entity_type VARCHAR(100) NOT NULL,
+                entity_id   VARCHAR(255) NOT NULL,
+                amount      INTEGER      NOT NULL,
+                reason      TEXT         NULL,
+                status      VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                issued_at   DATETIME     NOT NULL,
+                applied_at  DATETIME     NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->cn = new CreditNote($this->pdo);
+    }
+
+    // ── issue ─────────────────────────────────────────────────────────────────
+
+    public function testIssueReturnsId(): void
+    {
+        $id = $this->cn->issue('order', 'ord-1', 1000);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testIssueStoresFields(): void
+    {
+        $id  = $this->cn->issue('order', 'ord-1', 1000, 'Damaged item', 'CN-001');
+        $row = $this->cn->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('order', $row['entity_type']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('ord-1', $row['entity_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1000, (int)$row['amount']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Damaged item', $row['reason']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('CN-001', $row['reference']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(CreditNote::STATUS_PENDING, $row['status']);
+    }
+
+    public function testIssueThrowsOnEmptyEntityType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cn->issue('', 'ord-1', 1000);
+    }
+
+    public function testIssueThrowsOnEmptyEntityId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cn->issue('order', '', 1000);
+    }
+
+    public function testIssueThrowsOnZeroAmount(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cn->issue('order', 'ord-1', 0);
+    }
+
+    public function testIssueThrowsOnNegativeAmount(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cn->issue('order', 'ord-1', -500);
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->cn->get(9999));
+    }
+
+    // ── apply ─────────────────────────────────────────────────────────────────
+
+    public function testApplyChangesStatus(): void
+    {
+        $id  = $this->cn->issue('order', 'ord-1', 1000);
+        $this->assertTrue($this->cn->apply($id));
+        $row = $this->cn->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(CreditNote::STATUS_APPLIED, $row['status']);
+    }
+
+    public function testApplySetsAppliedAt(): void
+    {
+        $id  = $this->cn->issue('order', 'ord-1', 1000);
+        $this->cn->apply($id);
+        $row = $this->cn->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['applied_at']);
+    }
+
+    public function testApplyReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->cn->apply(9999));
+    }
+
+    // ── void ──────────────────────────────────────────────────────────────────
+
+    public function testVoidChangesStatus(): void
+    {
+        $id  = $this->cn->issue('order', 'ord-1', 1000);
+        $this->assertTrue($this->cn->void($id));
+        $row = $this->cn->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(CreditNote::STATUS_VOIDED, $row['status']);
+    }
+
+    public function testVoidReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->cn->void(9999));
+    }
+
+    // ── forEntity ─────────────────────────────────────────────────────────────
+
+    public function testForEntityReturnsAllStatuses(): void
+    {
+        $id1 = $this->cn->issue('order', 'ord-1', 1000);
+        $id2 = $this->cn->issue('order', 'ord-1', 500);
+        $this->cn->apply($id1);
+        $list = $this->cn->forEntity('order', 'ord-1');
+        $this->assertCount(2, $list);
+        unset($id2);
+    }
+
+    public function testForEntityIsIsolatedByEntity(): void
+    {
+        $this->cn->issue('order', 'ord-1', 1000);
+        $this->cn->issue('order', 'ord-2', 500);
+        $this->assertCount(1, $this->cn->forEntity('order', 'ord-1'));
+        $this->assertCount(1, $this->cn->forEntity('order', 'ord-2'));
+    }
+
+    public function testForEntityReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->cn->forEntity('order', 'ord-99'));
+    }
+
+    // ── total / pendingTotal ──────────────────────────────────────────────────
+
+    public function testTotalSumsPendingAmounts(): void
+    {
+        $this->cn->issue('order', 'ord-1', 1000);
+        $this->cn->issue('order', 'ord-1', 500);
+        $this->assertSame(1500, $this->cn->total('order', 'ord-1'));
+    }
+
+    public function testTotalExcludesApplied(): void
+    {
+        $id = $this->cn->issue('order', 'ord-1', 1000);
+        $this->cn->issue('order', 'ord-1', 500);
+        $this->cn->apply($id);
+        $this->assertSame(500, $this->cn->total('order', 'ord-1'));
+    }
+
+    public function testTotalCanFilterByStatus(): void
+    {
+        $id = $this->cn->issue('order', 'ord-1', 1000);
+        $this->cn->apply($id);
+        $this->assertSame(1000, $this->cn->total('order', 'ord-1', CreditNote::STATUS_APPLIED));
+    }
+
+    public function testTotalReturnsZeroWhenNone(): void
+    {
+        $this->assertSame(0, $this->cn->total('order', 'ord-99'));
+    }
+
+    public function testPendingTotalIsSameAsTotal(): void
+    {
+        $this->cn->issue('order', 'ord-1', 750);
+        $this->assertSame(750, $this->cn->pendingTotal('order', 'ord-1'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldNonPending(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO credit_notes
+                 (entity_type, entity_id, amount, status, issued_at, created_at)
+             VALUES ('order', 'ord-1', 1000, 'applied', '2020-01-01', '2020-01-01 00:00:00')"
+        );
+        $this->pdo->exec(
+            "INSERT INTO credit_notes
+                 (entity_type, entity_id, amount, status, issued_at, created_at)
+             VALUES ('order', 'ord-2', 500, 'voided', '2020-01-01', '2020-01-02 00:00:00')"
+        );
+        $deleted = $this->cn->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(2, $deleted);
+    }
+
+    public function testPurgeOlderThanDoesNotDeletePending(): void
+    {
+        $id = $this->cn->issue('order', 'ord-1', 1000);
+        $this->pdo->exec("UPDATE credit_notes SET created_at = '2020-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->cn->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+
+    public function testPurgeOlderThanDoesNotDeleteRecent(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO credit_notes
+                 (entity_type, entity_id, amount, status, issued_at, created_at)
+             VALUES ('order', 'ord-1', 1000, 'applied', '2025-01-01', '2025-01-01 00:00:00')"
+        );
+        $deleted = $this->cn->purgeOlderThan('2020-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\CreditNote` — financial credit notes / refund adjustments against any entity.

## What's included
- `class/xion/CreditNote.php` — helper class
- `tests/Unit/Xion/CreditNoteTest.php` — 23 tests, 35 assertions

## CreditNote API
| Method | Description |
|---|---|
| `issue(entityType, entityId, amountCents, reason, reference)` | Create a PENDING credit note |
| `get(id)` | Retrieve by ID |
| `apply(id)` | Mark as APPLIED + set applied_at |
| `void(id)` | Mark as VOIDED |
| `forEntity(entityType, entityId)` | All notes for an entity |
| `total(entityType, entityId, status)` | Sum amounts by status |
| `pendingTotal(entityType, entityId)` | Sum of pending amounts |
| `purgeOlderThan(cutoff)` | Delete old applied/voided rows |

## Schema
```sql
CREATE TABLE credit_notes (
    id          INTEGER PRIMARY KEY AUTOINCREMENT,
    reference   VARCHAR(100) NOT NULL DEFAULT '',
    entity_type VARCHAR(100) NOT NULL,
    entity_id   VARCHAR(255) NOT NULL,
    amount      INTEGER      NOT NULL,
    reason      TEXT         NULL,
    status      VARCHAR(20)  NOT NULL DEFAULT 'pending',
    issued_at   DATETIME     NOT NULL,
    applied_at  DATETIME     NULL,
    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)