### PR TITLE
chore(dx): Phan local runner, DbUpsert helper, Xion INDEX, CLAUDE.md

### DIFF
--- a/.phan/suppress-cheatsheet.md
+++ b/.phan/suppress-cheatsheet.md
@@ -1,0 +1,118 @@
+# Phan Suppression Cheatsheet
+
+Quick reference for `@phan-suppress-next-line` annotations used in this codebase.
+Run `composer analyze:file <file>` to check locally before pushing.
+
+---
+
+## よく出るエラーと使いどころ
+
+### `PhanTypeArraySuspiciousNullable`
+
+**出る場面**: `?array` 型の変数でキーアクセスするとき。  
+`assertNotNull($row)` の後でも Phan は型を絞り込まないため毎回必要。
+
+```php
+$row = $this->cb->get($id);
+$this->assertNotNull($row);
+// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
+$this->assertSame('hero', $row['block_type']);
+```
+
+---
+
+### `PhanTypeMismatchArgumentNullable`
+
+**出る場面**: `?T` 型の変数を `T` を期待するユーザー定義関数・メソッドに渡すとき。
+
+```php
+$id = $this->lock->acquire('resource', 'owner', 60); // returns ?int
+$this->assertNotNull($id);
+// @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+$this->lock->extend($id, 60);  // extend(int $id, ...) expects non-null int
+```
+
+---
+
+### `PhanTypeMismatchArgumentNullableInternal`
+
+**出る場面**: `?T` 型を PHP **組み込み関数**（`strlen`, `json_decode`, `strtotime` など）に渡すとき。  
+`PhanTypeMismatchArgumentNullable` と名前が似ているが **Internal** がつく点に注意。
+
+```php
+$secret = $this->aw->rotateSecret($id); // returns ?string
+$this->assertNotNull($secret);
+// @phan-suppress-next-line PhanTypeMismatchArgumentNullableInternal
+$this->assertSame(64, strlen($secret));
+```
+
+---
+
+### `PhanTypeMismatchDeclaredParamNullable`
+
+**出る場面**: メソッドの実装が `?T` を受けるのに PHPDoc が `@param T` と書いているとき。
+
+```php
+// Bad: @param bool $suppress  but signature is ?bool $suppress
+// Fix:
+/** @param bool|null $suppress */
+public function record(string $email, string $type, ?bool $suppress = null): int
+```
+
+---
+
+### `PhanTypeMismatchDeclaredReturn`
+
+**出る場面**: 実装の戻り値型と PHPDoc の `@return` が不一致。
+
+```php
+// Bad: @return array<string,int>  but returns int
+// Fix:
+/** @return int */
+public function countByType(string $type): int
+```
+
+---
+
+### `PhanTypeComparisonFromArray`
+
+**出る場面**: `fetchAll()` の戻り値（`array|false`）を `=== false` と比較するとき。
+
+```php
+$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+// @phan-suppress-next-line PhanTypeComparisonFromArray
+if ($rows === false) {
+    return [];
+}
+```
+
+---
+
+## 使い分けフローチャート
+
+```
+対象の型が ?T ?
+├─ YES → PHP組み込み関数に渡す？
+│         ├─ YES → PhanTypeMismatchArgumentNullableInternal
+│         └─ NO  → PhanTypeMismatchArgumentNullable
+├─ NO → ?array のキーアクセス？
+│        └─ YES → PhanTypeArraySuspiciousNullable
+├─ NO → fetchAll()=== false 比較？
+│        └─ YES → PhanTypeComparisonFromArray
+├─ NO → PHPDoc @param と実装シグネチャの nullable 不一致？
+│        └─ YES → PhanTypeMismatchDeclaredParamNullable
+└─ NO → PHPDoc @return と実装戻り値型の不一致？
+          └─ YES → PhanTypeMismatchDeclaredReturn
+```
+
+---
+
+## ローカル実行
+
+```bash
+# 新規クラス + テストを書いたら push 前に:
+composer analyze:file -- class/xion/Foo.php tests/Unit/Xion/FooTest.php
+
+# 全体チェック（CI と同等、約40秒）:
+composer analyze
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,41 @@ Full context is in `docs/ai/README.md` and the `docs/ai/self-review/` checklists
 
 ---
 
+## Pre-commit Checklist
+
+Run this before every `git push`:
+
+```bash
+composer precommit   # format → analyze (full) → test
+```
+
+Or piecemeal:
+
+```bash
+composer format                      # auto-fix code style
+composer analyze:file -- class/xion/Foo.php tests/Unit/Xion/FooTest.php   # targeted Phan (~14 s)
+composer analyze                     # full Phan (~40 s) — same as CI
+composer test                        # PHPUnit unit suite
+```
+
+---
+
+## Scaffolding a New Xion Class
+
+```bash
+composer make:xion -- ClassName
+```
+
+Creates `class/xion/ClassName.php` + `tests/Unit/Xion/ClassNameTest.php` with
+the PDO injection skeleton. Then:
+
+1. Fill in the public API and table DDL
+2. Add the table to `class/xion/SchemaDefinition.php`
+3. Run `composer xion:index` to refresh the class index
+4. Run `composer analyze:file -- class/xion/ClassName.php tests/Unit/Xion/ClassNameTest.php`
+
+---
+
 ## Static Analysis (Phan)
 
 ```bash
@@ -76,6 +111,12 @@ Never use a date that is only "near" the boundary and hope it works.
 
 `class/xion/INDEX.md` — all ~230 Xion classes grouped by domain.
 Consult it before starting a new Xion class to avoid duplicates.
+
+To regenerate after adding classes:
+
+```bash
+composer xion:index   # updates descriptions, adds new classes to Uncategorized
+```
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md — NeNe Developer Notes for AI Agents
+
+Quick-reference conventions for AI-assisted development on NeNe.
+Full context is in `docs/ai/README.md` and the `docs/ai/self-review/` checklists.
+
+---
+
+## Static Analysis (Phan)
+
+```bash
+# Full run (~40 s) — same as CI:
+composer analyze
+
+# Targeted run (~14 s) — before pushing a new Xion class:
+composer analyze:file -- class/xion/Foo.php tests/Unit/Xion/FooTest.php
+
+# Multiple files:
+composer analyze:file -- class/xion/Foo.php class/xion/Bar.php tests/Unit/Xion/FooTest.php
+```
+
+Suppression annotations go on the line **before** the offending line.
+See `.phan/suppress-cheatsheet.md` for the full reference; quick guide:
+
+| Error name | When |
+|---|---|
+| `PhanTypeMismatchArgumentNullable` | `?T` → user-defined function expecting `T` |
+| `PhanTypeMismatchArgumentNullableInternal` | `?T` → PHP built-in (`strlen`, `json_decode`, …) |
+| `PhanTypeArraySuspiciousNullable` | `?array` key access (even after `assertNotNull`) |
+| `PhanTypeComparisonFromArray` | `fetchAll() === false` comparison |
+| `PhanTypeMismatchDeclaredParamNullable` | PHPDoc `@param T` vs `?T` signature |
+| `PhanTypeMismatchDeclaredReturn` | PHPDoc `@return` vs actual return type |
+
+---
+
+## Cross-Driver Upsert
+
+Use `DbUpsert::run()` instead of writing driver-specific SQL by hand:
+
+```php
+use Nene\Xion\DbUpsert;
+
+DbUpsert::run(
+    $this->db(),
+    table:        'presence',
+    data:         ['user_id' => $userId, 'context' => $context],
+    conflictCols: ['user_id', 'context'],          // SQLite ON CONFLICT clause
+    updateCols:   ['context'],                     // copied from excluded row
+    updateExprs:  ['seen_at' => 'CURRENT_TIMESTAMP'], // raw SQL expressions
+);
+```
+
+- `updateCols` → `col = VALUES(col)` (MySQL) / `col = excluded.col` (SQLite)
+- `updateExprs` → raw SQL appended to SET, e.g. `'seen_at' => 'CURRENT_TIMESTAMP'`
+- Both optional; omit both for INSERT … DO NOTHING on conflict
+
+---
+
+## Date Boundary Tests
+
+Off-by-one errors are the most common test bug. Always annotate literal dates
+with a relative comment so the intent is obvious and reviewable:
+
+```php
+$now      = '2026-05-28';
+$expiry6  = '2026-06-03'; // +6 days — within 7-day window
+$expiry7  = '2026-06-04'; // +7 days — exactly at boundary (included)
+$expiry8  = '2026-06-05'; // +8 days — outside window, must NOT appear
+```
+
+Rule: **one line per boundary case**, each line with its `// +N days` comment.
+Never use a date that is only "near" the boundary and hope it works.
+
+---
+
+## Xion Class Index
+
+`class/xion/INDEX.md` — all ~230 Xion classes grouped by domain.
+Consult it before starting a new Xion class to avoid duplicates.
+
+---
+
+## PDO Injection Pattern
+
+All Xion classes accept an optional `?PDO $db` in their constructor and fall
+back to `PdoConnection::getInstance()` when it is `null`:
+
+```php
+public function __construct(private readonly ?PDO $db = null) {}
+
+private function db(): PDO
+{
+    return $this->db ?? PdoConnection::getInstance();
+}
+```
+
+Tests pass an in-memory SQLite PDO; production uses the singleton.
+
+---
+
+## Monetary Values
+
+All amounts are stored as **integer cents** (e.g. `$1.50` → `150`).
+No floats in the database, no `DECIMAL` in SQLite tests.
+
+---
+
+## Token Security
+
+Never store raw tokens. Always hash with SHA-256:
+
+```php
+$token  = bin2hex(random_bytes(32));        // 64 hex chars, plaintext — return to caller
+$hashed = hash('sha256', $token);           // store this
+```
+
+---
+
+## Session State
+
+At the end of each work session, write a brief `.claude/session-state.md`
+noting what branch you are on, what is uncommitted, and what remains to do.
+This lets the next session resume without re-deriving state from git.

