### PR TITLE
feat(xion): add MediaConversionJob helper (FT238)

### DIFF
--- a/class/xion/MediaConversionJob.php
+++ b/class/xion/MediaConversionJob.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * MediaConversionJob — async media processing job tracking.
+ *
+ * Tracks background jobs that convert or transcode media files
+ * (image resize, video transcode, audio encode, PDF generation, etc.).
+ * A worker picks up PENDING jobs, marks them IN_PROGRESS, then either
+ * completes or fails them.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $mc = new MediaConversionJob($pdo);
+ *
+ * // Enqueue a conversion
+ * $id = $mc->enqueue('image', '/uploads/photo.jpg', 'webp', ['width' => 800]);
+ *
+ * // Worker loop
+ * $jobs = $mc->nextPending(5);
+ * foreach ($jobs as $job) {
+ *     $mc->start($job['id']);
+ *     try {
+ *         $output = convertFile($job);
+ *         $mc->complete($job['id'], $output);
+ *     } catch (\Throwable $e) {
+ *         $mc->fail($job['id'], $e->getMessage());
+ *     }
+ * }
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE media_conversion_jobs (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     media_type   VARCHAR(50)  NOT NULL,
+ *     source_path  TEXT         NOT NULL,
+ *     output_format VARCHAR(50) NOT NULL,
+ *     options      TEXT         NULL,
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     output_path  TEXT         NULL,
+ *     error        TEXT         NULL,
+ *     attempts     INTEGER      NOT NULL DEFAULT 0,
+ *     started_at   DATETIME     NULL,
+ *     completed_at DATETIME     NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class MediaConversionJob
+{
+    public const STATUS_PENDING     = 'pending';
+    public const STATUS_IN_PROGRESS = 'in_progress';
+    public const STATUS_COMPLETED   = 'completed';
+    public const STATUS_FAILED      = 'failed';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Enqueue a new media conversion job.
+     *
+     * @param array<string,mixed>|null $options Conversion options (e.g. dimensions, quality).
+     * @return int New job ID.
+     * @throws \InvalidArgumentException on empty mediaType/sourcePath/outputFormat.
+     */
+    public function enqueue(
+        string $mediaType,
+        string $sourcePath,
+        string $outputFormat,
+        ?array $options = null
+    ): int {
+        $mediaType    = trim($mediaType);
+        $sourcePath   = trim($sourcePath);
+        $outputFormat = trim($outputFormat);
+        if ($mediaType === '') {
+            throw new \InvalidArgumentException('media_type must not be empty.');
+        }
+        if ($sourcePath === '') {
+            throw new \InvalidArgumentException('source_path must not be empty.');
+        }
+        if ($outputFormat === '') {
+            throw new \InvalidArgumentException('output_format must not be empty.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO media_conversion_jobs
+                 (media_type, source_path, output_format, options, status, created_at)
+             VALUES (:type, :src, :fmt, :opts, :status, :now)'
+        );
+        $stmt->execute([
+            ':type'   => $mediaType,
+            ':src'    => $sourcePath,
+            ':fmt'    => $outputFormat,
+            ':opts'   => $options !== null ? json_encode($options, JSON_UNESCAPED_UNICODE) : null,
+            ':status' => self::STATUS_PENDING,
+            ':now'    => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve a job by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM media_conversion_jobs WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Fetch the next N pending jobs, ordered by creation time (FIFO).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function nextPending(int $limit = 10): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM media_conversion_jobs
+             WHERE status = :status
+             ORDER BY created_at ASC, id ASC
+             LIMIT :lim'
+        );
+        $stmt->bindValue(':status', self::STATUS_PENDING);
+        $stmt->bindValue(':lim', max(1, $limit), PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Mark a job as in-progress and increment the attempt counter.
+     *
+     * @return bool True if found and updated.
+     */
+    public function start(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE media_conversion_jobs
+             SET status = :status, started_at = :now, attempts = attempts + 1
+             WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_IN_PROGRESS, ':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark a job as completed with the output file path.
+     *
+     * @return bool True if found and updated.
+     */
+    public function complete(int $id, string $outputPath): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE media_conversion_jobs
+             SET status = :status, output_path = :out, completed_at = :now
+             WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_COMPLETED, ':out' => $outputPath, ':now' => $now, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark a job as failed with an error message.
+     *
+     * @return bool True if found and updated.
+     */
+    public function fail(int $id, string $error): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE media_conversion_jobs SET status = :status, error = :error WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_FAILED, ':error' => $error, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Reset a failed job back to pending for retry.
+     *
+     * @return bool True if found and reset.
+     */
+    public function retry(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE media_conversion_jobs
+             SET status = :status, error = NULL, started_at = NULL
+             WHERE id = :id AND status = :failed'
+        );
+        $stmt->execute([
+            ':status' => self::STATUS_PENDING,
+            ':id'     => $id,
+            ':failed' => self::STATUS_FAILED,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Return jobs by status, newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function byStatus(string $status, int $limit = 50): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM media_conversion_jobs
+             WHERE status = :status
+             ORDER BY created_at DESC, id DESC
+             LIMIT :lim'
+        );
+        $stmt->bindValue(':status', $status);
+        $stmt->bindValue(':lim', max(1, $limit), PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Delete completed/failed jobs older than $cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM media_conversion_jobs
+             WHERE status IN (:completed, :failed) AND created_at < :cutoff'
+        );
+        $stmt->execute([
+            ':completed' => self::STATUS_COMPLETED,
+            ':failed'    => self::STATUS_FAILED,
+            ':cutoff'    => $cutoff,
+        ]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/MediaConversionJobTest.php
+++ b/tests/Unit/Xion/MediaConversionJobTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\MediaConversionJob;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class MediaConversionJobTest extends TestCase
+{
+    private PDO $pdo;
+    private MediaConversionJob $mc;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE media_conversion_jobs (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                media_type    VARCHAR(50)  NOT NULL,
+                source_path   TEXT         NOT NULL,
+                output_format VARCHAR(50)  NOT NULL,
+                options       TEXT         NULL,
+                status        VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                output_path   TEXT         NULL,
+                error         TEXT         NULL,
+                attempts      INTEGER      NOT NULL DEFAULT 0,
+                started_at    DATETIME     NULL,
+                completed_at  DATETIME     NULL,
+                created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->mc = new MediaConversionJob($this->pdo);
+    }
+
+    // ── enqueue ───────────────────────────────────────────────────────────────
+
+    public function testEnqueueReturnsId(): void
+    {
+        $id = $this->mc->enqueue('image', '/uploads/photo.jpg', 'webp');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testEnqueueStoresFields(): void
+    {
+        $id  = $this->mc->enqueue('image', '/uploads/photo.jpg', 'webp', ['width' => 800]);
+        $row = $this->mc->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('image', $row['media_type']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('/uploads/photo.jpg', $row['source_path']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('webp', $row['output_format']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(MediaConversionJob::STATUS_PENDING, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertStringContainsString('800', $row['options']);
+    }
+
+    public function testEnqueueThrowsOnEmptyMediaType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mc->enqueue('', '/uploads/photo.jpg', 'webp');
+    }
+
+    public function testEnqueueThrowsOnEmptySourcePath(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mc->enqueue('image', '', 'webp');
+    }
+
+    public function testEnqueueThrowsOnEmptyOutputFormat(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mc->enqueue('image', '/uploads/photo.jpg', '');
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->mc->get(9999));
+    }
+
+    // ── nextPending ───────────────────────────────────────────────────────────
+
+    public function testNextPendingReturnsFifo(): void
+    {
+        $id1 = $this->mc->enqueue('image', '/a.jpg', 'webp');
+        $id2 = $this->mc->enqueue('image', '/b.jpg', 'webp');
+        $jobs = $this->mc->nextPending(10);
+        $this->assertCount(2, $jobs);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame($id1, (int)$jobs[0]['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame($id2, (int)$jobs[1]['id']);
+    }
+
+    public function testNextPendingRespectsLimit(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->mc->enqueue('image', "/img{$i}.jpg", 'webp');
+        }
+        $this->assertCount(3, $this->mc->nextPending(3));
+    }
+
+    public function testNextPendingExcludesNonPending(): void
+    {
+        $id = $this->mc->enqueue('image', '/a.jpg', 'webp');
+        $this->mc->start($id);
+        $this->assertSame([], $this->mc->nextPending());
+    }
+
+    // ── start ─────────────────────────────────────────────────────────────────
+
+    public function testStartChangesStatus(): void
+    {
+        $id  = $this->mc->enqueue('image', '/a.jpg', 'webp');
+        $this->assertTrue($this->mc->start($id));
+        $row = $this->mc->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(MediaConversionJob::STATUS_IN_PROGRESS, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['attempts']);
+    }
+
+    public function testStartReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->mc->start(9999));
+    }
+
+    // ── complete ──────────────────────────────────────────────────────────────
+
+    public function testCompleteChangesStatus(): void
+    {
+        $id  = $this->mc->enqueue('image', '/a.jpg', 'webp');
+        $this->mc->start($id);
+        $this->assertTrue($this->mc->complete($id, '/outputs/a.webp'));
+        $row = $this->mc->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(MediaConversionJob::STATUS_COMPLETED, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('/outputs/a.webp', $row['output_path']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['completed_at']);
+    }
+
+    public function testCompleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->mc->complete(9999, '/out.webp'));
+    }
+
+    // ── fail ──────────────────────────────────────────────────────────────────
+
+    public function testFailChangesStatus(): void
+    {
+        $id  = $this->mc->enqueue('image', '/a.jpg', 'webp');
+        $this->mc->start($id);
+        $this->assertTrue($this->mc->fail($id, 'OOM error'));
+        $row = $this->mc->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(MediaConversionJob::STATUS_FAILED, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('OOM error', $row['error']);
+    }
+
+    public function testFailReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->mc->fail(9999, 'err'));
+    }
+
+    // ── retry ─────────────────────────────────────────────────────────────────
+
+    public function testRetryResetsToPending(): void
+    {
+        $id = $this->mc->enqueue('image', '/a.jpg', 'webp');
+        $this->mc->start($id);
+        $this->mc->fail($id, 'err');
+        $this->assertTrue($this->mc->retry($id));
+        $row = $this->mc->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(MediaConversionJob::STATUS_PENDING, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNull($row['error']);
+    }
+
+    public function testRetryReturnsFalseIfNotFailed(): void
+    {
+        $id = $this->mc->enqueue('image', '/a.jpg', 'webp');
+        $this->assertFalse($this->mc->retry($id)); // pending, not failed
+    }
+
+    // ── byStatus ──────────────────────────────────────────────────────────────
+
+    public function testByStatusFiltersByStatus(): void
+    {
+        $id1 = $this->mc->enqueue('image', '/a.jpg', 'webp');
+        $id2 = $this->mc->enqueue('image', '/b.jpg', 'webp');
+        $this->mc->start($id1);
+        $this->mc->complete($id1, '/a.webp');
+        $completed = $this->mc->byStatus(MediaConversionJob::STATUS_COMPLETED);
+        $this->assertCount(1, $completed);
+        $pending = $this->mc->byStatus(MediaConversionJob::STATUS_PENDING);
+        $this->assertCount(1, $pending);
+        unset($id2);
+    }
+
+    public function testByStatusReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->mc->byStatus(MediaConversionJob::STATUS_FAILED));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldTerminalJobs(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO media_conversion_jobs
+                 (media_type, source_path, output_format, status, created_at)
+             VALUES ('image', '/old.jpg', 'webp', 'completed', '2020-01-01 00:00:00')"
+        );
+        $this->pdo->exec(
+            "INSERT INTO media_conversion_jobs
+                 (media_type, source_path, output_format, status, created_at)
+             VALUES ('image', '/fail.jpg', 'webp', 'failed', '2020-01-02 00:00:00')"
+        );
+        $deleted = $this->mc->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(2, $deleted);
+    }
+
+    public function testPurgeOlderThanDoesNotDeletePending(): void
+    {
+        $id = $this->mc->enqueue('image', '/a.jpg', 'webp');
+        $this->pdo->exec("UPDATE media_conversion_jobs SET created_at = '2020-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->mc->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\MediaConversionJob` — async media processing job tracking.

## What's included
- `class/xion/MediaConversionJob.php` — helper class
- `tests/Unit/Xion/MediaConversionJobTest.php` — 21 tests, 42 assertions

## MediaConversionJob API
| Method | Description |
|---|---|
| `enqueue(mediaType, sourcePath, outputFormat, options)` | Add PENDING job |
| `get(id)` | Retrieve by ID |
| `nextPending(limit)` | Fetch next N jobs FIFO |
| `start(id)` | Mark IN_PROGRESS, increment attempts |
| `complete(id, outputPath)` | Mark COMPLETED with output path |
| `fail(id, error)` | Mark FAILED with error message |
| `retry(id)` | Reset FAILED → PENDING |
| `byStatus(status, limit)` | List jobs by status |
| `purgeOlderThan(cutoff)` | Delete old completed/failed rows |

## Schema
```sql
CREATE TABLE media_conversion_jobs (
    id            INTEGER PRIMARY KEY AUTOINCREMENT,
    media_type    VARCHAR(50)  NOT NULL,
    source_path   TEXT         NOT NULL,
    output_format VARCHAR(50)  NOT NULL,
    options       TEXT         NULL,
    status        VARCHAR(20)  NOT NULL DEFAULT 'pending',
    output_path   TEXT         NULL,
    error         TEXT         NULL,
    attempts      INTEGER      NOT NULL DEFAULT 0,
    started_at    DATETIME     NULL,
    completed_at  DATETIME     NULL,
    created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)