### PR TITLE
feat(xion): AccessLog — append-only security resource access log (FT263)

### DIFF
--- a/class/xion/AccessLog.php
+++ b/class/xion/AccessLog.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Security-focused resource access log.
+ *
+ * An append-only record of who accessed which resource, when, and from what
+ * IP address.  Useful for security auditing, detecting suspicious access
+ * patterns, and proving regulatory compliance.
+ *
+ * Distinct from AuditLog (which records before/after data mutations) and
+ * IntegrationLog (which records outgoing HTTP calls).  AccessLog records
+ * read/view events and other access actions.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $al = new AccessLog($pdo);
+ *
+ * // Record a read event
+ * $al->record('document', 'doc-42', 'user-1', 'read', '203.0.113.1');
+ * $al->record('invoice', 'inv-99', 'user-1', 'download');
+ *
+ * // Audit queries
+ * $al->forResource('document', 'doc-42');
+ * $al->byActor('user-1');
+ * $al->purgeOlderThan('2025-01-01 00:00:00');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE access_log (
+ *     id             INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     resource_type  VARCHAR(100) NOT NULL,
+ *     resource_id    VARCHAR(255) NOT NULL,
+ *     actor_id       VARCHAR(255) NOT NULL,
+ *     action         VARCHAR(100) NOT NULL,
+ *     ip_address     VARCHAR(45)  NULL,
+ *     created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class AccessLog
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    // ── record ────────────────────────────────────────────────────────────────
+
+    /**
+     * Append an access event.
+     *
+     * @return int New log entry ID.
+     * @throws \InvalidArgumentException if required fields are empty.
+     */
+    public function record(
+        string $resourceType,
+        string $resourceId,
+        string $actorId,
+        string $action,
+        ?string $ipAddress = null,
+    ): int {
+        if ($resourceType === '') {
+            throw new \InvalidArgumentException('resourceType must not be empty.');
+        }
+
+        if ($resourceId === '') {
+            throw new \InvalidArgumentException('resourceId must not be empty.');
+        }
+
+        if ($actorId === '') {
+            throw new \InvalidArgumentException('actorId must not be empty.');
+        }
+
+        if ($action === '') {
+            throw new \InvalidArgumentException('action must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO access_log (resource_type, resource_id, actor_id, action, ip_address)
+             VALUES (?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([$resourceType, $resourceId, $actorId, $action, $ipAddress]);
+        return (int)$this->db()->lastInsertId();
+    }
+
+    // ── queries ───────────────────────────────────────────────────────────────
+
+    /**
+     * Return recent access events for a specific resource, newest first.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function forResource(string $resourceType, string $resourceId, int $limit = 50): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM access_log
+             WHERE resource_type = ? AND resource_id = ?
+             ORDER BY id DESC LIMIT ?'
+        );
+        $stmt->execute([$resourceType, $resourceId, $limit]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Return recent access events by a specific actor, newest first.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function byActor(string $actorId, int $limit = 50): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM access_log
+             WHERE actor_id = ?
+             ORDER BY id DESC LIMIT ?'
+        );
+        $stmt->execute([$actorId, $limit]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Return recent access events for a specific action type, newest first.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function byAction(string $action, int $limit = 50): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM access_log
+             WHERE action = ?
+             ORDER BY id DESC LIMIT ?'
+        );
+        $stmt->execute([$action, $limit]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    // ── purge ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Delete entries older than the given datetime string.
+     *
+     * @return int Number of rows deleted.
+     */
+    public function purgeOlderThan(string $before): int
+    {
+        $stmt = $this->db()->prepare(
+            'DELETE FROM access_log WHERE created_at < ?'
+        );
+        $stmt->execute([$before]);
+        return (int)$stmt->rowCount();
+    }
+}

--- a/tests/Unit/Xion/AccessLogTest.php
+++ b/tests/Unit/Xion/AccessLogTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\AccessLog;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class AccessLogTest extends TestCase
+{
+    private PDO $pdo;
+    private AccessLog $al;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE access_log (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                resource_type  VARCHAR(100) NOT NULL,
+                resource_id    VARCHAR(255) NOT NULL,
+                actor_id       VARCHAR(255) NOT NULL,
+                action         VARCHAR(100) NOT NULL,
+                ip_address     VARCHAR(45)  NULL,
+                created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->al = new AccessLog($this->pdo);
+    }
+
+    // ── record ────────────────────────────────────────────────────────────────
+
+    public function testRecordReturnsId(): void
+    {
+        $id = $this->al->record('document', 'doc-1', 'user-1', 'read');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testRecordStoresAllFields(): void
+    {
+        $id   = $this->al->record('document', 'doc-1', 'user-1', 'download', '203.0.113.1');
+        $rows = $this->al->forResource('document', 'doc-1');
+        $this->assertCount(1, $rows);
+        $this->assertSame('document', $rows[0]['resource_type']);
+        $this->assertSame('doc-1', $rows[0]['resource_id']);
+        $this->assertSame('user-1', $rows[0]['actor_id']);
+        $this->assertSame('download', $rows[0]['action']);
+        $this->assertSame('203.0.113.1', $rows[0]['ip_address']);
+        $this->assertSame($id, (int)$rows[0]['id']);
+    }
+
+    public function testRecordAllowsNullIp(): void
+    {
+        $this->al->record('document', 'doc-1', 'user-1', 'read');
+        $rows = $this->al->forResource('document', 'doc-1');
+        $this->assertNull($rows[0]['ip_address']);
+    }
+
+    public function testRecordThrowsOnEmptyResourceType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->al->record('', 'doc-1', 'user-1', 'read');
+    }
+
+    public function testRecordThrowsOnEmptyResourceId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->al->record('document', '', 'user-1', 'read');
+    }
+
+    public function testRecordThrowsOnEmptyActorId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->al->record('document', 'doc-1', '', 'read');
+    }
+
+    public function testRecordThrowsOnEmptyAction(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->al->record('document', 'doc-1', 'user-1', '');
+    }
+
+    // ── forResource ───────────────────────────────────────────────────────────
+
+    public function testForResourceFilters(): void
+    {
+        $this->al->record('document', 'doc-1', 'user-1', 'read');
+        $this->al->record('document', 'doc-2', 'user-1', 'read');
+        $this->al->record('invoice', 'doc-1', 'user-1', 'view');
+        $rows = $this->al->forResource('document', 'doc-1');
+        $this->assertCount(1, $rows);
+    }
+
+    public function testForResourceReturnsNewestFirst(): void
+    {
+        $this->al->record('document', 'doc-1', 'user-1', 'read');
+        $this->al->record('document', 'doc-1', 'user-2', 'download');
+        $rows = $this->al->forResource('document', 'doc-1');
+        $this->assertSame('download', $rows[0]['action']);
+    }
+
+    public function testForResourceLimitApplied(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->al->record('document', 'doc-1', "user-{$i}", 'read');
+        }
+
+        $rows = $this->al->forResource('document', 'doc-1', 3);
+        $this->assertCount(3, $rows);
+    }
+
+    public function testForResourceReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->al->forResource('document', 'missing'));
+    }
+
+    // ── byActor ───────────────────────────────────────────────────────────────
+
+    public function testByActorFilters(): void
+    {
+        $this->al->record('document', 'doc-1', 'user-1', 'read');
+        $this->al->record('invoice', 'inv-1', 'user-1', 'view');
+        $this->al->record('document', 'doc-2', 'user-2', 'read');
+        $rows = $this->al->byActor('user-1');
+        $this->assertCount(2, $rows);
+    }
+
+    public function testByActorReturnsEmptyForUnknown(): void
+    {
+        $this->assertSame([], $this->al->byActor('unknown'));
+    }
+
+    // ── byAction ──────────────────────────────────────────────────────────────
+
+    public function testByActionFilters(): void
+    {
+        $this->al->record('document', 'doc-1', 'user-1', 'read');
+        $this->al->record('document', 'doc-2', 'user-2', 'download');
+        $this->al->record('document', 'doc-3', 'user-3', 'read');
+        $rows = $this->al->byAction('read');
+        $this->assertCount(2, $rows);
+    }
+
+    // ── purgeOlderThan ────────────────────────────────────────────────────────
+
+    public function testPurgeOlderThanDeletesOldRows(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO access_log (resource_type, resource_id, actor_id, action, created_at)
+             VALUES ('doc', '1', 'user-1', 'read', '2020-01-01 00:00:00')"
+        );
+        $this->pdo->exec(
+            "INSERT INTO access_log (resource_type, resource_id, actor_id, action, created_at)
+             VALUES ('doc', '2', 'user-1', 'read', '2020-06-01 00:00:00')"
+        );
+        $deleted = $this->al->purgeOlderThan('2021-01-01 00:00:00');
+        $this->assertSame(2, $deleted);
+    }
+
+    public function testPurgeOlderThanDoesNotDeleteRecentRows(): void
+    {
+        $this->al->record('document', 'doc-1', 'user-1', 'read');
+        $deleted = $this->al->purgeOlderThan('2020-01-01 00:00:00');
+        $this->assertSame(0, $deleted);
+    }
+}


### PR DESCRIPTION
## Summary
Add `Nene\Xion\AccessLog` — security-focused append-only access audit log.

Distinct from AuditLog (data mutations) and IntegrationLog (outgoing HTTP).
Records read/view/download access events with optional IP address.

## What it does
- `record(resourceType, resourceId, actorId, action, ?ip)` — append log entry
- `forResource(type, id, limit)` — newest-first events for a resource
- `byActor(actorId, limit)` — newest-first events by an actor
- `byAction(action, limit)` — newest-first events of a specific action type
- `purgeOlderThan(before)` — TTL cleanup

## Tests
16 tests, 22 assertions — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)