### PR TITLE
feat(xion): FeatureRequest — user-submitted feature requests with voting and status tracking (FT249)

### DIFF
--- a/class/xion/FeatureRequest.php
+++ b/class/xion/FeatureRequest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * FeatureRequest — user-submitted feature requests with voting and status tracking.
+ *
+ * Lets users submit feature ideas, upvote others' requests, and track
+ * implementation status from submitted through to shipped.
+ *
+ * Distinct from:
+ * - `VotePoll`     (named-option polls with yes/no answers)
+ * - `VotingBooth`  (election-style ballot voting)
+ * - `ContentFlag`  (content moderation reports)
+ *
+ * ## Usage
+ *
+ * ```php
+ * $fr = new FeatureRequest($pdo);
+ *
+ * $id = $fr->submit('user-1', 'Dark mode', 'Please add a dark theme');
+ * $fr->upvote($id, 'user-2');
+ * $fr->upvote($id, 'user-3');
+ * $fr->plan($id);     // STATUS_PLANNED
+ * $fr->ship($id);     // STATUS_SHIPPED
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE feature_requests (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     submitter_id VARCHAR(255) NOT NULL,
+ *     title        TEXT         NOT NULL,
+ *     description  TEXT         NULL,
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'open',
+ *     vote_count   INTEGER      NOT NULL DEFAULT 0,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE TABLE feature_request_votes (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     request_id INTEGER      NOT NULL,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     voted_at   DATETIME     NOT NULL,
+ *     UNIQUE (request_id, user_id)
+ * );
+ * ```
+ */
+final class FeatureRequest
+{
+    public const STATUS_OPEN      = 'open';
+    public const STATUS_PLANNED   = 'planned';
+    public const STATUS_IN_PROGRESS = 'in_progress';
+    public const STATUS_SHIPPED   = 'shipped';
+    public const STATUS_DECLINED  = 'declined';
+    public const STATUS_DUPLICATE = 'duplicate';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Submit a new feature request.
+     *
+     * @return int New request ID.
+     * @throws \InvalidArgumentException on empty submitterId or title.
+     */
+    public function submit(string $submitterId, string $title, ?string $description = null): int
+    {
+        $submitterId = trim($submitterId);
+        $title       = trim($title);
+        if ($submitterId === '') {
+            throw new \InvalidArgumentException('submitter_id must not be empty.');
+        }
+        if ($title === '') {
+            throw new \InvalidArgumentException('title must not be empty.');
+        }
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO feature_requests (submitter_id, title, description, status, vote_count, created_at)
+             VALUES (:sid, :title, :desc, :status, 0, :now)'
+        );
+        $stmt->execute([
+            ':sid'    => $submitterId,
+            ':title'  => $title,
+            ':desc'   => $description,
+            ':status' => self::STATUS_OPEN,
+            ':now'    => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve a feature request by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM feature_requests WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Upvote a feature request. Each user can vote once per request.
+     *
+     * @return bool True if vote was recorded; false if already voted or request not found.
+     * @throws \InvalidArgumentException on empty userId.
+     */
+    public function upvote(int $requestId, string $userId): bool
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+
+        $req = $this->get($requestId);
+        if ($req === null) {
+            return false;
+        }
+
+        // Check if already voted
+        $check = $this->db()->prepare(
+            'SELECT COUNT(*) FROM feature_request_votes WHERE request_id = :rid AND user_id = :uid'
+        );
+        $check->execute([':rid' => $requestId, ':uid' => $userId]);
+        if ((int)$check->fetchColumn() > 0) {
+            return false;
+        }
+
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $this->db()->prepare(
+            'INSERT INTO feature_request_votes (request_id, user_id, voted_at)
+             VALUES (:rid, :uid, :now)'
+        )->execute([':rid' => $requestId, ':uid' => $userId, ':now' => $now]);
+
+        $this->db()->prepare(
+            'UPDATE feature_requests SET vote_count = vote_count + 1 WHERE id = :id'
+        )->execute([':id' => $requestId]);
+
+        return true;
+    }
+
+    /**
+     * Remove a user's vote from a feature request.
+     *
+     * @return bool True if vote existed and was removed.
+     */
+    public function downvote(int $requestId, string $userId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM feature_request_votes WHERE request_id = :rid AND user_id = :uid'
+        );
+        $stmt->execute([':rid' => $requestId, ':uid' => trim($userId)]);
+        if ($stmt->rowCount() === 0) {
+            return false;
+        }
+        $this->db()->prepare(
+            'UPDATE feature_requests SET vote_count = MAX(0, vote_count - 1) WHERE id = :id'
+        )->execute([':id' => $requestId]);
+        return true;
+    }
+
+    /**
+     * Whether a user has voted on a request.
+     */
+    public function hasVoted(int $requestId, string $userId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM feature_request_votes WHERE request_id = :rid AND user_id = :uid'
+        );
+        $stmt->execute([':rid' => $requestId, ':uid' => trim($userId)]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Move request to PLANNED status.
+     *
+     * @return bool True if found and was OPEN.
+     */
+    public function plan(int $requestId): bool
+    {
+        return $this->transition($requestId, self::STATUS_PLANNED, [self::STATUS_OPEN]);
+    }
+
+    /**
+     * Move request to IN_PROGRESS status.
+     *
+     * @return bool True if found and was PLANNED.
+     */
+    public function startWork(int $requestId): bool
+    {
+        return $this->transition($requestId, self::STATUS_IN_PROGRESS, [self::STATUS_PLANNED]);
+    }
+
+    /**
+     * Move request to SHIPPED status.
+     *
+     * @return bool True if found and was IN_PROGRESS or PLANNED.
+     */
+    public function ship(int $requestId): bool
+    {
+        return $this->transition($requestId, self::STATUS_SHIPPED, [self::STATUS_IN_PROGRESS, self::STATUS_PLANNED]);
+    }
+
+    /**
+     * Decline a feature request.
+     *
+     * @return bool True if found and was OPEN or PLANNED.
+     */
+    public function decline(int $requestId): bool
+    {
+        return $this->transition($requestId, self::STATUS_DECLINED, [self::STATUS_OPEN, self::STATUS_PLANNED]);
+    }
+
+    /**
+     * Mark request as a duplicate.
+     *
+     * @return bool True if found and was OPEN.
+     */
+    public function markDuplicate(int $requestId): bool
+    {
+        return $this->transition($requestId, self::STATUS_DUPLICATE, [self::STATUS_OPEN]);
+    }
+
+    /**
+     * Top requests by vote count, optionally filtered by status.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function top(int $limit = 20, ?string $status = null): array
+    {
+        if ($status !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT * FROM feature_requests WHERE status = :status
+                 ORDER BY vote_count DESC, created_at ASC
+                 LIMIT :limit'
+            );
+            $stmt->bindValue(':status', $status);
+            $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT * FROM feature_requests
+                 ORDER BY vote_count DESC, created_at ASC
+                 LIMIT :limit'
+            );
+            $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        }
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * All requests by a specific submitter.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function bySubmitter(string $submitterId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM feature_requests WHERE submitter_id = :sid
+             ORDER BY created_at DESC, id DESC'
+        );
+        $stmt->execute([':sid' => trim($submitterId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Delete a feature request and all its votes.
+     *
+     * @return bool True if the request existed.
+     */
+    public function delete(int $requestId): bool
+    {
+        $req = $this->get($requestId);
+        if ($req === null) {
+            return false;
+        }
+        $this->db()->prepare('DELETE FROM feature_request_votes WHERE request_id = :rid')
+            ->execute([':rid' => $requestId]);
+        $this->db()->prepare('DELETE FROM feature_requests WHERE id = :id')
+            ->execute([':id' => $requestId]);
+        return true;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    /**
+     * @param list<string> $fromStatuses
+     */
+    private function transition(int $requestId, string $toStatus, array $fromStatuses): bool
+    {
+        $placeholders = implode(',', array_fill(0, count($fromStatuses), '?'));
+        $stmt = $this->db()->prepare(
+            "UPDATE feature_requests SET status = ? WHERE id = ? AND status IN ({$placeholders})"
+        );
+        $stmt->execute(array_merge([$toStatus, $requestId], $fromStatuses));
+        return $stmt->rowCount() > 0;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/FeatureRequestTest.php
+++ b/tests/Unit/Xion/FeatureRequestTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\FeatureRequest;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class FeatureRequestTest extends TestCase
+{
+    private PDO $pdo;
+    private FeatureRequest $fr;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE feature_requests (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                submitter_id VARCHAR(255) NOT NULL,
+                title        TEXT         NOT NULL,
+                description  TEXT         NULL,
+                status       VARCHAR(20)  NOT NULL DEFAULT \'open\',
+                vote_count   INTEGER      NOT NULL DEFAULT 0,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->pdo->exec('
+            CREATE TABLE feature_request_votes (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                request_id INTEGER      NOT NULL,
+                user_id    VARCHAR(255) NOT NULL,
+                voted_at   DATETIME     NOT NULL,
+                UNIQUE (request_id, user_id)
+            )
+        ');
+        $this->fr = new FeatureRequest($this->pdo);
+    }
+
+    // ── submit ────────────────────────────────────────────────────────────────
+
+    public function testSubmitReturnsId(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testSubmitStoresFields(): void
+    {
+        $id  = $this->fr->submit('user-1', 'Dark mode', 'Please add a dark theme');
+        $row = $this->fr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['submitter_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Dark mode', $row['title']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Please add a dark theme', $row['description']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(FeatureRequest::STATUS_OPEN, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['vote_count']);
+    }
+
+    public function testSubmitThrowsOnEmptySubmitterId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fr->submit('', 'Dark mode');
+    }
+
+    public function testSubmitThrowsOnEmptyTitle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fr->submit('user-1', '');
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->fr->get(9999));
+    }
+
+    // ── upvote ────────────────────────────────────────────────────────────────
+
+    public function testUpvoteIncreasesVoteCount(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->assertTrue($this->fr->upvote($id, 'user-2'));
+        $row = $this->fr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['vote_count']);
+    }
+
+    public function testUpvoteReturnsFalseIfAlreadyVoted(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->upvote($id, 'user-2');
+        $this->assertFalse($this->fr->upvote($id, 'user-2'));
+    }
+
+    public function testUpvoteReturnsFalseForMissingRequest(): void
+    {
+        $this->assertFalse($this->fr->upvote(9999, 'user-2'));
+    }
+
+    public function testUpvoteThrowsOnEmptyUserId(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fr->upvote($id, '');
+    }
+
+    public function testMultipleUsersCanVote(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->upvote($id, 'user-2');
+        $this->fr->upvote($id, 'user-3');
+        $row = $this->fr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(2, (int)$row['vote_count']);
+    }
+
+    // ── downvote ──────────────────────────────────────────────────────────────
+
+    public function testDownvoteDecreasesVoteCount(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->upvote($id, 'user-2');
+        $this->assertTrue($this->fr->downvote($id, 'user-2'));
+        $row = $this->fr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['vote_count']);
+    }
+
+    public function testDownvoteReturnsFalseIfNotVoted(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->assertFalse($this->fr->downvote($id, 'user-2'));
+    }
+
+    // ── hasVoted ──────────────────────────────────────────────────────────────
+
+    public function testHasVotedReturnsTrueAfterUpvote(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->upvote($id, 'user-2');
+        $this->assertTrue($this->fr->hasVoted($id, 'user-2'));
+    }
+
+    public function testHasVotedReturnsFalseWhenNotVoted(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->assertFalse($this->fr->hasVoted($id, 'user-2'));
+    }
+
+    public function testHasVotedReturnsFalseAfterDownvote(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->upvote($id, 'user-2');
+        $this->fr->downvote($id, 'user-2');
+        $this->assertFalse($this->fr->hasVoted($id, 'user-2'));
+    }
+
+    // ── plan / startWork / ship ───────────────────────────────────────────────
+
+    public function testPlanChangesOpenToPlanned(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->assertTrue($this->fr->plan($id));
+        $row = $this->fr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(FeatureRequest::STATUS_PLANNED, $row['status']);
+    }
+
+    public function testStartWorkChangesPlanedToInProgress(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->plan($id);
+        $this->assertTrue($this->fr->startWork($id));
+        $row = $this->fr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(FeatureRequest::STATUS_IN_PROGRESS, $row['status']);
+    }
+
+    public function testShipChangesStatus(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->plan($id);
+        $this->fr->startWork($id);
+        $this->assertTrue($this->fr->ship($id));
+        $row = $this->fr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(FeatureRequest::STATUS_SHIPPED, $row['status']);
+    }
+
+    public function testShipCanSkipStartWork(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->plan($id);
+        $this->assertTrue($this->fr->ship($id));
+    }
+
+    public function testPlanReturnsFalseWhenNotOpen(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->plan($id);
+        $this->assertFalse($this->fr->plan($id)); // already planned
+    }
+
+    // ── decline / markDuplicate ───────────────────────────────────────────────
+
+    public function testDeclineChangesStatus(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->assertTrue($this->fr->decline($id));
+        $row = $this->fr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(FeatureRequest::STATUS_DECLINED, $row['status']);
+    }
+
+    public function testMarkDuplicateChangesStatus(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->assertTrue($this->fr->markDuplicate($id));
+        $row = $this->fr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(FeatureRequest::STATUS_DUPLICATE, $row['status']);
+    }
+
+    // ── top ───────────────────────────────────────────────────────────────────
+
+    public function testTopOrdersByVoteCount(): void
+    {
+        $id1 = $this->fr->submit('user-1', 'Dark mode');
+        $id2 = $this->fr->submit('user-1', 'Light mode');
+        $this->fr->upvote($id1, 'user-2');
+        $this->fr->upvote($id1, 'user-3');
+        $this->fr->upvote($id2, 'user-4');
+        $top = $this->fr->top();
+        $this->assertSame($id1, (int)$top[0]['id']);
+    }
+
+    public function testTopFiltersByStatus(): void
+    {
+        $id1 = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->submit('user-1', 'Light mode');
+        $this->fr->plan($id1);
+        $this->assertCount(1, $this->fr->top(20, FeatureRequest::STATUS_PLANNED));
+        $this->assertCount(1, $this->fr->top(20, FeatureRequest::STATUS_OPEN));
+    }
+
+    // ── bySubmitter ───────────────────────────────────────────────────────────
+
+    public function testBySubmitterFilters(): void
+    {
+        $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->submit('user-1', 'Light mode');
+        $this->fr->submit('user-2', 'Bold font');
+        $this->assertCount(2, $this->fr->bySubmitter('user-1'));
+        $this->assertCount(1, $this->fr->bySubmitter('user-2'));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesRequestAndVotes(): void
+    {
+        $id = $this->fr->submit('user-1', 'Dark mode');
+        $this->fr->upvote($id, 'user-2');
+        $this->assertTrue($this->fr->delete($id));
+        $this->assertNull($this->fr->get($id));
+    }
+
+    public function testDeleteReturnsFalseForMissingRequest(): void
+    {
+        $this->assertFalse($this->fr->delete(9999));
+    }
+}


### PR DESCRIPTION
## FT249 — FeatureRequest

Product feedback board: submit ideas, upvote/downvote, and track through delivery.

### Class: `Nene\Xion\FeatureRequest`
- Constants: `STATUS_OPEN`, `STATUS_PLANNED`, `STATUS_IN_PROGRESS`, `STATUS_SHIPPED`, `STATUS_DECLINED`, `STATUS_DUPLICATE`
- `submit()` — create feature request; validates submitter_id and title
- `get()` — fetch by ID
- `upvote()` — one-vote-per-user enforcement; increments `vote_count` denorm
- `downvote()` — remove vote; decrements `vote_count`
- `hasVoted()` — check if user has voted
- `plan()` — OPEN → PLANNED
- `startWork()` — PLANNED → IN_PROGRESS
- `ship()` — IN_PROGRESS/PLANNED → SHIPPED
- `decline()` — OPEN/PLANNED → DECLINED
- `markDuplicate()` — OPEN → DUPLICATE
- `top()` — list by vote count desc, optional status filter
- `bySubmitter()` — all requests from a user
- `delete()` — remove request and all votes

### Tests
27 tests, 50 assertions — all green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)