### PR TITLE
docs: update FT log for FT255–FT264 (Xion tenth wave)

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -14,7 +14,7 @@ This file is for **forward-looking** ideas — once a trial fires, its record mo
 
 ## Active candidates
 
-The Xion helper wave (FT78–FT250) is ongoing as of 2026-05-28. Trigger-based and structural candidates are listed in the next section.
+The Xion helper wave (FT78–FT264) is ongoing as of 2026-05-28. Trigger-based and structural candidates are listed in the next section.
 
 ---
 
@@ -54,6 +54,16 @@ The Xion helper wave (FT78–FT250) is ongoing as of 2026-05-28. Trigger-based a
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT264 — PasswordExpiry** (2026-05-28): `Nene\Xion\PasswordExpiry` — password expiry policy; set() resets clock; forceChange() for incidents; expiringSoon() notification cron. PR #708.
+- **FT263 — AccessLog** (2026-05-28): `Nene\Xion\AccessLog` — append-only resource access log; forResource/byActor/byAction; purgeOlderThan(). PR #707.
+- **FT262 — TextTemplate** (2026-05-28): `Nene\Xion\TextTemplate` — body-only text template for SMS/push/Slack; {{variable}} substitution; locale fallback; cross-driver upsert. PR #706.
+- **FT261 — ImpersonationLog** (2026-05-28): `Nene\Xion\ImpersonationLog` — admin impersonation session audit; start()/end(); active(?admin); purgeOlderThan() skips active. PR #705.
+- **FT260 — RecurringPayment** (2026-05-28): `Nene\Xion\RecurringPayment` — subscription billing schedule; due() cron; recordBilling() advances next_billing_date; pause/resume/cancel. PR #704.
+- **FT259 — ApiWebhook** (2026-05-28): `Nene\Xion\ApiWebhook` — webhook subscription endpoint registry; auto-generates HMAC secret; rotateSecret(); forEvent() active subscribers. PR #703.
+- **FT258 — ContentReport** (2026-05-28): `Nene\Xion\ContentReport` — user-submitted content moderation reports; STATUS_PENDING/ACTIONED/DISMISSED; action()/dismiss() guard pending status. PR #702.
+- **FT257 — ProfileBadge** (2026-05-28): `Nene\Xion\ProfileBadge` — gamification badge award/revoke; award() idempotent; userBadges()/usersWithBadge()/countForBadge(). PR #701.
+- **FT256 — UserFeedback** (2026-05-28): `Nene\Xion\UserFeedback` — general NPS/star satisfaction feedback; averageScore(); countByScore(); forUser()/recent()/clearContext(). PR #700.
+- **FT255 — DailyStreak** (2026-05-28): `Nene\Xion\DailyStreak` — per-user daily activity streak; checkin() idempotent same-day; longestStreak preserved through reset(). PR #699.
 - **FT250 — KpiTracker** (2026-05-28): `Nene\Xion\KpiTracker` — KPI/OKR metric tracking with target/actual; record() time-series; progress() {actual, target, pct}; purgeOlderThan() per definition. PR #693.
 - **FT249 — FeatureRequest** (2026-05-28): `Nene\Xion\FeatureRequest` — product feature requests with voting; OPEN→PLANNED→IN_PROGRESS→SHIPPED; one-vote-per-user; top() by vote count. PR #692.
 - **FT248 — DocumentSignature** (2026-05-28): `Nene\Xion\DocumentSignature` — e-signature workflow; multi-signatory; sign() auto-completes; decline() cancels; pendingFor() inbox. PR #691.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT250 complete as of 2026-05-28 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT264 complete as of 2026-05-28 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 
