### PR TITLE
feat(xion): add PresenceTracker helper (FT241)

### DIFF
--- a/class/xion/PresenceTracker.php
+++ b/class/xion/PresenceTracker.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * PresenceTracker — user online presence and last-seen tracking.
+ *
+ * Records when a user was last active so the application can show
+ * "online", "recently active", or "offline" indicators. A heartbeat
+ * call updates the last-seen timestamp; presence is derived by comparing
+ * that timestamp against a configurable "online window" in seconds.
+ *
+ * Per-room or per-channel presence is supported through an optional
+ * $context string.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $pt = new PresenceTracker($pdo);
+ *
+ * // User activity (call from each page load or heartbeat endpoint)
+ * $pt->ping('user-1');
+ *
+ * // Who's online right now? (active in the last 5 minutes)
+ * $online = $pt->online(300);
+ *
+ * // Is a specific user online?
+ * if ($pt->isOnline('user-1', 300)) { ... }
+ *
+ * // Channel presence
+ * $pt->ping('user-1', 'room:lobby');
+ * $inRoom = $pt->onlineIn('room:lobby', 300);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE presence_tracker (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id      VARCHAR(255) NOT NULL,
+ *     context      VARCHAR(255) NOT NULL DEFAULT '',
+ *     last_seen_at DATETIME     NOT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (user_id, context)
+ * );
+ * ```
+ */
+final class PresenceTracker
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record that a user was just seen (heartbeat).
+     *
+     * Creates the row on first call; updates last_seen_at on subsequent calls.
+     *
+     * @throws \InvalidArgumentException on empty userId.
+     */
+    public function ping(string $userId, string $context = ''): void
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+
+        $now    = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $stmt = $this->db()->prepare(
+                'INSERT INTO presence_tracker (user_id, context, last_seen_at, created_at)
+                 VALUES (:uid, :ctx, :now, :now2)
+                 ON CONFLICT (user_id, context) DO UPDATE SET
+                     last_seen_at = excluded.last_seen_at'
+            );
+        } else {
+            $stmt = $this->db()->prepare(
+                'INSERT INTO presence_tracker (user_id, context, last_seen_at, created_at)
+                 VALUES (:uid, :ctx, :now, :now2)
+                 ON DUPLICATE KEY UPDATE
+                     last_seen_at = VALUES(last_seen_at)'
+            );
+        }
+        $stmt->execute([':uid' => $userId, ':ctx' => $context, ':now' => $now, ':now2' => $now]);
+    }
+
+    /**
+     * Return the last-seen record for a user (and optional context).
+     *
+     * @return array<string,mixed>|null
+     */
+    public function lastSeen(string $userId, string $context = ''): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM presence_tracker WHERE user_id = :uid AND context = :ctx'
+        );
+        $stmt->execute([':uid' => trim($userId), ':ctx' => $context]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Return true if the user was seen within $windowSeconds.
+     *
+     * @param int $windowSeconds Seconds to consider "online" (default 300 = 5 min).
+     */
+    public function isOnline(string $userId, int $windowSeconds = 300, string $context = ''): bool
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$windowSeconds} seconds")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'SELECT COUNT(*) FROM presence_tracker
+             WHERE user_id = :uid AND context = :ctx AND last_seen_at >= :cutoff'
+        );
+        $stmt->execute([':uid' => trim($userId), ':ctx' => $context, ':cutoff' => $cutoff]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Return all users seen within $windowSeconds (globally or in a context).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function online(int $windowSeconds = 300, string $context = ''): array
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$windowSeconds} seconds")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'SELECT * FROM presence_tracker
+             WHERE context = :ctx AND last_seen_at >= :cutoff
+             ORDER BY last_seen_at DESC, id DESC'
+        );
+        $stmt->execute([':ctx' => $context, ':cutoff' => $cutoff]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Return all users online in a specific context within $windowSeconds.
+     *
+     * Alias for online() with a non-empty context.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function onlineIn(string $context, int $windowSeconds = 300): array
+    {
+        return $this->online($windowSeconds, $context);
+    }
+
+    /**
+     * Count users seen within $windowSeconds in a context.
+     */
+    public function countOnline(int $windowSeconds = 300, string $context = ''): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$windowSeconds} seconds")->format('Y-m-d H:i:s');
+        $stmt   = $this->db()->prepare(
+            'SELECT COUNT(*) FROM presence_tracker
+             WHERE context = :ctx AND last_seen_at >= :cutoff'
+        );
+        $stmt->execute([':ctx' => $context, ':cutoff' => $cutoff]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Remove a user's presence record for a context (e.g. explicit "leave room").
+     *
+     * @return bool True if found and removed.
+     */
+    public function leave(string $userId, string $context = ''): bool
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM presence_tracker WHERE user_id = :uid AND context = :ctx'
+        );
+        $stmt->execute([':uid' => trim($userId), ':ctx' => $context]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Remove all presence records for a user (across all contexts).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function removeUser(string $userId): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM presence_tracker WHERE user_id = :uid');
+        $stmt->execute([':uid' => trim($userId)]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Delete presence records not updated since $cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM presence_tracker WHERE last_seen_at < :cutoff');
+        $stmt->execute([':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/PresenceTrackerTest.php
+++ b/tests/Unit/Xion/PresenceTrackerTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\PresenceTracker;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class PresenceTrackerTest extends TestCase
+{
+    private PDO $pdo;
+    private PresenceTracker $pt;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE presence_tracker (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id      VARCHAR(255) NOT NULL,
+                context      VARCHAR(255) NOT NULL DEFAULT \'\',
+                last_seen_at DATETIME     NOT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (user_id, context)
+            )
+        ');
+        $this->pt = new PresenceTracker($this->pdo);
+    }
+
+    // ── ping ──────────────────────────────────────────────────────────────────
+
+    public function testPingCreatesRecord(): void
+    {
+        $this->pt->ping('user-1');
+        $row = $this->pt->lastSeen('user-1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['user_id']);
+    }
+
+    public function testPingIsIdempotent(): void
+    {
+        $this->pt->ping('user-1');
+        $this->pt->ping('user-1');
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM presence_tracker WHERE user_id = 'user-1'");
+        $this->assertNotFalse($stmt);
+        $this->assertSame(1, (int)$stmt->fetchColumn());
+    }
+
+    public function testPingThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pt->ping('');
+    }
+
+    public function testPingWithContext(): void
+    {
+        $this->pt->ping('user-1', 'room:lobby');
+        $row = $this->pt->lastSeen('user-1', 'room:lobby');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('room:lobby', $row['context']);
+    }
+
+    public function testPingCreatesDistinctRowsPerContext(): void
+    {
+        $this->pt->ping('user-1');
+        $this->pt->ping('user-1', 'room:lobby');
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM presence_tracker WHERE user_id = 'user-1'");
+        $this->assertNotFalse($stmt);
+        $this->assertSame(2, (int)$stmt->fetchColumn());
+    }
+
+    // ── lastSeen ──────────────────────────────────────────────────────────────
+
+    public function testLastSeenReturnsNullWhenNotPinged(): void
+    {
+        $this->assertNull($this->pt->lastSeen('user-99'));
+    }
+
+    // ── isOnline ──────────────────────────────────────────────────────────────
+
+    public function testIsOnlineTrueWhenRecentlyPinged(): void
+    {
+        $this->pt->ping('user-1');
+        $this->assertTrue($this->pt->isOnline('user-1', 300));
+    }
+
+    public function testIsOnlineFalseWhenNotPinged(): void
+    {
+        $this->assertFalse($this->pt->isOnline('user-99', 300));
+    }
+
+    public function testIsOnlineFalseWhenLastSeenTooLongAgo(): void
+    {
+        // Manually insert an old record
+        $this->pdo->exec(
+            "INSERT INTO presence_tracker (user_id, context, last_seen_at, created_at)
+             VALUES ('user-1', '', '2020-01-01 00:00:00', '2020-01-01 00:00:00')"
+        );
+        $this->assertFalse($this->pt->isOnline('user-1', 300));
+    }
+
+    // ── online ────────────────────────────────────────────────────────────────
+
+    public function testOnlineReturnsRecentUsers(): void
+    {
+        $this->pt->ping('user-1');
+        $this->pt->ping('user-2');
+        $this->assertCount(2, $this->pt->online(300));
+    }
+
+    public function testOnlineExcludesOldRecords(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO presence_tracker (user_id, context, last_seen_at, created_at)
+             VALUES ('user-old', '', '2020-01-01 00:00:00', '2020-01-01 00:00:00')"
+        );
+        $this->assertSame([], $this->pt->online(300));
+    }
+
+    public function testOnlineIsIsolatedByContext(): void
+    {
+        $this->pt->ping('user-1');
+        $this->pt->ping('user-2', 'room:lobby');
+        $global = $this->pt->online(300, '');
+        $lobby  = $this->pt->online(300, 'room:lobby');
+        $this->assertCount(1, $global);
+        $this->assertCount(1, $lobby);
+    }
+
+    // ── onlineIn ──────────────────────────────────────────────────────────────
+
+    public function testOnlineInReturnsUsersInContext(): void
+    {
+        $this->pt->ping('user-1', 'room:lobby');
+        $this->pt->ping('user-2', 'room:lobby');
+        $this->pt->ping('user-3', 'room:general');
+        $this->assertCount(2, $this->pt->onlineIn('room:lobby'));
+        $this->assertCount(1, $this->pt->onlineIn('room:general'));
+    }
+
+    // ── countOnline ───────────────────────────────────────────────────────────
+
+    public function testCountOnline(): void
+    {
+        $this->pt->ping('user-1');
+        $this->pt->ping('user-2');
+        $this->assertSame(2, $this->pt->countOnline(300));
+    }
+
+    public function testCountOnlineIsZeroWhenNone(): void
+    {
+        $this->assertSame(0, $this->pt->countOnline(300));
+    }
+
+    // ── leave ─────────────────────────────────────────────────────────────────
+
+    public function testLeaveRemovesRecord(): void
+    {
+        $this->pt->ping('user-1', 'room:lobby');
+        $this->assertTrue($this->pt->leave('user-1', 'room:lobby'));
+        $this->assertNull($this->pt->lastSeen('user-1', 'room:lobby'));
+    }
+
+    public function testLeaveReturnsFalseWhenNotPresent(): void
+    {
+        $this->assertFalse($this->pt->leave('user-99'));
+    }
+
+    public function testLeaveDoesNotRemoveOtherContexts(): void
+    {
+        $this->pt->ping('user-1');
+        $this->pt->ping('user-1', 'room:lobby');
+        $this->pt->leave('user-1', 'room:lobby');
+        $this->assertNotNull($this->pt->lastSeen('user-1')); // global still present
+    }
+
+    // ── removeUser ────────────────────────────────────────────────────────────
+
+    public function testRemoveUserDeletesAllContexts(): void
+    {
+        $this->pt->ping('user-1');
+        $this->pt->ping('user-1', 'room:lobby');
+        $deleted = $this->pt->removeUser('user-1');
+        $this->assertSame(2, $deleted);
+        $this->assertNull($this->pt->lastSeen('user-1'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldRecords(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO presence_tracker (user_id, context, last_seen_at, created_at)
+             VALUES ('user-1', '', '2020-01-01 00:00:00', '2020-01-01 00:00:00')"
+        );
+        $deleted = $this->pt->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(1, $deleted);
+    }
+
+    public function testPurgeOlderThanDoesNotDeleteRecent(): void
+    {
+        $this->pt->ping('user-1');
+        $deleted = $this->pt->purgeOlderThan('2020-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\PresenceTracker` — user online presence and last-seen tracking.

## What's included
- `class/xion/PresenceTracker.php` — helper class
- `tests/Unit/Xion/PresenceTrackerTest.php` — 21 tests, 29 assertions

## PresenceTracker API
| Method | Description |
|---|---|
| `ping(userId, context)` | Record heartbeat; cross-driver upsert |
| `lastSeen(userId, context)` | Get last-seen record |
| `isOnline(userId, windowSeconds, context)` | Check presence within window |
| `online(windowSeconds, context)` | List users seen within window |
| `onlineIn(context, windowSeconds)` | Alias for channel/room presence |
| `countOnline(windowSeconds, context)` | Count online users |
| `leave(userId, context)` | Explicit departure |
| `removeUser(userId)` | Remove all contexts for a user |
| `purgeOlderThan(cutoff)` | Delete old presence records |

## Schema
```sql
CREATE TABLE presence_tracker (
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    user_id      VARCHAR(255) NOT NULL,
    context      VARCHAR(255) NOT NULL DEFAULT '',
    last_seen_at DATETIME     NOT NULL,
    created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
    UNIQUE (user_id, context)
);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)