### PR TITLE
docs: mark FT265 (SequenceNumber) complete

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -54,6 +54,7 @@ The Xion helper wave (FT78–FT264) is ongoing as of 2026-05-28. Trigger-based a
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT265 — SequenceNumber** (2026-05-29): `Nene\Xion\SequenceNumber` — gapless per-scope sequential numbering (invoice/order/ticket numbers); atomic next(); formatted() prefix+padding; peek()/reset(); cross-driver via DbUpsert. PR #717.
 - **FT264 — PasswordExpiry** (2026-05-28): `Nene\Xion\PasswordExpiry` — password expiry policy; set() resets clock; forceChange() for incidents; expiringSoon() notification cron. PR #708.
 - **FT263 — AccessLog** (2026-05-28): `Nene\Xion\AccessLog` — append-only resource access log; forResource/byActor/byAction; purgeOlderThan(). PR #707.
 - **FT262 — TextTemplate** (2026-05-28): `Nene\Xion\TextTemplate` — body-only text template for SMS/push/Slack; {{variable}} substitution; locale fallback; cross-driver upsert. PR #706.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT264 complete as of 2026-05-28 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT265 complete as of 2026-05-29 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,7 +6,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-28: all non-promotion Issues are closed; FT1–FT264 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-29: all non-promotion Issues are closed; FT1–FT265 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
 


### PR DESCRIPTION
## Summary

Post-merge documentation update for **FT265** (`SequenceNumber`, PR #717), generated by `composer ft:done`.

- `docs/todo/current.md` — `FT1–FT264 complete` → `FT1–FT265`
- `docs/roadmap.md` — same advance
- `docs/field-trials/candidates.md` — prepended FT265 archive entry

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)