### PR TITLE
docs: update FT log for FT229–FT238 (Xion eighth wave)

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -14,7 +14,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ## Active candidates
 
-The Xion helper wave (FT78–FT228) is ongoing as of 2026-05-28. Trigger-based and structural candidates are listed in the next section.
+The Xion helper wave (FT78–FT238) is ongoing as of 2026-05-28. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -54,6 +54,16 @@ The Xion helper wave (FT78–FT228) is ongoing as of 2026-05-28. Trigger-based a
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT238 — MediaConversionJob** (2026-05-28): `Nene\Xion\MediaConversionJob` — async media processing FIFO queue; nextPending()/start()/complete()/fail()/retry(); attempts counter. PR #680.
+- **FT237 — SlaTracker** (2026-05-28): `Nene\Xion\SlaTracker` — SLA/SLO breach detection; start() computes deadline; pause/resume accumulates paused_seconds; breached() cron query. PR #679.
+- **FT236 — DeviceFingerprint** (2026-05-28): `Nene\Xion\DeviceFingerprint` — device recognition; SHA-256 hash; seen() cross-driver upsert increments seen_count; isTrusted()/isBlocked(). PR #678.
+- **FT235 — CreditNote** (2026-05-28): `Nene\Xion\CreditNote` — financial credit notes; integer-cent amounts; PENDING→APPLIED/VOIDED; pendingTotal() sum. PR #677.
+- **FT234 — ScoreBoard** (2026-05-28): `Nene\Xion\ScoreBoard` — high-score table; top() derives MAX(score) per player; rank() counts players with higher best; period scoping. PR #676.
+- **FT233 — ResourceReservation** (2026-05-28): `Nene\Xion\ResourceReservation` — time-bounded reservation with overlap detection; isAvailable() excludeId; forResource() range query. PR #675.
+- **FT232 — StockAlert** (2026-05-28): `Nene\Xion\StockAlert` — stock availability alerts; pendingTriggers()/markTriggered() for cron; dismiss() silences without delete. PR #674.
+- **FT231 — EntitySnapshot** (2026-05-28): `Nene\Xion\EntitySnapshot` — point-in-time entity snapshots; findAt() nearest; list() metadata only; purgeOlderThan() TTL. PR #673.
+- **FT230 — RecipientGroup** (2026-05-28): `Nene\Xion\RecipientGroup` — mailing list groups; UNIQUE slug; addMember() cross-driver upsert; isMember()/groupsFor(). PR #672.
+- **FT229 — SurveyTemplate** (2026-05-28): `Nene\Xion\SurveyTemplate` — two-table form template with typed questions; inactive by default; activate()/deactivate(). PR #671.
 - **FT210 — ResourceLock** (2026-05-27): `Nene\Xion\ResourceLock` — advisory entity locking with TTL; acquire() int|null; extend(); releaseExpired() cron cleanup. PR #650.
 - **FT209 — ContentTag** (2026-05-27): `Nene\Xion\ContentTag` — flexible entity tagging; tags normalised to lowercase slugs; cloud() tag→count; entitiesWith() reverse lookup. PR #649.
 - **FT208 — DeviceToken** (2026-05-27): `Nene\Xion\DeviceToken` — push notification device token management per user; register() reactivates existing; deleteInactive() cleanup. PR #648.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT228 complete as of 2026-05-28 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT238 complete as of 2026-05-28 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 
