### PR TITLE
feat(xion): ImpersonationLog — admin impersonation session audit trail (FT261)

### DIFF
--- a/class/xion/ImpersonationLog.php
+++ b/class/xion/ImpersonationLog.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Admin impersonation session audit log.
+ *
+ * Records when a privileged user (admin) starts impersonating another user
+ * account, and when the impersonation ends.  Provides an immutable audit trail
+ * for security reviews and compliance.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $il = new ImpersonationLog($pdo);
+ *
+ * // Admin starts impersonating a user
+ * $sessionId = $il->start('admin-1', 'user-42', 'Support request #1234');
+ *
+ * // Admin ends the session
+ * $il->end($sessionId);
+ *
+ * // Check for currently active impersonations
+ * $il->active();              // all active (no ended_at)
+ * $il->active('admin-1');     // by specific admin
+ *
+ * // Audit queries
+ * $il->history('user-42');    // all sessions where user-42 was target
+ * $il->purgeOlderThan('2025-01-01 00:00:00');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE impersonation_log (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     admin_id    VARCHAR(255) NOT NULL,
+ *     target_id   VARCHAR(255) NOT NULL,
+ *     reason      TEXT         NULL,
+ *     started_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     ended_at    DATETIME     NULL
+ * );
+ * ```
+ */
+final class ImpersonationLog
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    // ── start ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Record the start of an admin impersonation session.
+     *
+     * @return int New session ID.
+     * @throws \InvalidArgumentException if adminId or targetId are empty.
+     */
+    public function start(string $adminId, string $targetId, ?string $reason = null): int
+    {
+        if ($adminId === '') {
+            throw new \InvalidArgumentException('adminId must not be empty.');
+        }
+
+        if ($targetId === '') {
+            throw new \InvalidArgumentException('targetId must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO impersonation_log (admin_id, target_id, reason)
+             VALUES (?, ?, ?)'
+        );
+        $stmt->execute([$adminId, $targetId, $reason]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    // ── end ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Record the end of an impersonation session.
+     *
+     * Returns false if the session does not exist or has already ended.
+     */
+    public function end(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE impersonation_log
+             SET ended_at = CURRENT_TIMESTAMP
+             WHERE id = ? AND ended_at IS NULL'
+        );
+        $stmt->execute([$id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Retrieve a session row by ID.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM impersonation_log WHERE id = ?'
+        );
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    // ── queries ───────────────────────────────────────────────────────────────
+
+    /**
+     * Return currently active (not ended) impersonation sessions.
+     * Optionally filter by admin.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function active(?string $adminId = null): array
+    {
+        if ($adminId !== null) {
+            $stmt = $this->db()->prepare(
+                'SELECT * FROM impersonation_log
+                 WHERE ended_at IS NULL AND admin_id = ?
+                 ORDER BY started_at DESC'
+            );
+            $stmt->execute([$adminId]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT * FROM impersonation_log
+                 WHERE ended_at IS NULL
+                 ORDER BY started_at DESC'
+            );
+            $stmt->execute();
+        }
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Return all impersonation sessions where a user was the target.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function history(string $targetId): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM impersonation_log
+             WHERE target_id = ?
+             ORDER BY started_at DESC'
+        );
+        $stmt->execute([$targetId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    // ── purge ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Delete completed (ended) sessions older than a cutoff datetime.
+     *
+     * Active sessions (ended_at IS NULL) are never deleted.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $before): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM impersonation_log
+             WHERE ended_at IS NOT NULL AND started_at < ?'
+        );
+        $stmt->execute([$before]);
+        return (int)$stmt->rowCount();
+    }
+}

--- a/tests/Unit/Xion/ImpersonationLogTest.php
+++ b/tests/Unit/Xion/ImpersonationLogTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\ImpersonationLog;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class ImpersonationLogTest extends TestCase
+{
+    private PDO $pdo;
+    private ImpersonationLog $il;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE impersonation_log (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                admin_id    VARCHAR(255) NOT NULL,
+                target_id   VARCHAR(255) NOT NULL,
+                reason      TEXT         NULL,
+                started_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                ended_at    DATETIME     NULL
+            )
+        ');
+        $this->il = new ImpersonationLog($this->pdo);
+    }
+
+    // ── start ─────────────────────────────────────────────────────────────────
+
+    public function testStartReturnsId(): void
+    {
+        $id = $this->il->start('admin-1', 'user-42');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testStartStoresFields(): void
+    {
+        $id  = $this->il->start('admin-1', 'user-42', 'Support ticket #99');
+        $row = $this->il->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('admin-1', $row['admin_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-42', $row['target_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('Support ticket #99', $row['reason']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNull($row['ended_at']);
+    }
+
+    public function testStartThrowsOnEmptyAdminId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->il->start('', 'user-42');
+    }
+
+    public function testStartThrowsOnEmptyTargetId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->il->start('admin-1', '');
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForMissingId(): void
+    {
+        $this->assertNull($this->il->get(9999));
+    }
+
+    // ── end ───────────────────────────────────────────────────────────────────
+
+    public function testEndSetsEndedAt(): void
+    {
+        $id  = $this->il->start('admin-1', 'user-42');
+        $this->assertTrue($this->il->end($id));
+        $row = $this->il->get($id);
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertNotNull($row['ended_at']);
+    }
+
+    public function testEndReturnsFalseIfAlreadyEnded(): void
+    {
+        $id = $this->il->start('admin-1', 'user-42');
+        $this->il->end($id);
+        $this->assertFalse($this->il->end($id)); // already ended
+    }
+
+    public function testEndReturnsFalseForMissingId(): void
+    {
+        $this->assertFalse($this->il->end(9999));
+    }
+
+    // ── active ────────────────────────────────────────────────────────────────
+
+    public function testActiveReturnsOnlyOpenSessions(): void
+    {
+        $id1 = $this->il->start('admin-1', 'user-1');
+        $this->il->start('admin-2', 'user-2');
+        $this->il->end($id1);
+        $active = $this->il->active();
+        $this->assertCount(1, $active);
+        $this->assertSame('admin-2', $active[0]['admin_id']);
+    }
+
+    public function testActiveFiltersByAdmin(): void
+    {
+        $this->il->start('admin-1', 'user-1');
+        $this->il->start('admin-1', 'user-2');
+        $this->il->start('admin-2', 'user-3');
+        $active = $this->il->active('admin-1');
+        $this->assertCount(2, $active);
+    }
+
+    public function testActiveReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->il->active());
+    }
+
+    // ── history ───────────────────────────────────────────────────────────────
+
+    public function testHistoryReturnsAllSessionsForTarget(): void
+    {
+        $id1 = $this->il->start('admin-1', 'user-42');
+        $this->il->end($id1);
+        $this->il->start('admin-2', 'user-42');
+        $this->il->start('admin-1', 'user-99');
+        $history = $this->il->history('user-42');
+        $this->assertCount(2, $history);
+    }
+
+    public function testHistoryReturnsEmptyForUnknownUser(): void
+    {
+        $this->assertSame([], $this->il->history('unknown'));
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesEndedSessions(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO impersonation_log (admin_id, target_id, started_at, ended_at)
+             VALUES ('admin-1', 'user-1', '2020-01-01 00:00:00', '2020-01-01 01:00:00')"
+        );
+        $deleted = $this->il->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(1, $deleted);
+    }
+
+    public function testPurgeOlderThanDoesNotDeleteActiveSession(): void
+    {
+        $id = $this->il->start('admin-1', 'user-1');
+        $this->pdo->exec("UPDATE impersonation_log SET started_at = '2020-01-01 00:00:00' WHERE id = {$id}");
+        $deleted = $this->il->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+}


### PR DESCRIPTION
## Summary
Add `Nene\Xion\ImpersonationLog` — security audit log for admin impersonation.

## What it does
- `start(adminId, targetId, ?reason)` — record start of impersonation session
- `end(id)` — record session end; guards ended_at IS NULL (idempotent-safe)
- `get(id)` — retrieve session row
- `active(?adminId)` — currently open sessions (optionally filtered by admin)
- `history(targetId)` — all sessions for an impersonation target
- `purgeOlderThan(before)` — delete ended sessions older than cutoff; active sessions are never purged

## Tests
15 tests, 22 assertions — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)