### PR TITLE
chore(dx): FT docs automation and make:xion INDEX auto-register

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,31 @@ composer make:xion -- ClassName
 ```
 
 Creates `class/xion/ClassName.php` + `tests/Unit/Xion/ClassNameTest.php` with
-the PDO injection skeleton. Then:
+the PDO injection skeleton, **and automatically adds the class to the
+Uncategorized section of `class/xion/INDEX.md`**. Then:
 
 1. Fill in the public API and table DDL
 2. Add the table to `class/xion/SchemaDefinition.php`
-3. Run `composer xion:index` to refresh the class index
+3. Move the Uncategorized entry in `class/xion/INDEX.md` to the right section
 4. Run `composer analyze:file -- class/xion/ClassName.php tests/Unit/Xion/ClassNameTest.php`
+
+---
+
+## Completing an FT
+
+After merging the PR, run:
+
+```bash
+composer ft:done -- FT265 ClassName "one-line description of what it does" 712
+```
+
+Updates three files in one shot:
+
+| File | Change |
+|---|---|
+| `docs/todo/current.md` | Advances `FT1–FT264 are complete` → `FT1–FT265` |
+| `docs/field-trials/candidates.md` | Prepends archive entry |
+| `docs/roadmap.md` | Advances `FT1–FT264 complete as of …` → `FT1–FT265` |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,41 @@ Full context is in `docs/ai/README.md` and the `docs/ai/self-review/` checklists
 
 ---
 
+## Pre-commit Checklist
+
+Run this before every `git push`:
+
+```bash
+composer precommit   # format → analyze (full) → test
+```
+
+Or piecemeal:
+
+```bash
+composer format                      # auto-fix code style
+composer analyze:file -- class/xion/Foo.php tests/Unit/Xion/FooTest.php   # targeted Phan (~14 s)
+composer analyze                     # full Phan (~40 s) — same as CI
+composer test                        # PHPUnit unit suite
+```
+
+---
+
+## Scaffolding a New Xion Class
+
+```bash
+composer make:xion -- ClassName
+```
+
+Creates `class/xion/ClassName.php` + `tests/Unit/Xion/ClassNameTest.php` with
+the PDO injection skeleton. Then:
+
+1. Fill in the public API and table DDL
+2. Add the table to `class/xion/SchemaDefinition.php`
+3. Run `composer xion:index` to refresh the class index
+4. Run `composer analyze:file -- class/xion/ClassName.php tests/Unit/Xion/ClassNameTest.php`
+
+---
+
 ## Static Analysis (Phan)
 
 ```bash
@@ -76,6 +111,12 @@ Never use a date that is only "near" the boundary and hope it works.
 
 `class/xion/INDEX.md` — all ~230 Xion classes grouped by domain.
 Consult it before starting a new Xion class to avoid duplicates.
+
+To regenerate after adding classes:
+
+```bash
+composer xion:index   # updates descriptions, adds new classes to Uncategorized
+```
 
 ---
 

