### PR TITLE
docs(dx): tools/README update, mandatory FT report rules, xion report template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,39 @@ composer make:xion -- ClassName
 ```
 
 Creates `class/xion/ClassName.php` + `tests/Unit/Xion/ClassNameTest.php` with
-the PDO injection skeleton. Then:
+the PDO injection skeleton, **and automatically adds the class to the
+Uncategorized section of `class/xion/INDEX.md`**. Then:
 
 1. Fill in the public API and table DDL
 2. Add the table to `class/xion/SchemaDefinition.php`
-3. Run `composer xion:index` to refresh the class index
+3. Move the Uncategorized entry in `class/xion/INDEX.md` to the right section
 4. Run `composer analyze:file -- class/xion/ClassName.php tests/Unit/Xion/ClassNameTest.php`
+
+---
+
+## Completing an FT
+
+**Every FT must have a report file.** The archive trail entry in `candidates.md` is a one-line index pointer, not a substitute. An FT without a report file is not finished.
+
+```bash
+# 1. Create the report file (before or after merging)
+bash tools/ft-report-new.sh 265 ClassName --xion   # Xion helper → Format B (~50 lines)
+bash tools/ft-report-new.sh 18  topic-name          # Exploratory trial → Format A
+
+# 2. After the PR merges, update three tracking docs
+composer ft:done -- FT265 ClassName "one-line description" 712
+```
+
+`composer ft:done` updates:
+
+| File | Change |
+|---|---|
+| `docs/todo/current.md` | Advances `FT1–FT264 are complete` → `FT1–FT265` + date |
+| `docs/field-trials/candidates.md` | Prepends archive entry |
+| `docs/roadmap.md` | Advances `FT1–FT264 complete as of …` → `FT1–FT265` + date |
+
+**FT76–FT264** had no report files — process gap, not an approved exception.  
+**FT265 onward**: report file required, no exceptions.
 
 ---
 

--- a/docs/field-trials/README.md
+++ b/docs/field-trials/README.md
@@ -55,16 +55,50 @@ When a trial uncovers framework or documentation changes, those changes are made
 - Clone directories are named `ft{N}-{topic}` (lowercase, hyphenated topic). `N` matches the report number.
 - Each trial gets exactly one report file. Follow-up work that traces back to a trial is tracked through GitHub Issues, not by editing the report after the fact.
 
-## What to Record
+## Report Requirement — Every FT Must Have a Report File
 
-A trial report should be readable cold by someone who was not present for the trial. The required sections live in `docs/templates/field-trial-report.md`. The important parts are:
+**Every completed FT must have a report file in `docs/field-trials/`.** The archive trail entry in `candidates.md` is a one-line index pointer, not a substitute for the report. An FT without a report file is not considered finished.
 
-- **Baseline**: which NeNe commit, tag, or release was cloned, PHP version, DB, and any other environmental facts that would change the result.
+Two formats are recognized. Choose based on trial type.
+
+### Format A — Full exploratory report
+
+Use when: the trial is open-ended, friction was encountered, an ADR was triggered, or the outcome was unexpected.
+
+Template: `docs/templates/field-trial-report.md`  
+Create with: `tools/ft-report-new.sh FT{N} {topic}`
+
+Required sections:
+
+- **Baseline**: NeNe commit/ref, PHP version, DB, environment facts that affect reproducibility.
 - **Goal**: one or two sentences on what this trial is verifying.
-- **Steps Taken**: the actual flow of work, with `Finding (F-N)` notes embedded where friction occurred. Friction notes are the most valuable part of the report.
-- **Friction Summary**: a single table with one row per `F-N`, including location, severity (high / medium / low), kind, and decision.
-- **Recommendations**: grouped as immediate (documentation fix only), suggested (small framework or template change), and trade-off (changes that require an ADR or stakeholder discussion).
-- **Overall Impression**: a short paragraph. Useful for orienting future readers; not a marketing summary.
+- **Steps Taken**: the actual flow of work with `Finding (F-N)` notes embedded where friction occurred.
+- **Friction Summary**: one row per `F-N` — location, severity, kind, decision.
+- **Recommendations**: immediate / suggested / trade-off.
+- **Overall Impression**: one short paragraph.
+
+### Format B — Xion class report (lightweight)
+
+Use when: the trial adds one Xion helper class with no unexpected friction, no ADR trigger, and no open follow-up Issues.
+
+Template: `docs/templates/field-trial-report-xion.md`  
+Create with: `tools/ft-report-new.sh FT{N} {ClassName}`
+
+Required sections:
+
+- **Date / Branch / Baseline** (header block, three lines).
+- **Goal**: one sentence.
+- **What was built**: class name, public API table (method → description), key design points, test list.
+- **Findings**: `F-1 — No finding (clean trial)` if clean; otherwise one row per finding with kind and decision.
+- **Decision**: one line — merge as-is, or list follow-up Issues.
+
+Minimum length: ~50 lines. A report shorter than that is missing something.
+
+### Historical note
+
+FT1–FT75 used Format A (full reports, 60–225 lines each).  
+FT76–FT264 were completed with archive trail entries only — **this was a process gap**, not an approved exception. Those 189 trials are documented only at the archive-trail level. Future trials must not repeat this pattern.  
+FT265 onward: Format B minimum, Format A when warranted.
 
 ### Friction Kinds
 

--- a/docs/templates/field-trial-report-xion.md
+++ b/docs/templates/field-trial-report-xion.md
@@ -1,0 +1,63 @@
+# Field Trial {N} — {ClassName}
+
+**Date**: {YYYY-MM-DD}
+**Branch**: `feat/ft{N}-{topic}`
+**Baseline**: post FT{N-1} merge
+
+## Goal
+
+Add `Nene\Xion\{ClassName}` — {one-sentence description of what the class does}.
+
+## What was built
+
+### `Nene\Xion\{ClassName}` (`class/xion/{ClassName}.php`)
+
+{One or two sentences on the design intent.}
+
+| Method | Description |
+| --- | --- |
+| `method(args): return` | What it does. |
+
+Key design points:
+
+- **{Point 1}**: {explanation}.
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/{ClassName}Test.php`)
+
+{N} unit tests covering:
+
+- {test method description}
+- {test method description}
+
+### Howto (`docs/development/{topic}.md`)
+
+Covers: {list main sections}.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`{ClassName}` is a clean `Nene\Xion` helper. {N} tests pass; CS Fixer and Phan clean.
+
+<!--
+If friction was found, replace F-1 with one section per finding:
+
+### F-1 — {Short title}
+
+**Kind**: docs-gap | feature-gap | design-trade-off | legacy-preserved | process-gap
+**Severity**: high | medium | low
+**Decision**: fix-in-framework | document | keep-legacy | defer
+
+{Description of what happened and why it matters.}
+-->
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.
+
+<!--
+If follow-up Issues were opened:
+
+Opened follow-up Issues: #{issue1}, #{issue2}.
+-->

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,9 +11,24 @@ Single-purpose scripts that make NeNe's day-to-day workflow less typing-heavy. E
 | `tools/wait-healthy.sh [port] [timeout]` | Block until `/health` returns 200, with a timeout. | After `docker compose up -d app`, before running curl probes. |
 | `tools/trial-status.sh <FT-N>` | List every Issue + PR mentioning a trial number, open and closed. | Closing-out check: "is every spawned Issue closed?" |
 | `php tools/error-code-add.php CODE "Message" <http-status> ["notes"]` | Insert a new error code into both `config/error_codes.php` and `docs/development/error-codes.md` atomically. | Adding an error code without the manual two-file dance. |
