### PR TITLE
feat(xion): ContentReport — user-submitted content moderation reports (FT258)

### DIFF
--- a/class/xion/ContentReport.php
+++ b/class/xion/ContentReport.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * User-submitted content moderation reports.
+ *
+ * Any user can flag a piece of content (post, comment, profile, etc.) with a
+ * reason.  A moderator then reviews the report and either actions it (removes
+ * or penalises the content) or dismisses it.
+ *
+ * Unlike ContentFlag (admin-side) or ContentFilter (keyword blocking), this
+ * class manages the incoming community-report queue.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cr = new ContentReport($pdo);
+ *
+ * // User reports a post
+ * $id = $cr->report('user-1', 'post', '42', 'spam');
+ *
+ * // Moderator reviews
+ * $cr->action($id, 'mod-1');    // content removed/penalised
+ * $cr->dismiss($id, 'mod-1');   // report dismissed as invalid
+ *
+ * // Querying
+ * $cr->byStatus(ContentReport::STATUS_PENDING);
+ * $cr->forContent('post', '42');
+ * $cr->countByReason();
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE content_reports (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     reporter_id  VARCHAR(255) NOT NULL,
+ *     content_type VARCHAR(100) NOT NULL,
+ *     content_id   VARCHAR(255) NOT NULL,
+ *     reason       VARCHAR(100) NOT NULL,
+ *     note         TEXT         NULL,
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'pending',
+ *     reviewer_id  VARCHAR(255) NULL,
+ *     reviewed_at  DATETIME     NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ContentReport
+{
+    public const STATUS_PENDING  = 'pending';
+    public const STATUS_ACTIONED = 'actioned';
+    public const STATUS_DISMISSED = 'dismissed';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    // ── report ────────────────────────────────────────────────────────────────
+
+    /**
+     * Submit a report from a user.
+     *
+     * @return int New report ID.
+     * @throws \InvalidArgumentException if required fields are empty.
+     */
+    public function report(
+        string $reporterId,
+        string $contentType,
+        string $contentId,
+        string $reason,
+        ?string $note = null,
+    ): int {
+        if ($reporterId === '') {
+            throw new \InvalidArgumentException('reporterId must not be empty.');
+        }
+
+        if ($contentType === '') {
+            throw new \InvalidArgumentException('contentType must not be empty.');
+        }
+
+        if ($contentId === '') {
+            throw new \InvalidArgumentException('contentId must not be empty.');
+        }
+
+        if ($reason === '') {
+            throw new \InvalidArgumentException('reason must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO content_reports
+             (reporter_id, content_type, content_id, reason, note, status)
+             VALUES (?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            $reporterId, $contentType, $contentId, $reason, $note,
+            self::STATUS_PENDING,
+        ]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Retrieve a report by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM content_reports WHERE id = ?'
+        );
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    // ── review transitions ────────────────────────────────────────────────────
+
+    /**
+     * Mark a pending report as actioned (content removed / penalty applied).
+     */
+    public function action(int $id, string $reviewerId): bool
+    {
+        return $this->resolve($id, $reviewerId, self::STATUS_ACTIONED);
+    }
+
+    /**
+     * Mark a pending report as dismissed (report is invalid or unactionable).
+     */
+    public function dismiss(int $id, string $reviewerId): bool
+    {
+        return $this->resolve($id, $reviewerId, self::STATUS_DISMISSED);
+    }
+
+    private function resolve(int $id, string $reviewerId, string $status): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE content_reports
+             SET status      = ?,
+                 reviewer_id = ?,
+                 reviewed_at = CURRENT_TIMESTAMP
+             WHERE id = ? AND status = ?'
+        );
+        $stmt->execute([$status, $reviewerId, $id, self::STATUS_PENDING]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── queries ───────────────────────────────────────────────────────────────
+
+    /**
+     * Return all reports with a given status, newest first.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function byStatus(string $status): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM content_reports WHERE status = ? ORDER BY id DESC'
+        );
+        $stmt->execute([$status]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Return all reports against a specific piece of content, newest first.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function forContent(string $contentType, string $contentId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM content_reports
+             WHERE content_type = ? AND content_id = ?
+             ORDER BY id DESC'
+        );
+        $stmt->execute([$contentType, $contentId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Return a reason → count breakdown across all reports.
+     *
+     * @return array<string,int>
+     */
+    public function countByReason(): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT reason, COUNT(*) AS cnt
+             FROM content_reports
+             GROUP BY reason
+             ORDER BY cnt DESC'
+        );
+        $stmt->execute();
+        $rows   = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $result = [];
+
+        foreach ($rows as $row) {
+            $result[(string)$row['reason']] = (int)$row['cnt'];
+        }
+
+        return $result;
+    }
+}

--- a/tests/Unit/Xion/ContentReportTest.php
+++ b/tests/Unit/Xion/ContentReportTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\ContentReport;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ContentReportTest extends TestCase
+{
+    private PDO $pdo;
+    private ContentReport $cr;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE content_reports (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                reporter_id  VARCHAR(255) NOT NULL,
+                content_type VARCHAR(100) NOT NULL,
+                content_id   VARCHAR(255) NOT NULL,
+                reason       VARCHAR(100) NOT NULL,
+                note         TEXT         NULL,
+                status       VARCHAR(20)  NOT NULL DEFAULT \'pending\',
+                reviewer_id  VARCHAR(255) NULL,
+                reviewed_at  DATETIME     NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->cr = new ContentReport($this->pdo);
+    }
+
+    // ── report ────────────────────────────────────────────────────────────────
+
+    public function testReportReturnsId(): void
+    {
+        $id = $this->cr->report('user-1', 'post', '42', 'spam');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testReportStoresFields(): void
+    {
+        $id  = $this->cr->report('user-1', 'post', '42', 'spam', 'Repeated post');
+        $row = $this->cr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['reporter_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('post', $row['content_type']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('42', $row['content_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('spam', $row['reason']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Repeated post', $row['note']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ContentReport::STATUS_PENDING, $row['status']);
+    }
+
+    public function testReportThrowsOnEmptyReporterId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cr->report('', 'post', '1', 'spam');
+    }
+
+    public function testReportThrowsOnEmptyContentType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cr->report('user-1', '', '1', 'spam');
+    }
+
+    public function testReportThrowsOnEmptyContentId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cr->report('user-1', 'post', '', 'spam');
+    }
+
+    public function testReportThrowsOnEmptyReason(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cr->report('user-1', 'post', '1', '');
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->cr->get(9999));
+    }
+
+    // ── action ────────────────────────────────────────────────────────────────
+
+    public function testActionChangesStatusToActioned(): void
+    {
+        $id  = $this->cr->report('user-1', 'post', '1', 'spam');
+        $this->assertTrue($this->cr->action($id, 'mod-1'));
+        $row = $this->cr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ContentReport::STATUS_ACTIONED, $row['status']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('mod-1', $row['reviewer_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['reviewed_at']);
+    }
+
+    public function testActionReturnsFalseIfNotPending(): void
+    {
+        $id = $this->cr->report('user-1', 'post', '1', 'spam');
+        $this->cr->action($id, 'mod-1');
+        $this->assertFalse($this->cr->action($id, 'mod-2')); // already actioned
+    }
+
+    public function testActionReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->cr->action(9999, 'mod-1'));
+    }
+
+    // ── dismiss ───────────────────────────────────────────────────────────────
+
+    public function testDismissChangesStatusToDismissed(): void
+    {
+        $id  = $this->cr->report('user-1', 'post', '1', 'offensive');
+        $this->assertTrue($this->cr->dismiss($id, 'mod-1'));
+        $row = $this->cr->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(ContentReport::STATUS_DISMISSED, $row['status']);
+    }
+
+    public function testDismissReturnsFalseIfNotPending(): void
+    {
+        $id = $this->cr->report('user-1', 'post', '1', 'offensive');
+        $this->cr->dismiss($id, 'mod-1');
+        $this->assertFalse($this->cr->dismiss($id, 'mod-2'));
+    }
+
+    // ── byStatus ──────────────────────────────────────────────────────────────
+
+    public function testByStatusFiltersPending(): void
+    {
+        $id1 = $this->cr->report('user-1', 'post', '1', 'spam');
+        $this->cr->report('user-2', 'post', '2', 'hate');
+        $this->cr->action($id1, 'mod-1');
+        $pending = $this->cr->byStatus(ContentReport::STATUS_PENDING);
+        $this->assertCount(1, $pending);
+    }
+
+    public function testByStatusReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->cr->byStatus(ContentReport::STATUS_ACTIONED));
+    }
+
+    // ── forContent ────────────────────────────────────────────────────────────
+
+    public function testForContentReturnsMatchingReports(): void
+    {
+        $this->cr->report('user-1', 'post', '42', 'spam');
+        $this->cr->report('user-2', 'post', '42', 'hate');
+        $this->cr->report('user-3', 'post', '99', 'spam');
+        $rows = $this->cr->forContent('post', '42');
+        $this->assertCount(2, $rows);
+    }
+
+    public function testForContentReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->cr->forContent('post', '999'));
+    }
+
+    // ── countByReason ─────────────────────────────────────────────────────────
+
+    public function testCountByReasonDistribution(): void
+    {
+        $this->cr->report('user-1', 'post', '1', 'spam');
+        $this->cr->report('user-2', 'post', '2', 'spam');
+        $this->cr->report('user-3', 'post', '3', 'hate');
+        $dist = $this->cr->countByReason();
+        $this->assertSame(2, $dist['spam']);
+        $this->assertSame(1, $dist['hate']);
+    }
+
+    public function testCountByReasonEmptyWhenNoReports(): void
+    {
+        $this->assertSame([], $this->cr->countByReason());
+    }
+}


### PR DESCRIPTION
## Summary
Add `Nene\Xion\ContentReport` — community-driven content flagging queue.

## What it does
- `report(reporterId, contentType, contentId, reason, ?note)` — submit report (status: pending)
- `action(id, reviewerId)` — moderator marks report actioned
- `dismiss(id, reviewerId)` — moderator dismisses report as invalid
- Both transitions guard STATUS_PENDING in WHERE clause (idempotent-safe)
- `byStatus(status)` — filter reports by status
- `forContent(type, id)` — all reports against a piece of content
- `countByReason()` — reason→count breakdown for analytics

## Tests
18 tests, 31 assertions — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)