### PR TITLE
docs: update FT log for FT239–FT250 (Xion ninth wave)

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -14,7 +14,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ## Active candidates
 
-The Xion helper wave (FT78–FT238) is ongoing as of 2026-05-28. Trigger-based and structural candidates are listed in the next section.
+The Xion helper wave (FT78–FT250) is ongoing as of 2026-05-28. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -54,6 +54,18 @@ The Xion helper wave (FT78–FT238) is ongoing as of 2026-05-28. Trigger-based a
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT250 — KpiTracker** (2026-05-28): `Nene\Xion\KpiTracker` — KPI/OKR metric tracking with target/actual; record() time-series; progress() {actual, target, pct}; purgeOlderThan() per definition. PR #693.
+- **FT249 — FeatureRequest** (2026-05-28): `Nene\Xion\FeatureRequest` — product feature requests with voting; OPEN→PLANNED→IN_PROGRESS→SHIPPED; one-vote-per-user; top() by vote count. PR #692.
+- **FT248 — DocumentSignature** (2026-05-28): `Nene\Xion\DocumentSignature` — e-signature workflow; multi-signatory; sign() auto-completes; decline() cancels; pendingFor() inbox. PR #691.
+- **FT247 — EventRsvp** (2026-05-28): `Nene\Xion\EventRsvp` — event RSVP; RESPONSE_YES/NO/MAYBE; capacity guard; guests count; checkin() marks attendance. PR #690.
+- **FT246 — AssetRegistry** (2026-05-28): `Nene\Xion\AssetRegistry` — asset inventory; AVAILABLE/ASSIGNED/RETIRED; assign() records history; unassign() sets returned_at. PR #689.
+- **FT245 — BudgetTracker** (2026-05-28): `Nene\Xion\BudgetTracker` — period budget allocation; spend() with OverflowException; auto-marks EXHAUSTED at 100%; remaining()/isExhausted(). PR #688.
+- **FT244 — ChangeRequest** (2026-05-28): `Nene\Xion\ChangeRequest` — RFC change-management; DRAFT→SUBMITTED→APPROVED/REJECTED→IMPLEMENTED→CLOSED; each transition guards prior status. PR #687.
+- **FT243 — IncidentLog** (2026-05-28): `Nene\Xion\IncidentLog` — IT incident tracking; SEVERITY_P1–P4; two-table with events; investigate()/resolve()/close(); bySeverity(). PR #686.
+- **FT242 — GiftCard** (2026-05-28): `Nene\Xion\GiftCard` — partial-redemption gift cards; auto-generates code; STATUS_EXHAUSTED at balance=0; expireStale(). PR #685.
+- **FT241 — PresenceTracker** (2026-05-28): `Nene\Xion\PresenceTracker` — online presence per user+context; cross-driver upsert; isOnline() window-based; online()/onlineIn(). PR #684.
+- **FT240 — SubscriptionPlan** (2026-05-28): `Nene\Xion\SubscriptionPlan` — subscription lifecycle; STATUS_TRIAL/ACTIVE/CANCELLED/EXPIRED; isActive() checks status+date range; expireStale(). PR #683.
+- **FT239 — VotePoll** (2026-05-28): `Nene\Xion\VotePoll` — two-table polls; one-vote-per-user upsert; vote() validates option vs. JSON list; results() by popularity. PR #682.
 - **FT238 — MediaConversionJob** (2026-05-28): `Nene\Xion\MediaConversionJob` — async media processing FIFO queue; nextPending()/start()/complete()/fail()/retry(); attempts counter. PR #680.
 - **FT237 — SlaTracker** (2026-05-28): `Nene\Xion\SlaTracker` — SLA/SLO breach detection; start() computes deadline; pause/resume accumulates paused_seconds; breached() cron query. PR #679.
 - **FT236 — DeviceFingerprint** (2026-05-28): `Nene\Xion\DeviceFingerprint` — device recognition; SHA-256 hash; seen() cross-driver upsert increments seen_count; isTrusted()/isBlocked(). PR #678.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT238 complete as of 2026-05-28 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT250 complete as of 2026-05-28 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 
@@ -242,6 +242,7 @@ Completed (wave summary):
 - **FT201–FT210**: Xion sixth extended wave. 10 trials covering inventory stock tracking with atomic reserve/commit, work time entries with start/stop timers, appointment time slot booking with capacity, external API call logging, GDPR data-subject request tracking, product/feature waitlist management, regional tax rate calculation, push notification device token management, flexible entity tagging with tag clouds, and advisory resource locking with TTL. PRs #641–#650.
 - **FT211–FT228**: Xion seventh extended wave. 18 trials covering product price catalog with tiers, compliance audit log with before/after snapshots, loyalty point ledger, flat entity comments, survey/form response collection, product bundle catalog, channel-agnostic notification queue, persistent stateful workflow instances, type-ahead search suggestion management, metered billing usage tracking, multiple entity identifier aliases, multi-device session management, ordered page builder content blocks, database-backed multilingual content, service health monitoring, page/resource view analytics, contact form inbox management, and time-bounded access delegation. PRs #652–#669.
 - **FT229–FT238**: Xion eighth extended wave. 10 trials covering form/survey template definitions with questions, mailing list recipient group management, point-in-time entity state snapshots, stock/availability alert registrations with cron batch processing, time-bounded resource reservation with overlap detection, high-score leaderboard with personal-best tracking, financial credit notes with lifecycle management, device fingerprint recognition for fraud detection, SLA/SLO breach detection with pause/resume, and async media processing job tracking. PRs #671–#680.