+| `php tools/make-xion.php ClassName` | Scaffold `class/xion/ClassName.php` + `tests/Unit/Xion/ClassNameTest.php` with PDO injection skeleton; auto-registers in `class/xion/INDEX.md`. | Starting a new Xion helper class. |
+| `php tools/xion-index.php` | Regenerate `class/xion/INDEX.md` from PHPDoc. Updates descriptions, removes stale entries, adds new classes to Uncategorized. | After editing a Xion class PHPDoc description. |
+| `php tools/ft-done.php FT265 ClassName "desc" 712` | Update `docs/todo/current.md`, `docs/field-trials/candidates.md`, and `docs/roadmap.md` in one shot after merging an FT PR. | After every merged Xion FT PR. |
 | `tools/test-http-preflight.php` | Print a one-line summary of the HTTP smoke target before PHPUnit runs. | Called automatically by `composer test:http`. |
 
 ## Composer scripts (in `composer.json`)
+
+### Pre-push checklist
+
+```bash
+composer precommit    # format → analyze (full Phan) → unit tests — run before every push
+```
+
+`composer precommit` is the right command for day-to-day local verification. It runs everything that can fail CI, in the order that catches problems fastest.
+
+`composer ci` runs the full CI suite including HTTP smoke tests (requires Docker). Use it when changing HTTP-layer code or verifying a release candidate; it is slower and not needed for every push.
+
+### All scripts
 
 | Script | What it does |
 | --- | --- |
@@ -24,15 +39,20 @@ Single-purpose scripts that make NeNe's day-to-day workflow less typing-heavy. E
 | `composer test` | Unit tests (`phpunit --testsuite unit`). |
 | `composer test:http` | HTTP smoke tests (`phpunit --testsuite http`). |
 | `composer test:all` | Both suites. |