@@ -241,6 +241,7 @@ Completed (wave summary):
 - **FT196–FT200**: Xion fifth extended wave. 5 trials covering CSV import job tracking with per-row errors, topic-based pub/sub subscriptions, e-commerce orders with line items, deployment version history, and user cohort/segment assignment. PRs #635–#639.
 - **FT201–FT210**: Xion sixth extended wave. 10 trials covering inventory stock tracking with atomic reserve/commit, work time entries with start/stop timers, appointment time slot booking with capacity, external API call logging, GDPR data-subject request tracking, product/feature waitlist management, regional tax rate calculation, push notification device token management, flexible entity tagging with tag clouds, and advisory resource locking with TTL. PRs #641–#650.
 - **FT211–FT228**: Xion seventh extended wave. 18 trials covering product price catalog with tiers, compliance audit log with before/after snapshots, loyalty point ledger, flat entity comments, survey/form response collection, product bundle catalog, channel-agnostic notification queue, persistent stateful workflow instances, type-ahead search suggestion management, metered billing usage tracking, multiple entity identifier aliases, multi-device session management, ordered page builder content blocks, database-backed multilingual content, service health monitoring, page/resource view analytics, contact form inbox management, and time-bounded access delegation. PRs #652–#669.
+- **FT229–FT238**: Xion eighth extended wave. 10 trials covering form/survey template definitions with questions, mailing list recipient group management, point-in-time entity state snapshots, stock/availability alert registrations with cron batch processing, time-bounded resource reservation with overlap detection, high-score leaderboard with personal-best tracking, financial credit notes with lifecycle management, device fingerprint recognition for fraud detection, SLA/SLO breach detection with pause/resume, and async media processing job tracking. PRs #671–#680.
 
 Future candidates:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,24 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-28: all non-promotion Issues are closed; FT1–FT228 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-28: all non-promotion Issues are closed; FT1–FT238 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-28 — FT229–FT238: Xion eighth extended wave (10 trials)
+
+Continuous wave of 10 field trials adding further Xion helper patterns. All PRs #671–#680.
+
+**FT229 — SurveyTemplate**: `SurveyTemplate` two-table form/survey template definitions with typed questions (text/textarea/number/select/radio/checkbox); inactive by default. PR #671.
+**FT230 — RecipientGroup**: `RecipientGroup` mailing list / recipient group management; UNIQUE slug; addMember() cross-driver upsert; isMember()/groupsFor(). PR #672.
+**FT231 — EntitySnapshot**: `EntitySnapshot` point-in-time entity state snapshots; findAt() nearest snapshot; list() returns metadata only; purgeOlderThan() TTL. PR #673.
+**FT232 — StockAlert**: `StockAlert` stock/availability alert registrations; cron batch via pendingTriggers()/markTriggered(); dismiss() silences without delete. PR #674.
+**FT233 — ResourceReservation**: `ResourceReservation` time-bounded reservation with overlap detection; isAvailable() excludeId for re-booking; forResource() range query. PR #675.
+**FT234 — ScoreBoard**: `ScoreBoard` high-score table with personal-best per player; top() derives MAX(score) per player; rank() counts players with higher best. PR #676.
+**FT235 — CreditNote**: `CreditNote` financial credit notes against any entity; integer-cent amounts; PENDING→APPLIED/VOIDED lifecycle; pendingTotal() sum. PR #677.
+**FT236 — DeviceFingerprint**: `DeviceFingerprint` device recognition for fraud detection; SHA-256 hash storage; seen() cross-driver upsert increments seen_count; isTrusted()/isBlocked(). PR #678.
+**FT237 — SlaTracker**: `SlaTracker` SLA/SLO breach detection; start() computes deadline from duration; pause/resume accumulates paused_seconds; breached() cron query. PR #679.
+**FT238 — MediaConversionJob**: `MediaConversionJob` async media processing FIFO queue; nextPending()/start()/complete()/fail()/retry(); attempts counter for backoff. PR #680.
 
 ### 2026-05-28 — FT211–FT228: Xion seventh extended wave (18 trials)
 


### PR DESCRIPTION
Updates roadmap, todo, and candidates for the FT229–FT238 Xion eighth extended wave.

- roadmap.md: FT1–FT238 complete; wave summary added
- todo/current.md: per-FT details for all 10 trials (PRs #671–#680)
- candidates.md: archive entries for FT229–FT238

🤖 Generated with [Claude Code](https://claude.com/claude-code)