+- **FT239–FT250**: Xion ninth extended wave. 12 trials covering simple polls with one-vote-per-user enforcement, user subscription lifecycle management, online presence tracking with context scoping, partial-redemption gift cards, IT incident tracking with severity levels, RFC change-management approval workflow, period-based budget allocation with overflow protection, physical/digital asset inventory with assignment history, event RSVP management with capacity limits and check-in, e-signature requests with multi-signatory support, product feature requests with upvoting and delivery tracking, and KPI/OKR metric tracking with target vs. actual comparison. PRs #682–#693.
 
 Future candidates:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,26 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-28: all non-promotion Issues are closed; FT1–FT238 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-28: all non-promotion Issues are closed; FT1–FT250 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-28 — FT239–FT250: Xion ninth extended wave (12 trials)
+
+Continuous wave of 12 field trials adding further Xion helper patterns. All PRs #682–#693.
+
+**FT239 — VotePoll**: `VotePoll` two-table polls with named options; one-vote-per-user cross-driver upsert; vote() validates option against JSON-stored list; close() stops further votes. PR #682.
+**FT240 — SubscriptionPlan**: `SubscriptionPlan` user subscription lifecycle; STATUS_TRIAL/ACTIVE/CANCELLED/EXPIRED; isActive() checks status+date range; cancelAtEnd()/cancelNow()/changePlan(); expireStale(). PR #683.
+**FT241 — PresenceTracker**: `PresenceTracker` online presence tracking per user+context; cross-driver upsert; isOnline() window-based; online()/onlineIn() for room listing; leave()/purgeOlderThan(). PR #684.
+**FT242 — GiftCard**: `GiftCard` partial-redemption gift cards; auto-generates code; STATUS_EXHAUSTED when balance=0; redeem() validates redeemable+sufficient balance; expireStale(). PR #685.
+**FT243 — IncidentLog**: `IncidentLog` IT/service incident tracking; SEVERITY_P1–P4; two-table (incident_logs + incident_events); investigate()/resolve()/close() lifecycle; bySeverity(). PR #686.
+**FT244 — ChangeRequest**: `ChangeRequest` RFC change-management approval workflow; DRAFT→SUBMITTED→APPROVED/REJECTED→IMPLEMENTED→CLOSED; each transition guards prior status in WHERE clause. PR #687.
+**FT245 — BudgetTracker**: `BudgetTracker` period-based budget allocation and spend tracking; allocate()/spend() (OverflowException if exceeds); remaining()/isExhausted(); auto-marks EXHAUSTED at 100%. PR #688.
+**FT246 — AssetRegistry**: `AssetRegistry` physical/digital asset inventory; AVAILABLE/ASSIGNED/RETIRED; assign() records history row; unassign() sets returned_at; history() full assignment trail. PR #689.
+**FT247 — EventRsvp**: `EventRsvp` event RSVP tracking; RESPONSE_YES/NO/MAYBE; optional capacity limit with overflow guard; guests count; checkin() marks attendance; acceptedCount() includes guests. PR #690.
+**FT248 — DocumentSignature**: `DocumentSignature` e-signature request workflow; multi-signatory support; sign() auto-completes when all signed; decline() immediately cancels; pendingFor() pending inbox. PR #691.
+**FT249 — FeatureRequest**: `FeatureRequest` product feature requests with upvoting; OPEN→PLANNED→IN_PROGRESS→SHIPPED; upvote()/downvote() with one-per-user enforcement; hasVoted(); top() by vote count. PR #692.
+**FT250 — KpiTracker**: `KpiTracker` KPI/OKR metric tracking; define() with optional target/period/unit; record() time-series data points; progress() returns {actual, target, pct}; purgeOlderThan() per definition. PR #693.
 
 ### 2026-05-28 — FT229–FT238: Xion eighth extended wave (10 trials)
 


### PR DESCRIPTION
## Docs update: FT239–FT250

Updates roadmap, todo, and field-trial candidates for the ninth Xion wave.

### Changes
- `docs/roadmap.md`: FT1–FT250 complete; FT239–FT250 wave summary added
- `docs/todo/current.md`: per-FT details for all 12 trials (PRs #682–#693)
- `docs/field-trials/candidates.md`: Xion wave updated to FT78–FT250; archive entries added for FT239–FT250

### Trials covered
| FT | Class | PR |
|---|---|---|
| FT239 | VotePoll | #682 |
| FT240 | SubscriptionPlan | #683 |
| FT241 | PresenceTracker | #684 |
| FT242 | GiftCard | #685 |
| FT243 | IncidentLog | #686 |
| FT244 | ChangeRequest | #687 |
| FT245 | BudgetTracker | #688 |
| FT246 | AssetRegistry | #689 |
| FT247 | EventRsvp | #690 |
| FT248 | DocumentSignature | #691 |
| FT249 | FeatureRequest | #692 |
| FT250 | KpiTracker | #693 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)