### PR TITLE
chore(dx): fix make:xion scaffold template (wrong import + test namespace)

### DIFF
--- a/tools/make-xion.php
+++ b/tools/make-xion.php
@@ -51,7 +51,6 @@ declare(strict_types=1);
 
 namespace Nene\Xion;
 
-use Nene\Database\PdoConnection;
 use PDO;
 
 /**
@@ -82,7 +81,7 @@ $testBody = <<<PHP
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Xion;
 
 use Nene\Xion\\{$name};
 use PDO;


### PR DESCRIPTION
## Summary

Fixes two correctness bugs in the `composer make:xion` scaffold templates (`tools/make-xion.php`), surfaced as **FT265 F-1**:

1. **Wrong `PdoConnection` import** — the class stub emitted `use Nene\Database\PdoConnection;`, but `PdoConnection` is `Nene\Xion` (`class/xion/PdoConnection.php`). Latent bug: unit tests inject a PDO so `getInstance()` is never hit, but a production `$db === null` call would fatal, and full `composer analyze` flags `PhanUndeclaredClassMethod`. Removed — it resolves within the same namespace, matching every other Xion class.
2. **Non-PSR-4 test namespace** — the test stub used `namespace Tests\Unit\Xion;`, which the bootstrap (`Nene\Tests\` → `tests/`) does not autoload. Corrected to `Nene\Tests\Unit\Xion;`, matching the canonical majority of existing tests.

## Test plan

- [x] Scaffolded a throwaway class with the fixed template → class has `use PDO;` only; test has `namespace Nene\Tests\Unit\Xion;`
- [x] Targeted Phan on the generated files is clean (only the expected `PhanUnreferencedUseNormal` on the empty TODO test stub, which disappears once real tests are added)
- [x] Throwaway class removed; INDEX regenerated clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)