### PR TITLE
feat(xion): TenantConfig — per-tenant key-value configuration store (FT251)

### DIFF
--- a/class/xion/TenantConfig.php
+++ b/class/xion/TenantConfig.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * TenantConfig — per-tenant key-value configuration store.
+ *
+ * Manages configuration overrides on a per-tenant basis for multi-tenant
+ * or per-organization SaaS applications. Supports typed values
+ * (string/int/bool/json) with optional default fallbacks.
+ *
+ * Distinct from:
+ * - `ConfigStore`   (global application configuration)
+ * - `SystemSetting` (typed global admin settings)
+ * - `UserPreference` (per-user preferences)
+ *
+ * ## Usage
+ *
+ * ```php
+ * $tc = new TenantConfig($pdo);
+ *
+ * $tc->set('tenant-abc', 'max_seats', '50');
+ * $tc->set('tenant-abc', 'feature_analytics', 'true');
+ * $tc->get('tenant-abc', 'max_seats');           // '50'
+ * $tc->getInt('tenant-abc', 'max_seats', 10);    // 50
+ * $tc->getBool('tenant-abc', 'feature_analytics'); // true
+ * $tc->all('tenant-abc');                         // all k/v pairs
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE tenant_configs (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     tenant_id  VARCHAR(255) NOT NULL,
+ *     config_key VARCHAR(100) NOT NULL,
+ *     value      TEXT         NULL,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (tenant_id, config_key)
+ * );
+ * ```
+ */
+final class TenantConfig
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set a configuration value for a tenant (upsert).
+     *
+     * @throws \InvalidArgumentException on empty tenantId or key.
+     */
+    public function set(string $tenantId, string $key, ?string $value): void
+    {
+        $tenantId = trim($tenantId);
+        $key      = trim($key);
+        if ($tenantId === '') {
+            throw new \InvalidArgumentException('tenant_id must not be empty.');
+        }
+        if ($key === '') {
+            throw new \InvalidArgumentException('config_key must not be empty.');
+        }
+
+        $now    = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $sql = 'INSERT INTO tenant_configs (tenant_id, config_key, value, updated_at)
+                    VALUES (:tid, :key, :val, :now)
+                    ON CONFLICT (tenant_id, config_key) DO UPDATE SET
+                        value      = excluded.value,
+                        updated_at = excluded.updated_at';
+        } else {
+            $sql = 'INSERT INTO tenant_configs (tenant_id, config_key, value, updated_at)
+                    VALUES (:tid, :key, :val, :now)
+                    ON DUPLICATE KEY UPDATE
+                        value      = VALUES(value),
+                        updated_at = VALUES(updated_at)';
+        }
+        $this->db()->prepare($sql)->execute([
+            ':tid' => $tenantId,
+            ':key' => $key,
+            ':val' => $value,
+            ':now' => $now,
+        ]);
+    }
+
+    /**
+     * Get a raw string value for a tenant/key.
+     * Returns $default if not set.
+     */
+    public function get(string $tenantId, string $key, ?string $default = null): ?string
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT value FROM tenant_configs WHERE tenant_id = :tid AND config_key = :key'
+        );
+        $stmt->execute([':tid' => trim($tenantId), ':key' => trim($key)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row['value'] : $default;
+    }
+
+    /**
+     * Get value as integer.
+     */
+    public function getInt(string $tenantId, string $key, int $default = 0): int
+    {
+        $val = $this->get($tenantId, $key);
+        return $val !== null ? (int)$val : $default;
+    }
+
+    /**
+     * Get value as boolean ('true'/'1'/'yes' → true; others → false).
+     */
+    public function getBool(string $tenantId, string $key, bool $default = false): bool
+    {
+        $val = $this->get($tenantId, $key);
+        if ($val === null) {
+            return $default;
+        }
+        return in_array(strtolower($val), ['true', '1', 'yes', 'on'], true);
+    }
+
+    /**
+     * Get value decoded from JSON.
+     *
+     * @return mixed Decoded JSON value, or $default if not set or invalid JSON.
+     */
+    public function getJson(string $tenantId, string $key, mixed $default = null): mixed
+    {
+        $val = $this->get($tenantId, $key);
+        if ($val === null) {
+            return $default;
+        }
+        $decoded = json_decode($val, true);
+        return ($decoded !== null) ? $decoded : $default;
+    }
+
+    /**
+     * Check whether a key is configured for a tenant.
+     */
+    public function has(string $tenantId, string $key): bool
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM tenant_configs WHERE tenant_id = :tid AND config_key = :key'
+        );
+        $stmt->execute([':tid' => trim($tenantId), ':key' => trim($key)]);
+        return (int)$stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Remove a configuration key for a tenant.
+     *
+     * @return bool True if the key existed and was deleted.
+     */
+    public function delete(string $tenantId, string $key): bool
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM tenant_configs WHERE tenant_id = :tid AND config_key = :key'
+        );
+        $stmt->execute([':tid' => trim($tenantId), ':key' => trim($key)]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * All configuration entries for a tenant, as key → value map.
+     *
+     * @return array<string,string|null>
+     */
+    public function all(string $tenantId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT config_key, value FROM tenant_configs WHERE tenant_id = :tid
+             ORDER BY config_key ASC'
+        );
+        $stmt->execute([':tid' => trim($tenantId)]);
+        $rows   = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['config_key']] = $row['value'];
+        }
+        return $result;
+    }
+
+    /**
+     * Remove all configuration entries for a tenant.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purge(string $tenantId): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM tenant_configs WHERE tenant_id = :tid');
+        $stmt->execute([':tid' => trim($tenantId)]);
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Copy all config from one tenant to another (replaces existing keys).
+     *
+     * @return int Number of keys copied.
+     */
+    public function copyTo(string $sourceTenantId, string $targetTenantId): int
+    {
+        $configs = $this->all($sourceTenantId);
+        foreach ($configs as $key => $value) {
+            $this->set($targetTenantId, $key, $value);
+        }
+        return count($configs);
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/TenantConfigTest.php
+++ b/tests/Unit/Xion/TenantConfigTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\TenantConfig;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class TenantConfigTest extends TestCase
+{
+    private PDO $pdo;
+    private TenantConfig $tc;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE tenant_configs (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                tenant_id  VARCHAR(255) NOT NULL,
+                config_key VARCHAR(100) NOT NULL,
+                value      TEXT         NULL,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (tenant_id, config_key)
+            )
+        ');
+        $this->tc = new TenantConfig($this->pdo);
+    }
+
+    // ── set / get ─────────────────────────────────────────────────────────────
+
+    public function testSetAndGetValue(): void
+    {
+        $this->tc->set('tenant-abc', 'max_seats', '50');
+        $this->assertSame('50', $this->tc->get('tenant-abc', 'max_seats'));
+    }
+
+    public function testSetUpdatesExistingKey(): void
+    {
+        $this->tc->set('tenant-abc', 'max_seats', '10');
+        $this->tc->set('tenant-abc', 'max_seats', '99');
+        $this->assertSame('99', $this->tc->get('tenant-abc', 'max_seats'));
+    }
+
+    public function testGetReturnsDefaultWhenNotSet(): void
+    {
+        $this->assertSame('fallback', $this->tc->get('tenant-abc', 'nonexistent', 'fallback'));
+    }
+
+    public function testGetReturnsNullDefaultWhenNotSetAndNoDefault(): void
+    {
+        $this->assertNull($this->tc->get('tenant-abc', 'nonexistent'));
+    }
+
+    public function testSetNullValue(): void
+    {
+        $this->tc->set('tenant-abc', 'opt_key', null);
+        $this->assertNull($this->tc->get('tenant-abc', 'opt_key'));
+    }
+
+    public function testSetThrowsOnEmptyTenantId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->tc->set('', 'key', 'value');
+    }
+
+    public function testSetThrowsOnEmptyKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->tc->set('tenant-abc', '', 'value');
+    }
+
+    // ── getInt ────────────────────────────────────────────────────────────────
+
+    public function testGetIntConvertsString(): void
+    {
+        $this->tc->set('tenant-abc', 'max_seats', '50');
+        $this->assertSame(50, $this->tc->getInt('tenant-abc', 'max_seats'));
+    }
+
+    public function testGetIntReturnsDefaultWhenNotSet(): void
+    {
+        $this->assertSame(10, $this->tc->getInt('tenant-abc', 'nonexistent', 10));
+    }
+
+    // ── getBool ───────────────────────────────────────────────────────────────
+
+    public function testGetBoolTrueForTrueString(): void
+    {
+        $this->tc->set('tenant-abc', 'feature_on', 'true');
+        $this->assertTrue($this->tc->getBool('tenant-abc', 'feature_on'));
+    }
+
+    public function testGetBoolTrueForOneString(): void
+    {
+        $this->tc->set('tenant-abc', 'feature_on', '1');
+        $this->assertTrue($this->tc->getBool('tenant-abc', 'feature_on'));
+    }
+
+    public function testGetBoolTrueForYesString(): void
+    {
+        $this->tc->set('tenant-abc', 'feature_on', 'yes');
+        $this->assertTrue($this->tc->getBool('tenant-abc', 'feature_on'));
+    }
+
+    public function testGetBoolFalseForFalseString(): void
+    {
+        $this->tc->set('tenant-abc', 'feature_on', 'false');
+        $this->assertFalse($this->tc->getBool('tenant-abc', 'feature_on'));
+    }
+
+    public function testGetBoolReturnsDefaultWhenNotSet(): void
+    {
+        $this->assertTrue($this->tc->getBool('tenant-abc', 'nonexistent', true));
+    }
+
+    // ── getJson ───────────────────────────────────────────────────────────────
+
+    public function testGetJsonDecodesArray(): void
+    {
+        $this->tc->set('tenant-abc', 'limits', '{"api":100,"storage":500}');
+        $result = $this->tc->getJson('tenant-abc', 'limits');
+        $this->assertSame(['api' => 100, 'storage' => 500], $result);
+    }
+
+    public function testGetJsonReturnsDefaultForInvalidJson(): void
+    {
+        $this->tc->set('tenant-abc', 'limits', 'not-json');
+        $this->assertSame([], $this->tc->getJson('tenant-abc', 'limits', []));
+    }
+
+    public function testGetJsonReturnsDefaultWhenNotSet(): void
+    {
+        $this->assertNull($this->tc->getJson('tenant-abc', 'nonexistent'));
+    }
+
+    // ── has ───────────────────────────────────────────────────────────────────
+
+    public function testHasReturnsTrueWhenSet(): void
+    {
+        $this->tc->set('tenant-abc', 'key', 'value');
+        $this->assertTrue($this->tc->has('tenant-abc', 'key'));
+    }
+
+    public function testHasReturnsFalseWhenNotSet(): void
+    {
+        $this->assertFalse($this->tc->has('tenant-abc', 'nonexistent'));
+    }
+
+    public function testHasTrueForNullValue(): void
+    {
+        $this->tc->set('tenant-abc', 'key', null);
+        $this->assertTrue($this->tc->has('tenant-abc', 'key'));
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesKey(): void
+    {
+        $this->tc->set('tenant-abc', 'key', 'value');
+        $this->assertTrue($this->tc->delete('tenant-abc', 'key'));
+        $this->assertFalse($this->tc->has('tenant-abc', 'key'));
+    }
+
+    public function testDeleteReturnsFalseWhenNotExists(): void
+    {
+        $this->assertFalse($this->tc->delete('tenant-abc', 'nonexistent'));
+    }
+
+    // ── all ───────────────────────────────────────────────────────────────────
+
+    public function testAllReturnsKeyValueMap(): void
+    {
+        $this->tc->set('tenant-abc', 'a', '1');
+        $this->tc->set('tenant-abc', 'b', '2');
+        $this->tc->set('tenant-xyz', 'a', '99'); // different tenant
+        $all = $this->tc->all('tenant-abc');
+        $this->assertSame(['a' => '1', 'b' => '2'], $all);
+    }
+
+    public function testAllReturnsEmptyForUnknownTenant(): void
+    {
+        $this->assertSame([], $this->tc->all('tenant-unknown'));
+    }
+
+    // ── purge ─────────────────────────────────────────────────────────────────
+
+    public function testPurgeDeletesAllKeysForTenant(): void
+    {
+        $this->tc->set('tenant-abc', 'a', '1');
+        $this->tc->set('tenant-abc', 'b', '2');
+        $this->tc->set('tenant-xyz', 'a', '99');
+        $deleted = $this->tc->purge('tenant-abc');
+        $this->assertSame(2, $deleted);
+        $this->assertSame([], $this->tc->all('tenant-abc'));
+        $this->assertSame(['a' => '99'], $this->tc->all('tenant-xyz'));
+    }
+
+    // ── copyTo ────────────────────────────────────────────────────────────────
+
+    public function testCopyToCopiesAllKeys(): void
+    {
+        $this->tc->set('tenant-abc', 'x', '10');
+        $this->tc->set('tenant-abc', 'y', '20');
+        $count = $this->tc->copyTo('tenant-abc', 'tenant-new');
+        $this->assertSame(2, $count);
+        $this->assertSame('10', $this->tc->get('tenant-new', 'x'));
+        $this->assertSame('20', $this->tc->get('tenant-new', 'y'));
+    }
+
+    public function testCopyToOverwritesExistingKeys(): void
+    {
+        $this->tc->set('tenant-src', 'key', 'new-value');
+        $this->tc->set('tenant-dst', 'key', 'old-value');
+        $this->tc->copyTo('tenant-src', 'tenant-dst');
+        $this->assertSame('new-value', $this->tc->get('tenant-dst', 'key'));
+    }
+}


### PR DESCRIPTION
## FT251 — TenantConfig

Per-tenant SaaS configuration with typed value accessors and cross-driver upsert.

### Class: `Nene\Xion\TenantConfig`
- `set()` — upsert a config value (cross-driver); throws on empty tenantId/key
- `get()` — raw string value with optional default
- `getInt()` — typed integer accessor with default
- `getBool()` — typed boolean accessor; truthy for 'true'/'1'/'yes'/'on'
- `getJson()` — JSON-decoded value with default on parse failure
- `has()` — whether a key is configured (null value counts as configured)
- `delete()` — remove a single key
- `all()` — key → value map for entire tenant
- `purge()` — remove all keys for a tenant
- `copyTo()` — copy all keys from one tenant to another (replaces existing)

### Tests
27 tests, 32 assertions — all green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)