-| `composer analyze` | Static analysis (Phan + baseline). |
+| `composer analyze` | Full static analysis — Phan + baseline (~40 s). Same as CI. |
+| `composer analyze:file -- a.php b.php` | Targeted Phan analysis for one or a few files (~14 s). Use before pushing a new Xion class. |
 | `composer format` | Apply PHP CS Fixer. |
 | `composer format:check` | Dry-run PHP CS Fixer (CI gate). |
-| `composer check` | `test` + `test:http` + `analyze`. (Excludes `format:check` — see `composer ci`.) |
-| **`composer ci`** | **`test` + `test:http` + `analyze` + `format:check`** — runs exactly what CI runs. Use this before pushing. |
+| **`composer precommit`** | **format → analyze → test** — run before every push. |
+| `composer make:xion -- ClassName` | Scaffold a new Xion class + test file + INDEX registration. |
+| `composer xion:index` | Regenerate `class/xion/INDEX.md` from PHPDoc. |
+| `composer ft:done -- FT265 Foo "desc" 712` | Update three tracking docs after merging an FT PR. |
+| `composer check` | `test` + `test:http` + `analyze`. |
+| `composer ci` | `test` + `test:http` + `analyze` + `format:check` — full CI suite including Docker HTTP tests. |
 
 ### Argument passthrough
 
-Composer 2 forwards everything after `--` to the underlying tool. The most useful case:
+Composer 2 forwards everything after `--` to the underlying tool:
 
 ```bash
 # Run a single HTTP smoke test class
@@ -43,9 +63,10 @@ composer test -- --filter SchemaDifferTest
 
 # Run a single method
 composer test -- --filter 'SchemaDifferTest::testNewIndexEmitsCreateIndex'
-```
 
-The preflight in `test:http` silently ignores extra args, so the same pattern works for both suites.
+# Analyse specific files (fast Phan, ~14 s)
+composer analyze:file -- class/xion/Foo.php tests/Unit/Xion/FooTest.php
+```
 
 ## Shared composer cache
 
@@ -62,5 +83,5 @@ Each project's `vendor/` directory stays per-project (composer.lock may differ b
 
 1. Drop the script in `tools/`. PHP for anything that touches PHP source / config files; bash for shell glue.
 2. Add a one-line entry in the **Quick reference** table above.
-3. If the script ergonomically wraps a `composer` step, also add a composer script alias in `composer.json`.
+3. Add a row to the **All scripts** table if it wraps a `composer` step.
 4. Keep tools single-purpose. A script that does three unrelated things should be three scripts.

--- a/tools/ft-report-new.sh
+++ b/tools/ft-report-new.sh
@@ -1,26 +1,27 @@
 #!/usr/bin/env bash
 #
-# Bootstrap a Field Trial report file from the canonical template.
+# Bootstrap a Field Trial report file from a template.
 #
 # Usage:
-#   tools/ft-report-new.sh <FT-number> <topic-kebab>
+#   tools/ft-report-new.sh <FT-number> <topic-kebab> [--xion]
 #
 # Examples:
-#   tools/ft-report-new.sh 18 session-storage-backend
-#   tools/ft-report-new.sh 19 structured-logs
+#   tools/ft-report-new.sh 265 daily-streak --xion   # Xion class report (Format B, ~50 lines)
+#   tools/ft-report-new.sh 18  session-storage        # Full exploratory report (Format A)
+#
+# Templates:
+#   (default)  docs/templates/field-trial-report.md       — Format A, full exploratory
+#   --xion     docs/templates/field-trial-report-xion.md  — Format B, Xion helper class
 #
 # What it does:
-#   1. Copies `docs/templates/field-trial-report.md` to
+#   1. Copies the selected template to
 #      `docs/field-trials/YYYY-MM-field-trial-<N>.md`.
-#   2. Substitutes `{N}` → trial number and `{topic}` → topic name
-#      in the heading line.
-#   3. Fills the `YYYY-MM-DD` placeholder under `## Date` with today's date.
-#   4. Refuses to overwrite an existing file (so re-running on the same
-#      trial does not blow away in-progress notes).
+#   2. Substitutes `{N}` → trial number and `{topic}` → topic name.
+#   3. Fills `{YYYY-MM-DD}` with today's date.
+#   4. Refuses to overwrite an existing file.
 #
-# Why this exists:
-#   Every FT report uses the same skeleton, so writing each one from
-#   scratch wastes the first 5 minutes of the wrap-up step.
+# Every FT MUST have a report file — the archive trail entry in
+# candidates.md is an index pointer, not a substitute.
 #
 # Exit codes:
 #   0  report created
@@ -37,18 +38,26 @@ fi
 
 ft_num="$1"
 topic="$2"