--- a/class/xion/DbUpsert.php
+++ b/class/xion/DbUpsert.php
@@ -81,7 +81,7 @@ final class DbUpsert
         $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
 
         if ($driver === 'mysql') {
-            $setParts = array_map(fn(string $c) => "{$c} = VALUES({$c})", $updateCols);
+            $setParts = array_map(fn (string $c) => "{$c} = VALUES({$c})", $updateCols);
 
             foreach ($updateExprs as $col => $expr) {
                 $setParts[] = "{$col} = {$expr}";
@@ -92,7 +92,7 @@ final class DbUpsert
                        . ($setClause !== '' ? " ON DUPLICATE KEY UPDATE {$setClause}" : '');
         } else {
             $conflictList = implode(', ', $conflictCols);
-            $setParts     = array_map(fn(string $c) => "{$c} = excluded.{$c}", $updateCols);
+            $setParts     = array_map(fn (string $c) => "{$c} = excluded.{$c}", $updateCols);
 
             foreach ($updateExprs as $col => $expr) {
                 $setParts[] = "{$col} = {$expr}";

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -8,32 +8,32 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `AccessToken` | Issue, verify, and revoke personal access tokens (PATs) |
-| `AuthSession` | Application session management |
-| `BearerAuth` | Optional Bearer-token authentication for agent/MCP clients (ADR-0008) |
-| `DeviceFingerprint` | Device recognition for fraud detection and trust scoring |
-| `DeviceToken` | Push notification device token management per user |
-| `EmailVerification` | Token-based email address verification with expiry |
-| `GuestSession` | Anonymous visitor session tracking with key-value data bag |
-| `InvitationToken` | Token-based user invitation system |
-| `InviteCode` | Single-use invite codes with usage quota |
-| `JwtCodec` | JWT encode/decode helpers |
-| `LoginAttemptTracker` | Brute-force protection via login attempt counting |
-| `LoginHistory` | Append-only log of login attempts with IP, user-agent, and result |
-| `MagicLink` | Email-based passwordless authentication tokens |
-| `OAuthToken` | OAuth2 access/refresh token storage with TTL |
-| `OtpChallenge` | One-time password (OTP) challenge issuance and verification |
-| `PasswordExpiry` | Password expiry policy enforcement |
-| `PasswordHistory` | Prevent users from reusing recent passwords |
-| `PasswordResetToken` | Cryptographic helpers for password-reset token workflows |
-| `PersonalAccessToken` | Personal Access Token (PAT) management for user-facing dashboards |
-| `PinCode` | Short PIN/OTP issuance with attempt limiting and expiry |
-| `RedisSessionHandler` | Redis-backed PHP session handler |
-| `RefreshToken` | DB-backed refresh token management for JWT access token rotation |
-| `ServiceAccount` | Machine-to-machine auth credentials with key rotation |
-| `TotpAuthenticator` | TOTP (RFC 6238 / Google Authenticator compatible) |
-| `TwoFactorBackupCode` | One-time recovery codes for 2FA |
-| `UserSession` | Multi-device application session management |
+| `AccessToken` | issue, verify, and revoke personal access tokens (PATs). |
+| `AuthSession` | — |
+| `BearerAuth` | Optional Bearer-token authentication for agent / MCP clients (ADR-0008). |
+| `DeviceFingerprint` | device recognition for fraud detection and trust scoring. |
+| `DeviceToken` | push notification device token management per user. |
+| `EmailVerification` | token-based email address verification with expiry. |
+| `GuestSession` | anonymous visitor session tracking with key-value data bag. |
+| `InvitationToken` | Token-based user invitation system. |
+| `InviteCode` | single-use invite codes with usage quota. |
+| `JwtCodec` | — |
+| `LoginAttemptTracker` | — |
+| `LoginHistory` | append-only log of login attempts with IP, user-agent, and result. |
+| `MagicLink` | email-based passwordless authentication tokens. |
+| `OAuthToken` | OAuth2 access/refresh token storage with TTL. |
+| `OtpChallenge` | one-time password (OTP) challenge issuance and verification. |
+| `PasswordExpiry` | Password expiry policy enforcement. |
+| `PasswordHistory` | Password history — prevent users from reusing recent passwords. |
+| `PasswordResetToken` | Cryptographic helpers for password-reset token workflows. |
+| `PersonalAccessToken` | Personal Access Token (PAT) management for user-facing dashboards. |
+| `PinCode` | short PIN / OTP issuance with attempt limiting and expiry. |
+| `RedisSessionHandler` | — |
+| `RefreshToken` | DB-backed refresh token management for JWT access token rotation. |
+| `ServiceAccount` | machine-to-machine auth credentials with key rotation. |
+| `TotpAuthenticator` | TOTP (Time-based One-Time Password) authenticator — RFC 6238 / Google Authenticator compatible. |
+| `TwoFactorBackupCode` | one-time recovery codes for 2FA. |
+| `UserSession` | multi-device application session management. |
 
 ---
 
@@ -41,21 +41,21 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `AccessControl` | Per-resource subject ACL (access-control list) |
-| `AccessGrant` | Time-bounded access delegation between entities |
-| `AccessSchedule` | Recurring time-window access control for users and resources |
-| `BlockList` | User block list — prevent harassment and unwanted interactions |
-| `CsrfProtectionPolicy` | CSRF protection policy helpers |
-| `GeoBlocker` | Country-level access control via a configurable allow/block list |
-| `GeoFence` | Define named circular geo-fences and check point containment |
-| `ImpersonationLog` | Admin impersonation session audit log |
-| `IpAllowlist` | Per-resource IP allowlist with CIDR range support |
-| `IpBlocklist` | Global IP address blocklist with optional expiry |
-| `RedirectGuard` | Open-redirect guard for controllers that need to redirect |
-| `ResourceLock` | Advisory lock on any entity to prevent concurrent edits |
-| `RoleGuard` | Role-based access gate |
-| `TrustScore` | Append-only fraud/trust score per user |
-| `UserBan` | Ban/unban users with optional expiry and reason tracking |
+| `AccessControl` | per-resource subject ACL (access-control list). |
+| `AccessGrant` | time-bounded access delegation between entities. |
+| `AccessSchedule` | recurring time-window access control for users and resources. |
+| `BlockList` | User block list — prevent harassment and unwanted interactions. |
+| `CsrfProtectionPolicy` | — |
+| `GeoBlocker` | country-level access control via a configurable allow/block list. |
+| `GeoFence` | define named circular geo-fences and check point containment. |
+| `ImpersonationLog` | Admin impersonation session audit log. |
+| `IpAllowlist` | per-resource IP allowlist with CIDR range support. |
+| `IpBlocklist` | global IP address blocklist with optional expiry. |
+| `RedirectGuard` | Open-redirect guard for controllers that need to redirect to an |
+| `ResourceLock` | advisory lock on any entity to prevent concurrent edits. |
+| `RoleGuard` | — |
+| `TrustScore` | append-only fraud/trust score per user. |
+| `UserBan` | ban / unban users with optional expiry and reason tracking. |
 
 ---
 
@@ -63,27 +63,27 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `Announcement` | Site-wide announcements with scheduling and per-user dismissal |
-| `Checklist` | Ordered checklist items attached to any entity |
-| `CommentThread` | Threaded comments attached to any entity |
-| `ContentBlock` | Ordered content blocks for page builder/CMS layouts |
-| `ContentDraft` | Content draft lifecycle: draft → published → archived |
-| `ContentFilter` | DB-backed banned word/phrase list with masking |
-| `ContentFlag` | User content flagging and moderation queue |
-| `ContentReport` | User-submitted content moderation reports |
-| `ContentSchedule` | Schedule content for future publish and optional expiry |
-| `ContentTag` | Flexible tagging of arbitrary entities |
-| `ContentVersion` | Content versioning with rollback support |
-| `DraftManager` | Versioned draft persistence for any content type |
-| `EmailTemplate` | DB-stored email templates with variable substitution |
-| `EntityComment` | Flat comment list attached to any entity |
-| `FaqItem` | FAQ articles with categories, ordering, and helpfulness voting |
-| `KnowledgeBase` | Help articles with categories, lifecycle, and view tracking |
-| `MultiLangContent` | Multilingual content strings for CMS-style translation |
-| `NoticeBoard` | Admin-posted announcements with per-user read-acknowledgment |
-| `Poll` | Create polls with options and record per-user votes |
-| `Post` | Blog/content post management |
-| `TextTemplate` | DB-backed general-purpose text templates with variable substitution |
+| `Announcement` | site-wide announcements with scheduling and per-user dismissal. |
+| `Checklist` | ordered checklist items attached to any entity. |
+| `CommentThread` | threaded comments attached to any entity. |
+| `ContentBlock` | ordered content blocks for page builder / CMS layouts. |
+| `ContentDraft` | Content draft lifecycle: draft → published → archived. |
+| `ContentFilter` | DB-backed banned word/phrase list with masking. |
+| `ContentFlag` | User content flagging and moderation queue. |
+| `ContentReport` | User-submitted content moderation reports. |
+| `ContentSchedule` | schedule content for future publish and optional expiry. |
+| `ContentTag` | flexible tagging of arbitrary entities. |
+| `ContentVersion` | content versioning with rollback support. |
+| `DraftManager` | versioned draft persistence for any content type. |
+| `EmailTemplate` | DB-stored email templates with variable substitution. |
+| `EntityComment` | flat comment list attached to any entity. |
+| `FaqItem` | FAQ articles with categories, ordering, and helpfulness voting. |
+| `KnowledgeBase` | help articles with categories, lifecycle, and view tracking. |
+| `MultiLangContent` | multilingual content strings for CMS-style translation. |
+| `NoticeBoard` | admin-posted announcements with per-user read-acknowledgment. |
+| `Poll` | create polls with options and record per-user votes. |
+| `Post` | — |
+| `TextTemplate` | DB-backed general-purpose text templates with variable substitution. |
 
 ---
 
@@ -91,33 +91,35 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `ActivityFeed` | User-facing activity feed — append-only event timeline |
-| `AddressBook` | Per-user address book with multiple addresses and a default flag |
-| `Bookmark` | Generic per-user bookmark/saved-item manager |
-| `BookmarkCollection` | User-curated collections of bookmarked entities |
-| `ConsentLog` | Immutable record of user consent grants and withdrawals |
-| `DailyStreak` | Track per-user daily activity streaks |
-| `EntityAlias` | Multiple identifier aliases for an entity |
-| `FollowRelation` | User follow/unfollow relationship management |
-| `FriendRequest` | Friend request lifecycle (pending/accepted/declined/cancelled) |
-| `GdprRequest` | GDPR data-subject request tracking |
-| `Mention` | Track @-mentions of users within content items |
-| `NotificationPreference` | Per-user channel × type opt-in/opt-out |
-| `OnlineStatus` | Track user presence with heartbeat-based online/idle/offline states |
-| `PresenceChannel` | Track which users are currently "in" a named channel |
-| `PresenceTracker` | User online presence and last-seen tracking |
-| `ProfileBadge` | Gamification badge award and management |
-| `ReadProgress` | Track user read progress through content |
-| `SavedSearch` | Per-user named search queries |
-| `SearchHistory` | Per-user search history with deduplication and auto-trimming |
-| `TermConsent` | Track user acceptance of terms, privacy policies, and agreements |
-| `UserActivity` | User last-seen and named action tracking |
-| `UserFeedback` | Collect general user satisfaction feedback (NPS/star ratings + free text) |
-| `UserGroup` | User group and team membership management |
-| `UserNote` | Admin/staff notes attached to a user record |
-| `UserPreference` | Key-value preference store per user with typed defaults |
-| `UserSegment` | User cohort/segment assignment for targeting and analytics |
-| `UserTier` | Gamification tier/membership level assignment with history |
+| `ActivityFeed` | User-facing activity feed — append-only event timeline. |
+| `AddressBook` | Per-user address book with multiple addresses and a default flag. |
+| `Bookmark` | Generic per-user bookmark / saved-item manager. |
+| `BookmarkCollection` | user-curated collections of bookmarked entities. |
+| `ConsentLog` | immutable record of user consent grants and withdrawals. |
+| `DailyStreak` | Track per-user daily activity streaks. |
+| `EntityAlias` | multiple identifier aliases for an entity. |
+| `FollowRelation` | User follow/unfollow relationship management. |
+| `FriendRequest` | friend request lifecycle with pending/accepted/declined/cancelled states. |
+| `GdprRequest` | GDPR data-subject request tracking. |
+| `Mention` | track @-mentions of users within content items. |
+| `NotificationPreference` | Notification preference manager — per-user channel × type opt-in/opt-out. |
+| `OnlineStatus` | track user presence with heartbeat-based online/idle/offline states. |
+| `PresenceChannel` | track which users are currently "in" a named channel. |
+| `PresenceTracker` | user online presence and last-seen tracking. |
+| `ProfileBadge` | Gamification badge award and management. |
+| `ReadProgress` | Track user read progress through content (articles, books, courses, etc.). |
+| `SavedSearch` | per-user named search queries. |
+| `SearchHistory` | Per-user search history with deduplication and auto-trimming. |
+| `SearchIndex` | lightweight full-text search index for any entity. |
+| `SearchSuggestion` | type-ahead suggestion management with frequency weighting. |
+| `TermConsent` | Track user acceptance of terms of service, privacy policies, and other agreements. |
+| `UserActivity` | user last-seen and named action tracking. |
+| `UserFeedback` | Collect general user satisfaction feedback (NPS / star ratings + free text). |
+| `UserGroup` | user group and team membership management. |
+| `UserNote` | admin/staff notes attached to a user record. |
+| `UserPreference` | key-value preference store per user with typed defaults. |
+| `UserSegment` | user cohort/segment assignment for targeting and analytics. |
+| `UserTier` | gamification tier/membership level assignment with history. |
 
 ---
 
@@ -125,21 +127,21 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `ChatMessage` | Simple chat room message store with soft-delete |
-| `ContactMessage` | Customer contact form inbox management |
-| `DailyDigest` | Per-user daily digest item accumulator |
-| `EmailBounce` | Email bounce and complaint tracking for delivery health management |
-| `EmailQueue` | DB-backed outgoing email queue with retry and exponential backoff |
-| `MailMessage` | Plain immutable description of one outgoing email |
-| `Mailer` | Thin wrapper around Symfony Mailer (ADR-0006) |
-| `NewsletterSubscription` | Newsletter/mailing-list subscription manager with double opt-in |
-| `NotificationInbox` | User notification inbox: push, list, mark-as-read, unread count |
-| `NotificationQueue` | Channel-agnostic outbox-pattern notification queue |
-| `PushSubscription` | Web Push notification subscription registry |
-| `RecipientGroup` | Mailing list/recipient group management |
-| `Reminder` | User-set future reminders |
-| `SessionFlash` | One-time flash messages stored in DB, consumed on next read |
-| `TopicSubscription` | User subscriptions to named topics for notification routing |
+| `ChatMessage` | simple chat room message store with soft-delete. |
+| `ContactMessage` | customer contact form inbox management. |
+| `DailyDigest` | per-user daily digest item accumulator. |
+| `EmailBounce` | email bounce and complaint tracking for delivery health management. |
+| `EmailQueue` | DB-backed outgoing email queue with retry and exponential backoff. |
+| `MailMessage` | Plain immutable description of one outgoing email. |
+| `Mailer` | Thin wrapper around Symfony Mailer (ADR-0006). |
+| `NewsletterSubscription` | Newsletter / mailing-list subscription manager with double opt-in support. |
+| `NotificationInbox` | User notification inbox: push, list, mark-as-read, unread count. |
+| `NotificationQueue` | channel-agnostic outbox-pattern notification queue. |
+| `PushSubscription` | Web Push notification subscription registry. |
+| `RecipientGroup` | mailing list / recipient group management. |
+| `Reminder` | user-set future reminders. |
+| `SessionFlash` | one-time flash messages stored in DB, consumed on next read. |
+| `TopicSubscription` | user subscriptions to named topics for notification routing. |
 
 ---
 
@@ -147,18 +149,18 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `Attachment` | File attachments linked to any entity |
-| `FileChunk` | Chunked file upload tracking and reassembly coordination |
-| `FileMetadata` | File storage metadata management |
-| `FileQuarantine` | Quarantine suspicious/policy-violating files with release/reject workflow |
-| `FileUpload` | Safe wrapper for a single uploaded file (`$_FILES` entry) |
-| `MediaConversionJob` | Async media processing job tracking |
-| `MediaGallery` | Ordered media item gallery attached to any entity |
-| `MediaMetadata` | Store and retrieve metadata for uploaded media files |
-| `MediaProcessing` | Track async media conversion/processing jobs |
-| `SignedUrl` | Pre-signed URL generation and verification |
-| `StorageQuota` | Per-owner storage usage tracking with configurable limits |
-| `UploadedFile` | Typed wrapper around a single `$_FILES` entry |
+| `Attachment` | file attachments linked to any entity. |
+| `FileChunk` | chunked file upload tracking and reassembly coordination. |
+| `FileMetadata` | File storage metadata management. |
+| `FileQuarantine` | quarantine suspicious or policy-violating files with release/reject workflow. |
+| `FileUpload` | Safe wrapper for a single uploaded file ($_FILES entry). |
+| `MediaConversionJob` | async media processing job tracking. |
+| `MediaGallery` | ordered media item gallery attached to any entity. |
+| `MediaMetadata` | store and retrieve metadata for uploaded media files. |
+| `MediaProcessing` | track async media conversion/processing jobs. |
+| `SignedUrl` | — |
+| `StorageQuota` | per-owner storage usage tracking with configurable limits. |
+| `UploadedFile` | Typed wrapper around a single `$_FILES` entry. |
 
 ---
 
@@ -166,28 +168,29 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `BillingUsage` | Metered usage tracking for billing |
-| `BudgetTracker` | Period-based budget allocation and spend tracking |
-| `CouponCode` | Coupon/promo code management with usage limits and per-user redemption |
-| `CreditLedger` | Append-only double-entry credit/debit ledger per user |
-| `CreditNote` | Financial credit notes/refund adjustments |
-| `EventTicket` | Event ticketing with capacity management and check-in tracking |
-| `GiftCard` | Prepaid gift card balance with partial redemption support |
-| `InventoryStock` | Product/SKU stock tracking with atomic reserve/release/commit |
-| `OrderLine` | E-commerce order header with line items |
-| `PaymentRecord` | Simple payment/transaction ledger |
-| `PointBalance` | User loyalty/reward points with append-only ledger |
-| `PointLedger` | Append-only point/loyalty system with negative-balance prevention |
-| `PriceHistory` | Append-only price change log for products or any priced entity |
-| `PriceList` | Product price catalog with multiple price tiers per SKU |
-| `ProductBundle` | Product bundle definitions with included items |
-| `ProductReview` | Entity reviews with ratings and helpfulness voting |
-| `Quota` | Plan-based resource quota management |
-| `RecurringPayment` | Recurring payment schedule management |
-| `ShoppingCart` | Cart item management with quantity and price tracking |
-| `Subscription` | Track recurring subscription plans per user |
-| `SubscriptionPlan` | User subscription lifecycle management |
-| `TaxRate` | Tax rate lookup and amount calculation by region and category |
+| `BillingUsage` | metered usage tracking for billing. |
+| `BudgetTracker` | period-based budget allocation and spend tracking. |
+| `CouponCode` | Coupon / promo code management with usage limits and per-user redemption tracking. |
+| `CreditLedger` | append-only double-entry credit/debit ledger per user. |
+| `CreditNote` | financial credit notes / refund adjustments. |
+| `EventTicket` | event ticketing with capacity management and check-in tracking. |
+| `GiftCard` | prepaid gift card balance with partial redemption support. |
+| `InventoryStock` | product/SKU stock tracking with atomic reserve/release/commit. |
+| `OrderLine` | e-commerce order header with line items. |
+| `PaymentRecord` | simple payment/transaction ledger. |
+| `PointBalance` | user loyalty/reward points with append-only ledger. |
+| `PointLedger` | Append-only point / loyalty system with negative-balance prevention. |
+| `PriceHistory` | append-only price change log for products or any priced entity. |
+| `PriceList` | product price catalog with multiple price tiers per SKU. |
+| `ProductBundle` | product bundle definitions with included items. |
+| `ProductReview` | entity reviews with ratings and helpfulness voting. |
+| `Quota` | plan-based resource quota management. |
+| `RecurringPayment` | Recurring payment schedule management. |
+| `ShoppingCart` | cart item management with quantity and price tracking. |
+| `Subscription` | track recurring subscription plans per user. |
+| `SubscriptionPlan` | user subscription lifecycle management. |
+| `StockAlert` | user-defined stock/availability alert registrations. |
+| `TaxRate` | tax rate lookup and amount calculation by region and category. |
 
 ---
 
@@ -195,21 +198,24 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `AccessLog` | Security-focused resource access log |
-| `AlertRule` | Metric-based alert rules with threshold evaluation and event log |
-| `ApiUsageLog` | Per-API-key request tracking with endpoint and status logging |
-| `AuditLog` | Compliance-grade record of who changed what on any entity |
-| `AuditLogger` | Append-only audit log writer |
-| `ChangeLog` | Human-readable change history for any entity |
-| `CounterMetric` | Named metric counters with daily/hourly bucket aggregation |
-| `CronLog` | Scheduled task execution log |
-| `DownloadCounter` | Track file/asset download events |
-| `EventLog` | Append-only domain event log for event sourcing–lite patterns |
-| `IncidentLog` | IT/service incident tracking with severity and lifecycle |
-| `IntegrationLog` | Outbound/inbound API call log with request and response data |
-| `KpiTracker` | KPI/OKR metric tracking with target vs. actual comparison |
-| `PageView` | Page and resource view analytics tracking |
-| `SlaTracker` | SLA/SLO breach detection for timed work items |
+| `AccessLog` | Security-focused resource access log. |
+| `AlertRule` | metric-based alert rules with threshold evaluation and event log. |
+| `ApiUsageLog` | per-API-key request tracking with endpoint and status logging. |
+| `AuditLog` | compliance-grade record of who changed what on any entity. |
+| `AuditLogger` | Append-only audit log writer. |
+| `EntitySnapshot` | point-in-time entity state snapshots. |
+| `Log` | — |
+| `LogFormatterFactory` | — |
+| `ChangeLog` | human-readable change history for any entity. |
+| `CounterMetric` | named metric counters with daily/hourly bucket aggregation. |
+| `CronLog` | scheduled task execution log. |
+| `DownloadCounter` | Download counter — track file/asset download events. |
+| `EventLog` | append-only domain event log for event sourcing–lite patterns. |
+| `IncidentLog` | IT/service incident tracking with severity and lifecycle. |
+| `IntegrationLog` | outbound/inbound API call log with request and response data. |
+| `KpiTracker` | KPI / OKR metric tracking with target vs. actual comparison. |
+| `PageView` | page and resource view analytics tracking. |
+| `SlaTracker` | SLA/SLO breach detection for timed work items. |
 
 ---
 
@@ -217,37 +223,37 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `AbTest` | A/B test variant assignment and conversion tracking |
-| `Approval` | Single-approver workflow (request → approve/reject) |
-| `ChangeRequest` | Formal RFC/change-management approval workflow |
-| `EventRsvp` | Event attendance management with accept/decline/maybe responses |
-| `FaqItem` | FAQ articles (see also **Content & CMS**) |
-| `FeatureRequest` | User-submitted feature requests with voting and status tracking |
-| `Label` | Colored label definitions with entity assignment |
-| `Leaderboard` | Score-based leaderboard with best-score retention and ranking |
-| `Reaction` | Emoji/symbol reactions on any entity |
-| `ReactionCounter` | Emoji/type reactions with per-user state |
-| `Referral` | Referral code generation, attribution, and conversion tracking |
-| `ReferralCode` | Referral code system — generate invite links and track conversions |
-| `ResourceReservation` | Time-bounded reservation of a shared resource |
-| `ScoreBoard` | High-score table with personal-best and period tracking |
-| `ShareLink` | Shareable links with optional password and expiry |
-| `SupportTicket` | Simple help desk ticket queue with reply thread |
-| `SurveyResponse` | Form/survey response collection and analysis |
-| `SurveyTemplate` | Reusable form/survey template definitions |
-| `TagIndex` | Attach tags to any entity and query by tag |
-| `TagManager` | Generic tag/label system for M:N entity-tag relationships |
-| `TaskList` | Simple to-do list with per-user tasks and completion tracking |
-| `TeamMembership` | Organization/team membership with roles |
-| `TimeEntry` | Work time tracking with start/stop/duration |
-| `TimeSlot` | Appointment/time slot booking with availability |
-| `VotePoll` | Simple polls with named options and one-vote-per-user enforcement |
-| `VotingBooth` | Upvote/downvote system with toggle semantics and per-user vote state |
-| `Waitlist` | Manage sign-ups for gated access (beta, launches, events) |
-| `WaitlistEntry` | Product/feature/event waitlist management |
-| `Watchlist` | Users subscribe to watch entities for updates |
-| `Wishlist` | Per-user saved items using entity-agnostic (type, id) pairs |
-| `WorkflowInstance` | Persistent stateful workflow tracking |
+| `AbTest` | A/B test variant assignment and conversion tracking. |
+| `Approval` | single-approver workflow (request → approve / reject). |
+| `ChangeRequest` | formal RFC / change-management approval workflow. |
+| `EventRsvp` | event attendance management with accept/decline/maybe responses. |
+| `FaqItem` | FAQ articles with categories, ordering, and helpfulness voting. |
+| `FeatureRequest` | user-submitted feature requests with voting and status tracking. |
+| `Label` | colored label definitions with entity assignment. |
+| `Leaderboard` | Score-based leaderboard with best-score retention, ranking, and personal rank lookup. |
+| `Reaction` | emoji / symbol reactions on any entity. |
+| `ReactionCounter` | emoji/type reactions on any entity with per-user state. |
+| `Referral` | referral code generation, attribution, and conversion tracking. |
+| `ReferralCode` | Referral code system — generate invite links and track conversions. |
+| `ResourceReservation` | time-bounded reservation of a shared resource. |
+| `ScoreBoard` | high-score table with personal-best and period tracking. |
+| `ShareLink` | shareable links with optional password and expiry. |
+| `SupportTicket` | simple help desk ticket queue with reply thread. |
+| `SurveyResponse` | form/survey response collection and analysis. |
+| `SurveyTemplate` | reusable form/survey template definitions. |
+| `TagIndex` | attach tags to any entity and query by tag. |
+| `TagManager` | Generic tag/label system for M:N entity-tag relationships. |
+| `TaskList` | simple to-do list with per-user tasks and completion tracking. |
+| `TeamMembership` | organization/team membership with roles. |
+| `TimeEntry` | work time tracking with start/stop/duration. |
+| `TimeSlot` | appointment/time slot booking with availability. |
+| `VotePoll` | simple polls with named options and one-vote-per-user enforcement. |
+| `VotingBooth` | Upvote / downvote system with toggle semantics and per-user vote state. |
+| `Waitlist` | manage sign-ups for gated access (beta, launches, events). |
+| `WaitlistEntry` | product / feature / event waitlist management. |
+| `Watchlist` | users subscribe to watch entities for updates. |
+| `Wishlist` | per-user saved items using entity-agnostic (type, id) pairs. |
+| `WorkflowInstance` | persistent stateful workflow tracking. |
 
 ---
 
@@ -255,25 +261,25 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `ApiDeprecation` | RFC 8594 API deprecation signal helpers |
-| `ApiKey` | API key management: generation, hashed storage, scope-based auth, rotation |
-| `ApiResponse` | Standard API response wrapper |
-| `ApiWebhook` | Webhook subscription endpoint management |
-| `AppVersion` | Deployment/release version history tracking |
-| `BearerAuth` | Bearer-token auth (see also **Auth & Sessions**) |
-| `Cors` | CORS (Cross-Origin Resource Sharing) header utility |
-| `ExportJob` | Async data export job tracking |
-| `FeatureFlag` | DB-backed feature flags with global on/off and per-user overrides |
-| `HealthCheck` | Service/component health monitoring log |
-| `HttpCache` | HTTP cache header utilities for REST endpoints |
-| `IdempotencyStore` | DB-backed idempotency key store for POST endpoints |
-| `MaintenanceMode` | Global on/off maintenance flag with bypass allowlist |
-| `RequestId` | Per-request identifier for end-to-end correlation |
-| `ServerTiming` | Server-Timing header helpers |
-| `ShortUrl` | URL shortener with click tracking and optional expiry |
-| `SlugRegistry` | URL slug generation and uniqueness enforcement |
-| `WebhookDelivery` | Outbound webhook delivery log with retry tracking |
-| `WebhookSigner` | HMAC-SHA256 webhook signing and verification |
+| `ApiDeprecation` | RFC 8594 API deprecation signal helpers. |
+| `ApiKey` | API key management: generation, hashed storage, scope-based auth, revocation, rotation. |
+| `ApiResponse` | — |
+| `ApiWebhook` | Webhook subscription endpoint management. |
+| `AppVersion` | deployment/release version history tracking. |
+| `BearerAuth` | Optional Bearer-token authentication for agent / MCP clients (ADR-0008). |
+| `Cors` | CORS (Cross-Origin Resource Sharing) header utility. |
+| `ExportJob` | async data export job tracking. |
+| `FeatureFlag` | DB-backed feature flags with global on/off and per-user overrides. |
+| `HealthCheck` | service/component health monitoring log. |
+| `HttpCache` | HTTP cache header utilities for REST endpoints. |
+| `IdempotencyStore` | DB-backed idempotency key store for POST endpoints. |
+| `MaintenanceMode` | Maintenance mode — global on/off flag with allowlist for bypass users. |
+| `RequestId` | Per-request identifier used for end-to-end correlation across |
+| `ServerTiming` | — |
+| `ShortUrl` | URL shortener with click tracking and optional expiry. |
+| `SlugRegistry` | URL slug generation and uniqueness enforcement. |
+| `WebhookDelivery` | outbound webhook delivery log with retry tracking. |
+| `WebhookSigner` | HMAC-SHA256 webhook signing and verification. |
 
 ---
 
@@ -281,19 +287,19 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `AssetRegistry` | Physical and digital asset inventory with assignment tracking |
-| `BatchJob` | Batch processing job tracking with progress and status lifecycle |
-| `BatchResult` | Accumulates per-item results for a batch operation |
-| `CircuitBreaker` | Circuit breaker pattern for external service calls |
-| `DataImportJob` | CSV/data import job tracking with per-row error recording |
-| `DistributedLock` | DB-backed distributed lock with TTL, owner enforcement, and stale-lock reclaim |
-| `DocumentLock` | Optimistic editing lock for collaborative document editing |
-| `DocumentSignature` | E-signature request workflow with multi-signatory support |
-| `JobQueue` | Simple DB-backed background job queue |
-| `OptimisticLock` | Optimistic concurrency control helpers |
-| `ScheduledTask` | Cron-style task schedule registry with last-run tracking |
-| `TokenBucket` | DB-backed token bucket algorithm for flexible rate limiting |
-| `TransactionManager` | Database transaction management helpers |
+| `AssetRegistry` | physical and digital asset inventory with assignment tracking. |
+| `BatchJob` | batch processing job tracking with progress and status lifecycle. |
+| `BatchResult` | Accumulates per-item results for a batch operation. |
+| `CircuitBreaker` | — |
+| `DataImportJob` | CSV/data import job tracking with per-row error recording. |
+| `DistributedLock` | DB-backed distributed lock with TTL, owner enforcement, and stale-lock reclaim. |
+| `DocumentLock` | optimistic editing lock for collaborative document editing. |
+| `DocumentSignature` | e-signature request workflow with multi-signatory support. |
+| `JobQueue` | simple DB-backed background job queue. |
+| `OptimisticLock` | — |
+| `ScheduledTask` | cron-style task schedule registry with last-run tracking. |
+| `TokenBucket` | DB-backed token bucket algorithm for flexible rate limiting. |
+| `TransactionManager` | — |
 
 ---
 
@@ -301,17 +307,28 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `CacheEntry` | DB-backed key-value cache with optional TTL |
-| `ConfigStore` | Global application key-value configuration store |
-| `DatabaseInstaller` | Database setup and health checks for the sample runtime |
-| `DbUpsert` | Cross-driver upsert helper (MySQL + SQLite) — see `DbUpsert::run()` |
-| `EnvLoader` | Minimal dotenv-style loader for CLI setup commands |
-| `ErrorCode` | Application error code definitions |
-| `PdoConnection` | PDO singleton connection factory |
-| `SchemaCompiler` | Compile `SchemaDefinition` into MySQL and SQLite DDL |
-| `SchemaDefinition` | NeNe's sample-schema source of truth |
-| `SystemSetting` | Typed global application settings store |
-| `TenantConfig` | Per-tenant key-value configuration store |
+| `CacheEntry` | DB-backed key-value cache with optional TTL. |
+| `ConfigStore` | global application key-value configuration store. |
+| `DatabaseInstaller` | Database setup and health checks for the sample runtime. |
+| `Command` | — |
+| `DataMapperBase` | — |
+| `DataModelBase` | — |
+| `DbUpsert` | Cross-driver upsert helper (MySQL + SQLite). |
+| `DomainException` | Throwable that carries a NeNe error code to the top-level request handler. |
+| `EnvLoader` | Minimal dotenv-style loader for CLI setup commands. |
+| `ErrorCode` | — |
+| `GenerateSchemaSqlCommand` | — |
+| `InitSqliteCommand` | — |
+| `Initialize` | — |
+| `PdoConnection` | — |
+| `SchemaCompiler` | Compile {@see SchemaDefinition} into MySQL and SQLite DDL. |
+| `SchemaDefinition` | NeNe's sample-schema source of truth. |
+| `SchemaDiffCommand` | — |
+| `SchemaDiffer` | Schema-diff engine — compares a live database introspection against |
+| `SessionHandlerFactory` | — |
+| `SetupDatabaseCommand` | — |
+| `SystemSetting` | typed global application settings store. |
+| `TenantConfig` | per-tenant key-value configuration store. |
 
 ---
 
@@ -319,25 +336,26 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `ControllerBase` | Base class for all controllers |
-| `Cursor` | Cursor-based pagination token |
-| `CursorPage` | Cursor-paginated result set metadata |
-| `Dispatcher` | Front controller / request dispatcher |
-| `HttpEmitter` | HTTP response emitter |
-| `HttpResponse` | Mutable HTTP response builder |
-| `HttpTermination` | Request/response pipeline termination helpers |
-| `JsonResponder` | JSON response shortcut helpers |
-| `ModelBase` | Base class for models |
-| `OffsetPage` | Paginated result with offset-based (page number) navigation |
-| `QueryString` | Query string parsing and building helpers |
-| `RedirectGuard` | Open-redirect guard |
-| `Request` | HTTP request wrapper |
-| `RequestVariables` | Typed request variable extraction |
-| `ResponseDecorator` | Cross-cutting response decoration for PHP-generated responses |
-| `RouteContext` | Matched route context container |
-| `UrlParameter` | URL parameter helpers |
-| `View` | Template/view renderer |
+| `ControllerBase` | — |
+| `Cursor` | — |
+| `CursorPage` | — |
+| `Dispatcher` | — |
+| `HttpEmitter` | — |
+| `HttpResponse` | — |
+| `HttpTermination` | — |
+| `JsonResponder` | — |
+| `ModelBase` | — |
+| `OffsetPage` | Paginated result set with offset-based (page number) navigation metadata. |
+| `QueryString` | — |
+| `RedirectGuard` | Open-redirect guard for controllers that need to redirect to an |
+| `Request` | — |
+| `RequestVariables` | — |
+| `ResponseDecorator` | Cross-cutting response decoration that every PHP-generated response |
+| `RouteContext` | — |
+| `UrlParameter` | — |
+| `View` | — |
 
 ---
 
-*Generated from PHPDoc descriptions. Run `ls class/xion/` for the authoritative file list.*
+*Generated from PHPDoc descriptions. Run `composer xion:index` to refresh after adding classes.*
+

--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,15 @@
         "test:all": "phpunit",
         "analyze": "phan --allow-polyfill-parser --load-baseline .phan/baseline.php",
         "analyze:file": "bash tools/phan-file.sh",
+        "make:xion": "@php tools/make-xion.php",
+        "xion:index": "@php tools/xion-index.php",
         "format": "php-cs-fixer fix --config=.php-cs-fixer.dist.php",
         "format:check": "php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff",
+        "precommit": [
+            "@format",
+            "@analyze",
+            "@test"
+        ],
         "check": [
             "@test",
             "@test:http",

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "analyze:file": "bash tools/phan-file.sh",
         "make:xion": "@php tools/make-xion.php",
         "xion:index": "@php tools/xion-index.php",
+        "ft:done": "@php tools/ft-done.php",
         "format": "php-cs-fixer fix --config=.php-cs-fixer.dist.php",
         "format:check": "php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff",
         "precommit": [

--- a/tools/ft-done.php
+++ b/tools/ft-done.php
@@ -1,0 +1,158 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Mark an FT as done across the three tracking documents.
+ *
+ * Usage:
+ *   php tools/ft-done.php FT265 UserWidget "short description" 712
+ *   composer ft:done -- FT265 UserWidget "short description" 712
+ *
+ * Updates:
+ *   docs/todo/current.md           — advances FT count + date in status line
+ *   docs/field-trials/candidates.md — prepends archive entry
+ *   docs/roadmap.md                — advances FT count + date in status line
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    exit(1);
+}
+
+// ── Argument parsing ──────────────────────────────────────────────────────────
+
+$ftRaw  = $argv[1] ?? null;
+$class  = $argv[2] ?? null;
+$desc   = $argv[3] ?? null;
+$prRaw  = $argv[4] ?? null;
+
+if ($ftRaw === null || $class === null || $desc === null || $prRaw === null) {
+    fwrite(STDERR, "Usage: php tools/ft-done.php FT265 ClassName \"description\" 712\n");
+    fwrite(STDERR, "  FT265    — FT number (with or without 'FT' prefix)\n");
+    fwrite(STDERR, "  ClassName — PascalCase class name\n");
+    fwrite(STDERR, "  \"desc\"   — one-line description (quote it)\n");
+    fwrite(STDERR, "  712      — merged PR number\n");
+    exit(1);
+}
+
+// Normalise FT number
+$ftNum = (int) ltrim($ftRaw, 'FTft');
+if ($ftNum < 1) {
+    fwrite(STDERR, "Error: FT number must be a positive integer (got: {$ftRaw})\n");
+    exit(1);
+}
+$ftLabel = "FT{$ftNum}";
+
+$prNum = (int) ltrim($prRaw, '#');
+if ($prNum < 1) {
+    fwrite(STDERR, "Error: PR number must be a positive integer (got: {$prRaw})\n");
+    exit(1);
+}
+
+$today = date('Y-m-d');
+
+// ── File paths ────────────────────────────────────────────────────────────────
+
+$root         = dirname(__DIR__);
+$todoPath     = "{$root}/docs/todo/current.md";
+$candidatePath = "{$root}/docs/field-trials/candidates.md";
+$roadmapPath  = "{$root}/docs/roadmap.md";
+
+foreach ([$todoPath, $candidatePath, $roadmapPath] as $path) {
+    if (!file_exists($path)) {
+        fwrite(STDERR, "Error: not found — {$path}\n");
+        exit(1);
+    }
+}
+
+// ── 1. docs/todo/current.md ──────────────────────────────────────────────────
+//
+// Target line (in ## Active):
+//   "... As of YYYY-MM-DD: all non-promotion Issues are closed;
+//    FT1–FT264 are complete ..."
+//
+// Replace "FT1–FT\d+ are complete" and "As of YYYY-MM-DD:" in that line only.
+
+$todo = (string) file_get_contents($todoPath);
+
+// Update FT count in the active-section status line (matches "FT1–FTn are complete")
+$todoNew = (string) preg_replace(
+    '/FT1–FT\d+\s+are complete/',
+    "FT1–{$ftLabel} are complete",
+    $todo,
+    1   // first occurrence only (the active-section line)
+);
+
+// Update date in the same line
+$todoNew = (string) preg_replace(
+    '/As of \d{4}-\d{2}-\d{2}:/',
+    "As of {$today}:",
+    $todoNew,
+    1
+);
+
+if ($todoNew === $todo) {
+    fwrite(STDERR, "Warning: docs/todo/current.md — no pattern matched, file unchanged\n");
+} else {
+    file_put_contents($todoPath, $todoNew);
+    echo "  docs/todo/current.md           updated (FT1–{$ftLabel})\n";
+}
+
+// ── 2. docs/field-trials/candidates.md ───────────────────────────────────────
+//
+// Prepend a new archive entry just after the "archive trail" header + blank
+// line:
+//
+//   ## Recently picked-up (archive trail)
+//   <blank>
+//   When a candidate...
+//   <blank>
+//   - **FT264 — ...  ← insert new line here
+
+$candidates = (string) file_get_contents($candidatePath);
+
+$archiveLine = "- **{$ftLabel} — {$class}** ({$today}):"
+             . " `Nene\\Xion\\{$class}` — {$desc}. PR #{$prNum}.";
+
+// Insert before the first "- **FT" line in the archive section
+$candidatesNew = (string) preg_replace(
+    '/^(- \*\*FT\d+)/m',
+    $archiveLine . "\n" . '$1',
+    $candidates,
+    1
+);
+
+if ($candidatesNew === $candidates) {
+    fwrite(STDERR, "Warning: docs/field-trials/candidates.md — no archive line found, appending\n");
+    // Fall back: append to end of file
+    $candidatesNew = rtrim($candidates) . "\n" . $archiveLine . "\n";
+}
+
+file_put_contents($candidatePath, $candidatesNew);
+echo "  docs/field-trials/candidates.md updated (prepended {$ftLabel})\n";
+
+// ── 3. docs/roadmap.md ───────────────────────────────────────────────────────
+//
+// Target line (in ## 7. Field Trials):
+//   "Status: ... FT1–FT264 complete as of YYYY-MM-DD ..."
+
+$roadmap = (string) file_get_contents($roadmapPath);
+
+$roadmapNew = (string) preg_replace(
+    '/FT1–FT\d+\s+complete as of \d{4}-\d{2}-\d{2}/',
+    "FT1–{$ftLabel} complete as of {$today}",
+    $roadmap,
+    1
+);
+
+if ($roadmapNew === $roadmap) {
+    fwrite(STDERR, "Warning: docs/roadmap.md — no pattern matched, file unchanged\n");
+} else {
+    file_put_contents($roadmapPath, $roadmapNew);
+    echo "  docs/roadmap.md                updated (FT1–{$ftLabel})\n";
+}
+
+// ── Done ──────────────────────────────────────────────────────────────────────
+
+echo "\n✓ {$ftLabel} — {$class} marked done (PR #{$prNum})\n";

--- a/tools/make-xion.php
+++ b/tools/make-xion.php
@@ -113,15 +113,26 @@ PHP;
 file_put_contents($classFile, $classBody . "\n");
 file_put_contents($testFile,  $testBody  . "\n");
 
+// ── Register in INDEX.md ──────────────────────────────────────────────────────
+
+$indexScript = __DIR__ . '/xion-index.php';
+if (file_exists($indexScript)) {
+    passthru("php {$indexScript}", $indexExit);
+    if ($indexExit !== 0) {
+        fwrite(STDERR, "Warning: xion-index.php exited with code {$indexExit}\n");
+    }
+}
+
 // ── Summary ───────────────────────────────────────────────────────────────────
 
 echo "Created:\n";
 echo "  class/xion/{$name}.php\n";
 echo "  tests/Unit/Xion/{$name}Test.php\n";
+echo "  class/xion/INDEX.md updated (Uncategorized)\n";
 echo "\n";
 echo "Next steps:\n";
 echo "  1. Edit the class body and add your public methods\n";
 echo "  2. Add the table DDL to class/xion/SchemaDefinition.php\n";
-echo "  3. Add an entry to class/xion/INDEX.md  (or run: composer xion:index)\n";
+echo "  3. Move the Uncategorized entry in class/xion/INDEX.md to the right section\n";
 echo "  4. Write your tests\n";
 echo "  5. composer analyze:file -- class/xion/{$name}.php tests/Unit/Xion/{$name}Test.php\n";

--- a/tools/make-xion.php
+++ b/tools/make-xion.php
@@ -1,0 +1,127 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Scaffold a new Xion class + matching test file.
+ *
+ * Usage:
+ *   php tools/make-xion.php ClassName
+ *   composer make:xion -- ClassName
+ *
+ * Creates:
+ *   class/xion/ClassName.php          — PDO injection skeleton
+ *   tests/Unit/Xion/ClassNameTest.php — in-memory SQLite test skeleton
+ */
+
+declare(strict_types=1);
+
+// ── CLI guard ────────────────────────────────────────────────────────────────
+
+if (PHP_SAPI !== 'cli') {
+    exit(1);
+}
+
+$name = $argv[1] ?? null;
+
+if ($name === null || !preg_match('/^[A-Z][A-Za-z0-9]+$/', $name)) {
+    fwrite(STDERR, "Usage: php tools/make-xion.php ClassName\n");
+    fwrite(STDERR, "  ClassName must be PascalCase (e.g. UserWidget)\n");
+    exit(1);
+}
+
+// ── Paths ────────────────────────────────────────────────────────────────────
+
+$root     = dirname(__DIR__);
+$classFile = "{$root}/class/xion/{$name}.php";
+$testFile  = "{$root}/tests/Unit/Xion/{$name}Test.php";
+
+foreach ([$classFile, $testFile] as $path) {
+    if (file_exists($path)) {
+        fwrite(STDERR, "Error: already exists — {$path}\n");
+        exit(1);
+    }
+}
+
+// ── Templates ────────────────────────────────────────────────────────────────
+
+$classBody = <<<PHP
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use Nene\Database\PdoConnection;
+use PDO;
+
+/**
+ * {$name} — TODO: one-line description.
+ */
+final class {$name}
+{
+    public function __construct(private readonly ?PDO \$db = null) {}
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    // TODO: implement methods
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return \$this->db ?? PdoConnection::getInstance();
+    }
+}
+PHP;
+
+// Convert PascalCase to snake_case for the default table name hint
+$snake = strtolower(preg_replace('/[A-Z]/', '_$0', lcfirst($name)) ?? $name);
+
+$testBody = <<<PHP
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Xion;
+
+use Nene\Xion\\{$name};
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class {$name}Test extends TestCase
+{
+    private PDO \$pdo;
+
+    protected function setUp(): void
+    {
+        \$this->pdo = new PDO('sqlite::memory:');
+        \$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        \$this->pdo->exec('
+            CREATE TABLE {$snake} (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+    }
+
+    // TODO: add tests
+}
+PHP;
+
+// ── Write ─────────────────────────────────────────────────────────────────────
+
+file_put_contents($classFile, $classBody . "\n");
+file_put_contents($testFile,  $testBody  . "\n");
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+echo "Created:\n";
+echo "  class/xion/{$name}.php\n";
+echo "  tests/Unit/Xion/{$name}Test.php\n";
+echo "\n";
+echo "Next steps:\n";
+echo "  1. Edit the class body and add your public methods\n";
+echo "  2. Add the table DDL to class/xion/SchemaDefinition.php\n";
+echo "  3. Add an entry to class/xion/INDEX.md  (or run: composer xion:index)\n";
+echo "  4. Write your tests\n";
+echo "  5. composer analyze:file -- class/xion/{$name}.php tests/Unit/Xion/{$name}Test.php\n";

--- a/tools/xion-index.php
+++ b/tools/xion-index.php
@@ -103,6 +103,13 @@ foreach ($classDesc as $cls => $_) {
     }
 }
 
+// Remove any existing empty Uncategorized section first (table has no data rows)
+$updated = (string)preg_replace(
+    '/\n---\n\n## Uncategorized\n\n_[^\n]+_\n\n\| Class \| Description \|\n\|[-| ]+\|\n\n?/s',
+    "\n",
+    $updated
+);
+
 if ($newClasses !== []) {
     // Strip trailing newlines then append the section
     $updated = rtrim($updated) . "\n\n";

--- a/tools/xion-index.php
+++ b/tools/xion-index.php
@@ -1,0 +1,137 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Regenerate class/xion/INDEX.md.
+ *
+ * - Updates descriptions of existing entries from each class's PHPDoc.
+ * - Removes entries whose class file no longer exists.
+ * - Appends newly discovered classes to an "## Uncategorized" section.
+ * - Preserves all section headings, category order, and table structure.
+ *
+ * Usage:
+ *   php tools/xion-index.php
+ *   composer xion:index
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    exit(1);
+}
+
+$root      = dirname(__DIR__);
+$indexPath = "{$root}/class/xion/INDEX.md";
+
+// ── Load existing INDEX ───────────────────────────────────────────────────────
+
+if (!file_exists($indexPath)) {
+    fwrite(STDERR, "Error: {$indexPath} not found\n");
+    exit(1);
+}
+
+$original = file_get_contents($indexPath);
+assert(is_string($original));
+
+// ── Discover all current class files ─────────────────────────────────────────
+
+/** @var array<string,string> $classDesc  className => description */
+$classDesc = [];
+
+foreach (glob("{$root}/class/xion/*.php") ?: [] as $file) {
+    $base = basename($file, '.php');
+    $src  = (string)file_get_contents($file);
+
+    $desc = '';
+    // First non-empty, non-tag docblock line
+    if (preg_match('#/\*\*\s*\n\s*\*\s*([^\n@*][^\n]+?)\s*\n#', $src, $m)) {
+        $desc = trim($m[1]);
+        $desc = ltrim($desc, '* ');
+        // Strip "ClassName — " prefix if present
+        $desc = (string)preg_replace('/^' . preg_quote($base, '/') . '\s*[—–-]\s*/u', '', $desc);
+        // Discard placeholder descriptions
+        if (str_contains($desc, 'AYANE') || strlen($desc) < 5) {
+            $desc = '';
+        }
+    }
+
+    $classDesc[$base] = $desc !== '' ? $desc : '—';
+}
+
+// ── Classes already mentioned in the INDEX ────────────────────────────────────
+
+$mentionedPattern = '/^\|\s*`([A-Za-z0-9]+)`\s*\|/m';
+preg_match_all($mentionedPattern, $original, $matches);
+/** @var string[] $mentioned */
+$mentioned = $matches[1];
+
+// ── Update description for each existing row ─────────────────────────────────
+
+$updated  = $original;
+$removed  = [];
+$outdated = [];
+
+foreach ($mentioned as $cls) {
+    if (!isset($classDesc[$cls])) {
+        // Class file deleted — mark for removal
+        $removed[] = $cls;
+        $updated = (string)preg_replace(
+            '/^\|[^\n]*`' . preg_quote($cls, '/') . '`[^\n]*\n/m',
+            '',   // remove the row
+            $updated
+        );
+        continue;
+    }
+
+    // Replace description column
+    $newRow  = "| `{$cls}` | {$classDesc[$cls]} |";
+    $updated = (string)preg_replace(
+        '/^\|\s*`' . preg_quote($cls, '/') . '`\s*\|[^\n]*/m',
+        $newRow,
+        $updated
+    );
+}
+
+// ── Append newly discovered classes ──────────────────────────────────────────
+
+$mentionedSet = array_flip($mentioned);
+/** @var string[] $newClasses */
+$newClasses = [];
+foreach ($classDesc as $cls => $_) {
+    if (!isset($mentionedSet[$cls])) {
+        $newClasses[] = $cls;
+    }
+}
+
+if ($newClasses !== []) {
+    // Strip trailing newlines then append the section
+    $updated = rtrim($updated) . "\n\n";
+    $updated .= "---\n\n## Uncategorized\n\n";
+    $updated .= "_Move these rows to the appropriate section above._\n\n";
+    $updated .= "| Class | Description |\n";
+    $updated .= "|-------|-------------|\n";
+    foreach ($newClasses as $cls) {
+        $updated .= "| `{$cls}` | {$classDesc[$cls]} |\n";
+    }
+    $updated .= "\n";
+}
+
+// ── Write output ──────────────────────────────────────────────────────────────
+
+file_put_contents($indexPath, $updated);
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+$countExisting = count($mentioned) - count($removed);
+echo "class/xion/INDEX.md updated\n";
+echo "  " . count($classDesc) . " classes in class/xion/\n";
+echo "  {$countExisting} existing entries refreshed\n";
+
+if ($removed !== []) {
+    echo "  removed (class deleted): " . implode(', ', $removed) . "\n";
+}
+
+if ($newClasses !== []) {
+    echo "  added to Uncategorized: " . implode(', ', $newClasses) . "\n";
+    echo "  → Move them to the correct section in class/xion/INDEX.md\n";
+}


### PR DESCRIPTION
## Summary

Round 3 of DX improvements — builds on #711 (already merged into `chore/dx-improvements`).

### Changes

| File | What |
|---|---|
| `tools/ft-done.php` | `composer ft:done -- FT265 ClassName "desc" 712` → updates 3 doc files at once |
| `tools/make-xion.php` | Now auto-calls `xion-index.php` after scaffolding |
| `tools/xion-index.php` | Removes empty Uncategorized section automatically |
| `composer.json` | `ft:done` alias added |
| `CLAUDE.md` | Documents ft:done and updated make:xion behaviour |

### `composer ft:done` — what it updates

```
composer ft:done -- FT265 UserWidget "short description" 712
```

| File | Change |
|---|---|
| `docs/todo/current.md` | `FT1–FT264 are complete` → `FT1–FT265` + updates date |
| `docs/field-trials/candidates.md` | Prepends archive entry at top of trail |
| `docs/roadmap.md` | `FT1–FT264 complete as of …` → `FT1–FT265` + updates date |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)