### PR TITLE
feat(xion): ApiWebhook — webhook subscription endpoint management with secret rotation (FT259)

### DIFF
--- a/class/xion/ApiWebhook.php
+++ b/class/xion/ApiWebhook.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Webhook subscription endpoint management.
+ *
+ * Manages the registry of webhook subscribers — who should be notified (URL)
+ * and for which event types.  Each subscription has an auto-generated HMAC
+ * secret used to sign outgoing payloads (see WebhookSigner).  Delivery
+ * tracking is handled separately by WebhookDelivery.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $aw = new ApiWebhook($pdo);
+ *
+ * // Register a subscriber
+ * ['id' => $id, 'secret' => $secret] = $aw->subscribe('order.created', 'https://example.com/hook');
+ *
+ * // Get active subscribers for an event
+ * $hooks = $aw->forEvent('order.created');
+ *
+ * // Rotate the signing secret
+ * $newSecret = $aw->rotateSecret($id);
+ *
+ * // Enable / disable without deleting
+ * $aw->deactivate($id);
+ * $aw->activate($id);
+ *
+ * // Remove permanently
+ * $aw->unsubscribe($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE api_webhooks (
+ *     id            INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     event_type    VARCHAR(100) NOT NULL,
+ *     endpoint_url  TEXT         NOT NULL,
+ *     secret        VARCHAR(64)  NOT NULL,
+ *     active        TINYINT(1)   NOT NULL DEFAULT 1,
+ *     created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ApiWebhook
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    /** Generate a random hex secret (32 bytes = 64 hex chars). */
+    private function generateSecret(): string
+    {
+        return bin2hex(random_bytes(32));
+    }
+
+    // ── subscribe ─────────────────────────────────────────────────────────────
+
+    /**
+     * Register a new webhook subscriber.
+     *
+     * Returns an array with 'id' (int) and 'secret' (plaintext hex string).
+     * Store the secret securely — it is only returned at registration time.
+     *
+     * @return array{id: int, secret: string}
+     * @throws \InvalidArgumentException if eventType or endpointUrl are empty.
+     */
+    public function subscribe(string $eventType, string $endpointUrl): array
+    {
+        if ($eventType === '') {
+            throw new \InvalidArgumentException('eventType must not be empty.');
+        }
+
+        if ($endpointUrl === '') {
+            throw new \InvalidArgumentException('endpointUrl must not be empty.');
+        }
+
+        $secret = $this->generateSecret();
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO api_webhooks (event_type, endpoint_url, secret)
+             VALUES (?, ?, ?)'
+        );
+        $stmt->execute([$eventType, $endpointUrl, $secret]);
+
+        return ['id' => (int)$this->db()->lastInsertId(), 'secret' => $secret];
+    }
+
+    // ── unsubscribe ───────────────────────────────────────────────────────────
+
+    /**
+     * Permanently remove a webhook subscription.
+     */
+    public function unsubscribe(int $id): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM api_webhooks WHERE id = ?');
+        $stmt->execute([$id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Retrieve a webhook subscription row (including hashed secret).
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT * FROM api_webhooks WHERE id = ?');
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    // ── rotateSecret ──────────────────────────────────────────────────────────
+
+    /**
+     * Generate and store a new signing secret, returning the new plaintext value.
+     *
+     * Returns null if the subscription does not exist.
+     */
+    public function rotateSecret(int $id): ?string
+    {
+        $secret = $this->generateSecret();
+        $stmt   = $this->db()->prepare(
+            'UPDATE api_webhooks
+             SET secret = ?, updated_at = CURRENT_TIMESTAMP
+             WHERE id = ?'
+        );
+        $stmt->execute([$secret, $id]);
+        return $stmt->rowCount() > 0 ? $secret : null;
+    }
+
+    // ── activate / deactivate ─────────────────────────────────────────────────
+
+    /**
+     * Enable a webhook subscription (allows delivery).
+     */
+    public function activate(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE api_webhooks SET active = 1, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+        );
+        $stmt->execute([$id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Disable a webhook subscription without deleting it.
+     */
+    public function deactivate(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE api_webhooks SET active = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+        );
+        $stmt->execute([$id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── queries ───────────────────────────────────────────────────────────────
+
+    /**
+     * Return all active subscriptions for a given event type.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function forEvent(string $eventType): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM api_webhooks
+             WHERE event_type = ? AND active = 1
+             ORDER BY id ASC'
+        );
+        $stmt->execute([$eventType]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Return all subscriptions (active and inactive).
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function all(): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM api_webhooks ORDER BY id ASC'
+        );
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}

--- a/tests/Unit/Xion/ApiWebhookTest.php
+++ b/tests/Unit/Xion/ApiWebhookTest.php
@@ -102,7 +102,7 @@ final class ApiWebhookTest extends TestCase
         $r         = $this->aw->subscribe('order.created', 'https://example.com/hook');
         $newSecret = $this->aw->rotateSecret($r['id']);
         $this->assertNotNull($newSecret);
-        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullableInternal
         $this->assertSame(64, strlen($newSecret));
         $this->assertNotSame($r['secret'], $newSecret);
     }

--- a/tests/Unit/Xion/ApiWebhookTest.php
+++ b/tests/Unit/Xion/ApiWebhookTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\ApiWebhook;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ApiWebhookTest extends TestCase
+{
+    private PDO $pdo;
+    private ApiWebhook $aw;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE api_webhooks (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type    VARCHAR(100) NOT NULL,
+                endpoint_url  TEXT         NOT NULL,
+                secret        VARCHAR(64)  NOT NULL,
+                active        TINYINT(1)   NOT NULL DEFAULT 1,
+                created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->aw = new ApiWebhook($this->pdo);
+    }
+
+    // ── subscribe ─────────────────────────────────────────────────────────────
+
+    public function testSubscribeReturnsIdAndSecret(): void
+    {
+        $result = $this->aw->subscribe('order.created', 'https://example.com/hook');
+        $this->assertArrayHasKey('id', $result);
+        $this->assertArrayHasKey('secret', $result);
+        $this->assertGreaterThan(0, $result['id']);
+        $this->assertSame(64, strlen($result['secret']));
+    }
+
+    public function testSubscribeStoresRow(): void
+    {
+        $result = $this->aw->subscribe('order.created', 'https://example.com/hook');
+        $row    = $this->aw->get($result['id']);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('order.created', $row['event_type']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('https://example.com/hook', $row['endpoint_url']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['active']);
+    }
+
+    public function testSubscribeThrowsOnEmptyEventType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->aw->subscribe('', 'https://example.com/hook');
+    }
+
+    public function testSubscribeThrowsOnEmptyEndpointUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->aw->subscribe('order.created', '');
+    }
+
+    public function testSubscribeGeneratesUniqueSecrets(): void
+    {
+        $r1 = $this->aw->subscribe('order.created', 'https://a.com/hook');
+        $r2 = $this->aw->subscribe('order.created', 'https://b.com/hook');
+        $this->assertNotSame($r1['secret'], $r2['secret']);
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->aw->get(9999));
+    }
+
+    // ── unsubscribe ───────────────────────────────────────────────────────────
+
+    public function testUnsubscribeDeletesRow(): void
+    {
+        $r = $this->aw->subscribe('order.created', 'https://example.com/hook');
+        $this->assertTrue($this->aw->unsubscribe($r['id']));
+        $this->assertNull($this->aw->get($r['id']));
+    }
+
+    public function testUnsubscribeReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->aw->unsubscribe(9999));
+    }
+
+    // ── rotateSecret ──────────────────────────────────────────────────────────
+
+    public function testRotateSecretReturnsNewSecret(): void
+    {
+        $r         = $this->aw->subscribe('order.created', 'https://example.com/hook');
+        $newSecret = $this->aw->rotateSecret($r['id']);
+        $this->assertNotNull($newSecret);
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(64, strlen($newSecret));
+        $this->assertNotSame($r['secret'], $newSecret);
+    }
+
+    public function testRotateSecretUpdatesStoredValue(): void
+    {
+        $r         = $this->aw->subscribe('order.created', 'https://example.com/hook');
+        $newSecret = $this->aw->rotateSecret($r['id']);
+        $row       = $this->aw->get($r['id']);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame($newSecret, $row['secret']);
+    }
+
+    public function testRotateSecretReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->aw->rotateSecret(9999));
+    }
+
+    // ── activate / deactivate ─────────────────────────────────────────────────
+
+    public function testDeactivateHidesFromForEvent(): void
+    {
+        $r = $this->aw->subscribe('order.created', 'https://example.com/hook');
+        $this->aw->deactivate($r['id']);
+        $this->assertCount(0, $this->aw->forEvent('order.created'));
+    }
+
+    public function testActivateRestoresInForEvent(): void
+    {
+        $r = $this->aw->subscribe('order.created', 'https://example.com/hook');
+        $this->aw->deactivate($r['id']);
+        $this->aw->activate($r['id']);
+        $this->assertCount(1, $this->aw->forEvent('order.created'));
+    }
+
+    // ── forEvent ──────────────────────────────────────────────────────────────
+
+    public function testForEventReturnsActiveSubscribers(): void
+    {
+        $this->aw->subscribe('order.created', 'https://a.com/hook');
+        $this->aw->subscribe('order.created', 'https://b.com/hook');
+        $this->aw->subscribe('user.registered', 'https://c.com/hook');
+        $hooks = $this->aw->forEvent('order.created');
+        $this->assertCount(2, $hooks);
+    }
+
+    public function testForEventReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->aw->forEvent('nonexistent'));
+    }
+
+    // ── all ───────────────────────────────────────────────────────────────────
+
+    public function testAllIncludesInactive(): void
+    {
+        $r = $this->aw->subscribe('order.created', 'https://example.com/hook');
+        $this->aw->deactivate($r['id']);
+        $all = $this->aw->all();
+        $this->assertCount(1, $all);
+        $this->assertSame(0, (int)$all[0]['active']);
+    }
+}


### PR DESCRIPTION
## Summary
Add `Nene\Xion\ApiWebhook` — registry of webhook subscriber endpoints.

Distinct from WebhookDelivery (delivery tracking) and WebhookSigner (payload signing).
This class manages *who* to notify and *for which events*.

## What it does
- `subscribe(eventType, endpointUrl)` — register subscriber; returns {id, plaintext_secret}
- `unsubscribe(id)` — permanently remove
- `get(id)` — retrieve subscription row
- `rotateSecret(id)` — generate new HMAC secret; returns new plaintext
- `activate(id)` / `deactivate(id)` — toggle without deleting
- `forEvent(eventType)` — active subscribers for a given event type
- `all()` — all subscriptions including inactive

## Tests
16 tests, 27 assertions — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)