### PR TITLE
feat(xion): EventRsvp — event attendance management with accept/decline/maybe (FT247)

### DIFF
--- a/class/xion/EventRsvp.php
+++ b/class/xion/EventRsvp.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * EventRsvp — event attendance management with accept/decline/maybe responses.
+ *
+ * Tracks per-user RSVP responses to events with optional capacity limits
+ * and guest counts. Supports changing a response and attendance check-in.
+ *
+ * Distinct from:
+ * - `EventTicket`         (paid ticket purchasing and redemption)
+ * - `ResourceReservation` (time-bounded resource booking)
+ * - `TimeSlot`            (appointment booking with capacity)
+ *
+ * ## Usage
+ *
+ * ```php
+ * $rsvp = new EventRsvp($pdo);
+ *
+ * $id = $rsvp->create('evt-1', 'Annual Hackathon', '2026-06-15 09:00:00', 200);
+ * $rsvp->respond($id, 'user-42', EventRsvp::RESPONSE_YES, 2);
+ * $rsvp->respond($id, 'user-99', EventRsvp::RESPONSE_MAYBE);
+ * $rsvp->checkin($id, 'user-42');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE event_rsvp_events (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     event_ref    VARCHAR(255) NOT NULL,
+ *     title        TEXT         NOT NULL,
+ *     starts_at    DATETIME     NOT NULL,
+ *     capacity     INTEGER      NULL,
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'open',
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE TABLE event_rsvp_responses (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     event_id     INTEGER      NOT NULL,
+ *     user_id      VARCHAR(255) NOT NULL,
+ *     response     VARCHAR(20)  NOT NULL,
+ *     guests       INTEGER      NOT NULL DEFAULT 0,
+ *     checked_in   INTEGER      NOT NULL DEFAULT 0,
+ *     responded_at DATETIME     NOT NULL,
+ *     UNIQUE (event_id, user_id)
+ * );
+ * ```
+ */
+final class EventRsvp
+{
+    public const STATUS_OPEN   = 'open';
+    public const STATUS_CLOSED = 'closed';
+
+    public const RESPONSE_YES   = 'yes';
+    public const RESPONSE_NO    = 'no';
+    public const RESPONSE_MAYBE = 'maybe';
+
+    private const VALID_RESPONSES = [self::RESPONSE_YES, self::RESPONSE_NO, self::RESPONSE_MAYBE];
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create an event for RSVP tracking.
+     *
+     * @param  int|null $capacity Maximum accepted attendees (null = unlimited).
+     * @return int New event ID.
+     * @throws \InvalidArgumentException on empty eventRef, title, or startsAt.
+     */
+    public function create(
+        string $eventRef,
+        string $title,
+        string $startsAt,
+        ?int $capacity = null
+    ): int {
+        $eventRef = trim($eventRef);
+        $title    = trim($title);
+        $startsAt = trim($startsAt);
+        if ($eventRef === '') {
+            throw new \InvalidArgumentException('event_ref must not be empty.');
+        }
+        if ($title === '') {
+            throw new \InvalidArgumentException('title must not be empty.');
+        }
+        if ($startsAt === '') {
+            throw new \InvalidArgumentException('starts_at must not be empty.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO event_rsvp_events (event_ref, title, starts_at, capacity, status, created_at)
+             VALUES (:ref, :title, :starts, :cap, :status, :now)'
+        );
+        $stmt->execute([
+            ':ref'    => $eventRef,
+            ':title'  => $title,
+            ':starts' => $startsAt,
+            ':cap'    => $capacity,
+            ':status' => self::STATUS_OPEN,
+            ':now'    => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve an event by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function getEvent(int $eventId): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM event_rsvp_events WHERE id = :id');
+        $stmt->execute([':id' => $eventId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Submit or update a user's RSVP response.
+     *
+     * @param  int    $guests Extra guests the user is bringing (0-based, default 0).
+     * @return bool True on success; false if event not found or is closed.
+     * @throws \InvalidArgumentException on invalid response or empty userId.
+     */
+    public function respond(int $eventId, string $userId, string $response, int $guests = 0): bool
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if (!in_array($response, self::VALID_RESPONSES, true)) {
+            throw new \InvalidArgumentException('Invalid response value.');
+        }
+
+        $event = $this->getEvent($eventId);
+        if ($event === null || (string)$event['status'] !== self::STATUS_OPEN) {
+            return false;
+        }
+
+        // Capacity check for YES responses
+        if ($response === self::RESPONSE_YES && $event['capacity'] !== null) {
+            $existing = $this->getUserResponse($eventId, $userId);
+            // Don't count the current user's previous accepted count
+            $previousGuests = ($existing !== null && $existing['response'] === self::RESPONSE_YES)
+                ? (int)$existing['guests'] + 1
+                : 0;
+            $accepted = $this->acceptedCount($eventId);
+            if (($accepted - $previousGuests) + $guests + 1 > (int)$event['capacity']) {
+                return false; // would exceed capacity
+            }
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        // Cross-driver upsert
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $sql = 'INSERT INTO event_rsvp_responses (event_id, user_id, response, guests, responded_at)
+                    VALUES (:eid, :uid, :resp, :guests, :now)
+                    ON CONFLICT (event_id, user_id) DO UPDATE SET
+                        response = excluded.response,
+                        guests   = excluded.guests,
+                        responded_at = excluded.responded_at';
+        } else {
+            $sql = 'INSERT INTO event_rsvp_responses (event_id, user_id, response, guests, responded_at)
+                    VALUES (:eid, :uid, :resp, :guests, :now)
+                    ON DUPLICATE KEY UPDATE
+                        response = VALUES(response),
+                        guests   = VALUES(guests),
+                        responded_at = VALUES(responded_at)';
+        }
+        $this->db()->prepare($sql)->execute([
+            ':eid'    => $eventId,
+            ':uid'    => $userId,
+            ':resp'   => $response,
+            ':guests' => max(0, $guests),
+            ':now'    => $now,
+        ]);
+        return true;
+    }
+
+    /**
+     * Get a user's RSVP response for an event.
+     *
+     * @return array<string,mixed>|null  Null if not responded.
+     */
+    public function getUserResponse(int $eventId, string $userId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM event_rsvp_responses WHERE event_id = :eid AND user_id = :uid'
+        );
+        $stmt->execute([':eid' => $eventId, ':uid' => trim($userId)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Check a user in to an event (mark attendance).
+     *
+     * @return bool True if response exists and was YES; false otherwise.
+     */
+    public function checkin(int $eventId, string $userId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE event_rsvp_responses
+             SET checked_in = 1
+             WHERE event_id = :eid AND user_id = :uid AND response = :yes'
+        );
+        $stmt->execute([':eid' => $eventId, ':uid' => trim($userId), ':yes' => self::RESPONSE_YES]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Total number of accepted attendees (including guests).
+     */
+    public function acceptedCount(int $eventId): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COALESCE(SUM(guests + 1), 0)
+             FROM event_rsvp_responses
+             WHERE event_id = :eid AND response = :yes'
+        );
+        $stmt->execute([':eid' => $eventId, ':yes' => self::RESPONSE_YES]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * All responses for an event, optionally filtered by response type.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function responses(int $eventId, ?string $response = null): array
+    {
+        if ($response !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT * FROM event_rsvp_responses WHERE event_id = :eid AND response = :resp
+                 ORDER BY responded_at ASC, id ASC'
+            );
+            $stmt->execute([':eid' => $eventId, ':resp' => $response]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT * FROM event_rsvp_responses WHERE event_id = :eid
+                 ORDER BY responded_at ASC, id ASC'
+            );
+            $stmt->execute([':eid' => $eventId]);
+        }
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Close an event (no more responses accepted).
+     *
+     * @return bool True if found and updated.
+     */
+    public function close(int $eventId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE event_rsvp_events SET status = :status WHERE id = :id AND status = :open'
+        );
+        $stmt->execute([
+            ':status' => self::STATUS_CLOSED,
+            ':id'     => $eventId,
+            ':open'   => self::STATUS_OPEN,
+        ]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete an event and all its responses.
+     *
+     * @return bool True if the event existed.
+     */
+    public function delete(int $eventId): bool
+    {
+        $event = $this->getEvent($eventId);
+        if ($event === null) {
+            return false;
+        }
+        $this->db()->prepare('DELETE FROM event_rsvp_responses WHERE event_id = :eid')
+            ->execute([':eid' => $eventId]);
+        $this->db()->prepare('DELETE FROM event_rsvp_events WHERE id = :id')
+            ->execute([':id' => $eventId]);
+        return true;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/EventRsvpTest.php
+++ b/tests/Unit/Xion/EventRsvpTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\EventRsvp;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class EventRsvpTest extends TestCase
+{
+    private PDO $pdo;
+    private EventRsvp $rsvp;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE event_rsvp_events (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_ref  VARCHAR(255) NOT NULL,
+                title      TEXT         NOT NULL,
+                starts_at  DATETIME     NOT NULL,
+                capacity   INTEGER      NULL,
+                status     VARCHAR(20)  NOT NULL DEFAULT \'open\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->pdo->exec('
+            CREATE TABLE event_rsvp_responses (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id     INTEGER      NOT NULL,
+                user_id      VARCHAR(255) NOT NULL,
+                response     VARCHAR(20)  NOT NULL,
+                guests       INTEGER      NOT NULL DEFAULT 0,
+                checked_in   INTEGER      NOT NULL DEFAULT 0,
+                responded_at DATETIME     NOT NULL,
+                UNIQUE (event_id, user_id)
+            )
+        ');
+        $this->rsvp = new EventRsvp($this->pdo);
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsId(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testCreateStoresFields(): void
+    {
+        $id  = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00', 200);
+        $row = $this->rsvp->getEvent($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('evt-1', $row['event_ref']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Hackathon', $row['title']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(200, (int)$row['capacity']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(EventRsvp::STATUS_OPEN, $row['status']);
+    }
+
+    public function testCreateWithoutCapacity(): void
+    {
+        $id  = $this->rsvp->create('evt-2', 'Open Day', '2026-07-01 10:00:00');
+        $row = $this->rsvp->getEvent($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNull($row['capacity']);
+    }
+
+    public function testCreateThrowsOnEmptyEventRef(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rsvp->create('', 'Title', '2026-06-15 09:00:00');
+    }
+
+    public function testCreateThrowsOnEmptyTitle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rsvp->create('evt-1', '', '2026-06-15 09:00:00');
+    }
+
+    public function testCreateThrowsOnEmptyStartsAt(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rsvp->create('evt-1', 'Title', '');
+    }
+
+    // ── getEvent ──────────────────────────────────────────────────────────────
+
+    public function testGetEventReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->rsvp->getEvent(9999));
+    }
+
+    // ── respond ───────────────────────────────────────────────────────────────
+
+    public function testRespondRecordsYes(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->assertTrue($this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_YES));
+        $row = $this->rsvp->getUserResponse($id, 'user-1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(EventRsvp::RESPONSE_YES, $row['response']);
+    }
+
+    public function testRespondRecordsNo(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->assertTrue($this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_NO));
+        $row = $this->rsvp->getUserResponse($id, 'user-1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(EventRsvp::RESPONSE_NO, $row['response']);
+    }
+
+    public function testRespondCanChangeResponse(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_MAYBE);
+        $this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_YES);
+        $row = $this->rsvp->getUserResponse($id, 'user-1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(EventRsvp::RESPONSE_YES, $row['response']);
+    }
+
+    public function testRespondWithGuests(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_YES, 2);
+        $row = $this->rsvp->getUserResponse($id, 'user-1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(2, (int)$row['guests']);
+    }
+
+    public function testRespondReturnsFalseWhenClosed(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->rsvp->close($id);
+        $this->assertFalse($this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_YES));
+    }
+
+    public function testRespondReturnsFalseForMissingEvent(): void
+    {
+        $this->assertFalse($this->rsvp->respond(9999, 'user-1', EventRsvp::RESPONSE_YES));
+    }
+
+    public function testRespondThrowsOnInvalidResponse(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rsvp->respond($id, 'user-1', 'going');
+    }
+
+    public function testRespondThrowsOnEmptyUserId(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rsvp->respond($id, '', EventRsvp::RESPONSE_YES);
+    }
+
+    public function testRespondReturnsFalseWhenCapacityExceeded(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Small Event', '2026-06-15 09:00:00', 2);
+        $this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_YES);
+        $this->rsvp->respond($id, 'user-2', EventRsvp::RESPONSE_YES);
+        $this->assertFalse($this->rsvp->respond($id, 'user-3', EventRsvp::RESPONSE_YES));
+    }
+
+    // ── getUserResponse ───────────────────────────────────────────────────────
+
+    public function testGetUserResponseReturnsNullWhenNotResponded(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->assertNull($this->rsvp->getUserResponse($id, 'user-1'));
+    }
+
+    // ── checkin ───────────────────────────────────────────────────────────────
+
+    public function testCheckinSetsFlag(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_YES);
+        $this->assertTrue($this->rsvp->checkin($id, 'user-1'));
+        $row = $this->rsvp->getUserResponse($id, 'user-1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['checked_in']);
+    }
+
+    public function testCheckinReturnsFalseIfNotYes(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_MAYBE);
+        $this->assertFalse($this->rsvp->checkin($id, 'user-1'));
+    }
+
+    public function testCheckinReturnsFalseIfNotResponded(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->assertFalse($this->rsvp->checkin($id, 'user-1'));
+    }
+
+    // ── acceptedCount ─────────────────────────────────────────────────────────
+
+    public function testAcceptedCountIncludesGuests(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_YES, 1); // 2 total
+        $this->rsvp->respond($id, 'user-2', EventRsvp::RESPONSE_YES, 0); // 1 total
+        $this->assertSame(3, $this->rsvp->acceptedCount($id));
+    }
+
+    public function testAcceptedCountIgnoresMaybeAndNo(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_MAYBE);
+        $this->rsvp->respond($id, 'user-2', EventRsvp::RESPONSE_NO);
+        $this->assertSame(0, $this->rsvp->acceptedCount($id));
+    }
+
+    // ── responses ─────────────────────────────────────────────────────────────
+
+    public function testResponsesFiltersCorrectly(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_YES);
+        $this->rsvp->respond($id, 'user-2', EventRsvp::RESPONSE_NO);
+        $this->rsvp->respond($id, 'user-3', EventRsvp::RESPONSE_MAYBE);
+        $this->assertCount(1, $this->rsvp->responses($id, EventRsvp::RESPONSE_YES));
+        $this->assertCount(3, $this->rsvp->responses($id));
+    }
+
+    // ── close ─────────────────────────────────────────────────────────────────
+
+    public function testCloseChangesStatus(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->assertTrue($this->rsvp->close($id));
+        $row = $this->rsvp->getEvent($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(EventRsvp::STATUS_CLOSED, $row['status']);
+    }
+
+    public function testCloseReturnsFalseWhenAlreadyClosed(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->rsvp->close($id);
+        $this->assertFalse($this->rsvp->close($id));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesEventAndResponses(): void
+    {
+        $id = $this->rsvp->create('evt-1', 'Hackathon', '2026-06-15 09:00:00');
+        $this->rsvp->respond($id, 'user-1', EventRsvp::RESPONSE_YES);
+        $this->assertTrue($this->rsvp->delete($id));
+        $this->assertNull($this->rsvp->getEvent($id));
+        $this->assertSame([], $this->rsvp->responses($id));
+    }
+
+    public function testDeleteReturnsFalseForMissingEvent(): void
+    {
+        $this->assertFalse($this->rsvp->delete(9999));
+    }
+}


### PR DESCRIPTION
## FT247 — EventRsvp

Event RSVP tracking with capacity limits, guest counts, and check-in support.

### Class: `Nene\Xion\EventRsvp`
- Constants: `STATUS_OPEN`, `STATUS_CLOSED`, `RESPONSE_YES`, `RESPONSE_NO`, `RESPONSE_MAYBE`
- `create()` — register event with optional capacity limit
- `getEvent()` — fetch event by ID
- `respond()` — submit/update RSVP (cross-driver upsert); enforces capacity for YES; throws on invalid response or empty userId
- `getUserResponse()` — get a specific user's response
- `checkin()` — mark user as attended (only for YES responses)
- `acceptedCount()` — total accepted headcount including guests
- `responses()` — list all responses, optionally filtered by type
- `close()` — OPEN → CLOSED (no more responses)
- `delete()` — remove event and all responses

### Tests
27 tests, 45 assertions — all green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)