### PR TITLE
feat(xion): OtpChallenge — OTP challenge issuance and verification with attempt limiting (FT252)

### DIFF
--- a/class/xion/OtpChallenge.php
+++ b/class/xion/OtpChallenge.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * OtpChallenge — one-time password (OTP) challenge issuance and verification.
+ *
+ * Issues short numeric or alphanumeric OTPs for email/SMS verification,
+ * step-up authentication, or any context requiring a single-use code.
+ * Codes are SHA-256 hashed at rest; attempts are limited to prevent brute-force.
+ *
+ * Distinct from:
+ * - `PinCode`            (admin-set user PIN codes)
+ * - `MagicLink`          (tokenized login links)
+ * - `TotpAuthenticator`  (HMAC time-based OTP / RFC 6238)
+ * - `TwoFactorBackupCode` (static recovery codes for 2FA)
+ *
+ * ## Usage
+ *
+ * ```php
+ * $otp = new OtpChallenge($pdo);
+ *
+ * [$id, $code] = $otp->issue('user-1', 'email-verify', 6, 900);
+ * // send $code to user via email/SMS
+ *
+ * if ($otp->verify($id, $userInput)) {
+ *     // valid
+ * }
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE otp_challenges (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id    VARCHAR(255) NOT NULL,
+ *     purpose    VARCHAR(100) NOT NULL,
+ *     code_hash  VARCHAR(64)  NOT NULL,
+ *     expires_at DATETIME     NOT NULL,
+ *     attempts   INTEGER      NOT NULL DEFAULT 0,
+ *     used       INTEGER      NOT NULL DEFAULT 0,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class OtpChallenge
+{
+    public const DEFAULT_LENGTH      = 6;
+    public const DEFAULT_TTL_SECONDS = 600;
+    public const DEFAULT_MAX_ATTEMPTS = 5;
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Issue a new OTP challenge.
+     *
+     * Any previous active challenges for the same user+purpose are invalidated.
+     *
+     * @param  int $length     Code length in characters (default 6).
+     * @param  int $ttlSeconds Seconds until expiry (default 600).
+     * @return array{0: int, 1: string}  [challengeId, plaintext code]
+     * @throws \InvalidArgumentException on empty userId or purpose.
+     */
+    public function issue(
+        string $userId,
+        string $purpose,
+        int $length = self::DEFAULT_LENGTH,
+        int $ttlSeconds = self::DEFAULT_TTL_SECONDS
+    ): array {
+        $userId  = trim($userId);
+        $purpose = trim($purpose);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('user_id must not be empty.');
+        }
+        if ($purpose === '') {
+            throw new \InvalidArgumentException('purpose must not be empty.');
+        }
+        if ($length < 4) {
+            throw new \InvalidArgumentException('length must be at least 4.');
+        }
+
+        // Invalidate any previous active challenges for this user+purpose
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $this->db()->prepare(
+            'UPDATE otp_challenges SET used = 1
+             WHERE user_id = :uid AND purpose = :purpose AND used = 0 AND expires_at > :now'
+        )->execute([':uid' => $userId, ':purpose' => $purpose, ':now' => $now]);
+
+        $code      = $this->generateCode($length);
+        $codeHash  = hash('sha256', $code);
+        $expiresAt = (new \DateTimeImmutable())
+            ->modify("+{$ttlSeconds} seconds")
+            ->format('Y-m-d H:i:s');
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO otp_challenges (user_id, purpose, code_hash, expires_at, attempts, used, created_at)
+             VALUES (:uid, :purpose, :hash, :expires, 0, 0, :now)'
+        );
+        $stmt->execute([
+            ':uid'     => $userId,
+            ':purpose' => $purpose,
+            ':hash'    => $codeHash,
+            ':expires' => $expiresAt,
+            ':now'     => $now,
+        ]);
+        return [(int)$this->db()->lastInsertId(), $code];
+    }
+
+    /**
+     * Retrieve a challenge record by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM otp_challenges WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Verify a code against a challenge.
+     *
+     * Increments attempt count. Marks challenge as used if code matches.
+     *
+     * @param  int $maxAttempts Maximum allowed incorrect attempts before the challenge is voided.
+     * @return bool True if the code is correct and the challenge is active.
+     */
+    public function verify(
+        int $id,
+        string $code,
+        int $maxAttempts = self::DEFAULT_MAX_ATTEMPTS
+    ): bool {
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $row  = $this->get($id);
+
+        if ($row === null) {
+            return false;
+        }
+        if ((int)$row['used'] !== 0) {
+            return false;
+        }
+        if ($row['expires_at'] <= $now) {
+            return false;
+        }
+        if ((int)$row['attempts'] >= $maxAttempts) {
+            return false;
+        }
+
+        $match = hash_equals((string)$row['code_hash'], hash('sha256', $code));
+
+        // Increment attempt count
+        $this->db()->prepare(
+            'UPDATE otp_challenges SET attempts = attempts + 1 WHERE id = :id'
+        )->execute([':id' => $id]);
+
+        if ($match) {
+            // Mark as used
+            $this->db()->prepare(
+                'UPDATE otp_challenges SET used = 1 WHERE id = :id'
+            )->execute([':id' => $id]);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Whether a challenge is still valid (not used, not expired, under attempt limit).
+     *
+     * @param int $maxAttempts
+     */
+    public function isValid(
+        int $id,
+        int $maxAttempts = self::DEFAULT_MAX_ATTEMPTS
+    ): bool {
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $row = $this->get($id);
+        if ($row === null) {
+            return false;
+        }
+        return (int)$row['used'] === 0
+            && $row['expires_at'] > $now
+            && (int)$row['attempts'] < $maxAttempts;
+    }
+
+    /**
+     * Invalidate a challenge manually (mark as used).
+     *
+     * @return bool True if found and not already used.
+     */
+    public function invalidate(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE otp_challenges SET used = 1 WHERE id = :id AND used = 0'
+        );
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete expired or used challenges older than a cutoff.
+     *
+     * @return int Rows deleted.
+     */
+    public function purgeOlderThan(string $cutoff): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM otp_challenges
+             WHERE (used = 1 OR expires_at < :now) AND created_at < :cutoff'
+        );
+        $stmt->execute([':now' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'), ':cutoff' => $cutoff]);
+        return $stmt->rowCount();
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function generateCode(int $length): string
+    {
+        $chars  = '0123456789';
+        $code   = '';
+        $max    = strlen($chars) - 1;
+        for ($i = 0; $i < $length; $i++) {
+            $code .= $chars[random_int(0, $max)];
+        }
+        return $code;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/OtpChallengeTest.php
+++ b/tests/Unit/Xion/OtpChallengeTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\OtpChallenge;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class OtpChallengeTest extends TestCase
+{
+    private PDO $pdo;
+    private OtpChallenge $otp;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE otp_challenges (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    VARCHAR(255) NOT NULL,
+                purpose    VARCHAR(100) NOT NULL,
+                code_hash  VARCHAR(64)  NOT NULL,
+                expires_at DATETIME     NOT NULL,
+                attempts   INTEGER      NOT NULL DEFAULT 0,
+                used       INTEGER      NOT NULL DEFAULT 0,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->otp = new OtpChallenge($this->pdo);
+    }
+
+    // ── issue ─────────────────────────────────────────────────────────────────
+
+    public function testIssueReturnsIdAndCode(): void
+    {
+        [$id, $code] = $this->otp->issue('user-1', 'email-verify');
+        $this->assertGreaterThan(0, $id);
+        $this->assertSame(6, strlen($code)); // default length
+        $this->assertMatchesRegularExpression('/^\d{6}$/', $code);
+    }
+
+    public function testIssueStoresHashedCode(): void
+    {
+        [$id, $code] = $this->otp->issue('user-1', 'email-verify');
+        $row = $this->otp->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(hash('sha256', $code), $row['code_hash']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['used']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['attempts']);
+    }
+
+    public function testIssueCustomLength(): void
+    {
+        [, $code] = $this->otp->issue('user-1', 'phone-verify', 8);
+        $this->assertSame(8, strlen($code));
+    }
+
+    public function testIssueInvalidatesPreviousChallenge(): void
+    {
+        [$id1] = $this->otp->issue('user-1', 'email-verify', 6, 900);
+        $this->otp->issue('user-1', 'email-verify', 6, 900);
+        $row = $this->otp->get($id1);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['used']); // invalidated
+    }
+
+    public function testIssueDifferentPurposesCoexist(): void
+    {
+        [$id1] = $this->otp->issue('user-1', 'email-verify', 6, 900);
+        $this->otp->issue('user-1', 'phone-verify', 6, 900);
+        $row = $this->otp->get($id1);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['used']); // not invalidated
+    }
+
+    public function testIssueThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->otp->issue('', 'email-verify');
+    }
+
+    public function testIssueThrowsOnEmptyPurpose(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->otp->issue('user-1', '');
+    }
+
+    public function testIssueThrowsOnTooShortLength(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->otp->issue('user-1', 'email-verify', 3);
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->otp->get(9999));
+    }
+
+    // ── verify ────────────────────────────────────────────────────────────────
+
+    public function testVerifyReturnsTrueForCorrectCode(): void
+    {
+        [$id, $code] = $this->otp->issue('user-1', 'email-verify');
+        $this->assertTrue($this->otp->verify($id, $code));
+    }
+
+    public function testVerifyReturnsFalseForWrongCode(): void
+    {
+        [$id] = $this->otp->issue('user-1', 'email-verify');
+        $this->assertFalse($this->otp->verify($id, '000000'));
+    }
+
+    public function testVerifyIncreasesAttemptCount(): void
+    {
+        [$id] = $this->otp->issue('user-1', 'email-verify');
+        $this->otp->verify($id, '000000'); // wrong
+        $row = $this->otp->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['attempts']);
+    }
+
+    public function testVerifyMarksUsedOnSuccess(): void
+    {
+        [$id, $code] = $this->otp->issue('user-1', 'email-verify');
+        $this->otp->verify($id, $code);
+        $row = $this->otp->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['used']);
+    }
+
+    public function testVerifyReturnsFalseAfterUsed(): void
+    {
+        [$id, $code] = $this->otp->issue('user-1', 'email-verify');
+        $this->otp->verify($id, $code);
+        $this->assertFalse($this->otp->verify($id, $code)); // already used
+    }
+
+    public function testVerifyReturnsFalseWhenExpired(): void
+    {
+        [$id] = $this->otp->issue('user-1', 'email-verify', 6, 1);
+        // Manually expire it
+        $this->pdo->exec("UPDATE otp_challenges SET expires_at = '2000-01-01 00:00:00' WHERE id = {$id}");
+        $this->assertFalse($this->otp->verify($id, '123456'));
+    }
+
+    public function testVerifyReturnsFalseAfterMaxAttempts(): void
+    {
+        [$id] = $this->otp->issue('user-1', 'email-verify');
+        for ($i = 0; $i < 3; $i++) {
+            $this->otp->verify($id, '000000', 3);
+        }
+        $this->assertFalse($this->otp->verify($id, '000000', 3));
+    }
+
+    public function testVerifyReturnsFalseForMissingChallenge(): void
+    {
+        $this->assertFalse($this->otp->verify(9999, '123456'));
+    }
+
+    // ── isValid ───────────────────────────────────────────────────────────────
+
+    public function testIsValidTrueForFreshChallenge(): void
+    {
+        [$id] = $this->otp->issue('user-1', 'email-verify');
+        $this->assertTrue($this->otp->isValid($id));
+    }
+
+    public function testIsValidFalseAfterUse(): void
+    {
+        [$id, $code] = $this->otp->issue('user-1', 'email-verify');
+        $this->otp->verify($id, $code);
+        $this->assertFalse($this->otp->isValid($id));
+    }
+
+    public function testIsValidFalseForMissingId(): void
+    {
+        $this->assertFalse($this->otp->isValid(9999));
+    }
+
+    // ── invalidate ────────────────────────────────────────────────────────────
+
+    public function testInvalidateMarksUsed(): void
+    {
+        [$id] = $this->otp->issue('user-1', 'email-verify');
+        $this->assertTrue($this->otp->invalidate($id));
+        $this->assertFalse($this->otp->isValid($id));
+    }
+
+    public function testInvalidateReturnsFalseWhenAlreadyUsed(): void
+    {
+        [$id, $code] = $this->otp->issue('user-1', 'email-verify');
+        $this->otp->verify($id, $code);
+        $this->assertFalse($this->otp->invalidate($id));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldUsedChallenges(): void
+    {
+        [$id] = $this->otp->issue('user-1', 'email-verify');
+        $this->pdo->exec(
+            "UPDATE otp_challenges SET used = 1, created_at = '2020-01-01 00:00:00' WHERE id = {$id}"
+        );
+        $deleted = $this->otp->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(1, $deleted);
+    }
+}


### PR DESCRIPTION
## FT252 — OtpChallenge

One-time password issuance and verification for email/SMS verification and step-up auth.

### Class: `Nene\Xion\OtpChallenge`
- `issue()` — generate a random numeric OTP; invalidates previous active challenges for same user+purpose; returns `[id, plaintext_code]`; stores SHA-256 hash
- `get()` — fetch challenge record by ID
- `verify()` — constant-time hash comparison; increments attempt count; marks used on match; guards against: expired, already-used, over attempt limit
- `isValid()` — check whether a challenge is still usable (not used, not expired, under attempt limit)
- `invalidate()` — manually void a challenge
- `purgeOlderThan()` — clean up used/expired challenges older than cutoff

### Security notes
- Codes stored as SHA-256 hashes only (plaintext never persisted)
-  for timing-safe comparison
- Attempt limiting prevents brute-force (default 5 attempts)
- New issue() for same user+purpose invalidates previous to prevent code reuse

### Tests
23 tests, 33 assertions — all green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)