### PR TITLE
feat(xion): UserFeedback — general satisfaction feedback collection with NPS/star scores (FT256)

### DIFF
--- a/class/xion/UserFeedback.php
+++ b/class/xion/UserFeedback.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Collect general user satisfaction feedback (NPS / star ratings + free text).
+ *
+ * Unlike ProductReview (which is entity-scoped and moderated), UserFeedback is
+ * a lightweight signal-collection tool: any user can submit a numeric score and
+ * an optional comment against a named context (page slug, feature name, etc.).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $uf = new UserFeedback($pdo);
+ *
+ * // Submit feedback
+ * $id = $uf->submit('user-1', 'checkout', 8, 'Smooth experience!');
+ *
+ * // Aggregate signals
+ * $uf->averageScore('checkout');          // e.g. 7.4
+ * $uf->countByScore('checkout');          // [8 => 12, 9 => 5, ...]
+ * $uf->forUser('user-1');                 // all submissions by this user
+ * $uf->recent('checkout', 5);            // 5 most-recent rows
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE user_feedback (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     VARCHAR(255) NOT NULL,
+ *     context     VARCHAR(255) NOT NULL,
+ *     score       TINYINT      NOT NULL,
+ *     comment     TEXT         NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class UserFeedback
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    // ── submit ────────────────────────────────────────────────────────────────
+
+    /**
+     * Submit feedback from a user.
+     *
+     * @param  int    $score   Numeric score (typical ranges: 1-5 star, 0-10 NPS).
+     * @return int             New row ID.
+     * @throws \InvalidArgumentException if userId/context are empty or score < 0.
+     */
+    public function submit(
+        string $userId,
+        string $context,
+        int $score,
+        ?string $comment = null,
+    ): int {
+        if ($userId === '') {
+            throw new \InvalidArgumentException('userId must not be empty.');
+        }
+
+        if ($context === '') {
+            throw new \InvalidArgumentException('context must not be empty.');
+        }
+
+        if ($score < 0) {
+            throw new \InvalidArgumentException('score must be >= 0.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO user_feedback (user_id, context, score, comment)
+             VALUES (?, ?, ?, ?)'
+        );
+        $stmt->execute([$userId, $context, $score, $comment]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Retrieve a single feedback row by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM user_feedback WHERE id = ?'
+        );
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    // ── aggregates ────────────────────────────────────────────────────────────
+
+    /**
+     * Return the average score for a context, or null if no submissions exist.
+     */
+    public function averageScore(string $context): ?float
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT AVG(score) FROM user_feedback WHERE context = ?'
+        );
+        $stmt->execute([$context]);
+        $avg = $stmt->fetchColumn();
+        return $avg !== false && $avg !== null ? (float)$avg : null;
+    }
+
+    /**
+     * Return a score → count breakdown for a context (ordered by score asc).
+     *
+     * @return array<int,int>
+     */
+    public function countByScore(string $context): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT score, COUNT(*) AS cnt
+             FROM user_feedback
+             WHERE context = ?
+             GROUP BY score
+             ORDER BY score ASC'
+        );
+        $stmt->execute([$context]);
+        $rows   = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $result = [];
+
+        foreach ($rows as $row) {
+            $result[(int)$row['score']] = (int)$row['cnt'];
+        }
+
+        return $result;
+    }
+
+    // ── queries ───────────────────────────────────────────────────────────────
+
+    /**
+     * Return all feedback submitted by a user, newest first.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function forUser(string $userId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM user_feedback WHERE user_id = ? ORDER BY id DESC'
+        );
+        $stmt->execute([$userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Return the N most-recent feedback rows for a context.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function recent(string $context, int $limit = 10): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM user_feedback WHERE context = ? ORDER BY id DESC LIMIT ?'
+        );
+        $stmt->execute([$context, $limit]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    /**
+     * Hard-delete a single feedback row.
+     */
+    public function remove(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM user_feedback WHERE id = ?');
+        $stmt->execute([$id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Hard-delete all feedback for a context (e.g. after a feature is removed).
+     *
+     * @return int Number of rows deleted.
+     */
+    public function clearContext(string $context): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM user_feedback WHERE context = ?');
+        $stmt->execute([$context]);
+        return (int)$stmt->rowCount();
+    }
+}

--- a/tests/Unit/Xion/UserFeedbackTest.php
+++ b/tests/Unit/Xion/UserFeedbackTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\UserFeedback;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class UserFeedbackTest extends TestCase
+{
+    private PDO $pdo;
+    private UserFeedback $uf;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE user_feedback (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     VARCHAR(255) NOT NULL,
+                context     VARCHAR(255) NOT NULL,
+                score       TINYINT      NOT NULL,
+                comment     TEXT         NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->uf = new UserFeedback($this->pdo);
+    }
+
+    // ── submit ────────────────────────────────────────────────────────────────
+
+    public function testSubmitReturnsId(): void
+    {
+        $id = $this->uf->submit('user-1', 'checkout', 8);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testSubmitStoresFields(): void
+    {
+        $id  = $this->uf->submit('user-1', 'checkout', 9, 'Great!');
+        $row = $this->uf->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['user_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('checkout', $row['context']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(9, (int)$row['score']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Great!', $row['comment']);
+    }
+
+    public function testSubmitAllowsNullComment(): void
+    {
+        $id  = $this->uf->submit('user-1', 'checkout', 5);
+        $row = $this->uf->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNull($row['comment']);
+    }
+
+    public function testSubmitThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->uf->submit('', 'checkout', 5);
+    }
+
+    public function testSubmitThrowsOnEmptyContext(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->uf->submit('user-1', '', 5);
+    }
+
+    public function testSubmitThrowsOnNegativeScore(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->uf->submit('user-1', 'checkout', -1);
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->uf->get(9999));
+    }
+
+    // ── averageScore ──────────────────────────────────────────────────────────
+
+    public function testAverageScoreCalculates(): void
+    {
+        $this->uf->submit('user-1', 'checkout', 8);
+        $this->uf->submit('user-2', 'checkout', 6);
+        $avg = $this->uf->averageScore('checkout');
+        $this->assertNotNull($avg);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertEqualsWithDelta(7.0, $avg, 0.001);
+    }
+
+    public function testAverageScoreNullWhenNoRows(): void
+    {
+        $this->assertNull($this->uf->averageScore('nonexistent'));
+    }
+
+    // ── countByScore ──────────────────────────────────────────────────────────
+
+    public function testCountByScoreDistribution(): void
+    {
+        $this->uf->submit('user-1', 'checkout', 8);
+        $this->uf->submit('user-2', 'checkout', 8);
+        $this->uf->submit('user-3', 'checkout', 10);
+        $dist = $this->uf->countByScore('checkout');
+        $this->assertSame(2, $dist[8]);
+        $this->assertSame(1, $dist[10]);
+    }
+
+    public function testCountByScoreEmptyForUnknownContext(): void
+    {
+        $this->assertSame([], $this->uf->countByScore('unknown'));
+    }
+
+    // ── forUser ───────────────────────────────────────────────────────────────
+
+    public function testForUserReturnsAllSubmissions(): void
+    {
+        $this->uf->submit('user-1', 'checkout', 8);
+        $this->uf->submit('user-1', 'search', 6);
+        $this->uf->submit('user-2', 'checkout', 9);
+        $rows = $this->uf->forUser('user-1');
+        $this->assertCount(2, $rows);
+    }
+
+    public function testForUserReturnsEmptyForUnknownUser(): void
+    {
+        $this->assertSame([], $this->uf->forUser('unknown'));
+    }
+
+    // ── recent ────────────────────────────────────────────────────────────────
+
+    public function testRecentReturnsLimitedRows(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->uf->submit("user-{$i}", 'checkout', $i);
+        }
+
+        $rows = $this->uf->recent('checkout', 3);
+        $this->assertCount(3, $rows);
+    }
+
+    public function testRecentReturnsNewestFirst(): void
+    {
+        $this->uf->submit('user-1', 'checkout', 3);
+        $this->uf->submit('user-2', 'checkout', 9);
+        $rows = $this->uf->recent('checkout');
+        $this->assertSame(9, (int)$rows[0]['score']);
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    public function testRemoveDeletesRow(): void
+    {
+        $id = $this->uf->submit('user-1', 'checkout', 7);
+        $this->assertTrue($this->uf->remove($id));
+        $this->assertNull($this->uf->get($id));
+    }
+
+    public function testRemoveReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->uf->remove(9999));
+    }
+
+    // ── clearContext ──────────────────────────────────────────────────────────
+
+    public function testClearContextDeletesAllForContext(): void
+    {
+        $this->uf->submit('user-1', 'checkout', 8);
+        $this->uf->submit('user-2', 'checkout', 6);
+        $this->uf->submit('user-1', 'search', 9);
+        $deleted = $this->uf->clearContext('checkout');
+        $this->assertSame(2, $deleted);
+        $this->assertSame([], $this->uf->recent('checkout'));
+        $this->assertCount(1, $this->uf->recent('search'));
+    }
+}


### PR DESCRIPTION
## Summary
Add `Nene\Xion\UserFeedback` — lightweight user satisfaction signal collection.

## What it does
- `submit(userId, context, score, ?comment)` — store feedback (score >= 0)
- `get(id)` — retrieve single row
- `averageScore(context)` — float average or null if no data
- `countByScore(context)` — score→count breakdown map
- `forUser(userId)` — all submissions by a user
- `recent(context, limit)` — newest-first paginated results
- `remove(id)` — hard delete a row
- `clearContext(context)` — bulk-delete all rows for a context

## Tests
18 tests, 28 assertions — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)