### PR TITLE
feat(xion): SequenceNumber — gapless per-scope sequential numbering (FT265)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -325,6 +325,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `SchemaDefinition` | NeNe's sample-schema source of truth. |
 | `SchemaDiffCommand` | — |
 | `SchemaDiffer` | Schema-diff engine — compares a live database introspection against |
+| `SequenceNumber` | gapless sequential numbering per named scope. |
 | `SessionHandlerFactory` | — |
 | `SetupDatabaseCommand` | — |
 | `SystemSetting` | typed global application settings store. |

--- a/class/xion/SequenceNumber.php
+++ b/class/xion/SequenceNumber.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * SequenceNumber — gapless sequential numbering per named scope.
+ *
+ * Hands out monotonically increasing integers for a named scope using an
+ * atomic row-level increment, so concurrent callers never receive the same
+ * number and the sequence has no gaps. Useful for invoice numbers, order
+ * numbers, ticket numbers, and any human-facing identifier that must be
+ * sequential and unique rather than a random token or a raw auto-increment
+ * primary key.
+ *
+ * Unlike a database AUTOINCREMENT column, the counter is independent of any
+ * table's row lifecycle (deleting rows never burns numbers) and several
+ * independent sequences can live side by side, keyed by `scope`.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $seq = new SequenceNumber($pdo);
+ *
+ * // Atomic next value (1, 2, 3, ... per scope)
+ * $seq->next('invoice');                 // 1
+ * $seq->next('invoice');                 // 2
+ * $seq->next('order');                   // 1  (independent scope)
+ *
+ * // Formatted, zero-padded, with a prefix
+ * $seq->formatted('invoice', 'INV-');    // 'INV-000003'
+ * $seq->formatted('invoice', 'INV-2026-', 4); // 'INV-2026-0004'
+ *
+ * // Inspect without consuming a number
+ * $seq->peek('invoice');                 // 3
+ *
+ * // Administrative reset (e.g. yearly roll-over)
+ * $seq->reset('invoice');                // back to 0 → next() returns 1
+ * $seq->reset('invoice', 1000);          // next() returns 1001
+ * ```
+ *
+ * ## Concurrency
+ *
+ * `next()` performs the upsert+increment and the read inside a single
+ * transaction. The `current_value = current_value + 1` update takes a
+ * row-level write lock, so simultaneous callers serialise and each observes
+ * its own distinct value. If a transaction is already open, the existing one
+ * is reused rather than nested.
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE sequence_numbers (
+ *     id            INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     scope         VARCHAR(100) NOT NULL,
+ *     current_value BIGINT       NOT NULL DEFAULT 0,
+ *     updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (scope)
+ * );
+ * ```
+ */
+final class SequenceNumber
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Atomically consume and return the next value for a scope.
+     *
+     * The first call for a previously unseen scope returns 1.
+     *
+     * @param  string $scope Sequence name (e.g. 'invoice').
+     * @return int           The newly assigned value (>= 1).
+     * @throws \InvalidArgumentException if $scope is empty.
+     */
+    public function next(string $scope): int
+    {
+        $scope = $this->validateScope($scope);
+        $db    = $this->db();
+
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+
+        try {
+            DbUpsert::run(
+                $db,
+                table:        'sequence_numbers',
+                data:         ['scope' => $scope, 'current_value' => 1],
+                conflictCols: ['scope'],
+                updateExprs:  [
+                    'current_value' => 'current_value + 1',
+                    'updated_at'    => 'CURRENT_TIMESTAMP',
+                ],
+            );
+
+            $stmt = $db->prepare('SELECT current_value FROM sequence_numbers WHERE scope = ?');
+            $stmt->execute([$scope]);
+            $value = (int)$stmt->fetchColumn();
+
+            if ($ownTransaction) {
+                $db->commit();
+            }
+
+            return $value;
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Consume the next value and return it formatted with a prefix and padding.
+     *
+     * @param  string $scope  Sequence name.
+     * @param  string $prefix Literal prefix prepended to the padded number.
+     * @param  int    $pad    Minimum digit width, left-padded with zeros (>= 1).
+     * @return string         e.g. 'INV-000042'.
+     * @throws \InvalidArgumentException if $scope is empty or $pad < 1.
+     */
+    public function formatted(string $scope, string $prefix = '', int $pad = 6): string
+    {
+        if ($pad < 1) {
+            throw new \InvalidArgumentException('Pad width must be at least 1.');
+        }
+
+        $value = $this->next($scope);
+
+        return $prefix . str_pad((string)$value, $pad, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Return the current value for a scope without consuming a number.
+     *
+     * @param  string $scope Sequence name.
+     * @return int           Current value, or 0 if the scope has never been used.
+     * @throws \InvalidArgumentException if $scope is empty.
+     */
+    public function peek(string $scope): int
+    {
+        $scope = $this->validateScope($scope);
+
+        $stmt = $this->db()->prepare('SELECT current_value FROM sequence_numbers WHERE scope = ?');
+        $stmt->execute([$scope]);
+        $value = $stmt->fetchColumn();
+
+        return $value === false ? 0 : (int)$value;
+    }
+
+    /**
+     * Reset a scope's counter to a fixed value (default 0).
+     *
+     * After `reset($scope, $to)`, the next `next()` returns `$to + 1`.
+     *
+     * @param  string $scope Sequence name.
+     * @param  int    $to    Value to reset the counter to (>= 0).
+     * @throws \InvalidArgumentException if $scope is empty or $to < 0.
+     */
+    public function reset(string $scope, int $to = 0): void
+    {
+        $scope = $this->validateScope($scope);
+        if ($to < 0) {
+            throw new \InvalidArgumentException('Reset value must not be negative.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'sequence_numbers',
+            data:         ['scope' => $scope, 'current_value' => $to],
+            conflictCols: ['scope'],
+            updateCols:   ['current_value'],
+            updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validateScope(string $scope): string
+    {
+        $scope = trim($scope);
+        if ($scope === '') {
+            throw new \InvalidArgumentException('Scope must not be empty.');
+        }
+
+        return $scope;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-265.md
+++ b/docs/field-trials/2026-05-field-trial-265.md
@@ -1,0 +1,55 @@
+# Field Trial 265 — SequenceNumber
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft265-sequence-number`
+**Baseline**: post FT264 merge
+
+## Goal
+
+Add `Nene\Xion\SequenceNumber` — gapless, per-scope sequential numbering for human-facing identifiers (invoice / order / ticket numbers) that must be sequential and unique rather than random tokens or raw auto-increment primary keys.
+
+## What was built
+
+### `Nene\Xion\SequenceNumber` (`class/xion/SequenceNumber.php`)
+
+A small helper that hands out monotonically increasing integers per named `scope` using an atomic row-level increment. Independent of any table's row lifecycle (deleting rows never burns numbers) and supports many independent sequences side by side.
+
+| Method | Description |
+| --- | --- |
+| `next(scope): int` | Atomically consume and return the next value (first call returns 1). |
+| `formatted(scope, prefix='', pad=6): string` | `next()` then prefix + zero-padded, e.g. `'INV-000042'`. |
+| `peek(scope): int` | Current value without consuming (0 if scope never used). |
+| `reset(scope, to=0): void` | Reset the counter; next `next()` returns `to + 1`. |
+
+Key design points:
+
+- **Atomic increment**: `next()` runs the upsert (`current_value = current_value + 1`) and the read inside one transaction; the row-level write lock serialises concurrent callers so each gets a distinct value with no gaps.
+- **Transaction reuse**: if a transaction is already open, the existing one is reused rather than nested (`inTransaction()` guard); the helper only begins/commits/rolls back the transaction it owns.
+- **Cross-driver upsert**: uses `DbUpsert::run()` with `updateExprs` (raw `current_value + 1`) — works identically on SQLite (`ON CONFLICT … DO UPDATE`) and MySQL (`ON DUPLICATE KEY UPDATE`).
+- **PDO injection**: `__construct(private readonly ?PDO $db = null)`.
+
+### Tests (`tests/Unit/Xion/SequenceNumberTest.php`)
+
+20 unit tests (83 assertions) covering:
+
+- `next()` first value is 1, increments sequentially, gapless over 50 calls
+- independent scopes advance independently
+- scope is trimmed; empty scope throws
+- `next()` reuses an already-open transaction
+- `formatted()` prefix + default/custom padding; no truncation when value exceeds width; consumes the number; `pad < 1` throws
+- `peek()` returns 0 for unknown scope and does not consume
+- `reset()` to zero restarts at 1, to N continues at N+1, creates a missing scope; negative value and empty scope throw
+
+## Findings
+
+### F-1 — process-gap: `make:xion` scaffold emits a wrong `PdoConnection` import
+
+**Kind**: process-gap
+**Severity**: low
+**Decision**: fix-in-framework (separate PR)
+
+The `composer make:xion` template (`tools/make-xion.php`) inserts `use Nene\Database\PdoConnection;`, but `PdoConnection` lives in `Nene\Xion` (`class/xion/PdoConnection.php`). The bad import is latent: unit tests inject a PDO so `getInstance()` is never reached, but a production call with `$db === null` would fatal, and full Phan flags `PhanUndeclaredClassMethod`. Removed the import in this class to match the convention used by every other Xion class (bare `PdoConnection::getInstance()`, same namespace). Scaffold template fix tracked as a follow-up.
+
+## Decision
+
+Merge as-is. Follow-up: correct the `make:xion` scaffold import (see F-1).

--- a/tests/Unit/Xion/SequenceNumberTest.php
+++ b/tests/Unit/Xion/SequenceNumberTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\SequenceNumber;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for SequenceNumber.
+ */
+final class SequenceNumberTest extends TestCase
+{
+    private PDO $db;
+    private SequenceNumber $seq;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE sequence_numbers (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                scope         VARCHAR(100) NOT NULL,
+                current_value BIGINT       NOT NULL DEFAULT 0,
+                updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (scope)
+            )
+        ');
+        $this->seq = new SequenceNumber($this->db);
+    }
+
+    // ── next ────────────────────────────────────────────────────────────────────
+
+    public function testFirstNextReturnsOne(): void
+    {
+        $this->assertSame(1, $this->seq->next('invoice'));
+    }
+
+    public function testNextIncrementsSequentially(): void
+    {
+        $this->assertSame(1, $this->seq->next('invoice'));
+        $this->assertSame(2, $this->seq->next('invoice'));
+        $this->assertSame(3, $this->seq->next('invoice'));
+    }
+
+    public function testScopesAreIndependent(): void
+    {
+        $this->assertSame(1, $this->seq->next('invoice'));
+        $this->assertSame(2, $this->seq->next('invoice'));
+        $this->assertSame(1, $this->seq->next('order'));
+        $this->assertSame(3, $this->seq->next('invoice'));
+        $this->assertSame(2, $this->seq->next('order'));
+    }
+
+    public function testSequenceIsGaplessAfterManyCalls(): void
+    {
+        for ($i = 1; $i <= 50; $i++) {
+            $this->assertSame($i, $this->seq->next('ticket'));
+        }
+    }
+
+    public function testNextTrimsScope(): void
+    {
+        $this->assertSame(1, $this->seq->next('  invoice  '));
+        $this->assertSame(2, $this->seq->next('invoice'));
+    }
+
+    public function testNextThrowsOnEmptyScope(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->seq->next('   ');
+    }
+
+    public function testNextReusesAnOpenTransaction(): void
+    {
+        $this->db->beginTransaction();
+        $a = $this->seq->next('invoice');
+        $b = $this->seq->next('invoice');
+        $this->db->commit();
+
+        $this->assertSame(1, $a);
+        $this->assertSame(2, $b);
+        // The outer transaction having been committed by the caller, the value
+        // is durable and visible to a subsequent peek.
+        $this->assertSame(2, $this->seq->peek('invoice'));
+    }
+
+    // ── formatted ─────────────────────────────────────────────────────────────
+
+    public function testFormattedWithPrefixAndDefaultPadding(): void
+    {
+        $this->assertSame('INV-000001', $this->seq->formatted('invoice', 'INV-'));
+        $this->assertSame('INV-000002', $this->seq->formatted('invoice', 'INV-'));
+    }
+
+    public function testFormattedCustomPadding(): void
+    {
+        $this->assertSame('0001', $this->seq->formatted('order', '', 4));
+    }
+
+    public function testFormattedDoesNotPadWhenValueExceedsWidth(): void
+    {
+        $this->seq->reset('order', 12344);
+        $this->assertSame('A-12345', $this->seq->formatted('order', 'A-', 3));
+    }
+
+    public function testFormattedConsumesTheNumber(): void
+    {
+        $this->seq->formatted('invoice', 'INV-');
+        $this->assertSame(1, $this->seq->peek('invoice'));
+    }
+
+    public function testFormattedThrowsOnZeroPad(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->seq->formatted('invoice', 'INV-', 0);
+    }
+
+    // ── peek ──────────────────────────────────────────────────────────────────
+
+    public function testPeekReturnsZeroForUnknownScope(): void
+    {
+        $this->assertSame(0, $this->seq->peek('never-used'));
+    }
+
+    public function testPeekDoesNotConsume(): void
+    {
+        $this->seq->next('invoice');
+        $this->assertSame(1, $this->seq->peek('invoice'));
+        $this->assertSame(1, $this->seq->peek('invoice'));
+        $this->assertSame(2, $this->seq->next('invoice'));
+    }
+
+    public function testPeekThrowsOnEmptyScope(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->seq->peek('');
+    }
+
+    // ── reset ─────────────────────────────────────────────────────────────────
+
+    public function testResetToZeroRestartsAtOne(): void
+    {
+        $this->seq->next('invoice');
+        $this->seq->next('invoice');
+        $this->seq->reset('invoice');
+        $this->assertSame(0, $this->seq->peek('invoice'));
+        $this->assertSame(1, $this->seq->next('invoice'));
+    }
+
+    public function testResetToValueContinuesAfterThatValue(): void
+    {
+        $this->seq->reset('invoice', 1000);
+        $this->assertSame(1000, $this->seq->peek('invoice'));
+        $this->assertSame(1001, $this->seq->next('invoice'));
+    }
+
+    public function testResetCreatesScopeIfMissing(): void
+    {
+        $this->seq->reset('fresh', 5);
+        $this->assertSame(6, $this->seq->next('fresh'));
+    }
+
+    public function testResetThrowsOnNegativeValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->seq->reset('invoice', -1);
+    }
+
+    public function testResetThrowsOnEmptyScope(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->seq->reset('  ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT265** — `Nene\Xion\SequenceNumber`: gapless, per-scope sequential numbering for human-facing identifiers (invoice / order / ticket numbers) that must be sequential and unique rather than random tokens or raw auto-increment primary keys.

`next()` runs the upsert-increment and the read inside a single transaction, so concurrent callers serialise on the row-level write lock and each receives a distinct, gapless value; an already-open transaction is reused rather than nested. Cross-driver via `DbUpsert` (SQLite `ON CONFLICT` / MySQL `ON DUPLICATE KEY`).

| Method | Description |
| --- | --- |
| `next(scope): int` | Atomically consume and return the next value (first call → 1). |
| `formatted(scope, prefix='', pad=6): string` | `next()` + prefix + zero-padding, e.g. `'INV-000042'`. |
| `peek(scope): int` | Current value without consuming (0 if unused). |
| `reset(scope, to=0): void` | Reset the counter; next `next()` returns `to + 1`. |

## F-N findings

- **F-1** (low, process-gap): `composer make:xion` scaffold emits `use Nene\Database\PdoConnection;` but `PdoConnection` lives in `Nene\Xion`. Latent (tests inject PDO; production `getInstance()` path would fatal, full Phan flags it). Removed the import here to match every other Xion class → **fix-in-framework (separate PR)** for `tools/make-xion.php`.

## Aftermath plan

- Feat PR: this PR (helper lands in `class/xion/`).
- Docs PR: report at `docs/field-trials/2026-05-field-trial-265.md`; `class/xion/INDEX.md` updated (Infrastructure & DB).
- Follow-up issues: scaffold import fix (F-1).

## Test plan

- [x] 20 unit tests / 83 assertions (gapless over 50 calls, independent scopes, transaction reuse, formatted padding/overflow, peek non-consuming, reset semantics, validation throws)
- [x] `composer precommit` green (format → Phan → 4546 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)