--- a/class/xion/DbUpsert.php
+++ b/class/xion/DbUpsert.php
@@ -81,7 +81,7 @@ final class DbUpsert
         $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
 
         if ($driver === 'mysql') {
-            $setParts = array_map(fn(string $c) => "{$c} = VALUES({$c})", $updateCols);
+            $setParts = array_map(fn (string $c) => "{$c} = VALUES({$c})", $updateCols);
 
             foreach ($updateExprs as $col => $expr) {
                 $setParts[] = "{$col} = {$expr}";
@@ -92,7 +92,7 @@ final class DbUpsert
                        . ($setClause !== '' ? " ON DUPLICATE KEY UPDATE {$setClause}" : '');
         } else {
             $conflictList = implode(', ', $conflictCols);
-            $setParts     = array_map(fn(string $c) => "{$c} = excluded.{$c}", $updateCols);
+            $setParts     = array_map(fn (string $c) => "{$c} = excluded.{$c}", $updateCols);
 
             foreach ($updateExprs as $col => $expr) {
                 $setParts[] = "{$col} = {$expr}";

--- a/class/xion/DbUpsert.php
+++ b/class/xion/DbUpsert.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Cross-driver upsert helper (MySQL + SQLite).
+ *
+ * Eliminates the repeated if/else driver-check boilerplate in Xion classes.
+ *
+ * ## Usage
+ *
+ * ```php
+ * // Instead of:
+ * $driver = $this->db()->getAttribute(PDO::ATTR_DRIVER_NAME);
+ * if ($driver === 'mysql') {
+ *     $stmt = $this->db()->prepare(
+ *         'INSERT INTO presence (user_id, context, seen_at)
+ *          VALUES (?, ?, CURRENT_TIMESTAMP)
+ *          ON DUPLICATE KEY UPDATE seen_at = CURRENT_TIMESTAMP'
+ *     );
+ * } else {
+ *     $stmt = $this->db()->prepare(
+ *         'INSERT INTO presence (user_id, context, seen_at)
+ *          VALUES (?, ?, CURRENT_TIMESTAMP)
+ *          ON CONFLICT (user_id, context)
+ *          DO UPDATE SET seen_at = CURRENT_TIMESTAMP'
+ *     );
+ * }
+ * $stmt->execute([$userId, $context, ...]);
+ *
+ * // Write this instead:
+ * DbUpsert::run(
+ *     $this->db(),
+ *     table: 'presence',
+ *     data:  ['user_id' => $userId, 'context' => $context],
+ *     conflictCols: ['user_id', 'context'],
+ *     updateCols:   ['seen_at'],
+ *     updateExprs:  ['seen_at' => 'CURRENT_TIMESTAMP'],
+ * );
+ * ```
+ *
+ * ## Parameters
+ *
+ * - `$data`        Column→value map for the INSERT.
+ * - `$conflictCols` Unique columns that trigger the ON DUPLICATE / ON CONFLICT
+ *                   (used for SQLite's ON CONFLICT clause; MySQL infers from the
+ *                   unique key automatically).
+ * - `$updateCols`  Columns to copy from the inserted row on conflict
+ *                  (uses `VALUES(col)` / `excluded.col` syntax).
+ * - `$updateExprs` Columns whose update value is a raw SQL expression, e.g.
+ *                  `['updated_at' => 'CURRENT_TIMESTAMP']`.
+ *                  These are appended after `$updateCols`.
+ */
+final class DbUpsert
+{
+    /**
+     * Execute a cross-driver upsert.
+     *
+     * @param array<string,mixed>  $data         Column→value pairs for INSERT.
+     * @param string[]             $conflictCols Unique columns (for SQLite ON CONFLICT clause).
+     * @param string[]             $updateCols   Columns to mirror from inserted values on conflict.
+     * @param array<string,string> $updateExprs  Column→raw-SQL-expression pairs appended to the SET clause.
+     */
+    public static function run(
+        PDO $pdo,
+        string $table,
+        array $data,
+        array $conflictCols,
+        array $updateCols = [],
+        array $updateExprs = [],
+    ): void {
+        $cols         = array_keys($data);
+        $values       = array_values($data);
+        $colList      = implode(', ', $cols);
+        $placeholders = implode(', ', array_fill(0, count($cols), '?'));
+
+        $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $setParts = array_map(fn(string $c) => "{$c} = VALUES({$c})", $updateCols);
+
+            foreach ($updateExprs as $col => $expr) {
+                $setParts[] = "{$col} = {$expr}";
+            }
+
+            $setClause = implode(', ', $setParts);
+            $sql       = "INSERT INTO {$table} ({$colList}) VALUES ({$placeholders})"
+                       . ($setClause !== '' ? " ON DUPLICATE KEY UPDATE {$setClause}" : '');
+        } else {
+            $conflictList = implode(', ', $conflictCols);
+            $setParts     = array_map(fn(string $c) => "{$c} = excluded.{$c}", $updateCols);
+
+            foreach ($updateExprs as $col => $expr) {
+                $setParts[] = "{$col} = {$expr}";
+            }
+
+            $setClause = implode(', ', $setParts);
+            $sql       = "INSERT INTO {$table} ({$colList}) VALUES ({$placeholders})"
+                       . ($setClause !== ''
+                            ? " ON CONFLICT ({$conflictList}) DO UPDATE SET {$setClause}"
+                            : " ON CONFLICT ({$conflictList}) DO NOTHING");
+        }
+
+        $pdo->prepare($sql)->execute($values);
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -8,32 +8,32 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `AccessToken` | Issue, verify, and revoke personal access tokens (PATs) |
-| `AuthSession` | Application session management |
-| `BearerAuth` | Optional Bearer-token authentication for agent/MCP clients (ADR-0008) |
-| `DeviceFingerprint` | Device recognition for fraud detection and trust scoring |
-| `DeviceToken` | Push notification device token management per user |
-| `EmailVerification` | Token-based email address verification with expiry |
-| `GuestSession` | Anonymous visitor session tracking with key-value data bag |
-| `InvitationToken` | Token-based user invitation system |
-| `InviteCode` | Single-use invite codes with usage quota |
-| `JwtCodec` | JWT encode/decode helpers |
-| `LoginAttemptTracker` | Brute-force protection via login attempt counting |
-| `LoginHistory` | Append-only log of login attempts with IP, user-agent, and result |
-| `MagicLink` | Email-based passwordless authentication tokens |
-| `OAuthToken` | OAuth2 access/refresh token storage with TTL |
-| `OtpChallenge` | One-time password (OTP) challenge issuance and verification |
-| `PasswordExpiry` | Password expiry policy enforcement |
-| `PasswordHistory` | Prevent users from reusing recent passwords |
-| `PasswordResetToken` | Cryptographic helpers for password-reset token workflows |
-| `PersonalAccessToken` | Personal Access Token (PAT) management for user-facing dashboards |
-| `PinCode` | Short PIN/OTP issuance with attempt limiting and expiry |
-| `RedisSessionHandler` | Redis-backed PHP session handler |
-| `RefreshToken` | DB-backed refresh token management for JWT access token rotation |
-| `ServiceAccount` | Machine-to-machine auth credentials with key rotation |
-| `TotpAuthenticator` | TOTP (RFC 6238 / Google Authenticator compatible) |
-| `TwoFactorBackupCode` | One-time recovery codes for 2FA |
-| `UserSession` | Multi-device application session management |
+| `AccessToken` | issue, verify, and revoke personal access tokens (PATs). |
+| `AuthSession` | — |
+| `BearerAuth` | Optional Bearer-token authentication for agent / MCP clients (ADR-0008). |
+| `DeviceFingerprint` | device recognition for fraud detection and trust scoring. |
+| `DeviceToken` | push notification device token management per user. |
+| `EmailVerification` | token-based email address verification with expiry. |
+| `GuestSession` | anonymous visitor session tracking with key-value data bag. |
+| `InvitationToken` | Token-based user invitation system. |
+| `InviteCode` | single-use invite codes with usage quota. |
+| `JwtCodec` | — |
+| `LoginAttemptTracker` | — |
+| `LoginHistory` | append-only log of login attempts with IP, user-agent, and result. |
+| `MagicLink` | email-based passwordless authentication tokens. |
+| `OAuthToken` | OAuth2 access/refresh token storage with TTL. |
+| `OtpChallenge` | one-time password (OTP) challenge issuance and verification. |
+| `PasswordExpiry` | Password expiry policy enforcement. |
+| `PasswordHistory` | Password history — prevent users from reusing recent passwords. |
+| `PasswordResetToken` | Cryptographic helpers for password-reset token workflows. |
+| `PersonalAccessToken` | Personal Access Token (PAT) management for user-facing dashboards. |
+| `PinCode` | short PIN / OTP issuance with attempt limiting and expiry. |
+| `RedisSessionHandler` | — |
+| `RefreshToken` | DB-backed refresh token management for JWT access token rotation. |
+| `ServiceAccount` | machine-to-machine auth credentials with key rotation. |
+| `TotpAuthenticator` | TOTP (Time-based One-Time Password) authenticator — RFC 6238 / Google Authenticator compatible. |
+| `TwoFactorBackupCode` | one-time recovery codes for 2FA. |
+| `UserSession` | multi-device application session management. |
 
 ---
 
@@ -41,21 +41,21 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `AccessControl` | Per-resource subject ACL (access-control list) |
-| `AccessGrant` | Time-bounded access delegation between entities |
-| `AccessSchedule` | Recurring time-window access control for users and resources |
-| `BlockList` | User block list — prevent harassment and unwanted interactions |
-| `CsrfProtectionPolicy` | CSRF protection policy helpers |
-| `GeoBlocker` | Country-level access control via a configurable allow/block list |
-| `GeoFence` | Define named circular geo-fences and check point containment |
-| `ImpersonationLog` | Admin impersonation session audit log |
-| `IpAllowlist` | Per-resource IP allowlist with CIDR range support |
-| `IpBlocklist` | Global IP address blocklist with optional expiry |
-| `RedirectGuard` | Open-redirect guard for controllers that need to redirect |
-| `ResourceLock` | Advisory lock on any entity to prevent concurrent edits |
-| `RoleGuard` | Role-based access gate |
-| `TrustScore` | Append-only fraud/trust score per user |
-| `UserBan` | Ban/unban users with optional expiry and reason tracking |
+| `AccessControl` | per-resource subject ACL (access-control list). |
+| `AccessGrant` | time-bounded access delegation between entities. |
+| `AccessSchedule` | recurring time-window access control for users and resources. |
+| `BlockList` | User block list — prevent harassment and unwanted interactions. |
+| `CsrfProtectionPolicy` | — |
+| `GeoBlocker` | country-level access control via a configurable allow/block list. |
+| `GeoFence` | define named circular geo-fences and check point containment. |
+| `ImpersonationLog` | Admin impersonation session audit log. |
+| `IpAllowlist` | per-resource IP allowlist with CIDR range support. |
+| `IpBlocklist` | global IP address blocklist with optional expiry. |
+| `RedirectGuard` | Open-redirect guard for controllers that need to redirect to an |
+| `ResourceLock` | advisory lock on any entity to prevent concurrent edits. |
+| `RoleGuard` | — |
+| `TrustScore` | append-only fraud/trust score per user. |
+| `UserBan` | ban / unban users with optional expiry and reason tracking. |
 
 ---
 
@@ -63,27 +63,27 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `Announcement` | Site-wide announcements with scheduling and per-user dismissal |
-| `Checklist` | Ordered checklist items attached to any entity |
-| `CommentThread` | Threaded comments attached to any entity |
-| `ContentBlock` | Ordered content blocks for page builder/CMS layouts |
-| `ContentDraft` | Content draft lifecycle: draft → published → archived |
-| `ContentFilter` | DB-backed banned word/phrase list with masking |
-| `ContentFlag` | User content flagging and moderation queue |
-| `ContentReport` | User-submitted content moderation reports |
-| `ContentSchedule` | Schedule content for future publish and optional expiry |
-| `ContentTag` | Flexible tagging of arbitrary entities |
-| `ContentVersion` | Content versioning with rollback support |
-| `DraftManager` | Versioned draft persistence for any content type |
-| `EmailTemplate` | DB-stored email templates with variable substitution |
-| `EntityComment` | Flat comment list attached to any entity |
-| `FaqItem` | FAQ articles with categories, ordering, and helpfulness voting |
-| `KnowledgeBase` | Help articles with categories, lifecycle, and view tracking |
-| `MultiLangContent` | Multilingual content strings for CMS-style translation |
-| `NoticeBoard` | Admin-posted announcements with per-user read-acknowledgment |
-| `Poll` | Create polls with options and record per-user votes |
-| `Post` | Blog/content post management |
-| `TextTemplate` | DB-backed general-purpose text templates with variable substitution |
+| `Announcement` | site-wide announcements with scheduling and per-user dismissal. |
+| `Checklist` | ordered checklist items attached to any entity. |
+| `CommentThread` | threaded comments attached to any entity. |
+| `ContentBlock` | ordered content blocks for page builder / CMS layouts. |
+| `ContentDraft` | Content draft lifecycle: draft → published → archived. |
+| `ContentFilter` | DB-backed banned word/phrase list with masking. |
+| `ContentFlag` | User content flagging and moderation queue. |
+| `ContentReport` | User-submitted content moderation reports. |
+| `ContentSchedule` | schedule content for future publish and optional expiry. |
+| `ContentTag` | flexible tagging of arbitrary entities. |
+| `ContentVersion` | content versioning with rollback support. |
+| `DraftManager` | versioned draft persistence for any content type. |
+| `EmailTemplate` | DB-stored email templates with variable substitution. |
+| `EntityComment` | flat comment list attached to any entity. |
+| `FaqItem` | FAQ articles with categories, ordering, and helpfulness voting. |
+| `KnowledgeBase` | help articles with categories, lifecycle, and view tracking. |
+| `MultiLangContent` | multilingual content strings for CMS-style translation. |
+| `NoticeBoard` | admin-posted announcements with per-user read-acknowledgment. |
+| `Poll` | create polls with options and record per-user votes. |
+| `Post` | — |
+| `TextTemplate` | DB-backed general-purpose text templates with variable substitution. |
 
 ---
 
@@ -91,33 +91,35 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `ActivityFeed` | User-facing activity feed — append-only event timeline |
-| `AddressBook` | Per-user address book with multiple addresses and a default flag |
-| `Bookmark` | Generic per-user bookmark/saved-item manager |
-| `BookmarkCollection` | User-curated collections of bookmarked entities |
-| `ConsentLog` | Immutable record of user consent grants and withdrawals |
-| `DailyStreak` | Track per-user daily activity streaks |
-| `EntityAlias` | Multiple identifier aliases for an entity |
-| `FollowRelation` | User follow/unfollow relationship management |
-| `FriendRequest` | Friend request lifecycle (pending/accepted/declined/cancelled) |
-| `GdprRequest` | GDPR data-subject request tracking |
-| `Mention` | Track @-mentions of users within content items |
-| `NotificationPreference` | Per-user channel × type opt-in/opt-out |
-| `OnlineStatus` | Track user presence with heartbeat-based online/idle/offline states |
-| `PresenceChannel` | Track which users are currently "in" a named channel |
-| `PresenceTracker` | User online presence and last-seen tracking |
-| `ProfileBadge` | Gamification badge award and management |
-| `ReadProgress` | Track user read progress through content |
-| `SavedSearch` | Per-user named search queries |
-| `SearchHistory` | Per-user search history with deduplication and auto-trimming |
-| `TermConsent` | Track user acceptance of terms, privacy policies, and agreements |
-| `UserActivity` | User last-seen and named action tracking |
-| `UserFeedback` | Collect general user satisfaction feedback (NPS/star ratings + free text) |
-| `UserGroup` | User group and team membership management |
-| `UserNote` | Admin/staff notes attached to a user record |
-| `UserPreference` | Key-value preference store per user with typed defaults |
-| `UserSegment` | User cohort/segment assignment for targeting and analytics |
-| `UserTier` | Gamification tier/membership level assignment with history |
+| `ActivityFeed` | User-facing activity feed — append-only event timeline. |
+| `AddressBook` | Per-user address book with multiple addresses and a default flag. |
+| `Bookmark` | Generic per-user bookmark / saved-item manager. |
+| `BookmarkCollection` | user-curated collections of bookmarked entities. |
+| `ConsentLog` | immutable record of user consent grants and withdrawals. |
+| `DailyStreak` | Track per-user daily activity streaks. |
+| `EntityAlias` | multiple identifier aliases for an entity. |
+| `FollowRelation` | User follow/unfollow relationship management. |
+| `FriendRequest` | friend request lifecycle with pending/accepted/declined/cancelled states. |
+| `GdprRequest` | GDPR data-subject request tracking. |
+| `Mention` | track @-mentions of users within content items. |
+| `NotificationPreference` | Notification preference manager — per-user channel × type opt-in/opt-out. |
+| `OnlineStatus` | track user presence with heartbeat-based online/idle/offline states. |
+| `PresenceChannel` | track which users are currently "in" a named channel. |
+| `PresenceTracker` | user online presence and last-seen tracking. |
+| `ProfileBadge` | Gamification badge award and management. |
+| `ReadProgress` | Track user read progress through content (articles, books, courses, etc.). |
+| `SavedSearch` | per-user named search queries. |
+| `SearchHistory` | Per-user search history with deduplication and auto-trimming. |
+| `SearchIndex` | lightweight full-text search index for any entity. |
+| `SearchSuggestion` | type-ahead suggestion management with frequency weighting. |
+| `TermConsent` | Track user acceptance of terms of service, privacy policies, and other agreements. |
+| `UserActivity` | user last-seen and named action tracking. |
+| `UserFeedback` | Collect general user satisfaction feedback (NPS / star ratings + free text). |
+| `UserGroup` | user group and team membership management. |
+| `UserNote` | admin/staff notes attached to a user record. |
+| `UserPreference` | key-value preference store per user with typed defaults. |
+| `UserSegment` | user cohort/segment assignment for targeting and analytics. |
+| `UserTier` | gamification tier/membership level assignment with history. |
 
 ---
 
@@ -125,21 +127,21 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `ChatMessage` | Simple chat room message store with soft-delete |
-| `ContactMessage` | Customer contact form inbox management |
-| `DailyDigest` | Per-user daily digest item accumulator |
-| `EmailBounce` | Email bounce and complaint tracking for delivery health management |
-| `EmailQueue` | DB-backed outgoing email queue with retry and exponential backoff |
-| `MailMessage` | Plain immutable description of one outgoing email |
-| `Mailer` | Thin wrapper around Symfony Mailer (ADR-0006) |
-| `NewsletterSubscription` | Newsletter/mailing-list subscription manager with double opt-in |
-| `NotificationInbox` | User notification inbox: push, list, mark-as-read, unread count |
-| `NotificationQueue` | Channel-agnostic outbox-pattern notification queue |
-| `PushSubscription` | Web Push notification subscription registry |
-| `RecipientGroup` | Mailing list/recipient group management |
-| `Reminder` | User-set future reminders |
-| `SessionFlash` | One-time flash messages stored in DB, consumed on next read |
-| `TopicSubscription` | User subscriptions to named topics for notification routing |
+| `ChatMessage` | simple chat room message store with soft-delete. |
+| `ContactMessage` | customer contact form inbox management. |
+| `DailyDigest` | per-user daily digest item accumulator. |
+| `EmailBounce` | email bounce and complaint tracking for delivery health management. |
+| `EmailQueue` | DB-backed outgoing email queue with retry and exponential backoff. |
+| `MailMessage` | Plain immutable description of one outgoing email. |
+| `Mailer` | Thin wrapper around Symfony Mailer (ADR-0006). |
+| `NewsletterSubscription` | Newsletter / mailing-list subscription manager with double opt-in support. |
+| `NotificationInbox` | User notification inbox: push, list, mark-as-read, unread count. |
+| `NotificationQueue` | channel-agnostic outbox-pattern notification queue. |
+| `PushSubscription` | Web Push notification subscription registry. |
+| `RecipientGroup` | mailing list / recipient group management. |
+| `Reminder` | user-set future reminders. |
+| `SessionFlash` | one-time flash messages stored in DB, consumed on next read. |
+| `TopicSubscription` | user subscriptions to named topics for notification routing. |
 
 ---
 
@@ -147,18 +149,18 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `Attachment` | File attachments linked to any entity |
-| `FileChunk` | Chunked file upload tracking and reassembly coordination |
-| `FileMetadata` | File storage metadata management |
-| `FileQuarantine` | Quarantine suspicious/policy-violating files with release/reject workflow |
-| `FileUpload` | Safe wrapper for a single uploaded file (`$_FILES` entry) |
-| `MediaConversionJob` | Async media processing job tracking |
-| `MediaGallery` | Ordered media item gallery attached to any entity |
-| `MediaMetadata` | Store and retrieve metadata for uploaded media files |
-| `MediaProcessing` | Track async media conversion/processing jobs |
-| `SignedUrl` | Pre-signed URL generation and verification |
-| `StorageQuota` | Per-owner storage usage tracking with configurable limits |
-| `UploadedFile` | Typed wrapper around a single `$_FILES` entry |
+| `Attachment` | file attachments linked to any entity. |
+| `FileChunk` | chunked file upload tracking and reassembly coordination. |
+| `FileMetadata` | File storage metadata management. |
+| `FileQuarantine` | quarantine suspicious or policy-violating files with release/reject workflow. |
+| `FileUpload` | Safe wrapper for a single uploaded file ($_FILES entry). |
+| `MediaConversionJob` | async media processing job tracking. |
+| `MediaGallery` | ordered media item gallery attached to any entity. |
+| `MediaMetadata` | store and retrieve metadata for uploaded media files. |
+| `MediaProcessing` | track async media conversion/processing jobs. |
+| `SignedUrl` | — |
+| `StorageQuota` | per-owner storage usage tracking with configurable limits. |
+| `UploadedFile` | Typed wrapper around a single `$_FILES` entry. |
 
 ---
 
@@ -166,28 +168,29 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `BillingUsage` | Metered usage tracking for billing |
-| `BudgetTracker` | Period-based budget allocation and spend tracking |
-| `CouponCode` | Coupon/promo code management with usage limits and per-user redemption |
-| `CreditLedger` | Append-only double-entry credit/debit ledger per user |
-| `CreditNote` | Financial credit notes/refund adjustments |
-| `EventTicket` | Event ticketing with capacity management and check-in tracking |
-| `GiftCard` | Prepaid gift card balance with partial redemption support |
-| `InventoryStock` | Product/SKU stock tracking with atomic reserve/release/commit |
-| `OrderLine` | E-commerce order header with line items |
-| `PaymentRecord` | Simple payment/transaction ledger |
-| `PointBalance` | User loyalty/reward points with append-only ledger |
-| `PointLedger` | Append-only point/loyalty system with negative-balance prevention |
-| `PriceHistory` | Append-only price change log for products or any priced entity |
-| `PriceList` | Product price catalog with multiple price tiers per SKU |
-| `ProductBundle` | Product bundle definitions with included items |
-| `ProductReview` | Entity reviews with ratings and helpfulness voting |
-| `Quota` | Plan-based resource quota management |
-| `RecurringPayment` | Recurring payment schedule management |
-| `ShoppingCart` | Cart item management with quantity and price tracking |
-| `Subscription` | Track recurring subscription plans per user |
-| `SubscriptionPlan` | User subscription lifecycle management |
-| `TaxRate` | Tax rate lookup and amount calculation by region and category |
+| `BillingUsage` | metered usage tracking for billing. |
+| `BudgetTracker` | period-based budget allocation and spend tracking. |
+| `CouponCode` | Coupon / promo code management with usage limits and per-user redemption tracking. |
+| `CreditLedger` | append-only double-entry credit/debit ledger per user. |
+| `CreditNote` | financial credit notes / refund adjustments. |
+| `EventTicket` | event ticketing with capacity management and check-in tracking. |
+| `GiftCard` | prepaid gift card balance with partial redemption support. |
+| `InventoryStock` | product/SKU stock tracking with atomic reserve/release/commit. |
+| `OrderLine` | e-commerce order header with line items. |
+| `PaymentRecord` | simple payment/transaction ledger. |
+| `PointBalance` | user loyalty/reward points with append-only ledger. |
+| `PointLedger` | Append-only point / loyalty system with negative-balance prevention. |
+| `PriceHistory` | append-only price change log for products or any priced entity. |
+| `PriceList` | product price catalog with multiple price tiers per SKU. |
+| `ProductBundle` | product bundle definitions with included items. |
+| `ProductReview` | entity reviews with ratings and helpfulness voting. |
+| `Quota` | plan-based resource quota management. |
+| `RecurringPayment` | Recurring payment schedule management. |
+| `ShoppingCart` | cart item management with quantity and price tracking. |
+| `Subscription` | track recurring subscription plans per user. |
+| `SubscriptionPlan` | user subscription lifecycle management. |
+| `StockAlert` | user-defined stock/availability alert registrations. |
+| `TaxRate` | tax rate lookup and amount calculation by region and category. |
 
 ---
 
@@ -195,21 +198,24 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `AccessLog` | Security-focused resource access log |
-| `AlertRule` | Metric-based alert rules with threshold evaluation and event log |
-| `ApiUsageLog` | Per-API-key request tracking with endpoint and status logging |
-| `AuditLog` | Compliance-grade record of who changed what on any entity |
-| `AuditLogger` | Append-only audit log writer |
-| `ChangeLog` | Human-readable change history for any entity |
-| `CounterMetric` | Named metric counters with daily/hourly bucket aggregation |
-| `CronLog` | Scheduled task execution log |
-| `DownloadCounter` | Track file/asset download events |
-| `EventLog` | Append-only domain event log for event sourcing–lite patterns |
-| `IncidentLog` | IT/service incident tracking with severity and lifecycle |
-| `IntegrationLog` | Outbound/inbound API call log with request and response data |
-| `KpiTracker` | KPI/OKR metric tracking with target vs. actual comparison |
-| `PageView` | Page and resource view analytics tracking |
-| `SlaTracker` | SLA/SLO breach detection for timed work items |
+| `AccessLog` | Security-focused resource access log. |
+| `AlertRule` | metric-based alert rules with threshold evaluation and event log. |
+| `ApiUsageLog` | per-API-key request tracking with endpoint and status logging. |
+| `AuditLog` | compliance-grade record of who changed what on any entity. |
+| `AuditLogger` | Append-only audit log writer. |
+| `EntitySnapshot` | point-in-time entity state snapshots. |
+| `Log` | — |
+| `LogFormatterFactory` | — |
+| `ChangeLog` | human-readable change history for any entity. |
+| `CounterMetric` | named metric counters with daily/hourly bucket aggregation. |
+| `CronLog` | scheduled task execution log. |
+| `DownloadCounter` | Download counter — track file/asset download events. |
+| `EventLog` | append-only domain event log for event sourcing–lite patterns. |
+| `IncidentLog` | IT/service incident tracking with severity and lifecycle. |
+| `IntegrationLog` | outbound/inbound API call log with request and response data. |
+| `KpiTracker` | KPI / OKR metric tracking with target vs. actual comparison. |
+| `PageView` | page and resource view analytics tracking. |
+| `SlaTracker` | SLA/SLO breach detection for timed work items. |
 
 ---
 
@@ -217,37 +223,37 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `AbTest` | A/B test variant assignment and conversion tracking |
-| `Approval` | Single-approver workflow (request → approve/reject) |
-| `ChangeRequest` | Formal RFC/change-management approval workflow |
-| `EventRsvp` | Event attendance management with accept/decline/maybe responses |
-| `FaqItem` | FAQ articles (see also **Content & CMS**) |
-| `FeatureRequest` | User-submitted feature requests with voting and status tracking |
-| `Label` | Colored label definitions with entity assignment |
-| `Leaderboard` | Score-based leaderboard with best-score retention and ranking |
-| `Reaction` | Emoji/symbol reactions on any entity |
-| `ReactionCounter` | Emoji/type reactions with per-user state |
-| `Referral` | Referral code generation, attribution, and conversion tracking |
-| `ReferralCode` | Referral code system — generate invite links and track conversions |
-| `ResourceReservation` | Time-bounded reservation of a shared resource |
-| `ScoreBoard` | High-score table with personal-best and period tracking |
-| `ShareLink` | Shareable links with optional password and expiry |
-| `SupportTicket` | Simple help desk ticket queue with reply thread |
-| `SurveyResponse` | Form/survey response collection and analysis |
-| `SurveyTemplate` | Reusable form/survey template definitions |
-| `TagIndex` | Attach tags to any entity and query by tag |
-| `TagManager` | Generic tag/label system for M:N entity-tag relationships |
-| `TaskList` | Simple to-do list with per-user tasks and completion tracking |
-| `TeamMembership` | Organization/team membership with roles |
-| `TimeEntry` | Work time tracking with start/stop/duration |
-| `TimeSlot` | Appointment/time slot booking with availability |
-| `VotePoll` | Simple polls with named options and one-vote-per-user enforcement |
-| `VotingBooth` | Upvote/downvote system with toggle semantics and per-user vote state |
-| `Waitlist` | Manage sign-ups for gated access (beta, launches, events) |
-| `WaitlistEntry` | Product/feature/event waitlist management |
-| `Watchlist` | Users subscribe to watch entities for updates |
-| `Wishlist` | Per-user saved items using entity-agnostic (type, id) pairs |
-| `WorkflowInstance` | Persistent stateful workflow tracking |
+| `AbTest` | A/B test variant assignment and conversion tracking. |
+| `Approval` | single-approver workflow (request → approve / reject). |
+| `ChangeRequest` | formal RFC / change-management approval workflow. |
+| `EventRsvp` | event attendance management with accept/decline/maybe responses. |
+| `FaqItem` | FAQ articles with categories, ordering, and helpfulness voting. |
+| `FeatureRequest` | user-submitted feature requests with voting and status tracking. |
+| `Label` | colored label definitions with entity assignment. |
+| `Leaderboard` | Score-based leaderboard with best-score retention, ranking, and personal rank lookup. |
+| `Reaction` | emoji / symbol reactions on any entity. |
+| `ReactionCounter` | emoji/type reactions on any entity with per-user state. |
+| `Referral` | referral code generation, attribution, and conversion tracking. |
+| `ReferralCode` | Referral code system — generate invite links and track conversions. |
+| `ResourceReservation` | time-bounded reservation of a shared resource. |
+| `ScoreBoard` | high-score table with personal-best and period tracking. |
+| `ShareLink` | shareable links with optional password and expiry. |
+| `SupportTicket` | simple help desk ticket queue with reply thread. |
+| `SurveyResponse` | form/survey response collection and analysis. |
+| `SurveyTemplate` | reusable form/survey template definitions. |
+| `TagIndex` | attach tags to any entity and query by tag. |
+| `TagManager` | Generic tag/label system for M:N entity-tag relationships. |
+| `TaskList` | simple to-do list with per-user tasks and completion tracking. |
+| `TeamMembership` | organization/team membership with roles. |
+| `TimeEntry` | work time tracking with start/stop/duration. |
+| `TimeSlot` | appointment/time slot booking with availability. |
+| `VotePoll` | simple polls with named options and one-vote-per-user enforcement. |
+| `VotingBooth` | Upvote / downvote system with toggle semantics and per-user vote state. |
+| `Waitlist` | manage sign-ups for gated access (beta, launches, events). |
+| `WaitlistEntry` | product / feature / event waitlist management. |
+| `Watchlist` | users subscribe to watch entities for updates. |
+| `Wishlist` | per-user saved items using entity-agnostic (type, id) pairs. |
+| `WorkflowInstance` | persistent stateful workflow tracking. |
 
 ---
 
@@ -255,25 +261,25 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `ApiDeprecation` | RFC 8594 API deprecation signal helpers |
-| `ApiKey` | API key management: generation, hashed storage, scope-based auth, rotation |
-| `ApiResponse` | Standard API response wrapper |
-| `ApiWebhook` | Webhook subscription endpoint management |
-| `AppVersion` | Deployment/release version history tracking |
-| `BearerAuth` | Bearer-token auth (see also **Auth & Sessions**) |
-| `Cors` | CORS (Cross-Origin Resource Sharing) header utility |
-| `ExportJob` | Async data export job tracking |
-| `FeatureFlag` | DB-backed feature flags with global on/off and per-user overrides |
-| `HealthCheck` | Service/component health monitoring log |
-| `HttpCache` | HTTP cache header utilities for REST endpoints |
-| `IdempotencyStore` | DB-backed idempotency key store for POST endpoints |
-| `MaintenanceMode` | Global on/off maintenance flag with bypass allowlist |
-| `RequestId` | Per-request identifier for end-to-end correlation |
-| `ServerTiming` | Server-Timing header helpers |
-| `ShortUrl` | URL shortener with click tracking and optional expiry |
-| `SlugRegistry` | URL slug generation and uniqueness enforcement |
-| `WebhookDelivery` | Outbound webhook delivery log with retry tracking |
-| `WebhookSigner` | HMAC-SHA256 webhook signing and verification |
+| `ApiDeprecation` | RFC 8594 API deprecation signal helpers. |
+| `ApiKey` | API key management: generation, hashed storage, scope-based auth, revocation, rotation. |
+| `ApiResponse` | — |
+| `ApiWebhook` | Webhook subscription endpoint management. |
+| `AppVersion` | deployment/release version history tracking. |
+| `BearerAuth` | Optional Bearer-token authentication for agent / MCP clients (ADR-0008). |
+| `Cors` | CORS (Cross-Origin Resource Sharing) header utility. |
+| `ExportJob` | async data export job tracking. |
+| `FeatureFlag` | DB-backed feature flags with global on/off and per-user overrides. |
+| `HealthCheck` | service/component health monitoring log. |
+| `HttpCache` | HTTP cache header utilities for REST endpoints. |
+| `IdempotencyStore` | DB-backed idempotency key store for POST endpoints. |
+| `MaintenanceMode` | Maintenance mode — global on/off flag with allowlist for bypass users. |
+| `RequestId` | Per-request identifier used for end-to-end correlation across |
+| `ServerTiming` | — |
+| `ShortUrl` | URL shortener with click tracking and optional expiry. |
+| `SlugRegistry` | URL slug generation and uniqueness enforcement. |
+| `WebhookDelivery` | outbound webhook delivery log with retry tracking. |
+| `WebhookSigner` | HMAC-SHA256 webhook signing and verification. |
 
 ---
 
@@ -281,19 +287,19 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `AssetRegistry` | Physical and digital asset inventory with assignment tracking |
-| `BatchJob` | Batch processing job tracking with progress and status lifecycle |
-| `BatchResult` | Accumulates per-item results for a batch operation |
-| `CircuitBreaker` | Circuit breaker pattern for external service calls |
-| `DataImportJob` | CSV/data import job tracking with per-row error recording |
-| `DistributedLock` | DB-backed distributed lock with TTL, owner enforcement, and stale-lock reclaim |
-| `DocumentLock` | Optimistic editing lock for collaborative document editing |
-| `DocumentSignature` | E-signature request workflow with multi-signatory support |
-| `JobQueue` | Simple DB-backed background job queue |
-| `OptimisticLock` | Optimistic concurrency control helpers |
-| `ScheduledTask` | Cron-style task schedule registry with last-run tracking |
-| `TokenBucket` | DB-backed token bucket algorithm for flexible rate limiting |
-| `TransactionManager` | Database transaction management helpers |
+| `AssetRegistry` | physical and digital asset inventory with assignment tracking. |
+| `BatchJob` | batch processing job tracking with progress and status lifecycle. |
+| `BatchResult` | Accumulates per-item results for a batch operation. |
+| `CircuitBreaker` | — |
+| `DataImportJob` | CSV/data import job tracking with per-row error recording. |
+| `DistributedLock` | DB-backed distributed lock with TTL, owner enforcement, and stale-lock reclaim. |
+| `DocumentLock` | optimistic editing lock for collaborative document editing. |
+| `DocumentSignature` | e-signature request workflow with multi-signatory support. |
+| `JobQueue` | simple DB-backed background job queue. |
+| `OptimisticLock` | — |
+| `ScheduledTask` | cron-style task schedule registry with last-run tracking. |
+| `TokenBucket` | DB-backed token bucket algorithm for flexible rate limiting. |
+| `TransactionManager` | — |
 
 ---
 
@@ -301,17 +307,28 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `CacheEntry` | DB-backed key-value cache with optional TTL |
-| `ConfigStore` | Global application key-value configuration store |
-| `DatabaseInstaller` | Database setup and health checks for the sample runtime |
-| `DbUpsert` | Cross-driver upsert helper (MySQL + SQLite) — see `DbUpsert::run()` |
-| `EnvLoader` | Minimal dotenv-style loader for CLI setup commands |
-| `ErrorCode` | Application error code definitions |
-| `PdoConnection` | PDO singleton connection factory |
-| `SchemaCompiler` | Compile `SchemaDefinition` into MySQL and SQLite DDL |
-| `SchemaDefinition` | NeNe's sample-schema source of truth |
-| `SystemSetting` | Typed global application settings store |
-| `TenantConfig` | Per-tenant key-value configuration store |
+| `CacheEntry` | DB-backed key-value cache with optional TTL. |
+| `ConfigStore` | global application key-value configuration store. |
+| `DatabaseInstaller` | Database setup and health checks for the sample runtime. |
+| `Command` | — |
+| `DataMapperBase` | — |
+| `DataModelBase` | — |
+| `DbUpsert` | Cross-driver upsert helper (MySQL + SQLite). |
+| `DomainException` | Throwable that carries a NeNe error code to the top-level request handler. |
+| `EnvLoader` | Minimal dotenv-style loader for CLI setup commands. |
+| `ErrorCode` | — |
+| `GenerateSchemaSqlCommand` | — |
+| `InitSqliteCommand` | — |
+| `Initialize` | — |
+| `PdoConnection` | — |
+| `SchemaCompiler` | Compile {@see SchemaDefinition} into MySQL and SQLite DDL. |
+| `SchemaDefinition` | NeNe's sample-schema source of truth. |
+| `SchemaDiffCommand` | — |
+| `SchemaDiffer` | Schema-diff engine — compares a live database introspection against |
+| `SessionHandlerFactory` | — |
+| `SetupDatabaseCommand` | — |
+| `SystemSetting` | typed global application settings store. |
+| `TenantConfig` | per-tenant key-value configuration store. |
 
 ---
 
@@ -319,25 +336,26 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `ControllerBase` | Base class for all controllers |
-| `Cursor` | Cursor-based pagination token |
-| `CursorPage` | Cursor-paginated result set metadata |
-| `Dispatcher` | Front controller / request dispatcher |
-| `HttpEmitter` | HTTP response emitter |
-| `HttpResponse` | Mutable HTTP response builder |
-| `HttpTermination` | Request/response pipeline termination helpers |
-| `JsonResponder` | JSON response shortcut helpers |
-| `ModelBase` | Base class for models |
-| `OffsetPage` | Paginated result with offset-based (page number) navigation |
-| `QueryString` | Query string parsing and building helpers |
-| `RedirectGuard` | Open-redirect guard |
-| `Request` | HTTP request wrapper |
-| `RequestVariables` | Typed request variable extraction |
-| `ResponseDecorator` | Cross-cutting response decoration for PHP-generated responses |
-| `RouteContext` | Matched route context container |
-| `UrlParameter` | URL parameter helpers |
-| `View` | Template/view renderer |
+| `ControllerBase` | — |
+| `Cursor` | — |
+| `CursorPage` | — |
+| `Dispatcher` | — |
+| `HttpEmitter` | — |
+| `HttpResponse` | — |
+| `HttpTermination` | — |
+| `JsonResponder` | — |
+| `ModelBase` | — |
+| `OffsetPage` | Paginated result set with offset-based (page number) navigation metadata. |
+| `QueryString` | — |
+| `RedirectGuard` | Open-redirect guard for controllers that need to redirect to an |
+| `Request` | — |
+| `RequestVariables` | — |
+| `ResponseDecorator` | Cross-cutting response decoration that every PHP-generated response |
+| `RouteContext` | — |
+| `UrlParameter` | — |
+| `View` | — |
 
 ---
 
-*Generated from PHPDoc descriptions. Run `ls class/xion/` for the authoritative file list.*
+*Generated from PHPDoc descriptions. Run `composer xion:index` to refresh after adding classes.*
+

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -1,0 +1,343 @@
+# Xion Class Index
+
+Quick reference for all classes in `class/xion/`. Grouped by functional domain.
+
+---
+
+## Auth & Sessions
+
+| Class | Description |
+|-------|-------------|
+| `AccessToken` | Issue, verify, and revoke personal access tokens (PATs) |
+| `AuthSession` | Application session management |
+| `BearerAuth` | Optional Bearer-token authentication for agent/MCP clients (ADR-0008) |
+| `DeviceFingerprint` | Device recognition for fraud detection and trust scoring |
+| `DeviceToken` | Push notification device token management per user |
+| `EmailVerification` | Token-based email address verification with expiry |
+| `GuestSession` | Anonymous visitor session tracking with key-value data bag |
+| `InvitationToken` | Token-based user invitation system |
+| `InviteCode` | Single-use invite codes with usage quota |
+| `JwtCodec` | JWT encode/decode helpers |
+| `LoginAttemptTracker` | Brute-force protection via login attempt counting |
+| `LoginHistory` | Append-only log of login attempts with IP, user-agent, and result |
+| `MagicLink` | Email-based passwordless authentication tokens |
+| `OAuthToken` | OAuth2 access/refresh token storage with TTL |
+| `OtpChallenge` | One-time password (OTP) challenge issuance and verification |
+| `PasswordExpiry` | Password expiry policy enforcement |
+| `PasswordHistory` | Prevent users from reusing recent passwords |
+| `PasswordResetToken` | Cryptographic helpers for password-reset token workflows |
+| `PersonalAccessToken` | Personal Access Token (PAT) management for user-facing dashboards |
+| `PinCode` | Short PIN/OTP issuance with attempt limiting and expiry |
+| `RedisSessionHandler` | Redis-backed PHP session handler |
+| `RefreshToken` | DB-backed refresh token management for JWT access token rotation |
+| `ServiceAccount` | Machine-to-machine auth credentials with key rotation |
+| `TotpAuthenticator` | TOTP (RFC 6238 / Google Authenticator compatible) |
+| `TwoFactorBackupCode` | One-time recovery codes for 2FA |
+| `UserSession` | Multi-device application session management |
+
+---
+
+## Access Control & Security
+
+| Class | Description |
+|-------|-------------|
+| `AccessControl` | Per-resource subject ACL (access-control list) |
+| `AccessGrant` | Time-bounded access delegation between entities |
+| `AccessSchedule` | Recurring time-window access control for users and resources |
+| `BlockList` | User block list — prevent harassment and unwanted interactions |
+| `CsrfProtectionPolicy` | CSRF protection policy helpers |
+| `GeoBlocker` | Country-level access control via a configurable allow/block list |
+| `GeoFence` | Define named circular geo-fences and check point containment |
+| `ImpersonationLog` | Admin impersonation session audit log |
+| `IpAllowlist` | Per-resource IP allowlist with CIDR range support |
+| `IpBlocklist` | Global IP address blocklist with optional expiry |
+| `RedirectGuard` | Open-redirect guard for controllers that need to redirect |
+| `ResourceLock` | Advisory lock on any entity to prevent concurrent edits |
+| `RoleGuard` | Role-based access gate |
+| `TrustScore` | Append-only fraud/trust score per user |
+| `UserBan` | Ban/unban users with optional expiry and reason tracking |
+
+---
+
+## Content & CMS
+
+| Class | Description |
+|-------|-------------|
+| `Announcement` | Site-wide announcements with scheduling and per-user dismissal |
+| `Checklist` | Ordered checklist items attached to any entity |
+| `CommentThread` | Threaded comments attached to any entity |
+| `ContentBlock` | Ordered content blocks for page builder/CMS layouts |
+| `ContentDraft` | Content draft lifecycle: draft → published → archived |
+| `ContentFilter` | DB-backed banned word/phrase list with masking |
+| `ContentFlag` | User content flagging and moderation queue |
+| `ContentReport` | User-submitted content moderation reports |
+| `ContentSchedule` | Schedule content for future publish and optional expiry |
+| `ContentTag` | Flexible tagging of arbitrary entities |
+| `ContentVersion` | Content versioning with rollback support |
+| `DraftManager` | Versioned draft persistence for any content type |
+| `EmailTemplate` | DB-stored email templates with variable substitution |
+| `EntityComment` | Flat comment list attached to any entity |
+| `FaqItem` | FAQ articles with categories, ordering, and helpfulness voting |
+| `KnowledgeBase` | Help articles with categories, lifecycle, and view tracking |
+| `MultiLangContent` | Multilingual content strings for CMS-style translation |
+| `NoticeBoard` | Admin-posted announcements with per-user read-acknowledgment |
+| `Poll` | Create polls with options and record per-user votes |
+| `Post` | Blog/content post management |
+| `TextTemplate` | DB-backed general-purpose text templates with variable substitution |
+
+---
+
+## Users & Profiles
+
+| Class | Description |
+|-------|-------------|
+| `ActivityFeed` | User-facing activity feed — append-only event timeline |
+| `AddressBook` | Per-user address book with multiple addresses and a default flag |
+| `Bookmark` | Generic per-user bookmark/saved-item manager |
+| `BookmarkCollection` | User-curated collections of bookmarked entities |
+| `ConsentLog` | Immutable record of user consent grants and withdrawals |
+| `DailyStreak` | Track per-user daily activity streaks |
+| `EntityAlias` | Multiple identifier aliases for an entity |
+| `FollowRelation` | User follow/unfollow relationship management |
+| `FriendRequest` | Friend request lifecycle (pending/accepted/declined/cancelled) |
+| `GdprRequest` | GDPR data-subject request tracking |
+| `Mention` | Track @-mentions of users within content items |
+| `NotificationPreference` | Per-user channel × type opt-in/opt-out |
+| `OnlineStatus` | Track user presence with heartbeat-based online/idle/offline states |
+| `PresenceChannel` | Track which users are currently "in" a named channel |
+| `PresenceTracker` | User online presence and last-seen tracking |
+| `ProfileBadge` | Gamification badge award and management |
+| `ReadProgress` | Track user read progress through content |
+| `SavedSearch` | Per-user named search queries |
+| `SearchHistory` | Per-user search history with deduplication and auto-trimming |
+| `TermConsent` | Track user acceptance of terms, privacy policies, and agreements |
+| `UserActivity` | User last-seen and named action tracking |
+| `UserFeedback` | Collect general user satisfaction feedback (NPS/star ratings + free text) |
+| `UserGroup` | User group and team membership management |
+| `UserNote` | Admin/staff notes attached to a user record |
+| `UserPreference` | Key-value preference store per user with typed defaults |
+| `UserSegment` | User cohort/segment assignment for targeting and analytics |
+| `UserTier` | Gamification tier/membership level assignment with history |
+
+---
+
+## Notifications & Messaging
+
+| Class | Description |
+|-------|-------------|
+| `ChatMessage` | Simple chat room message store with soft-delete |
+| `ContactMessage` | Customer contact form inbox management |
+| `DailyDigest` | Per-user daily digest item accumulator |
+| `EmailBounce` | Email bounce and complaint tracking for delivery health management |
+| `EmailQueue` | DB-backed outgoing email queue with retry and exponential backoff |
+| `MailMessage` | Plain immutable description of one outgoing email |
+| `Mailer` | Thin wrapper around Symfony Mailer (ADR-0006) |
+| `NewsletterSubscription` | Newsletter/mailing-list subscription manager with double opt-in |
+| `NotificationInbox` | User notification inbox: push, list, mark-as-read, unread count |
+| `NotificationQueue` | Channel-agnostic outbox-pattern notification queue |
+| `PushSubscription` | Web Push notification subscription registry |
+| `RecipientGroup` | Mailing list/recipient group management |
+| `Reminder` | User-set future reminders |
+| `SessionFlash` | One-time flash messages stored in DB, consumed on next read |
+| `TopicSubscription` | User subscriptions to named topics for notification routing |
+
+---
+
+## Files & Media
+
+| Class | Description |
+|-------|-------------|
+| `Attachment` | File attachments linked to any entity |
+| `FileChunk` | Chunked file upload tracking and reassembly coordination |
+| `FileMetadata` | File storage metadata management |
+| `FileQuarantine` | Quarantine suspicious/policy-violating files with release/reject workflow |
+| `FileUpload` | Safe wrapper for a single uploaded file (`$_FILES` entry) |
+| `MediaConversionJob` | Async media processing job tracking |
+| `MediaGallery` | Ordered media item gallery attached to any entity |
+| `MediaMetadata` | Store and retrieve metadata for uploaded media files |
+| `MediaProcessing` | Track async media conversion/processing jobs |
+| `SignedUrl` | Pre-signed URL generation and verification |
+| `StorageQuota` | Per-owner storage usage tracking with configurable limits |
+| `UploadedFile` | Typed wrapper around a single `$_FILES` entry |
+
+---
+
+## Commerce & Billing
+
+| Class | Description |
+|-------|-------------|
+| `BillingUsage` | Metered usage tracking for billing |
+| `BudgetTracker` | Period-based budget allocation and spend tracking |
+| `CouponCode` | Coupon/promo code management with usage limits and per-user redemption |
+| `CreditLedger` | Append-only double-entry credit/debit ledger per user |
+| `CreditNote` | Financial credit notes/refund adjustments |
+| `EventTicket` | Event ticketing with capacity management and check-in tracking |
+| `GiftCard` | Prepaid gift card balance with partial redemption support |
+| `InventoryStock` | Product/SKU stock tracking with atomic reserve/release/commit |
+| `OrderLine` | E-commerce order header with line items |
+| `PaymentRecord` | Simple payment/transaction ledger |
+| `PointBalance` | User loyalty/reward points with append-only ledger |
+| `PointLedger` | Append-only point/loyalty system with negative-balance prevention |
+| `PriceHistory` | Append-only price change log for products or any priced entity |
+| `PriceList` | Product price catalog with multiple price tiers per SKU |
+| `ProductBundle` | Product bundle definitions with included items |
+| `ProductReview` | Entity reviews with ratings and helpfulness voting |
+| `Quota` | Plan-based resource quota management |
+| `RecurringPayment` | Recurring payment schedule management |
+| `ShoppingCart` | Cart item management with quantity and price tracking |
+| `Subscription` | Track recurring subscription plans per user |
+| `SubscriptionPlan` | User subscription lifecycle management |
+| `TaxRate` | Tax rate lookup and amount calculation by region and category |
+
+---
+
+## Analytics & Audit
+
+| Class | Description |
+|-------|-------------|
+| `AccessLog` | Security-focused resource access log |
+| `AlertRule` | Metric-based alert rules with threshold evaluation and event log |
+| `ApiUsageLog` | Per-API-key request tracking with endpoint and status logging |
+| `AuditLog` | Compliance-grade record of who changed what on any entity |
+| `AuditLogger` | Append-only audit log writer |
+| `ChangeLog` | Human-readable change history for any entity |
+| `CounterMetric` | Named metric counters with daily/hourly bucket aggregation |
+| `CronLog` | Scheduled task execution log |
+| `DownloadCounter` | Track file/asset download events |
+| `EventLog` | Append-only domain event log for event sourcing–lite patterns |
+| `IncidentLog` | IT/service incident tracking with severity and lifecycle |
+| `IntegrationLog` | Outbound/inbound API call log with request and response data |
+| `KpiTracker` | KPI/OKR metric tracking with target vs. actual comparison |
+| `PageView` | Page and resource view analytics tracking |
+| `SlaTracker` | SLA/SLO breach detection for timed work items |
+
+---
+
+## Social & Community
+
+| Class | Description |
+|-------|-------------|
+| `AbTest` | A/B test variant assignment and conversion tracking |
+| `Approval` | Single-approver workflow (request → approve/reject) |
+| `ChangeRequest` | Formal RFC/change-management approval workflow |
+| `EventRsvp` | Event attendance management with accept/decline/maybe responses |
+| `FaqItem` | FAQ articles (see also **Content & CMS**) |
+| `FeatureRequest` | User-submitted feature requests with voting and status tracking |
+| `Label` | Colored label definitions with entity assignment |
+| `Leaderboard` | Score-based leaderboard with best-score retention and ranking |
+| `Reaction` | Emoji/symbol reactions on any entity |
+| `ReactionCounter` | Emoji/type reactions with per-user state |
+| `Referral` | Referral code generation, attribution, and conversion tracking |
+| `ReferralCode` | Referral code system — generate invite links and track conversions |
+| `ResourceReservation` | Time-bounded reservation of a shared resource |
+| `ScoreBoard` | High-score table with personal-best and period tracking |
+| `ShareLink` | Shareable links with optional password and expiry |
+| `SupportTicket` | Simple help desk ticket queue with reply thread |
+| `SurveyResponse` | Form/survey response collection and analysis |
+| `SurveyTemplate` | Reusable form/survey template definitions |
+| `TagIndex` | Attach tags to any entity and query by tag |
+| `TagManager` | Generic tag/label system for M:N entity-tag relationships |
+| `TaskList` | Simple to-do list with per-user tasks and completion tracking |
+| `TeamMembership` | Organization/team membership with roles |
+| `TimeEntry` | Work time tracking with start/stop/duration |
+| `TimeSlot` | Appointment/time slot booking with availability |
+| `VotePoll` | Simple polls with named options and one-vote-per-user enforcement |
+| `VotingBooth` | Upvote/downvote system with toggle semantics and per-user vote state |
+| `Waitlist` | Manage sign-ups for gated access (beta, launches, events) |
+| `WaitlistEntry` | Product/feature/event waitlist management |
+| `Watchlist` | Users subscribe to watch entities for updates |
+| `Wishlist` | Per-user saved items using entity-agnostic (type, id) pairs |
+| `WorkflowInstance` | Persistent stateful workflow tracking |
+
+---
+
+## API & Integration
+
+| Class | Description |
+|-------|-------------|
+| `ApiDeprecation` | RFC 8594 API deprecation signal helpers |
+| `ApiKey` | API key management: generation, hashed storage, scope-based auth, rotation |
+| `ApiResponse` | Standard API response wrapper |
+| `ApiWebhook` | Webhook subscription endpoint management |
+| `AppVersion` | Deployment/release version history tracking |
+| `BearerAuth` | Bearer-token auth (see also **Auth & Sessions**) |
+| `Cors` | CORS (Cross-Origin Resource Sharing) header utility |
+| `ExportJob` | Async data export job tracking |
+| `FeatureFlag` | DB-backed feature flags with global on/off and per-user overrides |
+| `HealthCheck` | Service/component health monitoring log |
+| `HttpCache` | HTTP cache header utilities for REST endpoints |
+| `IdempotencyStore` | DB-backed idempotency key store for POST endpoints |
+| `MaintenanceMode` | Global on/off maintenance flag with bypass allowlist |
+| `RequestId` | Per-request identifier for end-to-end correlation |
+| `ServerTiming` | Server-Timing header helpers |
+| `ShortUrl` | URL shortener with click tracking and optional expiry |
+| `SlugRegistry` | URL slug generation and uniqueness enforcement |
+| `WebhookDelivery` | Outbound webhook delivery log with retry tracking |
+| `WebhookSigner` | HMAC-SHA256 webhook signing and verification |
+
+---
+
+## Tasks & Workflows
+
+| Class | Description |
+|-------|-------------|
+| `AssetRegistry` | Physical and digital asset inventory with assignment tracking |
+| `BatchJob` | Batch processing job tracking with progress and status lifecycle |
+| `BatchResult` | Accumulates per-item results for a batch operation |
+| `CircuitBreaker` | Circuit breaker pattern for external service calls |
+| `DataImportJob` | CSV/data import job tracking with per-row error recording |
+| `DistributedLock` | DB-backed distributed lock with TTL, owner enforcement, and stale-lock reclaim |
+| `DocumentLock` | Optimistic editing lock for collaborative document editing |
+| `DocumentSignature` | E-signature request workflow with multi-signatory support |
+| `JobQueue` | Simple DB-backed background job queue |
+| `OptimisticLock` | Optimistic concurrency control helpers |
+| `ScheduledTask` | Cron-style task schedule registry with last-run tracking |
+| `TokenBucket` | DB-backed token bucket algorithm for flexible rate limiting |
+| `TransactionManager` | Database transaction management helpers |
+
+---
+
+## Infrastructure & DB
+
+| Class | Description |
+|-------|-------------|
+| `CacheEntry` | DB-backed key-value cache with optional TTL |
+| `ConfigStore` | Global application key-value configuration store |
+| `DatabaseInstaller` | Database setup and health checks for the sample runtime |
+| `DbUpsert` | Cross-driver upsert helper (MySQL + SQLite) — see `DbUpsert::run()` |
+| `EnvLoader` | Minimal dotenv-style loader for CLI setup commands |
+| `ErrorCode` | Application error code definitions |
+| `PdoConnection` | PDO singleton connection factory |
+| `SchemaCompiler` | Compile `SchemaDefinition` into MySQL and SQLite DDL |
+| `SchemaDefinition` | NeNe's sample-schema source of truth |
+| `SystemSetting` | Typed global application settings store |
+| `TenantConfig` | Per-tenant key-value configuration store |
+
+---
+
+## HTTP Layer
+
+| Class | Description |
+|-------|-------------|
+| `ControllerBase` | Base class for all controllers |
+| `Cursor` | Cursor-based pagination token |
+| `CursorPage` | Cursor-paginated result set metadata |
+| `Dispatcher` | Front controller / request dispatcher |
+| `HttpEmitter` | HTTP response emitter |
+| `HttpResponse` | Mutable HTTP response builder |
+| `HttpTermination` | Request/response pipeline termination helpers |
+| `JsonResponder` | JSON response shortcut helpers |
+| `ModelBase` | Base class for models |
+| `OffsetPage` | Paginated result with offset-based (page number) navigation |
+| `QueryString` | Query string parsing and building helpers |
+| `RedirectGuard` | Open-redirect guard |
+| `Request` | HTTP request wrapper |
+| `RequestVariables` | Typed request variable extraction |
+| `ResponseDecorator` | Cross-cutting response decoration for PHP-generated responses |
+| `RouteContext` | Matched route context container |
+| `UrlParameter` | URL parameter helpers |
+| `View` | Template/view renderer |
+
+---
+
+*Generated from PHPDoc descriptions. Run `ls class/xion/` for the authoritative file list.*

--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,15 @@
         "test:all": "phpunit",
         "analyze": "phan --allow-polyfill-parser --load-baseline .phan/baseline.php",
         "analyze:file": "bash tools/phan-file.sh",
+        "make:xion": "@php tools/make-xion.php",
+        "xion:index": "@php tools/xion-index.php",
         "format": "php-cs-fixer fix --config=.php-cs-fixer.dist.php",
         "format:check": "php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff",
+        "precommit": [
+            "@format",
+            "@analyze",
+            "@test"
+        ],
         "check": [
             "@test",
             "@test:http",

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         ],
         "test:all": "phpunit",
         "analyze": "phan --allow-polyfill-parser --load-baseline .phan/baseline.php",
+        "analyze:file": "bash tools/phan-file.sh",
         "format": "php-cs-fixer fix --config=.php-cs-fixer.dist.php",
         "format:check": "php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff",
         "check": [

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -15,5 +15,6 @@ NeNe should stay small, explicit, and reviewable. AI-assisted code is acceptable
 - `self-review/service-implementation.md`: full feature checklist for small-service changes.
 - `self-review/controller.md`: controller size and HTTP boundary checklist.
 - `self-review/database.md`: mapper, model, SQL, and transaction checklist.
+- `self-review/xion-class.md`: checklist for adding or modifying a `class/xion/` framework class.
 
 Use these checklists before opening a PR. If a change intentionally does not follow one of these rules, explain the reason in the Issue or PR.

--- a/docs/ai/self-review/xion-class.md
+++ b/docs/ai/self-review/xion-class.md
@@ -1,0 +1,52 @@
+# Xion Class Self-Review
+
+Use this checklist when adding a new class to `class/xion/`.
+These classes are framework-level building blocks — hold them to a higher standard than feature code.
+
+## Before Starting
+
+- [ ] Check `class/xion/INDEX.md` — a class for this purpose may already exist.
+- [ ] The feature has a GitHub Issue (`FTxxx`).
+- [ ] The class name clearly signals its domain (e.g. `AuditLog`, not `Logger`).
+
+## Class Structure
+
+- [ ] Constructor uses the PDO injection pattern:
+  ```php
+  public function __construct(private readonly ?PDO $db = null) {}
+  private function db(): PDO { return $this->db ?? PdoConnection::getInstance(); }
+  ```
+- [ ] No static state; all data flows through constructor injection.
+- [ ] `final class` unless inheritance is explicitly needed.
+- [ ] PHPDoc on the class and all public methods (`@param`, `@return`).
+- [ ] All `array` parameters have generics in PHPDoc (`array<string,mixed>`, `string[]`, etc.).
+
+## SQL & Database
+
+- [ ] Use `DbUpsert::run()` for cross-driver upsert — do not write driver-specific SQL by hand.
+- [ ] All amounts stored as **integer cents** (no floats, no DECIMAL in tests).
+- [ ] Tokens/secrets stored as SHA-256 hash; plaintext returned to caller only at creation/rotation.
+- [ ] SQLite-compatible SQL in production code (no MySQL-only functions in non-upsert paths).
+- [ ] Queries use prepared statements with `?` placeholders; no raw string interpolation of user input.
+
+## Tests
+
+- [ ] Test file lives at `tests/Unit/Xion/ClassNameTest.php`.
+- [ ] `setUp()` creates an in-memory SQLite database with the required table(s).
+- [ ] Happy path, conflict/idempotent case, and edge cases (empty result, not-found) all covered.
+- [ ] Date boundary tests annotate every literal date with `// +N days` comment.
+- [ ] Phan suppression comments use the correct variant:
+  - `PhanTypeMismatchArgumentNullableInternal` for PHP built-ins (`strlen`, etc.)
+  - `PhanTypeMismatchArgumentNullable` for user-defined methods
+
+## Static Analysis
+
+- [ ] Run `composer analyze:file -- class/xion/NewClass.php tests/Unit/Xion/NewClassTest.php` before pushing.
+- [ ] Zero new Phan errors (add suppressions with a comment explaining why, not silently).
+
+## Docs & Tracking
+
+- [ ] Class description added to `class/xion/INDEX.md` in the correct category.
+- [ ] Schema columns added to `class/xion/SchemaDefinition.php`.
+- [ ] `docs/todo/current.md` entry marked done.
+- [ ] `docs/field-trials/candidates.md` archive entry added.

--- a/tests/Unit/Xion/DbUpsertTest.php
+++ b/tests/Unit/Xion/DbUpsertTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\DbUpsert;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class DbUpsertTest extends TestCase
+{
+    private PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('
+            CREATE TABLE kv_store (
+                key_name    VARCHAR(100) PRIMARY KEY,
+                value       TEXT         NOT NULL,
+                hit_count   INT          NOT NULL DEFAULT 0,
+                updated_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (key_name)
+            )
+        ');
+    }
+
+    // ── insert (no conflict) ──────────────────────────────────────────────────
+
+    public function testRunInsertsNewRow(): void
+    {
+        DbUpsert::run(
+            $this->pdo,
+            table: 'kv_store',
+            data: ['key_name' => 'foo', 'value' => 'bar'],
+            conflictCols: ['key_name'],
+            updateCols: ['value'],
+            updateExprs: ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+
+        $stmt = $this->pdo->query("SELECT * FROM kv_store WHERE key_name = 'foo'");
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->assertNotFalse($row);
+        $this->assertSame('bar', $row['value']);
+    }
+
+    // ── update on conflict (updateCols) ───────────────────────────────────────
+
+    public function testRunUpdatesOnConflictViaUpdateCols(): void
+    {
+        $this->pdo->exec("INSERT INTO kv_store (key_name, value) VALUES ('foo', 'old')");
+
+        DbUpsert::run(
+            $this->pdo,
+            table: 'kv_store',
+            data: ['key_name' => 'foo', 'value' => 'new'],
+            conflictCols: ['key_name'],
+            updateCols: ['value'],
+        );
+
+        $stmt = $this->pdo->query("SELECT value FROM kv_store WHERE key_name = 'foo'");
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('new', $stmt->fetchColumn());
+    }
+
+    // ── update via updateExprs (raw SQL) ──────────────────────────────────────
+
+    public function testRunUpdatesViaUpdateExprs(): void
+    {
+        $this->pdo->exec("INSERT INTO kv_store (key_name, value) VALUES ('foo', 'bar')");
+
+        DbUpsert::run(
+            $this->pdo,
+            table: 'kv_store',
+            data: ['key_name' => 'foo', 'value' => 'bar'],
+            conflictCols: ['key_name'],
+            updateExprs: ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+
+        $stmt = $this->pdo->query("SELECT updated_at FROM kv_store WHERE key_name = 'foo'");
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertNotNull($stmt->fetchColumn());
+    }
+
+    // ── no update clause (DO NOTHING on conflict) ─────────────────────────────
+
+    public function testRunDoesNothingOnConflictWhenNoUpdateCols(): void
+    {
+        $this->pdo->exec("INSERT INTO kv_store (key_name, value) VALUES ('foo', 'original')");
+
+        DbUpsert::run(
+            $this->pdo,
+            table: 'kv_store',
+            data: ['key_name' => 'foo', 'value' => 'ignored'],
+            conflictCols: ['key_name'],
+        );
+
+        $stmt = $this->pdo->query("SELECT value FROM kv_store WHERE key_name = 'foo'");
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame('original', $stmt->fetchColumn());
+    }
+
+    // ── idempotent — same call twice leaves one row ───────────────────────────
+
+    public function testRunIsIdempotent(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            DbUpsert::run(
+                $this->pdo,
+                table: 'kv_store',
+                data: ['key_name' => 'counter', 'value' => 'x'],
+                conflictCols: ['key_name'],
+                updateCols: ['value'],
+            );
+        }
+
+        $stmt = $this->pdo->query('SELECT COUNT(*) FROM kv_store');
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $this->assertSame(1, (int)$stmt->fetchColumn());
+    }
+
+    // ── multiple data columns ─────────────────────────────────────────────────
+
+    public function testRunWithMultipleDataColumns(): void
+    {
+        DbUpsert::run(
+            $this->pdo,
+            table: 'kv_store',
+            data: ['key_name' => 'multi', 'value' => 'first', 'hit_count' => 1],
+            conflictCols: ['key_name'],
+            updateCols: ['value', 'hit_count'],
+        );
+
+        DbUpsert::run(
+            $this->pdo,
+            table: 'kv_store',
+            data: ['key_name' => 'multi', 'value' => 'second', 'hit_count' => 2],
+            conflictCols: ['key_name'],
+            updateCols: ['value', 'hit_count'],
+        );
+
+        $stmt = $this->pdo->query("SELECT value, hit_count FROM kv_store WHERE key_name = 'multi'");
+        // @phan-suppress-next-line PhanTypeMismatchArgumentNullable
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->assertNotFalse($row);
+        $this->assertSame('second', $row['value']);
+        $this->assertSame(2, (int)$row['hit_count']);
+    }
+}

--- a/tools/make-xion.php
+++ b/tools/make-xion.php
@@ -1,0 +1,127 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Scaffold a new Xion class + matching test file.
+ *
+ * Usage:
+ *   php tools/make-xion.php ClassName
+ *   composer make:xion -- ClassName
+ *
+ * Creates:
+ *   class/xion/ClassName.php          — PDO injection skeleton
+ *   tests/Unit/Xion/ClassNameTest.php — in-memory SQLite test skeleton
+ */
+
+declare(strict_types=1);
+
+// ── CLI guard ────────────────────────────────────────────────────────────────
+
+if (PHP_SAPI !== 'cli') {
+    exit(1);
+}
+
+$name = $argv[1] ?? null;
+
+if ($name === null || !preg_match('/^[A-Z][A-Za-z0-9]+$/', $name)) {
+    fwrite(STDERR, "Usage: php tools/make-xion.php ClassName\n");
+    fwrite(STDERR, "  ClassName must be PascalCase (e.g. UserWidget)\n");
+    exit(1);
+}
+
+// ── Paths ────────────────────────────────────────────────────────────────────
+
+$root     = dirname(__DIR__);
+$classFile = "{$root}/class/xion/{$name}.php";
+$testFile  = "{$root}/tests/Unit/Xion/{$name}Test.php";
+
+foreach ([$classFile, $testFile] as $path) {
+    if (file_exists($path)) {
+        fwrite(STDERR, "Error: already exists — {$path}\n");
+        exit(1);
+    }
+}
+
+// ── Templates ────────────────────────────────────────────────────────────────
+
+$classBody = <<<PHP
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use Nene\Database\PdoConnection;
+use PDO;
+
+/**
+ * {$name} — TODO: one-line description.
+ */
+final class {$name}
+{
+    public function __construct(private readonly ?PDO \$db = null) {}
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    // TODO: implement methods
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return \$this->db ?? PdoConnection::getInstance();
+    }
+}
+PHP;
+
+// Convert PascalCase to snake_case for the default table name hint
+$snake = strtolower(preg_replace('/[A-Z]/', '_$0', lcfirst($name)) ?? $name);
+
+$testBody = <<<PHP
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\\{$name};
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class {$name}Test extends TestCase
+{
+    private PDO \$pdo;
+
+    protected function setUp(): void
+    {
+        \$this->pdo = new PDO('sqlite::memory:');
+        \$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        \$this->pdo->exec('
+            CREATE TABLE {$snake} (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+    }
+
+    // TODO: add tests
+}
+PHP;
+
+// ── Write ─────────────────────────────────────────────────────────────────────
+
+file_put_contents($classFile, $classBody . "\n");
+file_put_contents($testFile,  $testBody  . "\n");
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+echo "Created:\n";
+echo "  class/xion/{$name}.php\n";
+echo "  tests/Unit/Xion/{$name}Test.php\n";
+echo "\n";
+echo "Next steps:\n";
+echo "  1. Edit the class body and add your public methods\n";
+echo "  2. Add the table DDL to class/xion/SchemaDefinition.php\n";
+echo "  3. Add an entry to class/xion/INDEX.md  (or run: composer xion:index)\n";
+echo "  4. Write your tests\n";
+echo "  5. composer analyze:file -- class/xion/{$name}.php tests/Unit/Xion/{$name}Test.php\n";

--- a/tools/phan-file.sh
+++ b/tools/phan-file.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Run Phan analysis limited to specific files (fast local check before push).
+#
+# Usage:
+#   bash tools/phan-file.sh class/xion/Foo.php tests/Unit/Xion/FooTest.php
+#   bash tools/phan-file.sh class/xion/Foo.php   # class only
+#
+# Phan still parses all vendor stubs for type info, but only analyses the
+# listed files — typically ~14s vs ~40s for the full baseline run.
+#
+# Exit code mirrors Phan: 0 = clean, 1 = errors found.
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <file1.php> [file2.php ...]" >&2
+    exit 1
+fi
+
+# Join args with comma for --include-analysis-file-list
+FILES=$(IFS=,; echo "$*")
+
+exec php vendor/bin/phan \
+    --allow-polyfill-parser \
+    --load-baseline .phan/baseline.php \
+    --include-analysis-file-list "${FILES}"

--- a/tools/xion-index.php
+++ b/tools/xion-index.php
@@ -1,0 +1,137 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Regenerate class/xion/INDEX.md.
+ *
+ * - Updates descriptions of existing entries from each class's PHPDoc.
+ * - Removes entries whose class file no longer exists.
+ * - Appends newly discovered classes to an "## Uncategorized" section.
+ * - Preserves all section headings, category order, and table structure.
+ *
+ * Usage:
+ *   php tools/xion-index.php
+ *   composer xion:index
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    exit(1);
+}
+
+$root      = dirname(__DIR__);
+$indexPath = "{$root}/class/xion/INDEX.md";
+
+// ── Load existing INDEX ───────────────────────────────────────────────────────
+
+if (!file_exists($indexPath)) {
+    fwrite(STDERR, "Error: {$indexPath} not found\n");
+    exit(1);
+}
+
+$original = file_get_contents($indexPath);
+assert(is_string($original));
+
+// ── Discover all current class files ─────────────────────────────────────────
+
+/** @var array<string,string> $classDesc  className => description */
+$classDesc = [];
+
+foreach (glob("{$root}/class/xion/*.php") ?: [] as $file) {
+    $base = basename($file, '.php');
+    $src  = (string)file_get_contents($file);
+
+    $desc = '';
+    // First non-empty, non-tag docblock line
+    if (preg_match('#/\*\*\s*\n\s*\*\s*([^\n@*][^\n]+?)\s*\n#', $src, $m)) {
+        $desc = trim($m[1]);
+        $desc = ltrim($desc, '* ');
+        // Strip "ClassName — " prefix if present
+        $desc = (string)preg_replace('/^' . preg_quote($base, '/') . '\s*[—–-]\s*/u', '', $desc);
+        // Discard placeholder descriptions
+        if (str_contains($desc, 'AYANE') || strlen($desc) < 5) {
+            $desc = '';
+        }
+    }
+
+    $classDesc[$base] = $desc !== '' ? $desc : '—';
+}
+
+// ── Classes already mentioned in the INDEX ────────────────────────────────────
+
+$mentionedPattern = '/^\|\s*`([A-Za-z0-9]+)`\s*\|/m';
+preg_match_all($mentionedPattern, $original, $matches);
+/** @var string[] $mentioned */
+$mentioned = $matches[1];
+
+// ── Update description for each existing row ─────────────────────────────────
+
+$updated  = $original;
+$removed  = [];
+$outdated = [];
+
+foreach ($mentioned as $cls) {
+    if (!isset($classDesc[$cls])) {
+        // Class file deleted — mark for removal
+        $removed[] = $cls;
+        $updated = (string)preg_replace(
+            '/^\|[^\n]*`' . preg_quote($cls, '/') . '`[^\n]*\n/m',
+            '',   // remove the row
+            $updated
+        );
+        continue;
+    }
+
+    // Replace description column
+    $newRow  = "| `{$cls}` | {$classDesc[$cls]} |";
+    $updated = (string)preg_replace(
+        '/^\|\s*`' . preg_quote($cls, '/') . '`\s*\|[^\n]*/m',
+        $newRow,
+        $updated
+    );
+}
+
+// ── Append newly discovered classes ──────────────────────────────────────────
+
+$mentionedSet = array_flip($mentioned);
+/** @var string[] $newClasses */
+$newClasses = [];
+foreach ($classDesc as $cls => $_) {
+    if (!isset($mentionedSet[$cls])) {
+        $newClasses[] = $cls;
+    }
+}
+
+if ($newClasses !== []) {
+    // Strip trailing newlines then append the section
+    $updated = rtrim($updated) . "\n\n";
+    $updated .= "---\n\n## Uncategorized\n\n";
+    $updated .= "_Move these rows to the appropriate section above._\n\n";
+    $updated .= "| Class | Description |\n";
+    $updated .= "|-------|-------------|\n";
+    foreach ($newClasses as $cls) {
+        $updated .= "| `{$cls}` | {$classDesc[$cls]} |\n";
+    }
+    $updated .= "\n";
+}
+
+// ── Write output ──────────────────────────────────────────────────────────────
+
+file_put_contents($indexPath, $updated);
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+$countExisting = count($mentioned) - count($removed);
+echo "class/xion/INDEX.md updated\n";
+echo "  " . count($classDesc) . " classes in class/xion/\n";
+echo "  {$countExisting} existing entries refreshed\n";
+
+if ($removed !== []) {
+    echo "  removed (class deleted): " . implode(', ', $removed) . "\n";
+}
+
+if ($newClasses !== []) {
+    echo "  added to Uncategorized: " . implode(', ', $newClasses) . "\n";
+    echo "  → Move them to the correct section in class/xion/INDEX.md\n";
+}


### PR DESCRIPTION
## Summary

DX improvements addressing pain points raised in session review.

### Changes

| File | What |
|---|---|
| `tools/phan-file.sh` | Targeted Phan analysis for one or a few files (~14 s vs ~40 s full run) |
| `composer analyze:file` | Script alias for the above |
| `.phan/suppress-cheatsheet.md` | Quick reference for all six common Phan suppression types with code examples and a decision flowchart |
| `class/xion/DbUpsert.php` | Cross-driver upsert helper (MySQL + SQLite) — eliminates repeated driver-check boilerplate |
| `tests/Unit/Xion/DbUpsertTest.php` | 6 tests, 9 assertions — all green, Phan-clean |
| `class/xion/INDEX.md` | All ~230 Xion classes grouped by functional domain with one-line descriptions |
| `CLAUDE.md` | AI-agent quick reference: Phan commands, DbUpsert usage, date-boundary convention, token hashing, PDO injection pattern |
| `docs/ai/self-review/xion-class.md` | Checklist for new Xion class PRs |

### Pain points resolved

1. **Local Phan** — `composer analyze:file -- class/xion/Foo.php tests/Unit/Xion/FooTest.php`
2. **Cross-driver upsert boilerplate** — `DbUpsert::run()`
3. **Phan suppression names** — `.phan/suppress-cheatsheet.md`
4. **Xion class discovery** — `class/xion/INDEX.md`
5. **Date-boundary off-by-ones** — convention documented in `CLAUDE.md`
6. **Session-state recovery** — convention documented in `CLAUDE.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)