### PR TITLE
feat(xion): AccessSchedule — recurring time-window access control (FT254)

### DIFF
--- a/class/xion/AccessSchedule.php
+++ b/class/xion/AccessSchedule.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * AccessSchedule — recurring time-window access control for users and resources.
+ *
+ * Defines recurring weekly access windows (e.g. "Mon–Fri 09:00–17:00")
+ * and checks whether a given datetime falls within an allowed window.
+ * Useful for time-restricted feature access, maintenance windows,
+ * and shift-based permissions.
+ *
+ * Distinct from:
+ * - `AccessGrant`         (time-bounded delegation, ad-hoc)
+ * - `ResourceReservation` (single-occurrence slot booking)
+ * - `AccessControl`       (per-resource subject ACL)
+ *
+ * ## Usage
+ *
+ * ```php
+ * $as = new AccessSchedule($pdo);
+ *
+ * $id = $as->create('user-1', 'office-wifi', [1,2,3,4,5], '09:00', '17:00');
+ * $as->isAllowed('user-1', 'office-wifi'); // depends on current day/time
+ * $as->isAllowedAt('user-1', 'office-wifi', '2026-06-15 10:00:00'); // Monday 10am
+ * ```
+ *
+ * ## Day-of-week encoding
+ * 0 = Sunday, 1 = Monday, ..., 6 = Saturday (ISO-compatible).
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE access_schedules (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     subject_id  VARCHAR(255) NOT NULL,
+ *     resource    VARCHAR(255) NOT NULL,
+ *     days        VARCHAR(20)  NOT NULL,
+ *     time_start  VARCHAR(8)   NOT NULL,
+ *     time_end    VARCHAR(8)   NOT NULL,
+ *     active      INTEGER      NOT NULL DEFAULT 1,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class AccessSchedule
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create an access schedule for a subject/resource pair.
+     *
+     * @param  list<int> $days Days of week (0=Sun … 6=Sat).
+     * @param  string    $timeStart 'HH:MM' start time (inclusive).
+     * @param  string    $timeEnd   'HH:MM' end time (exclusive).
+     * @return int New schedule ID.
+     * @throws \InvalidArgumentException on empty subjectId/resource, no days, or bad time format.
+     */
+    public function create(
+        string $subjectId,
+        string $resource,
+        array $days,
+        string $timeStart,
+        string $timeEnd
+    ): int {
+        $subjectId = trim($subjectId);
+        $resource  = trim($resource);
+        if ($subjectId === '') {
+            throw new \InvalidArgumentException('subject_id must not be empty.');
+        }
+        if ($resource === '') {
+            throw new \InvalidArgumentException('resource must not be empty.');
+        }
+        if (count($days) === 0) {
+            throw new \InvalidArgumentException('At least one day must be specified.');
+        }
+        if (!$this->isValidTime($timeStart) || !$this->isValidTime($timeEnd)) {
+            throw new \InvalidArgumentException('time_start and time_end must be HH:MM format.');
+        }
+
+        // Normalize days: unique, sorted, within 0-6
+        $days = array_values(array_unique(array_filter($days, fn ($d) => $d >= 0 && $d <= 6)));
+        sort($days);
+
+        $now  = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->db()->prepare(
+            'INSERT INTO access_schedules (subject_id, resource, days, time_start, time_end, active, created_at)
+             VALUES (:sid, :res, :days, :ts, :te, 1, :now)'
+        );
+        $stmt->execute([
+            ':sid'  => $subjectId,
+            ':res'  => $resource,
+            ':days' => implode(',', $days),
+            ':ts'   => $timeStart,
+            ':te'   => $timeEnd,
+            ':now'  => $now,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Retrieve a schedule by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM access_schedules WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * Check whether subject/resource access is allowed right now.
+     */
+    public function isAllowed(string $subjectId, string $resource): bool
+    {
+        return $this->isAllowedAt($subjectId, $resource, (new \DateTimeImmutable())->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * Check whether subject/resource access is allowed at a given datetime.
+     *
+     * @param  string $datetime 'Y-m-d H:i:s' or 'Y-m-d H:i' format.
+     */
+    public function isAllowedAt(string $subjectId, string $resource, string $datetime): bool
+    {
+        $dt      = new \DateTimeImmutable($datetime);
+        $dayOfWk = (int)$dt->format('w'); // 0=Sun ... 6=Sat
+        $timeNow = $dt->format('H:i');
+
+        $schedules = $this->activeFor(trim($subjectId), trim($resource));
+        foreach ($schedules as $schedule) {
+            $days = explode(',', (string)$schedule['days']);
+            if (!in_array((string)$dayOfWk, $days, true)) {
+                continue;
+            }
+            if ($timeNow >= (string)$schedule['time_start'] && $timeNow < (string)$schedule['time_end']) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * All active schedules for a subject/resource pair.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function activeFor(string $subjectId, string $resource): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM access_schedules
+             WHERE subject_id = :sid AND resource = :res AND active = 1
+             ORDER BY id ASC'
+        );
+        $stmt->execute([':sid' => trim($subjectId), ':res' => trim($resource)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * All schedules for a subject (all resources).
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function forSubject(string $subjectId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM access_schedules WHERE subject_id = :sid ORDER BY resource ASC, id ASC'
+        );
+        $stmt->execute([':sid' => trim($subjectId)]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * Deactivate a schedule (stop it from being checked).
+     *
+     * @return bool True if found and active.
+     */
+    public function deactivate(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE access_schedules SET active = 0 WHERE id = :id AND active = 1'
+        );
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Reactivate a deactivated schedule.
+     *
+     * @return bool True if found and inactive.
+     */
+    public function activate(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE access_schedules SET active = 1 WHERE id = :id AND active = 0'
+        );
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Delete a schedule.
+     *
+     * @return bool True if found.
+     */
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM access_schedules WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── internal helpers ─────────────────────────────────────────────────────
+
+    private function isValidTime(string $time): bool
+    {
+        return (bool)preg_match('/^\d{2}:\d{2}$/', $time);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/tests/Unit/Xion/AccessScheduleTest.php
+++ b/tests/Unit/Xion/AccessScheduleTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\AccessSchedule;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class AccessScheduleTest extends TestCase
+{
+    private PDO $pdo;
+    private AccessSchedule $as;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE access_schedules (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                subject_id VARCHAR(255) NOT NULL,
+                resource   VARCHAR(255) NOT NULL,
+                days       VARCHAR(20)  NOT NULL,
+                time_start VARCHAR(8)   NOT NULL,
+                time_end   VARCHAR(8)   NOT NULL,
+                active     INTEGER      NOT NULL DEFAULT 1,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->as = new AccessSchedule($this->pdo);
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    public function testCreateReturnsId(): void
+    {
+        $id = $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '09:00', '17:00');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testCreateStoresFields(): void
+    {
+        $id  = $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '09:00', '17:00');
+        $row = $this->as->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['subject_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('office-wifi', $row['resource']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('1,2,3,4,5', $row['days']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('09:00', $row['time_start']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('17:00', $row['time_end']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['active']);
+    }
+
+    public function testCreateNormalizesAndSortsDays(): void
+    {
+        $id  = $this->as->create('user-1', 'r', [5, 1, 3, 1], '09:00', '17:00');
+        $row = $this->as->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('1,3,5', $row['days']);
+    }
+
+    public function testCreateThrowsOnEmptySubjectId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->as->create('', 'resource', [1], '09:00', '17:00');
+    }
+
+    public function testCreateThrowsOnEmptyResource(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->as->create('user-1', '', [1], '09:00', '17:00');
+    }
+
+    public function testCreateThrowsOnNoDays(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->as->create('user-1', 'resource', [], '09:00', '17:00');
+    }
+
+    public function testCreateThrowsOnBadTimeFormat(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->as->create('user-1', 'resource', [1], '9:00', '17:00');
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->as->get(9999));
+    }
+
+    // ── isAllowedAt ───────────────────────────────────────────────────────────
+
+    public function testIsAllowedAtReturnsTrueInsideWindow(): void
+    {
+        // 2026-06-15 is a Monday (day 1)
+        $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '09:00', '17:00');
+        $this->assertTrue($this->as->isAllowedAt('user-1', 'office-wifi', '2026-06-15 10:30:00'));
+    }
+
+    public function testIsAllowedAtReturnsFalseOutsideTimeWindow(): void
+    {
+        // 2026-06-15 is a Monday (day 1), but 08:59 is before start
+        $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '09:00', '17:00');
+        $this->assertFalse($this->as->isAllowedAt('user-1', 'office-wifi', '2026-06-15 08:59:00'));
+    }
+
+    public function testIsAllowedAtReturnsFalseOnEndTime(): void
+    {
+        // End time is exclusive
+        $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '09:00', '17:00');
+        $this->assertFalse($this->as->isAllowedAt('user-1', 'office-wifi', '2026-06-15 17:00:00'));
+    }
+
+    public function testIsAllowedAtReturnsFalseOnWrongDay(): void
+    {
+        // 2026-06-14 is a Sunday (day 0), weekdays-only schedule
+        $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '09:00', '17:00');
+        $this->assertFalse($this->as->isAllowedAt('user-1', 'office-wifi', '2026-06-14 10:00:00'));
+    }
+
+    public function testIsAllowedAtReturnsTrueOnWeekend(): void
+    {
+        // 2026-06-14 is a Sunday (day 0)
+        $this->as->create('user-1', 'gaming', [0, 6], '00:00', '23:59');
+        $this->assertTrue($this->as->isAllowedAt('user-1', 'gaming', '2026-06-14 12:00:00'));
+    }
+
+    public function testIsAllowedAtReturnsFalseWhenNoSchedule(): void
+    {
+        $this->assertFalse($this->as->isAllowedAt('user-1', 'unknown-resource', '2026-06-15 10:00:00'));
+    }
+
+    public function testIsAllowedAtReturnsFalseWhenScheduleInactive(): void
+    {
+        $id = $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '09:00', '17:00');
+        $this->as->deactivate($id);
+        $this->assertFalse($this->as->isAllowedAt('user-1', 'office-wifi', '2026-06-15 10:00:00'));
+    }
+
+    public function testMultipleSchedulesOneMatches(): void
+    {
+        $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '09:00', '12:00');
+        $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '13:00', '17:00');
+        $this->assertTrue($this->as->isAllowedAt('user-1', 'office-wifi', '2026-06-15 14:00:00'));
+        $this->assertFalse($this->as->isAllowedAt('user-1', 'office-wifi', '2026-06-15 12:30:00'));
+    }
+
+    // ── activeFor ─────────────────────────────────────────────────────────────
+
+    public function testActiveForFiltersInactiveSchedules(): void
+    {
+        $id1 = $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '09:00', '17:00');
+        $this->as->create('user-1', 'office-wifi', [6], '10:00', '16:00');
+        $this->as->deactivate($id1);
+        $this->assertCount(1, $this->as->activeFor('user-1', 'office-wifi'));
+    }
+
+    // ── forSubject ────────────────────────────────────────────────────────────
+
+    public function testForSubjectReturnsAllSchedules(): void
+    {
+        $this->as->create('user-1', 'office-wifi', [1, 2, 3, 4, 5], '09:00', '17:00');
+        $this->as->create('user-1', 'admin-panel', [1, 2, 3, 4, 5], '09:00', '17:00');
+        $this->as->create('user-2', 'office-wifi', [1], '08:00', '20:00');
+        $this->assertCount(2, $this->as->forSubject('user-1'));
+    }
+
+    // ── deactivate / activate ─────────────────────────────────────────────────
+
+    public function testDeactivateReturnsTrueWhenActive(): void
+    {
+        $id = $this->as->create('user-1', 'resource', [1], '09:00', '17:00');
+        $this->assertTrue($this->as->deactivate($id));
+    }
+
+    public function testDeactivateReturnsFalseWhenAlreadyInactive(): void
+    {
+        $id = $this->as->create('user-1', 'resource', [1], '09:00', '17:00');
+        $this->as->deactivate($id);
+        $this->assertFalse($this->as->deactivate($id));
+    }
+
+    public function testActivateRestoresInactiveSchedule(): void
+    {
+        $id = $this->as->create('user-1', 'resource', [1], '09:00', '17:00');
+        $this->as->deactivate($id);
+        $this->assertTrue($this->as->activate($id));
+        $row = $this->as->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['active']);
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public function testDeleteRemovesSchedule(): void
+    {
+        $id = $this->as->create('user-1', 'resource', [1], '09:00', '17:00');
+        $this->assertTrue($this->as->delete($id));
+        $this->assertNull($this->as->get($id));
+    }
+
+    public function testDeleteReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->as->delete(9999));
+    }
+}


### PR DESCRIPTION
## FT254 — AccessSchedule

Weekly recurring access windows with day-of-week and time-range checks.

### Class: `Nene\Xion\AccessSchedule`
- `create()` — define schedule with subject, resource, days (0=Sun…6=Sat), start/end time; normalizes & sorts days
- `get()` — fetch by ID
- `isAllowed()` — check against current datetime
- `isAllowedAt()` — check against a given datetime; end time is exclusive; multiple schedules OR'd together
- `activeFor()` — all active schedules for subject+resource
- `forSubject()` — all schedules for a subject (all resources)
- `deactivate()` / `activate()` — toggle schedule active flag
- `delete()` — remove a schedule

### Tests
23 tests, 34 assertions — all green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)