+xion_mode=0
+if [[ "${3:-}" == "--xion" ]]; then
+    xion_mode=1
+fi
 
 if ! [[ "$ft_num" =~ ^[0-9]+$ ]]; then
     echo "error: FT number must be numeric (got: $ft_num)" >&2
     exit 1
 fi
-if ! [[ "$topic" =~ ^[a-z][a-z0-9-]*$ ]]; then
-    echo "error: topic must be kebab-case lowercase (got: $topic)" >&2
+if ! [[ "$topic" =~ ^[a-zA-Z][a-zA-Z0-9-]*$ ]]; then
+    echo "error: topic must be kebab-case or PascalCase (got: $topic)" >&2
     exit 1
 fi
 
 framework_root="$(cd "$(dirname "$0")/.." && pwd)"
-template="$framework_root/docs/templates/field-trial-report.md"
+if [[ $xion_mode -eq 1 ]]; then
+    template="$framework_root/docs/templates/field-trial-report-xion.md"
+else
+    template="$framework_root/docs/templates/field-trial-report.md"
+fi
 year_month="$(date +%Y-%m)"
 today="$(date +%Y-%m-%d)"
 target="$framework_root/docs/field-trials/${year_month}-field-trial-${ft_num}.md"
@@ -63,14 +72,19 @@ if [[ -e "$target" ]]; then
 fi
 
 # Substitute placeholders:
-#   {N}      → trial number
-#   {topic}  → topic (keep the topic line literal until the author fills it)
-#   The `YYYY-MM-DD` literal under `## Date` → today's date (first occurrence only)
-awk -v num="$ft_num" -v topic="$topic" -v today="$today" '
+#   {N}          → trial number
+#   {N-1}        → trial number minus one
+#   {topic}      → topic string
+#   {YYYY-MM-DD} → today's date (braced form used in xion template)
+#   YYYY-MM-DD   → today's date (bare form used in full-report template, first occurrence)
+prev_num=$(( ft_num - 1 ))
+awk -v num="$ft_num" -v prev="$prev_num" -v topic="$topic" -v today="$today" '
     BEGIN { date_replaced = 0 }
     {
         gsub(/\{N\}/, num)
+        gsub(/\{N-1\}/, prev)
         gsub(/\{topic\}/, topic)
+        gsub(/\{YYYY-MM-DD\}/, today)
         if (!date_replaced && $0 == "YYYY-MM-DD") {
             print today
             date_replaced = 1
@@ -82,7 +96,15 @@ awk -v num="$ft_num" -v topic="$topic" -v today="$today" '
 
 echo "✓ created $target"
 echo
-echo "Next:"
-echo "  - Fill in Baseline / Goal / Service Built / Steps Taken"
-echo "  - Replace remaining {placeholders} as the trial progresses"
-echo "  - Commit via:  git checkout -b docs/<issue>-field-trial-${ft_num}-${topic}"
+if [[ $xion_mode -eq 1 ]]; then
+    echo "Format: B (Xion class report)"
+    echo "Next:"
+    echo "  - Fill in {ClassName}, API table, test list, key design points"
+    echo "  - After PR merges: composer ft:done -- FT${ft_num} {ClassName} \"desc\" {PR}"
+else
+    echo "Format: A (full exploratory report)"
+    echo "Next:"
+    echo "  - Fill in Baseline / Goal / Service Built / Steps Taken"
+    echo "  - Replace remaining {placeholders} as the trial progresses"
+fi
+echo "  - Commit via:  git checkout -b docs/ft${ft_num}-report"


### PR DESCRIPTION
## Summary

Two gaps identified in codebase review, now fixed.

### 1. `tools/README.md` was stale

Missing: `composer precommit`, `make:xion`, `xion:index`, `ft:done`, `analyze:file`.
`composer ci` was documented as the pre-push command — now clarified that `composer precommit` is the right default.

### 2. FT report requirement was unenforced

FT1–FT75 had full reports. FT76–FT264 had archive trail entries only — a process gap.

**Changes:**

| File | What |
|---|---|
| `docs/field-trials/README.md` | Define two formats (A: exploratory, B: Xion class); make report file mandatory; document FT76–FT264 gap explicitly |
| `docs/templates/field-trial-report-xion.md` | New Format B template for Xion helper FTs (~50 lines) |
| `tools/ft-report-new.sh` | `--xion` flag selects Format B; fix `{YYYY-MM-DD}` and `{N-1}` substitution |
| `CLAUDE.md` | Add FT completion workflow; update scaffolding section |
| `tools/README.md` | Add all new composer scripts; clarify precommit vs ci |

### FT265+ rule

```bash
# Before (or after) merging a Xion FT PR:
bash tools/ft-report-new.sh 265 ClassName --xion

# After merging:
composer ft:done -- FT265 ClassName "description" 712
```

Format B report is ~50 lines — header + API table + test list + finding + decision. Minimum, not optional.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)