### PR TITLE
feat(xion): add IncidentLog helper (FT243)

### DIFF
--- a/class/xion/IncidentLog.php
+++ b/class/xion/IncidentLog.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * IncidentLog — IT/service incident tracking with severity and lifecycle.
+ *
+ * Tracks service incidents from detection through resolution. Incidents
+ * have a severity level (P1–P4) and a lifecycle: OPEN → INVESTIGATING →
+ * RESOLVED → CLOSED. Timeline events are appended as the incident
+ * progresses so post-mortem analysis is possible.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $il = new IncidentLog($pdo);
+ *
+ * // Open a P1 incident
+ * $id = $il->open('Payment service outage', IncidentLog::SEVERITY_P1);
+ *
+ * // Transition through lifecycle
+ * $il->investigate($id);
+ * $il->addEvent($id, 'Root cause identified: DB connection pool exhausted.');
+ * $il->resolve($id, 'Increased connection pool size; service restored.');
+ * $il->close($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE incident_logs (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     title        TEXT         NOT NULL,
+ *     severity     VARCHAR(10)  NOT NULL DEFAULT 'P3',
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'open',
+ *     description  TEXT         NULL,
+ *     resolution   TEXT         NULL,
+ *     opened_at    DATETIME     NOT NULL,
+ *     resolved_at  DATETIME     NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ *
+ * CREATE TABLE incident_events (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     incident_id  INTEGER      NOT NULL,
+ *     message      TEXT         NOT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class IncidentLog
+{
+    public const SEVERITY_P1 = 'P1';
+    public const SEVERITY_P2 = 'P2';
+    public const SEVERITY_P3 = 'P3';
+    public const SEVERITY_P4 = 'P4';
+
+    public const STATUS_OPEN          = 'open';
+    public const STATUS_INVESTIGATING = 'investigating';
+    public const STATUS_RESOLVED      = 'resolved';
+    public const STATUS_CLOSED        = 'closed';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Open a new incident.
+     *
+     * @return int New incident ID.
+     * @throws \InvalidArgumentException on empty title or invalid severity.
+     */
+    public function open(string $title, string $severity = self::SEVERITY_P3, ?string $description = null): int
+    {
+        $title = trim($title);
+        if ($title === '') {
+            throw new \InvalidArgumentException('title must not be empty.');
+        }
+        if (!in_array($severity, [self::SEVERITY_P1, self::SEVERITY_P2, self::SEVERITY_P3, self::SEVERITY_P4], true)) {
+            throw new \InvalidArgumentException('severity must be P1, P2, P3, or P4.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO incident_logs
+                 (title, severity, status, description, opened_at, created_at)
+             VALUES (:title, :sev, :status, :desc, :now, :now2)'
+        );
+        $stmt->execute([
+            ':title'  => $title,
+            ':sev'    => $severity,
+            ':status' => self::STATUS_OPEN,
+            ':desc'   => $description,
+            ':now'    => $now,
+            ':now2'   => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve an incident by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM incident_logs WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Transition an incident to INVESTIGATING.
+     *
+     * @return bool True if found and updated.
+     */
+    public function investigate(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE incident_logs SET status = :status WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_INVESTIGATING, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Resolve an incident with an optional resolution note.
+     *
+     * @return bool True if found and updated.
+     */
+    public function resolve(int $id, ?string $resolution = null): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE incident_logs
+             SET status = :status, resolution = :resolution, resolved_at = :now
+             WHERE id = :id'
+        );
+        $stmt->execute([
+            ':status'     => self::STATUS_RESOLVED,
+            ':resolution' => $resolution,
+            ':now'        => $now,
+            ':id'         => $id,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Close a resolved incident (post-mortem complete).
+     *
+     * @return bool True if found and updated.
+     */
+    public function close(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE incident_logs SET status = :status WHERE id = :id'
+        );
+        $stmt->execute([':status' => self::STATUS_CLOSED, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Update the severity of an open incident.
+     *
+     * @return bool True if found and updated.
+     * @throws \InvalidArgumentException on invalid severity.
+     */
+    public function updateSeverity(int $id, string $severity): bool
+    {
+        if (!in_array($severity, [self::SEVERITY_P1, self::SEVERITY_P2, self::SEVERITY_P3, self::SEVERITY_P4], true)) {
+            throw new \InvalidArgumentException('severity must be P1, P2, P3, or P4.');
+        }
+        $stmt = $this->db()->prepare('UPDATE incident_logs SET severity = :sev WHERE id = :id');
+        $stmt->execute([':sev' => $severity, ':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Append a timeline event message to an incident.
+     *
+     * @return int New event ID.
+     * @throws \InvalidArgumentException on empty message.
+     */
+    public function addEvent(int $incidentId, string $message): int
+    {
+        $message = trim($message);
+        if ($message === '') {
+            throw new \InvalidArgumentException('message must not be empty.');
+        }
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO incident_events (incident_id, message, created_at) VALUES (:iid, :msg, :now)'
+        );
+        $stmt->execute([':iid' => $incidentId, ':msg' => $message, ':now' => $now]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Return all timeline events for an incident, oldest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function events(int $incidentId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM incident_events WHERE incident_id = :iid ORDER BY created_at ASC, id ASC'
+        );
+        $stmt->execute([':iid' => $incidentId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List open/investigating incidents, most severe first (P1 before P4).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function listOpen(): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM incident_logs
+             WHERE status IN (:open, :investigating)
+             ORDER BY severity ASC, opened_at ASC, id ASC'
+        );
+        $stmt->execute([':open' => self::STATUS_OPEN, ':investigating' => self::STATUS_INVESTIGATING]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List incidents by severity.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function bySeverity(string $severity): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM incident_logs WHERE severity = :sev ORDER BY opened_at DESC, id DESC'
+        );
+        $stmt->execute([':sev' => $severity]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Delete closed incidents older than $cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $cutoff): int
+    {
+        // Find IDs to purge first so we can delete events too
+        $stmt = $this->db()->prepare(
+            'SELECT id FROM incident_logs WHERE status = :closed AND created_at < :cutoff'
+        );
+        $stmt->execute([':closed' => self::STATUS_CLOSED, ':cutoff' => $cutoff]);
+        $ids = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        if (empty($ids)) {
+            return 0;
+        }
+
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $del = $this->db()->prepare("DELETE FROM incident_events WHERE incident_id IN ({$placeholders})");
+        $del->execute($ids);
+
+        $del = $this->db()->prepare("DELETE FROM incident_logs WHERE id IN ({$placeholders})");
+        $del->execute($ids);
+        return $del->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/IncidentLogTest.php
+++ b/tests/Unit/Xion/IncidentLogTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\IncidentLog;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class IncidentLogTest extends TestCase
+{
+    private PDO $pdo;
+    private IncidentLog $il;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE incident_logs (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                title        TEXT         NOT NULL,
+                severity     VARCHAR(10)  NOT NULL DEFAULT \'P3\',
+                status       VARCHAR(20)  NOT NULL DEFAULT \'open\',
+                description  TEXT         NULL,
+                resolution   TEXT         NULL,
+                opened_at    DATETIME     NOT NULL,
+                resolved_at  DATETIME     NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->pdo->exec('
+            CREATE TABLE incident_events (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                incident_id  INTEGER      NOT NULL,
+                message      TEXT         NOT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->il = new IncidentLog($this->pdo);
+    }
+
+    // ── open ──────────────────────────────────────────────────────────────────
+
+    public function testOpenReturnsId(): void
+    {
+        $id = $this->il->open('DB outage', IncidentLog::SEVERITY_P1);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testOpenStoresFields(): void
+    {
+        $id  = $this->il->open('DB outage', IncidentLog::SEVERITY_P1, 'Primary DB unreachable.');
+        $row = $this->il->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('DB outage', $row['title']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(IncidentLog::SEVERITY_P1, $row['severity']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(IncidentLog::STATUS_OPEN, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Primary DB unreachable.', $row['description']);
+    }
+
+    public function testOpenThrowsOnEmptyTitle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->il->open('', IncidentLog::SEVERITY_P2);
+    }
+
+    public function testOpenThrowsOnInvalidSeverity(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->il->open('Title', 'P5');
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->il->get(9999));
+    }
+
+    // ── investigate ───────────────────────────────────────────────────────────
+
+    public function testInvestigateChangesStatus(): void
+    {
+        $id  = $this->il->open('DB outage', IncidentLog::SEVERITY_P1);
+        $this->assertTrue($this->il->investigate($id));
+        $row = $this->il->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(IncidentLog::STATUS_INVESTIGATING, $row['status']);
+    }
+
+    public function testInvestigateReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->il->investigate(9999));
+    }
+
+    // ── resolve ───────────────────────────────────────────────────────────────
+
+    public function testResolveChangesStatus(): void
+    {
+        $id  = $this->il->open('DB outage', IncidentLog::SEVERITY_P1);
+        $this->assertTrue($this->il->resolve($id, 'Failover completed.'));
+        $row = $this->il->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(IncidentLog::STATUS_RESOLVED, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Failover completed.', $row['resolution']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['resolved_at']);
+    }
+
+    public function testResolveReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->il->resolve(9999));
+    }
+
+    // ── close ─────────────────────────────────────────────────────────────────
+
+    public function testCloseChangesStatus(): void
+    {
+        $id  = $this->il->open('DB outage', IncidentLog::SEVERITY_P1);
+        $this->il->resolve($id);
+        $this->assertTrue($this->il->close($id));
+        $row = $this->il->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(IncidentLog::STATUS_CLOSED, $row['status']);
+    }
+
+    public function testCloseReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->il->close(9999));
+    }
+
+    // ── updateSeverity ────────────────────────────────────────────────────────
+
+    public function testUpdateSeverityChanges(): void
+    {
+        $id  = $this->il->open('DB outage', IncidentLog::SEVERITY_P3);
+        $this->assertTrue($this->il->updateSeverity($id, IncidentLog::SEVERITY_P1));
+        $row = $this->il->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(IncidentLog::SEVERITY_P1, $row['severity']);
+    }
+
+    public function testUpdateSeverityThrowsOnInvalid(): void
+    {
+        $id = $this->il->open('DB outage', IncidentLog::SEVERITY_P3);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->il->updateSeverity($id, 'P0');
+    }
+
+    // ── addEvent / events ─────────────────────────────────────────────────────
+
+    public function testAddEventReturnsId(): void
+    {
+        $id  = $this->il->open('DB outage', IncidentLog::SEVERITY_P1);
+        $eid = $this->il->addEvent($id, 'On-call engineer paged.');
+        $this->assertGreaterThan(0, $eid);
+    }
+
+    public function testAddEventThrowsOnEmptyMessage(): void
+    {
+        $id = $this->il->open('DB outage', IncidentLog::SEVERITY_P1);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->il->addEvent($id, '');
+    }
+
+    public function testEventsReturnsAllOldestFirst(): void
+    {
+        $id = $this->il->open('DB outage', IncidentLog::SEVERITY_P1);
+        $e1 = $this->il->addEvent($id, 'Event 1');
+        $e2 = $this->il->addEvent($id, 'Event 2');
+        $list = $this->il->events($id);
+        $this->assertCount(2, $list);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame($e1, (int)$list[0]['id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame($e2, (int)$list[1]['id']);
+    }
+
+    public function testEventsReturnsEmptyWhenNone(): void
+    {
+        $id = $this->il->open('DB outage', IncidentLog::SEVERITY_P1);
+        $this->assertSame([], $this->il->events($id));
+    }
+
+    // ── listOpen ──────────────────────────────────────────────────────────────
+
+    public function testListOpenReturnsOpenAndInvestigating(): void
+    {
+        $id1 = $this->il->open('Inc 1', IncidentLog::SEVERITY_P2);
+        $id2 = $this->il->open('Inc 2', IncidentLog::SEVERITY_P1);
+        $this->il->investigate($id1);
+        $list = $this->il->listOpen();
+        $this->assertCount(2, $list);
+        // P1 should come before P2 (ordered by severity ASC = alphabetical P1 < P2)
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame($id2, (int)$list[0]['id']);
+        unset($id1);
+    }
+
+    public function testListOpenExcludesResolvedAndClosed(): void
+    {
+        $id = $this->il->open('Inc 1', IncidentLog::SEVERITY_P3);
+        $this->il->resolve($id);
+        $this->assertSame([], $this->il->listOpen());
+    }
+
+    // ── bySeverity ────────────────────────────────────────────────────────────
+
+    public function testBySeverityFilters(): void
+    {
+        $this->il->open('P1 inc', IncidentLog::SEVERITY_P1);
+        $this->il->open('P3 inc', IncidentLog::SEVERITY_P3);
+        $this->assertCount(1, $this->il->bySeverity(IncidentLog::SEVERITY_P1));
+        $this->assertCount(1, $this->il->bySeverity(IncidentLog::SEVERITY_P3));
+    }
+
+    public function testBySeverityReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->il->bySeverity(IncidentLog::SEVERITY_P2));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesClosedIncidentsAndEvents(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO incident_logs (title, severity, status, opened_at, created_at)
+             VALUES ('Old', 'P3', 'closed', '2020-01-01', '2020-01-01 00:00:00')"
+        );
+        $oldId = (int)$this->pdo->lastInsertId();
+        $this->pdo->exec(
+            "INSERT INTO incident_events (incident_id, message, created_at)
+             VALUES ({$oldId}, 'Old event', '2020-01-01 00:00:00')"
+        );
+        $deleted = $this->il->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(1, $deleted);
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM incident_events WHERE incident_id = {$oldId}");
+        $this->assertNotFalse($stmt);
+        $this->assertSame(0, (int)$stmt->fetchColumn());
+    }
+
+    public function testPurgeOlderThanDoesNotDeleteOpen(): void
+    {
+        $id = $this->il->open('Open inc', IncidentLog::SEVERITY_P3);
+        $this->pdo->exec("UPDATE incident_logs SET created_at = '2020-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->il->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Nene\Xion\IncidentLog` — IT/service incident tracking with severity and lifecycle.

## What's included
- `class/xion/IncidentLog.php` — helper class
- `tests/Unit/Xion/IncidentLogTest.php` — 23 tests, 43 assertions

## IncidentLog API
| Method | Description |
|---|---|
| `open(title, severity, description)` | Create P1–P4 incident |
| `get(id)` | Retrieve by ID |
| `investigate(id)` | Transition to INVESTIGATING |
| `resolve(id, resolution)` | Mark RESOLVED with note |
| `close(id)` | Close after post-mortem |
| `updateSeverity(id, severity)` | Escalate/de-escalate |
| `addEvent(incidentId, message)` | Append timeline event |
| `events(incidentId)` | All timeline events oldest-first |
| `listOpen()` | Active incidents ordered P1→P4 |
| `bySeverity(severity)` | Filter by severity |
| `purgeOlderThan(cutoff)` | Delete closed incidents + events |

🤖 Generated with [Claude Code](https://claude.com/claude-code)