### PR TITLE
feat(xion): add DeviceFingerprint helper (FT236)

### DIFF
--- a/class/xion/DeviceFingerprint.php
+++ b/class/xion/DeviceFingerprint.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * DeviceFingerprint — device recognition for fraud detection and trust scoring.
+ *
+ * Records device signatures (browser fingerprint, user-agent, IP, etc.) seen
+ * for each user. A known, trusted device lowers friction; an unknown or
+ * suspicious device can trigger step-up authentication.
+ *
+ * The raw fingerprint string is hashed (SHA-256) before storage so that
+ * sensitive signals are not persisted in plain text.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $df = new DeviceFingerprint($pdo);
+ *
+ * // Register / update a device seen by a user
+ * $id = $df->seen('user-1', 'Mozilla/5.0...', '203.0.113.5', ['screen' => '1920x1080']);
+ *
+ * // Check trust
+ * if ($df->isTrusted('user-1', 'Mozilla/5.0...')) {
+ *     // skip extra verification
+ * }
+ *
+ * // Mark a device as blocked (e.g. stolen device)
+ * $df->block($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE device_fingerprints (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id      VARCHAR(255) NOT NULL,
+ *     fingerprint  VARCHAR(64)  NOT NULL,
+ *     user_agent   TEXT         NULL,
+ *     ip_address   VARCHAR(45)  NULL,
+ *     meta         TEXT         NULL,
+ *     trust_level  INTEGER      NOT NULL DEFAULT 0,
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'seen',
+ *     seen_count   INTEGER      NOT NULL DEFAULT 1,
+ *     last_seen_at DATETIME     NOT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (user_id, fingerprint)
+ * );
+ * ```
+ */
+final class DeviceFingerprint
+{
+    public const STATUS_SEEN    = 'seen';
+    public const STATUS_TRUSTED = 'trusted';
+    public const STATUS_BLOCKED = 'blocked';
+
+    /** Minimum seen_count before a device is auto-trusted via trust(). */
+    public const DEFAULT_TRUST_THRESHOLD = 3;
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record a device observation for a user.
+     *
+     * If the (user_id, fingerprint-hash) pair already exists the row is
+     * updated: seen_count incremented, last_seen_at refreshed, ip / user-agent
+     * updated to the latest values.
+     *
+     * @param array<string,mixed>|null $meta Optional extra signals.
+     * @return int Row ID (new or existing).
+     * @throws \InvalidArgumentException on empty userId or rawFingerprint.
+     */
+    public function seen(string $userId, string $rawFingerprint, ?string $ip = null, ?array $meta = null): int
+    {
+        $userId = trim($userId);
+        $rawFingerprint = trim($rawFingerprint);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($rawFingerprint === '') {
+            throw new \InvalidArgumentException('fingerprint must not be empty.');
+        }
+
+        $hash = hash('sha256', $rawFingerprint);
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        // Cross-driver upsert
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $stmt = $this->db()->prepare(
+                'INSERT INTO device_fingerprints
+                     (user_id, fingerprint, ip_address, meta, last_seen_at, created_at)
+                 VALUES (:uid, :fp, :ip, :meta, :now, :now2)
+                 ON CONFLICT (user_id, fingerprint) DO UPDATE SET
+                     ip_address   = excluded.ip_address,
+                     meta         = excluded.meta,
+                     seen_count   = seen_count + 1,
+                     last_seen_at = excluded.last_seen_at'
+            );
+        } else {
+            $stmt = $this->db()->prepare(
+                'INSERT INTO device_fingerprints
+                     (user_id, fingerprint, ip_address, meta, last_seen_at, created_at)
+                 VALUES (:uid, :fp, :ip, :meta, :now, :now2)
+                 ON DUPLICATE KEY UPDATE
+                     ip_address   = VALUES(ip_address),
+                     meta         = VALUES(meta),
+                     seen_count   = seen_count + 1,
+                     last_seen_at = VALUES(last_seen_at)'
+            );
+        }
+        $stmt->execute([
+            ':uid'  => $userId,
+            ':fp'   => $hash,
+            ':ip'   => $ip,
+            ':meta' => $meta !== null ? json_encode($meta, JSON_UNESCAPED_UNICODE) : null,
+            ':now'  => $now,
+            ':now2' => $now,
+        ]);
+
+        // Fetch the row id after upsert
+        $sel = $this->db()->prepare(
+            'SELECT id FROM device_fingerprints WHERE user_id = :uid AND fingerprint = :fp'
+        );
+        $sel->execute([':uid' => $userId, ':fp' => $hash]);
+        return (int)$sel->fetchColumn();
+    }
+
+    /**
+     * Retrieve a device record by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM device_fingerprints WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Return the device record for a user+fingerprint pair.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function find(string $userId, string $rawFingerprint): ?array
+    {
+        $hash = hash('sha256', trim($rawFingerprint));
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM device_fingerprints WHERE user_id = :uid AND fingerprint = :fp'
+        );
+        $stmt->execute([':uid' => trim($userId), ':fp' => $hash]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Return true if the device is STATUS_TRUSTED for this user.
+     */
+    public function isTrusted(string $userId, string $rawFingerprint): bool
+    {
+        $row = $this->find($userId, $rawFingerprint);
+        return $row !== null && $row['status'] === self::STATUS_TRUSTED;
+    }
+
+    /**
+     * Return true if the device is STATUS_BLOCKED for this user.
+     */
+    public function isBlocked(string $userId, string $rawFingerprint): bool
+    {
+        $row = $this->find($userId, $rawFingerprint);
+        return $row !== null && $row['status'] === self::STATUS_BLOCKED;
+    }
+
+    /**
+     * Explicitly trust a device.
+     *
+     * @return bool True if found and updated.
+     */
+    public function trust(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE device_fingerprints SET status = :status WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_TRUSTED, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Block a device.
+     *
+     * @return bool True if found and updated.
+     */
+    public function block(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE device_fingerprints SET status = :status WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_BLOCKED, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List all device records for a user, most-recently-seen first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forUser(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM device_fingerprints WHERE user_id = :uid ORDER BY last_seen_at DESC, id DESC'
+        );
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List trusted device records for a user.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function trustedFor(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM device_fingerprints
+             WHERE user_id = :uid AND status = :status
+             ORDER BY last_seen_at DESC, id DESC'
+        );
+        $stmt->execute([':uid' => trim($userId), ':status' => self::STATUS_TRUSTED]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Remove a device record.
+     *
+     * @return bool True if found and deleted.
+     */
+    public function remove(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM device_fingerprints WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete blocked/seen device records last seen before $cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM device_fingerprints WHERE status != :trusted AND last_seen_at < :cutoff'
+        );
+        $stmt->execute([':trusted' => self::STATUS_TRUSTED, ':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/DeviceFingerprintTest.php
+++ b/tests/Unit/Xion/DeviceFingerprintTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\DeviceFingerprint;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class DeviceFingerprintTest extends TestCase
+{
+    private PDO $pdo;
+    private DeviceFingerprint $df;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE device_fingerprints (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id      VARCHAR(255) NOT NULL,
+                fingerprint  VARCHAR(64)  NOT NULL,
+                user_agent   TEXT         NULL,
+                ip_address   VARCHAR(45)  NULL,
+                meta         TEXT         NULL,
+                trust_level  INTEGER      NOT NULL DEFAULT 0,
+                status       VARCHAR(20)  NOT NULL DEFAULT \'seen\',
+                seen_count   INTEGER      NOT NULL DEFAULT 1,
+                last_seen_at DATETIME     NOT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (user_id, fingerprint)
+            )
+        ');
+        $this->df = new DeviceFingerprint($this->pdo);
+    }
+
+    // ── seen ──────────────────────────────────────────────────────────────────
+
+    public function testSeenReturnsId(): void
+    {
+        $id = $this->df->seen('user-1', 'fp-abc');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testSeenStoresHashedFingerprint(): void
+    {
+        $id  = $this->df->seen('user-1', 'fp-abc', '127.0.0.1');
+        $row = $this->df->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(hash('sha256', 'fp-abc'), $row['fingerprint']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('127.0.0.1', $row['ip_address']);
+    }
+
+    public function testSeenStoresMeta(): void
+    {
+        $id  = $this->df->seen('user-1', 'fp-abc', null, ['screen' => '1920x1080']);
+        $row = $this->df->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertStringContainsString('screen', $row['meta']);
+    }
+
+    public function testSeenIsIdempotent(): void
+    {
+        $id1 = $this->df->seen('user-1', 'fp-abc');
+        $id2 = $this->df->seen('user-1', 'fp-abc');
+        $this->assertSame($id1, $id2);
+    }
+
+    public function testSeenIncrementsSeenCount(): void
+    {
+        $id = $this->df->seen('user-1', 'fp-abc');
+        $this->df->seen('user-1', 'fp-abc');
+        $this->df->seen('user-1', 'fp-abc');
+        $row = $this->df->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(3, (int)$row['seen_count']);
+    }
+
+    public function testSeenThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->df->seen('', 'fp-abc');
+    }
+
+    public function testSeenThrowsOnEmptyFingerprint(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->df->seen('user-1', '');
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->df->get(9999));
+    }
+
+    // ── find ──────────────────────────────────────────────────────────────────
+
+    public function testFindReturnsByUserAndFingerprint(): void
+    {
+        $id  = $this->df->seen('user-1', 'fp-abc');
+        $row = $this->df->find('user-1', 'fp-abc');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame($id, (int)$row['id']);
+    }
+
+    public function testFindReturnsNullWhenNotSeen(): void
+    {
+        $this->assertNull($this->df->find('user-1', 'fp-unknown'));
+    }
+
+    // ── isTrusted / isBlocked ─────────────────────────────────────────────────
+
+    public function testIsTrustedReturnsFalseInitially(): void
+    {
+        $this->df->seen('user-1', 'fp-abc');
+        $this->assertFalse($this->df->isTrusted('user-1', 'fp-abc'));
+    }
+
+    public function testIsTrustedReturnsTrueAfterTrust(): void
+    {
+        $id = $this->df->seen('user-1', 'fp-abc');
+        $this->df->trust($id);
+        $this->assertTrue($this->df->isTrusted('user-1', 'fp-abc'));
+    }
+
+    public function testIsBlockedReturnsFalseInitially(): void
+    {
+        $this->df->seen('user-1', 'fp-abc');
+        $this->assertFalse($this->df->isBlocked('user-1', 'fp-abc'));
+    }
+
+    public function testIsBlockedReturnsTrueAfterBlock(): void
+    {
+        $id = $this->df->seen('user-1', 'fp-abc');
+        $this->df->block($id);
+        $this->assertTrue($this->df->isBlocked('user-1', 'fp-abc'));
+    }
+
+    // ── trust / block ─────────────────────────────────────────────────────────
+
+    public function testTrustChangesStatus(): void
+    {
+        $id  = $this->df->seen('user-1', 'fp-abc');
+        $this->assertTrue($this->df->trust($id));
+        $row = $this->df->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(DeviceFingerprint::STATUS_TRUSTED, $row['status']);
+    }
+
+    public function testTrustReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->df->trust(9999));
+    }
+
+    public function testBlockChangesStatus(): void
+    {
+        $id  = $this->df->seen('user-1', 'fp-abc');
+        $this->assertTrue($this->df->block($id));
+        $row = $this->df->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(DeviceFingerprint::STATUS_BLOCKED, $row['status']);
+    }
+
+    public function testBlockReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->df->block(9999));
+    }
+
+    // ── forUser ───────────────────────────────────────────────────────────────
+
+    public function testForUserReturnsAllDevices(): void
+    {
+        $this->df->seen('user-1', 'fp-abc');
+        $this->df->seen('user-1', 'fp-def');
+        $this->assertCount(2, $this->df->forUser('user-1'));
+    }
+
+    public function testForUserIsIsolatedByUser(): void
+    {
+        $this->df->seen('user-1', 'fp-abc');
+        $this->df->seen('user-2', 'fp-abc');
+        $this->assertCount(1, $this->df->forUser('user-1'));
+        $this->assertCount(1, $this->df->forUser('user-2'));
+    }
+
+    public function testForUserReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->df->forUser('user-99'));
+    }
+
+    // ── trustedFor ────────────────────────────────────────────────────────────
+
+    public function testTrustedForReturnsOnlyTrusted(): void
+    {
+        $id1 = $this->df->seen('user-1', 'fp-abc');
+        $this->df->seen('user-1', 'fp-def');
+        $this->df->trust($id1);
+        $this->assertCount(1, $this->df->trustedFor('user-1'));
+    }
+
+    public function testTrustedForReturnsEmptyWhenNone(): void
+    {
+        $this->df->seen('user-1', 'fp-abc');
+        $this->assertSame([], $this->df->trustedFor('user-1'));
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesRow(): void
+    {
+        $id = $this->df->seen('user-1', 'fp-abc');
+        $this->assertTrue($this->df->remove($id));
+        $this->assertNull($this->df->get($id));
+    }
+
+    public function testRemoveReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->df->remove(9999));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldSeenRows(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO device_fingerprints (user_id, fingerprint, status, last_seen_at, created_at)
+             VALUES ('user-1', 'hash1', 'seen', '2020-01-01 00:00:00', '2020-01-01 00:00:00')"
+        );
+        $deleted = $this->df->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(1, $deleted);
+    }
+
+    public function testPurgeOlderThanDoesNotDeleteTrusted(): void
+    {
+        $id = $this->df->seen('user-1', 'fp-abc');
+        $this->df->trust($id);
+        $this->pdo->exec("UPDATE device_fingerprints SET last_seen_at = '2020-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->df->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\DeviceFingerprint` — device recognition for fraud detection and trust scoring.

## What's included
- `class/xion/DeviceFingerprint.php` — helper class
- `tests/Unit/Xion/DeviceFingerprintTest.php` — 27 tests, 38 assertions

## DeviceFingerprint API
| Method | Description |
|---|---|
| `seen(userId, rawFingerprint, ip, meta)` | Upsert device observation; increments seen_count |
| `get(id)` | Retrieve by ID |
| `find(userId, rawFingerprint)` | Lookup by user + fingerprint |
| `isTrusted(userId, rawFingerprint)` | Check trust status |
| `isBlocked(userId, rawFingerprint)` | Check blocked status |
| `trust(id)` | Mark STATUS_TRUSTED |
| `block(id)` | Mark STATUS_BLOCKED |
| `forUser(userId)` | All devices for a user |
| `trustedFor(userId)` | Trusted devices for a user |
| `remove(id)` | Delete a device record |
| `purgeOlderThan(cutoff)` | Delete old non-trusted rows |

## Key design
- Raw fingerprint is hashed (SHA-256) before storage
- Cross-driver upsert (SQLite / MySQL) increments seen_count on repeat observations

🤖 Generated with [Claude Code](https://claude.com/claude-code)