@@ -243,6 +243,7 @@ Completed (wave summary):
 - **FT211–FT228**: Xion seventh extended wave. 18 trials covering product price catalog with tiers, compliance audit log with before/after snapshots, loyalty point ledger, flat entity comments, survey/form response collection, product bundle catalog, channel-agnostic notification queue, persistent stateful workflow instances, type-ahead search suggestion management, metered billing usage tracking, multiple entity identifier aliases, multi-device session management, ordered page builder content blocks, database-backed multilingual content, service health monitoring, page/resource view analytics, contact form inbox management, and time-bounded access delegation. PRs #652–#669.
 - **FT229–FT238**: Xion eighth extended wave. 10 trials covering form/survey template definitions with questions, mailing list recipient group management, point-in-time entity state snapshots, stock/availability alert registrations with cron batch processing, time-bounded resource reservation with overlap detection, high-score leaderboard with personal-best tracking, financial credit notes with lifecycle management, device fingerprint recognition for fraud detection, SLA/SLO breach detection with pause/resume, and async media processing job tracking. PRs #671–#680.
 - **FT239–FT250**: Xion ninth extended wave. 12 trials covering simple polls with one-vote-per-user enforcement, user subscription lifecycle management, online presence tracking with context scoping, partial-redemption gift cards, IT incident tracking with severity levels, RFC change-management approval workflow, period-based budget allocation with overflow protection, physical/digital asset inventory with assignment history, event RSVP management with capacity limits and check-in, e-signature requests with multi-signatory support, product feature requests with upvoting and delivery tracking, and KPI/OKR metric tracking with target vs. actual comparison. PRs #682–#693.
+- **FT255–FT264**: Xion tenth extended wave. 10 trials covering daily activity streak tracking, general satisfaction feedback (NPS/star ratings), gamification badge award/revoke, user-submitted content moderation reports, webhook subscription endpoint management, recurring payment schedule management, admin impersonation session audit, body-only text template for SMS/push/Slack, append-only resource access log, and password expiry policy enforcement. PRs #699–#708.
 
 Future candidates:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,9 +6,24 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-28: all non-promotion Issues are closed; FT1–FT250 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-28: all non-promotion Issues are closed; FT1–FT264 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
+
+### 2026-05-28 — FT255–FT264: Xion tenth extended wave (10 trials)
+
+Continuous wave of 10 field trials adding further Xion helper patterns. All PRs #699–#708.
+
+**FT255 — DailyStreak**: `DailyStreak` per-user daily activity streak tracker; checkin() increments on consecutive days, resets on gap; longestStreak() tracks all-time best; reset() preserves longest. PR #699.
+**FT256 — UserFeedback**: `UserFeedback` general satisfaction feedback (NPS/star ratings + free text) per context; averageScore(); countByScore() distribution; forUser()/recent()/clearContext(). PR #700.
+**FT257 — ProfileBadge**: `ProfileBadge` gamification badge award/revoke; award() idempotent; hasBadge()/userBadges()/usersWithBadge()/countForBadge(); revokeAll() for account cleanup. PR #701.
+**FT258 — ContentReport**: `ContentReport` user-submitted content moderation reports; STATUS_PENDING/ACTIONED/DISMISSED; action()/dismiss() guard pending status; forContent()/countByReason(). PR #702.
+**FT259 — ApiWebhook**: `ApiWebhook` webhook subscription endpoint registry; auto-generates HMAC secret; rotateSecret(); activate()/deactivate(); forEvent() active subscribers. PR #703.
+**FT260 — RecurringPayment**: `RecurringPayment` subscription billing schedule; due() for cron; recordBilling() advances next_billing_date by frequency; pause()/resume()/cancel(); integer-cent amounts. PR #704.
+**FT261 — ImpersonationLog**: `ImpersonationLog` admin impersonation session audit; start()/end() guards IS NULL; active(?adminId); history(targetId); purgeOlderThan() skips active sessions. PR #705.
+**FT262 — TextTemplate**: `TextTemplate` DB-backed body-only text template for SMS/push/Slack/etc.; {{variable}} substitution; locale fallback to 'en'; cross-driver upsert; activate()/deactivate()/remove(). PR #706.
+**FT263 — AccessLog**: `AccessLog` append-only security resource access log; forResource()/byActor()/byAction() queries; purgeOlderThan() TTL; distinct from AuditLog (mutations) and IntegrationLog (HTTP). PR #707.
+**FT264 — PasswordExpiry**: `PasswordExpiry` password expiry policy; set() resets clock on change; isExpired()/mustChange(); forceChange() for security incidents; expiringSoon() for proactive notification. PR #708.
 
 ### 2026-05-28 — FT239–FT250: Xion ninth extended wave (12 trials)
 


### PR DESCRIPTION
Update roadmap, TODO, and candidates for the tenth Xion wave (FT255–FT264).

- FT255 DailyStreak, FT256 UserFeedback, FT257 ProfileBadge, FT258 ContentReport
- FT259 ApiWebhook, FT260 RecurringPayment, FT261 ImpersonationLog, FT262 TextTemplate
- FT263 AccessLog, FT264 PasswordExpiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)