### PR TITLE
feat(xion): PasswordExpiry — password expiry policy enforcement with forced-change support (FT264)

### DIFF
--- a/class/xion/PasswordExpiry.php
+++ b/class/xion/PasswordExpiry.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Password expiry policy enforcement.
+ *
+ * Tracks when each user's password expires and whether a forced password
+ * change is required (e.g. after an admin reset or a security incident).
+ * Call set() after every successful password change to reset the clock.
+ *
+ * Distinct from PasswordHistory (which prevents reuse of old passwords).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $pe = new PasswordExpiry($pdo);
+ *
+ * // After a password change, reset the expiry clock (90-day policy)
+ * $pe->set('user-1', 90);
+ *
+ * // Check on login
+ * if ($pe->mustChange('user-1')) {
+ *     // Force user to choose a new password
+ * }
+ *
+ * // Security incident: force all impacted users to change password
+ * $pe->forceChange('user-1');
+ *
+ * // Find accounts expiring within 7 days (for proactive notification)
+ * $upcoming = $pe->expiringSoon(7);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE password_expiry (
+ *     user_id      VARCHAR(255) PRIMARY KEY,
+ *     expires_at   DATETIME     NOT NULL,
+ *     changed_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     must_change  TINYINT(1)   NOT NULL DEFAULT 0
+ * );
+ * ```
+ */
+final class PasswordExpiry
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+
+    // ── set ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Record a password change and set the expiry $expiryDays from now.
+     *
+     * Clears any must_change flag and upserts the row.
+     *
+     * @throws \InvalidArgumentException if userId is empty or expiryDays < 1.
+     */
+    public function set(string $userId, int $expiryDays): void
+    {
+        if ($userId === '') {
+            throw new \InvalidArgumentException('userId must not be empty.');
+        }
+
+        if ($expiryDays < 1) {
+            throw new \InvalidArgumentException('expiryDays must be >= 1.');
+        }
+
+        $expiresAt = date('Y-m-d H:i:s', strtotime("+{$expiryDays} days"));
+        $driver    = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $stmt = $this->db()->prepare(
+                'INSERT INTO password_expiry (user_id, expires_at, must_change)
+                 VALUES (?, ?, 0)
+                 ON DUPLICATE KEY UPDATE
+                     expires_at  = VALUES(expires_at),
+                     changed_at  = CURRENT_TIMESTAMP,
+                     must_change = 0'
+            );
+        } else {
+            $stmt = $this->db()->prepare(
+                'INSERT INTO password_expiry (user_id, expires_at, must_change)
+                 VALUES (?, ?, 0)
+                 ON CONFLICT (user_id)
+                 DO UPDATE SET
+                     expires_at  = excluded.expires_at,
+                     changed_at  = CURRENT_TIMESTAMP,
+                     must_change = 0'
+            );
+        }
+
+        $stmt->execute([$userId, $expiresAt]);
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Retrieve the expiry row for a user.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function get(string $userId): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT * FROM password_expiry WHERE user_id = ?'
+        );
+        $stmt->execute([$userId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    // ── checks ────────────────────────────────────────────────────────────────
+
+    /**
+     * Check whether the user's password is past its expiry date.
+     *
+     * Returns false if no expiry record exists (policy not enforced).
+     */
+    public function isExpired(string $userId): bool
+    {
+        $row = $this->get($userId);
+
+        if ($row === null) {
+            return false;
+        }
+
+        return strtotime((string)$row['expires_at']) < time();
+    }
+
+    /**
+     * Check whether the user must change their password.
+     *
+     * Returns true if must_change = 1 OR the password is expired.
+     */
+    public function mustChange(string $userId): bool
+    {
+        $row = $this->get($userId);
+
+        if ($row === null) {
+            return false;
+        }
+
+        return (int)$row['must_change'] === 1 || $this->isExpired($userId);
+    }
+
+    // ── forceChange ───────────────────────────────────────────────────────────
+
+    /**
+     * Require the user to change their password on next login.
+     *
+     * Returns false if no expiry record exists for this user.
+     */
+    public function forceChange(string $userId): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE password_expiry SET must_change = 1 WHERE user_id = ?'
+        );
+        $stmt->execute([$userId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── clear ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Remove the expiry record (no policy applied to this user).
+     */
+    public function clear(string $userId): bool
+    {
+        $stmt = $this->db()->prepare('DELETE FROM password_expiry WHERE user_id = ?');
+        $stmt->execute([$userId]);
+        return $stmt->rowCount() > 0;
+    }
+
+    // ── expiringSoon ──────────────────────────────────────────────────────────
+
+    /**
+     * Return rows for users whose password expires within $withinDays days.
+     *
+     * Excludes already-expired rows (those should be handled by isExpired()).
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function expiringSoon(int $withinDays = 7, ?string $now = null): array
+    {
+        $currentTime = $now ?? date('Y-m-d H:i:s');
+        $cutoff      = date('Y-m-d H:i:s', strtotime("+{$withinDays} days", strtotime($currentTime)));
+        $stmt        = $this->db()->prepare(
+            'SELECT * FROM password_expiry
+             WHERE expires_at > ? AND expires_at <= ?
+             ORDER BY expires_at ASC'
+        );
+        $stmt->execute([$currentTime, $cutoff]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}

--- a/tests/Unit/Xion/PasswordExpiryTest.php
+++ b/tests/Unit/Xion/PasswordExpiryTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\PasswordExpiry;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordExpiryTest extends TestCase
+{
+    private PDO $pdo;
+    private PasswordExpiry $pe;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE password_expiry (
+                user_id      VARCHAR(255) PRIMARY KEY,
+                expires_at   DATETIME     NOT NULL,
+                changed_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                must_change  TINYINT(1)   NOT NULL DEFAULT 0
+            )
+        ');
+        $this->pe = new PasswordExpiry($this->pdo);
+    }
+
+    // ── set ───────────────────────────────────────────────────────────────────
+
+    public function testSetCreatesRow(): void
+    {
+        $this->pe->set('user-1', 90);
+        $row = $this->pe->get('user-1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame('user-1', $row['user_id']);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(0, (int)$row['must_change']);
+    }
+
+    public function testSetUpdatesExistingRow(): void
+    {
+        $this->pe->set('user-1', 90);
+        $this->pe->set('user-1', 30); // shorter policy
+        $row = $this->pe->get('user-1');
+        $this->assertNotNull($row);
+        // Expires within ~30 days (not 90)
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $expires = strtotime((string)$row['expires_at']);
+        $this->assertGreaterThan(time() + (25 * 86400), $expires);
+        $this->assertLessThan(time() + (35 * 86400), $expires);
+    }
+
+    public function testSetClearsMustChangeFlag(): void
+    {
+        $this->pe->set('user-1', 90);
+        $this->pe->forceChange('user-1');
+        $this->pe->set('user-1', 90); // password change clears flag
+        $this->assertFalse($this->pe->mustChange('user-1'));
+    }
+
+    public function testSetThrowsOnEmptyUserId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pe->set('', 90);
+    }
+
+    public function testSetThrowsOnZeroExpiryDays(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pe->set('user-1', 0);
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    public function testGetReturnsNullForUnknownUser(): void
+    {
+        $this->assertNull($this->pe->get('unknown'));
+    }
+
+    // ── isExpired ─────────────────────────────────────────────────────────────
+
+    public function testIsExpiredFalseForFutureExpiry(): void
+    {
+        $this->pe->set('user-1', 90);
+        $this->assertFalse($this->pe->isExpired('user-1'));
+    }
+
+    public function testIsExpiredTrueForPastExpiry(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO password_expiry (user_id, expires_at)
+             VALUES ('user-1', '2020-01-01 00:00:00')"
+        );
+        $this->assertTrue($this->pe->isExpired('user-1'));
+    }
+
+    public function testIsExpiredFalseForUnknownUser(): void
+    {
+        $this->assertFalse($this->pe->isExpired('unknown'));
+    }
+
+    // ── mustChange ────────────────────────────────────────────────────────────
+
+    public function testMustChangeFalseNormally(): void
+    {
+        $this->pe->set('user-1', 90);
+        $this->assertFalse($this->pe->mustChange('user-1'));
+    }
+
+    public function testMustChangeTrueWhenExpired(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO password_expiry (user_id, expires_at)
+             VALUES ('user-1', '2020-01-01 00:00:00')"
+        );
+        $this->assertTrue($this->pe->mustChange('user-1'));
+    }
+
+    public function testMustChangeTrueWhenForceFlagSet(): void
+    {
+        $this->pe->set('user-1', 90);
+        $this->pe->forceChange('user-1');
+        $this->assertTrue($this->pe->mustChange('user-1'));
+    }
+
+    public function testMustChangeFalseForUnknownUser(): void
+    {
+        $this->assertFalse($this->pe->mustChange('unknown'));
+    }
+
+    // ── forceChange ───────────────────────────────────────────────────────────
+
+    public function testForceChangeSetsFlag(): void
+    {
+        $this->pe->set('user-1', 90);
+        $this->assertTrue($this->pe->forceChange('user-1'));
+        $row = $this->pe->get('user-1');
+        $this->assertNotNull($row);
+        // @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+        $this->assertSame(1, (int)$row['must_change']);
+    }
+
+    public function testForceChangeReturnsFalseForUnknownUser(): void
+    {
+        $this->assertFalse($this->pe->forceChange('unknown'));
+    }
+
+    // ── clear ─────────────────────────────────────────────────────────────────
+
+    public function testClearDeletesRow(): void
+    {
+        $this->pe->set('user-1', 90);
+        $this->assertTrue($this->pe->clear('user-1'));
+        $this->assertNull($this->pe->get('user-1'));
+    }
+
+    public function testClearReturnsFalseForUnknownUser(): void
+    {
+        $this->assertFalse($this->pe->clear('unknown'));
+    }
+
+    // ── expiringSoon ──────────────────────────────────────────────────────────
+
+    public function testExpiringSoonReturnsUpcomingRows(): void
+    {
+        $now     = '2026-05-28 00:00:00';
+        $expiry3 = '2026-05-31 00:00:00';
+        $expiry6 = '2026-06-03 00:00:00';
+        $this->pdo->exec(
+            "INSERT INTO password_expiry (user_id, expires_at) VALUES ('user-1', '{$expiry3}')"
+        );
+        $this->pdo->exec(
+            "INSERT INTO password_expiry (user_id, expires_at) VALUES ('user-2', '{$expiry6}')"
+        );
+        $rows = $this->pe->expiringSoon(7, $now);
+        $this->assertCount(2, $rows);
+    }
+
+    public function testExpiringSoonExcludesAlreadyExpired(): void
+    {
+        $now    = '2026-05-28 00:00:00';
+        $past   = '2026-05-20 00:00:00';
+        $future = '2026-06-01 00:00:00';
+        $this->pdo->exec(
+            "INSERT INTO password_expiry (user_id, expires_at) VALUES ('user-1', '{$past}')"
+        );
+        $this->pdo->exec(
+            "INSERT INTO password_expiry (user_id, expires_at) VALUES ('user-2', '{$future}')"
+        );
+        $rows = $this->pe->expiringSoon(7, $now);
+        $this->assertCount(1, $rows);
+        $this->assertSame('user-2', $rows[0]['user_id']);
+    }
+
+    public function testExpiringSoonReturnsEmptyWhenNone(): void
+    {
+        $this->assertSame([], $this->pe->expiringSoon(7, '2026-05-28 00:00:00'));
+    }
+}


### PR DESCRIPTION
## Summary
Add `Nene\Xion\PasswordExpiry` — per-user password expiry policy.

Distinct from PasswordHistory (prevents reuse); this class tracks *when* a password expires.

## What it does
- `set(userId, expiryDays)` — upsert expiry; clears must_change flag on password change
- `get(userId)` — retrieve row
- `isExpired(userId)` — expired if expires_at < now
- `mustChange(userId)` — true if expired OR must_change = 1
- `forceChange(userId)` — sets must_change flag (security incident / admin reset)
- `clear(userId)` — remove record (no policy enforced)
- `expiringSoon(withinDays, ?now)` — rows expiring within N days (for proactive notification)

## Tests
20 tests, 28 assertions — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)