### PR TITLE
feat(xion): ChangeRequest — RFC change-management approval workflow (FT244)

### DIFF
--- a/class/xion/ChangeRequest.php
+++ b/class/xion/ChangeRequest.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ChangeRequest — formal RFC / change-management approval workflow.
+ *
+ * Implements the classic Request For Change (RFC) pattern used in IT
+ * change management (ITIL-inspired). A proposer submits a change request
+ * for review; one or more reviewers approve or reject it; once approved
+ * the change is implemented and then closed.
+ *
+ * Distinct from:
+ * - `Approval` (generic single-approver approval)
+ * - `ChangeLog` (append-only log of changes that already happened)
+ * - `WorkflowInstance` (general-purpose stateful workflow)
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cr = new ChangeRequest($pdo);
+ *
+ * // Propose a change
+ * $id = $cr->propose('user-1', 'Update DB connection pool size', 'Increase from 10 to 50.');
+ *
+ * // Reviewer approves
+ * $cr->approve($id, 'user-2', 'Looks good.');
+ *
+ * // Implementer marks it done
+ * $cr->implement($id);
+ * $cr->close($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE change_requests (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     proposer_id  VARCHAR(255) NOT NULL,
+ *     title        TEXT         NOT NULL,
+ *     description  TEXT         NULL,
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'draft',
+ *     reviewer_id  VARCHAR(255) NULL,
+ *     reviewer_note TEXT        NULL,
+ *     decided_at   DATETIME     NULL,
+ *     implemented_at DATETIME   NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ChangeRequest
+{
+    public const STATUS_DRAFT       = 'draft';
+    public const STATUS_SUBMITTED   = 'submitted';
+    public const STATUS_APPROVED    = 'approved';
+    public const STATUS_REJECTED    = 'rejected';
+    public const STATUS_IMPLEMENTED = 'implemented';
+    public const STATUS_CLOSED      = 'closed';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create a change request as a draft.
+     *
+     * @return int New change request ID.
+     * @throws \InvalidArgumentException on empty proposerId or title.
+     */
+    public function propose(string $proposerId, string $title, ?string $description = null): int
+    {
+        $proposerId = trim($proposerId);
+        $title      = trim($title);
+        if ($proposerId === '') {
+            throw new \InvalidArgumentException('proposer_id must not be empty.');
+        }
+        if ($title === '') {
+            throw new \InvalidArgumentException('title must not be empty.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO change_requests
+                 (proposer_id, title, description, status, created_at)
+             VALUES (:pid, :title, :desc, :status, :now)'
+        );
+        $stmt->execute([
+            ':pid'    => $proposerId,
+            ':title'  => $title,
+            ':desc'   => $description,
+            ':status' => self::STATUS_DRAFT,
+            ':now'    => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve a change request by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM change_requests WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Submit the change request for review (DRAFT → SUBMITTED).
+     *
+     * @return bool True if found and updated.
+     */
+    public function submit(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE change_requests SET status = :status WHERE id = :id AND status = :draft'
+        );
+        $stmt->execute([':status' => self::STATUS_SUBMITTED, ':id' => $id, ':draft' => self::STATUS_DRAFT]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Approve a submitted change request.
+     *
+     * @throws \RuntimeException if the change request is not in SUBMITTED status.
+     * @return bool True if found and updated.
+     */
+    public function approve(int $id, string $reviewerId, ?string $note = null): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE change_requests
+             SET status = :status, reviewer_id = :rid, reviewer_note = :note, decided_at = :now
+             WHERE id = :id AND status = :submitted'
+        );
+        $stmt->execute([
+            ':status'    => self::STATUS_APPROVED,
+            ':rid'       => trim($reviewerId),
+            ':note'      => $note,
+            ':now'       => $now,
+            ':id'        => $id,
+            ':submitted' => self::STATUS_SUBMITTED,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Reject a submitted change request.
+     *
+     * @return bool True if found and updated.
+     */
+    public function reject(int $id, string $reviewerId, ?string $note = null): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE change_requests
+             SET status = :status, reviewer_id = :rid, reviewer_note = :note, decided_at = :now
+             WHERE id = :id AND status = :submitted'
+        );
+        $stmt->execute([
+            ':status'    => self::STATUS_REJECTED,
+            ':rid'       => trim($reviewerId),
+            ':note'      => $note,
+            ':now'       => $now,
+            ':id'        => $id,
+            ':submitted' => self::STATUS_SUBMITTED,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Mark an approved change request as implemented.
+     *
+     * @return bool True if found and updated.
+     */
+    public function implement(int $id): bool
+    {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'UPDATE change_requests
+             SET status = :status, implemented_at = :now
+             WHERE id = :id AND status = :approved'
+        );
+        $stmt->execute([
+            ':status'   => self::STATUS_IMPLEMENTED,
+            ':now'      => $now,
+            ':id'       => $id,
+            ':approved' => self::STATUS_APPROVED,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Close an implemented change request.
+     *
+     * @return bool True if found and updated.
+     */
+    public function close(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE change_requests SET status = :status WHERE id = :id AND status = :implemented'
+        );
+        $stmt->execute([
+            ':status'      => self::STATUS_CLOSED,
+            ':id'          => $id,
+            ':implemented' => self::STATUS_IMPLEMENTED,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * List change requests by status, newest first.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function byStatus(string $status): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM change_requests WHERE status = :status ORDER BY created_at DESC, id DESC'
+        );
+        $stmt->execute([':status' => $status]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * List all change requests by a proposer.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function byProposer(string $proposerId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM change_requests WHERE proposer_id = :pid ORDER BY created_at DESC, id DESC'
+        );
+        $stmt->execute([':pid' => trim($proposerId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Delete closed/rejected change requests older than $cutoff.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM change_requests
+             WHERE status IN (:closed, :rejected) AND created_at < :cutoff'
+        );
+        $stmt->execute([
+            ':closed'   => self::STATUS_CLOSED,
+            ':rejected' => self::STATUS_REJECTED,
+            ':cutoff'   => $cutoff,
+        ]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/ChangeRequestTest.php
+++ b/tests/Unit/Xion/ChangeRequestTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\ChangeRequest;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ChangeRequestTest extends TestCase
+{
+    private PDO $pdo;
+    private ChangeRequest $cr;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE change_requests (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                proposer_id     VARCHAR(255) NOT NULL,
+                title           TEXT         NOT NULL,
+                description     TEXT         NULL,
+                status          VARCHAR(20)  NOT NULL DEFAULT \'draft\',
+                reviewer_id     VARCHAR(255) NULL,
+                reviewer_note   TEXT         NULL,
+                decided_at      DATETIME     NULL,
+                implemented_at  DATETIME     NULL,
+                created_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->cr = new ChangeRequest($this->pdo);
+    }
+
+    // ── propose ───────────────────────────────────────────────────────────────
+
+    public function testProposeReturnsId(): void
+    {
+        $id = $this->cr->propose('user-1', 'Increase pool size');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testProposeStoresFields(): void
+    {
+        $id  = $this->cr->propose('user-1', 'Increase pool size', 'From 10 to 50.');
+        $row = $this->cr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['proposer_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Increase pool size', $row['title']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ChangeRequest::STATUS_DRAFT, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('From 10 to 50.', $row['description']);
+    }
+
+    public function testProposeThrowsOnEmptyProposerId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cr->propose('', 'Title');
+    }
+
+    public function testProposeThrowsOnEmptyTitle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cr->propose('user-1', '');
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->cr->get(9999));
+    }
+
+    // ── submit ────────────────────────────────────────────────────────────────
+
+    public function testSubmitChangesDraftToSubmitted(): void
+    {
+        $id  = $this->cr->propose('user-1', 'Title');
+        $this->assertTrue($this->cr->submit($id));
+        $row = $this->cr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ChangeRequest::STATUS_SUBMITTED, $row['status']);
+    }
+
+    public function testSubmitReturnsFalseIfNotDraft(): void
+    {
+        $id = $this->cr->propose('user-1', 'Title');
+        $this->cr->submit($id);
+        $this->assertFalse($this->cr->submit($id)); // already submitted
+    }
+
+    public function testSubmitReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->cr->submit(9999));
+    }
+
+    // ── approve ───────────────────────────────────────────────────────────────
+
+    public function testApproveChangesStatus(): void
+    {
+        $id = $this->cr->propose('user-1', 'Title');
+        $this->cr->submit($id);
+        $this->assertTrue($this->cr->approve($id, 'reviewer-1', 'LGTM'));
+        $row = $this->cr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ChangeRequest::STATUS_APPROVED, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('reviewer-1', $row['reviewer_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('LGTM', $row['reviewer_note']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['decided_at']);
+    }
+
+    public function testApproveReturnsFalseIfNotSubmitted(): void
+    {
+        $id = $this->cr->propose('user-1', 'Title');
+        // draft, not submitted
+        $this->assertFalse($this->cr->approve($id, 'reviewer-1'));
+    }
+
+    // ── reject ────────────────────────────────────────────────────────────────
+
+    public function testRejectChangesStatus(): void
+    {
+        $id = $this->cr->propose('user-1', 'Title');
+        $this->cr->submit($id);
+        $this->assertTrue($this->cr->reject($id, 'reviewer-1', 'Too risky'));
+        $row = $this->cr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ChangeRequest::STATUS_REJECTED, $row['status']);
+    }
+
+    public function testRejectReturnsFalseIfNotSubmitted(): void
+    {
+        $id = $this->cr->propose('user-1', 'Title');
+        $this->assertFalse($this->cr->reject($id, 'reviewer-1'));
+    }
+
+    // ── implement ─────────────────────────────────────────────────────────────
+
+    public function testImplementChangesStatus(): void
+    {
+        $id = $this->cr->propose('user-1', 'Title');
+        $this->cr->submit($id);
+        $this->cr->approve($id, 'reviewer-1');
+        $this->assertTrue($this->cr->implement($id));
+        $row = $this->cr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ChangeRequest::STATUS_IMPLEMENTED, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['implemented_at']);
+    }
+
+    public function testImplementReturnsFalseIfNotApproved(): void
+    {
+        $id = $this->cr->propose('user-1', 'Title');
+        $this->cr->submit($id);
+        $this->assertFalse($this->cr->implement($id)); // submitted, not approved
+    }
+
+    // ── close ─────────────────────────────────────────────────────────────────
+
+    public function testCloseChangesStatus(): void
+    {
+        $id = $this->cr->propose('user-1', 'Title');
+        $this->cr->submit($id);
+        $this->cr->approve($id, 'reviewer-1');
+        $this->cr->implement($id);
+        $this->assertTrue($this->cr->close($id));
+        $row = $this->cr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ChangeRequest::STATUS_CLOSED, $row['status']);
+    }
+
+    public function testCloseReturnsFalseIfNotImplemented(): void
+    {
+        $id = $this->cr->propose('user-1', 'Title');
+        $this->assertFalse($this->cr->close($id));
+    }
+
+    // ── byStatus ──────────────────────────────────────────────────────────────
+
+    public function testByStatusFilters(): void
+    {
+        $id1 = $this->cr->propose('user-1', 'CR1');
+        $this->cr->submit($id1);
+        $this->cr->propose('user-2', 'CR2'); // stays draft
+        $this->assertCount(1, $this->cr->byStatus(ChangeRequest::STATUS_SUBMITTED));
+        $this->assertCount(1, $this->cr->byStatus(ChangeRequest::STATUS_DRAFT));
+    }
+
+    public function testByStatusReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->cr->byStatus(ChangeRequest::STATUS_CLOSED));
+    }
+
+    // ── byProposer ────────────────────────────────────────────────────────────
+
+    public function testByProposerFilters(): void
+    {
+        $this->cr->propose('user-1', 'CR1');
+        $this->cr->propose('user-1', 'CR2');
+        $this->cr->propose('user-2', 'CR3');
+        $this->assertCount(2, $this->cr->byProposer('user-1'));
+        $this->assertCount(1, $this->cr->byProposer('user-2'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldTerminalRows(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO change_requests (proposer_id, title, status, created_at)
+             VALUES ('user-1', 'Old', 'closed', '2020-01-01 00:00:00')"
+        );
+        $this->pdo->exec(
+            "INSERT INTO change_requests (proposer_id, title, status, created_at)
+             VALUES ('user-2', 'Old2', 'rejected', '2020-01-02 00:00:00')"
+        );
+        $deleted = $this->cr->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(2, $deleted);
+    }
+
+    public function testPurgeOlderThanDoesNotDeleteDraft(): void
+    {
+        $id = $this->cr->propose('user-1', 'Draft CR');
+        $this->pdo->exec("UPDATE change_requests SET created_at = '2020-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->cr->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+}


### PR DESCRIPTION
## FT244 — ChangeRequest

Formal RFC / change-management approval workflow (ITIL-inspired).

### State machine
`DRAFT → SUBMITTED → APPROVED / REJECTED → IMPLEMENTED → CLOSED`

### Class: `Nene\Xion\ChangeRequest`
- Constants: `STATUS_DRAFT`, `STATUS_SUBMITTED`, `STATUS_APPROVED`, `STATUS_REJECTED`, `STATUS_IMPLEMENTED`, `STATUS_CLOSED`
- `propose()` — create draft; validates non-empty proposer_id and title
- `get()` — fetch by ID
- `submit()` — DRAFT → SUBMITTED (guarded)
- `approve()` — SUBMITTED → APPROVED; stores reviewer_id, note, decided_at
- `reject()` — SUBMITTED → REJECTED; stores reviewer_id, note, decided_at
- `implement()` — APPROVED → IMPLEMENTED; stores implemented_at
- `close()` — IMPLEMENTED → CLOSED
- `byStatus()` — list by status, newest first
- `byProposer()` — list all CRs for a proposer
- `purgeOlderThan()` — delete closed/rejected CRs older than cutoff

### Tests
21 tests, 41 assertions — all green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)