### PR TITLE
feat(xion): BusinessCalendar — working-day calendar with holidays (FT266)

### DIFF
--- a/class/xion/BusinessCalendar.php
+++ b/class/xion/BusinessCalendar.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * BusinessCalendar — working-day calendar with weekend and holiday awareness.
+ *
+ * Computes business days (excluding weekends and registered holidays) for
+ * SLA deadlines, due-date arithmetic, and "deliver in N working days" style
+ * scheduling. Several independent calendars can coexist, keyed by `calKey`
+ * (e.g. one per country or per office), so a single deployment can serve
+ * regions with different public holidays.
+ *
+ * "Business day" = Monday–Friday that is not a registered holiday. Saturday
+ * and Sunday are always non-business days; there is currently no support for
+ * regions with a non-Sat/Sun weekend (extend if a real need appears).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cal = new BusinessCalendar($pdo);
+ *
+ * // Register public holidays for a calendar
+ * $cal->addHoliday('jp', '2026-01-01', '元日');
+ * $cal->addHoliday('jp', '2026-01-12', '成人の日');
+ *
+ * // Is a given date a working day?
+ * $cal->isBusinessDay('jp', '2026-01-01'); // false (holiday)
+ * $cal->isBusinessDay('jp', '2026-01-03'); // false (Saturday)
+ * $cal->isBusinessDay('jp', '2026-01-05'); // true  (Monday)
+ *
+ * // Move forward/back by working days (skips weekends + holidays)
+ * $cal->addBusinessDays('jp', '2026-01-05', 5);   // '2026-01-13'
+ * $cal->addBusinessDays('jp', '2026-01-13', -2);  // '2026-01-08'
+ * $cal->nextBusinessDay('jp', '2026-01-01');      // '2026-01-02' (Fri, not a holiday)
+ *
+ * // Count working days in a half-open range [start, end)
+ * $cal->businessDaysBetween('jp', '2026-01-05', '2026-01-13'); // 5
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE calendar_holidays (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     cal_key      VARCHAR(50)  NOT NULL,
+ *     holiday_date CHAR(10)     NOT NULL,
+ *     label        VARCHAR(255) NOT NULL DEFAULT '',
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (cal_key, holiday_date)
+ * );
+ * ```
+ */
+final class BusinessCalendar
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── holidays ────────────────────────────────────────────────────────────────
+
+    /**
+     * Register (or relabel) a holiday for a calendar. Idempotent per date.
+     *
+     * @param  string $calKey Calendar identifier (e.g. 'jp').
+     * @param  string $date   Holiday date as 'Y-m-d'.
+     * @param  string $label  Optional human label.
+     * @throws \InvalidArgumentException if $calKey is empty or $date is malformed.
+     */
+    public function addHoliday(string $calKey, string $date, string $label = ''): void
+    {
+        $calKey = $this->validateKey($calKey);
+        $date   = $this->normalizeDate($date);
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'calendar_holidays',
+            data:         ['cal_key' => $calKey, 'holiday_date' => $date, 'label' => $label],
+            conflictCols: ['cal_key', 'holiday_date'],
+            updateCols:   ['label'],
+        );
+    }
+
+    /**
+     * Remove a holiday. No-op if it was not registered.
+     *
+     * @param string $calKey Calendar identifier.
+     * @param string $date   Holiday date as 'Y-m-d'.
+     */
+    public function removeHoliday(string $calKey, string $date): void
+    {
+        $calKey = $this->validateKey($calKey);
+        $date   = $this->normalizeDate($date);
+
+        $stmt = $this->db()->prepare(
+            'DELETE FROM calendar_holidays WHERE cal_key = ? AND holiday_date = ?'
+        );
+        $stmt->execute([$calKey, $date]);
+    }
+
+    /**
+     * Return whether a date is a registered holiday (ignores weekends).
+     *
+     * @param  string $calKey Calendar identifier.
+     * @param  string $date   Date as 'Y-m-d'.
+     * @return bool
+     */
+    public function isHoliday(string $calKey, string $date): bool
+    {
+        $calKey = $this->validateKey($calKey);
+        $date   = $this->normalizeDate($date);
+
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM calendar_holidays WHERE cal_key = ? AND holiday_date = ? LIMIT 1'
+        );
+        $stmt->execute([$calKey, $date]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * List registered holidays for a calendar within a half-open range [from, to).
+     *
+     * @param  string      $calKey Calendar identifier.
+     * @param  string|null $from   Inclusive lower bound 'Y-m-d', or null for no lower bound.
+     * @param  string|null $to     Exclusive upper bound 'Y-m-d', or null for no upper bound.
+     * @return array<int,array{date:string,label:string}> Ordered by date ascending.
+     */
+    public function holidays(string $calKey, ?string $from = null, ?string $to = null): array
+    {
+        $calKey = $this->validateKey($calKey);
+
+        $sql    = 'SELECT holiday_date, label FROM calendar_holidays WHERE cal_key = ?';
+        $params = [$calKey];
+
+        if ($from !== null) {
+            $sql     .= ' AND holiday_date >= ?';
+            $params[] = $this->normalizeDate($from);
+        }
+        if ($to !== null) {
+            $sql     .= ' AND holiday_date < ?';
+            $params[] = $this->normalizeDate($to);
+        }
+        $sql .= ' ORDER BY holiday_date ASC';
+
+        $stmt = $this->db()->prepare($sql);
+        $stmt->execute($params);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['date' => (string)$row['holiday_date'], 'label' => (string)$row['label']];
+        }
+
+        return $out;
+    }
+
+    // ── business-day queries ──────────────────────────────────────────────────
+
+    /**
+     * Return whether a date is a business day (Mon–Fri and not a holiday).
+     *
+     * @param string $calKey Calendar identifier.
+     * @param string $date   Date as 'Y-m-d'.
+     */
+    public function isBusinessDay(string $calKey, string $date): bool
+    {
+        $calKey = $this->validateKey($calKey);
+        $date   = $this->normalizeDate($date);
+
+        if ($this->isWeekend($date)) {
+            return false;
+        }
+
+        return !$this->isHoliday($calKey, $date);
+    }
+
+    /**
+     * Return the next business day strictly after the given date.
+     *
+     * @param  string $calKey Calendar identifier.
+     * @param  string $date   Date as 'Y-m-d'.
+     * @return string         Date as 'Y-m-d'.
+     */
+    public function nextBusinessDay(string $calKey, string $date): string
+    {
+        return $this->addBusinessDays($calKey, $date, 1);
+    }
+
+    /**
+     * Return the previous business day strictly before the given date.
+     *
+     * @param  string $calKey Calendar identifier.
+     * @param  string $date   Date as 'Y-m-d'.
+     * @return string         Date as 'Y-m-d'.
+     */
+    public function previousBusinessDay(string $calKey, string $date): string
+    {
+        return $this->addBusinessDays($calKey, $date, -1);
+    }
+
+    /**
+     * Add (or subtract, if negative) a number of business days to a date.
+     *
+     * Moves day-by-day, skipping weekends and holidays. With $days === 0 the
+     * input date is returned unchanged even if it is not itself a business day.
+     *
+     * @param  string $calKey Calendar identifier.
+     * @param  string $date   Start date as 'Y-m-d'.
+     * @param  int    $days   Number of business days to move (may be negative).
+     * @return string         Resulting date as 'Y-m-d'.
+     */
+    public function addBusinessDays(string $calKey, string $date, int $days): string
+    {
+        $calKey  = $this->validateKey($calKey);
+        $current = $this->toDate($this->normalizeDate($date));
+
+        if ($days === 0) {
+            return $current->format('Y-m-d');
+        }
+
+        $step      = $days > 0 ? 1 : -1;
+        $remaining = abs($days);
+        $interval  = new \DateInterval('P1D');
+
+        while ($remaining > 0) {
+            $current = $step > 0 ? $current->add($interval) : $current->sub($interval);
+            if ($this->isBusinessDay($calKey, $current->format('Y-m-d'))) {
+                $remaining--;
+            }
+        }
+
+        return $current->format('Y-m-d');
+    }
+
+    /**
+     * Count business days in the half-open range [from, to).
+     *
+     * Returns 0 if $from >= $to. The end date is exclusive, so
+     * businessDaysBetween('jp', 'Mon', 'Sat') over a holiday-free week is 5.
+     *
+     * @param  string $calKey Calendar identifier.
+     * @param  string $from   Inclusive start date as 'Y-m-d'.
+     * @param  string $to     Exclusive end date as 'Y-m-d'.
+     * @return int
+     */
+    public function businessDaysBetween(string $calKey, string $from, string $to): int
+    {
+        $calKey = $this->validateKey($calKey);
+        $start  = $this->toDate($this->normalizeDate($from));
+        $end    = $this->toDate($this->normalizeDate($to));
+
+        if ($start >= $end) {
+            return 0;
+        }
+
+        $count    = 0;
+        $cursor   = $start;
+        $interval = new \DateInterval('P1D');
+
+        while ($cursor < $end) {
+            if ($this->isBusinessDay($calKey, $cursor->format('Y-m-d'))) {
+                $count++;
+            }
+            $cursor = $cursor->add($interval);
+        }
+
+        return $count;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function isWeekend(string $date): bool
+    {
+        // 6 = Saturday, 7 = Sunday (ISO-8601 day-of-week).
+        $dow = (int)$this->toDate($date)->format('N');
+
+        return $dow >= 6;
+    }
+
+    private function validateKey(string $calKey): string
+    {
+        $calKey = trim($calKey);
+        if ($calKey === '') {
+            throw new \InvalidArgumentException('Calendar key must not be empty.');
+        }
+
+        return $calKey;
+    }
+
+    private function normalizeDate(string $date): string
+    {
+        return $this->toDate($date)->format('Y-m-d');
+    }
+
+    private function toDate(string $date): \DateTimeImmutable
+    {
+        $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', $date);
+
+        // Round-trip guard: rejects malformed input ('2026-13-40') and silent
+        // overflow ('2026-02-30' → Mar 2) by requiring the parse to re-render
+        // identically. Requires zero-padded 'Y-m-d', which is the API contract.
+        if ($parsed === false || $parsed->format('Y-m-d') !== $date) {
+            throw new \InvalidArgumentException("Invalid date (expected Y-m-d): {$date}");
+        }
+
+        return $parsed;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -288,6 +288,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | Class | Description |
 |-------|-------------|
 | `AssetRegistry` | physical and digital asset inventory with assignment tracking. |
+| `BusinessCalendar` | working-day calendar with weekend and holiday awareness. |
 | `BatchJob` | batch processing job tracking with progress and status lifecycle. |
 | `BatchResult` | Accumulates per-item results for a batch operation. |
 | `CircuitBreaker` | — |

--- a/docs/field-trials/2026-05-field-trial-266.md
+++ b/docs/field-trials/2026-05-field-trial-266.md
@@ -1,0 +1,54 @@
+# Field Trial 266 — BusinessCalendar
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft266-business-calendar`
+**Baseline**: post FT265 merge
+
+## Goal
+
+Add `Nene\Xion\BusinessCalendar` — a working-day calendar that excludes weekends and registered holidays, for SLA deadlines, due-date arithmetic, and "deliver in N working days" scheduling. Complements `SlaTracker` (FT237), whose deadline computation currently has no notion of business days.
+
+## What was built
+
+### `Nene\Xion\BusinessCalendar` (`class/xion/BusinessCalendar.php`)
+
+Multiple independent calendars coexist, keyed by `calKey` (e.g. one per country/office), so a single deployment serves regions with different public holidays. "Business day" = Mon–Fri that is not a registered holiday.
+
+| Method | Description |
+| --- | --- |
+| `addHoliday(calKey, date, label='')` | Register/relabel a holiday (idempotent per date, cross-driver upsert). |
+| `removeHoliday(calKey, date)` | Remove a holiday (no-op if absent). |
+| `isHoliday(calKey, date): bool` | Registered-holiday check (ignores weekends). |
+| `holidays(calKey, from=null, to=null): array` | List holidays in half-open range `[from, to)`. |
+| `isBusinessDay(calKey, date): bool` | Mon–Fri and not a holiday. |
+| `nextBusinessDay` / `previousBusinessDay(calKey, date): string` | Strictly after / before. |
+| `addBusinessDays(calKey, date, days): string` | Move ±N working days (skips weekends + holidays). |
+| `businessDaysBetween(calKey, from, to): int` | Count working days in `[from, to)`. |
+
+Key design points:
+
+- **Half-open ranges**: `businessDaysBetween` and `holidays` use `[from, to)` (end exclusive) so adjacent ranges compose without double-counting — the common off-by-one trap for date ranges.
+- **Round-trip date validation**: `toDate()` rejects malformed input (`2026-13-40`) and silent overflow (`2026-02-30` → Mar 2) by requiring `createFromFormat('!Y-m-d', …)->format('Y-m-d')` to match the input — no reliance on `getLastErrors()` (which also avoids a `PhanTypeComparisonFromArray` on its `array|false` return).
+- **Weekend = ISO `N` >= 6** (Sat/Sun); non-Sat/Sun weekends are explicitly out of scope until a real need appears.
+- **Cross-driver upsert** via `DbUpsert::run()`; **PDO injection** via `?PDO` constructor.
+
+### Tests (`tests/Unit/Xion/BusinessCalendarTest.php`)
+
+24 unit tests (34 assertions) over a fixed, fully day-of-week-annotated reference week (two holidays: 元日 Thu 2026-01-01, 成人の日 Mon 2026-01-12):
+
+- holiday register/relabel/remove/scoping; half-open `holidays()` range
+- `isBusinessDay` for weekday / weekend / holiday
+- `addBusinessDays` forward over weekend+holiday, single-day over weekend, negative, and zero (returns input unchanged even on a holiday)
+- `nextBusinessDay` from a holiday and strictly-after semantics; `previousBusinessDay`
+- `businessDaysBetween` end-exclusivity, spanning a holiday, empty (start==end), and reversed (start>end → 0)
+- validation: empty calendar key, malformed date; unknown calendar still applies weekends
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+`BusinessCalendar` is a clean `Nene\Xion` helper. 24 tests pass; CS Fixer and Phan clean. The FT265 scaffold-template fix (PR #719) held — generated stubs were namespace- and import-clean with no manual correction needed.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/BusinessCalendarTest.php
+++ b/tests/Unit/Xion/BusinessCalendarTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\BusinessCalendar;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for BusinessCalendar.
+ *
+ * Reference week (calendar 'jp'), with two registered holidays:
+ *   2026-01-01 Thu — 元日 (holiday)
+ *   2026-01-02 Fri — business day
+ *   2026-01-03 Sat — weekend
+ *   2026-01-04 Sun — weekend
+ *   2026-01-05 Mon — business day
+ *   2026-01-06 Tue — business day
+ *   2026-01-07 Wed — business day
+ *   2026-01-08 Thu — business day
+ *   2026-01-09 Fri — business day
+ *   2026-01-10 Sat — weekend
+ *   2026-01-11 Sun — weekend
+ *   2026-01-12 Mon — 成人の日 (holiday)
+ *   2026-01-13 Tue — business day
+ */
+final class BusinessCalendarTest extends TestCase
+{
+    private PDO $db;
+    private BusinessCalendar $cal;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE calendar_holidays (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                cal_key      VARCHAR(50)  NOT NULL,
+                holiday_date CHAR(10)     NOT NULL,
+                label        VARCHAR(255) NOT NULL DEFAULT \'\',
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (cal_key, holiday_date)
+            )
+        ');
+        $this->cal = new BusinessCalendar($this->db);
+        $this->cal->addHoliday('jp', '2026-01-01', '元日');       // Thu
+        $this->cal->addHoliday('jp', '2026-01-12', '成人の日');   // Mon
+    }
+
+    // ── holidays ────────────────────────────────────────────────────────────────
+
+    public function testIsHolidayMatchesRegistered(): void
+    {
+        $this->assertTrue($this->cal->isHoliday('jp', '2026-01-01'));
+        $this->assertFalse($this->cal->isHoliday('jp', '2026-01-02')); // Fri, not registered
+    }
+
+    public function testIsHolidayIgnoresWeekends(): void
+    {
+        // A Saturday is not a *holiday* even though it is a non-business day.
+        $this->assertFalse($this->cal->isHoliday('jp', '2026-01-03')); // Sat
+    }
+
+    public function testAddHolidayIsIdempotentAndRelabels(): void
+    {
+        $this->cal->addHoliday('jp', '2026-01-01', 'New Year');
+        $list = $this->cal->holidays('jp');
+        $this->assertCount(2, $list);
+        $this->assertSame('New Year', $list[0]['label']); // 2026-01-01 first
+    }
+
+    public function testHolidaysAreScopedByCalendar(): void
+    {
+        $this->assertFalse($this->cal->isHoliday('us', '2026-01-01'));
+        $this->cal->addHoliday('us', '2026-07-04', 'Independence Day');
+        $this->assertTrue($this->cal->isHoliday('us', '2026-07-04'));
+        $this->assertFalse($this->cal->isHoliday('jp', '2026-07-04'));
+    }
+
+    public function testRemoveHoliday(): void
+    {
+        $this->cal->removeHoliday('jp', '2026-01-01');
+        $this->assertFalse($this->cal->isHoliday('jp', '2026-01-01'));
+        // Now a Thursday with no holiday → business day.
+        $this->assertTrue($this->cal->isBusinessDay('jp', '2026-01-01'));
+    }
+
+    public function testRemoveHolidayMissingIsNoop(): void
+    {
+        $this->cal->removeHoliday('jp', '2026-03-20'); // never registered
+        $this->assertCount(2, $this->cal->holidays('jp'));
+    }
+
+    public function testHolidaysRangeIsHalfOpen(): void
+    {
+        // [2026-01-01, 2026-01-12) includes 元日 but not 成人の日 (exclusive end).
+        $list = $this->cal->holidays('jp', '2026-01-01', '2026-01-12');
+        $this->assertCount(1, $list);
+        $this->assertSame('2026-01-01', $list[0]['date']);
+    }
+
+    // ── isBusinessDay ───────────────────────────────────────────────────────────
+
+    public function testWeekdayIsBusinessDay(): void
+    {
+        $this->assertTrue($this->cal->isBusinessDay('jp', '2026-01-05'));  // Mon
+        $this->assertTrue($this->cal->isBusinessDay('jp', '2026-01-02'));  // Fri
+    }
+
+    public function testWeekendIsNotBusinessDay(): void
+    {
+        $this->assertFalse($this->cal->isBusinessDay('jp', '2026-01-03')); // Sat
+        $this->assertFalse($this->cal->isBusinessDay('jp', '2026-01-04')); // Sun
+    }
+
+    public function testHolidayIsNotBusinessDay(): void
+    {
+        $this->assertFalse($this->cal->isBusinessDay('jp', '2026-01-01')); // Thu holiday
+        $this->assertFalse($this->cal->isBusinessDay('jp', '2026-01-12')); // Mon holiday
+    }
+
+    // ── addBusinessDays ─────────────────────────────────────────────────────────
+
+    public function testAddBusinessDaysSkipsWeekendAndHoliday(): void
+    {
+        // From Mon 2026-01-05, +5 business days lands on Tue 2026-01-13,
+        // skipping Sat/Sun (10–11) and the Mon holiday (12).
+        $this->assertSame('2026-01-13', $this->cal->addBusinessDays('jp', '2026-01-05', 5));
+    }
+
+    public function testAddSingleBusinessDayOverWeekend(): void
+    {
+        // Fri 2026-01-02 +1 → Mon 2026-01-05 (Sat/Sun skipped).
+        $this->assertSame('2026-01-05', $this->cal->addBusinessDays('jp', '2026-01-02', 1));
+    }
+
+    public function testAddBusinessDaysNegative(): void
+    {
+        // Tue 2026-01-13, -2 business days: skip Mon holiday (12) + weekend (10–11),
+        // → Fri 2026-01-09 (−1), Thu 2026-01-08 (−2).
+        $this->assertSame('2026-01-08', $this->cal->addBusinessDays('jp', '2026-01-13', -2));
+    }
+
+    public function testAddZeroBusinessDaysReturnsInputEvenIfHoliday(): void
+    {
+        $this->assertSame('2026-01-01', $this->cal->addBusinessDays('jp', '2026-01-01', 0));
+    }
+
+    public function testNextBusinessDayFromHoliday(): void
+    {
+        // Thu 2026-01-01 holiday → next business day is Fri 2026-01-02.
+        $this->assertSame('2026-01-02', $this->cal->nextBusinessDay('jp', '2026-01-01'));
+    }
+
+    public function testNextBusinessDayIsStrictlyAfter(): void
+    {
+        // From a business day, "next" still advances (strictly after).
+        $this->assertSame('2026-01-06', $this->cal->nextBusinessDay('jp', '2026-01-05'));
+    }
+
+    public function testPreviousBusinessDayFromMonday(): void
+    {
+        // Mon 2026-01-05 → previous business day Fri 2026-01-02 (skips weekend).
+        $this->assertSame('2026-01-02', $this->cal->previousBusinessDay('jp', '2026-01-05'));
+    }
+
+    // ── businessDaysBetween ─────────────────────────────────────────────────────
+
+    public function testBusinessDaysBetweenExcludesEnd(): void
+    {
+        // [2026-01-05 Mon, 2026-01-13 Tue): Mon–Fri (5,6,7,8,9) = 5,
+        // weekend (10,11) and Mon holiday (12) excluded; end exclusive.
+        $this->assertSame(5, $this->cal->businessDaysBetween('jp', '2026-01-05', '2026-01-13'));
+    }
+
+    public function testBusinessDaysBetweenSpanningHoliday(): void
+    {
+        // [2026-01-01 Thu, 2026-01-06 Tue): Thu holiday(1), Fri(2) bd,
+        // Sat/Sun(3,4), Mon(5) bd → 2.
+        $this->assertSame(2, $this->cal->businessDaysBetween('jp', '2026-01-01', '2026-01-06'));
+    }
+
+    public function testBusinessDaysBetweenEmptyWhenStartEqualsEnd(): void
+    {
+        $this->assertSame(0, $this->cal->businessDaysBetween('jp', '2026-01-05', '2026-01-05'));
+    }
+
+    public function testBusinessDaysBetweenZeroWhenStartAfterEnd(): void
+    {
+        $this->assertSame(0, $this->cal->businessDaysBetween('jp', '2026-01-13', '2026-01-05'));
+    }
+
+    // ── validation ──────────────────────────────────────────────────────────────
+
+    public function testEmptyCalendarKeyThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cal->isBusinessDay('  ', '2026-01-05');
+    }
+
+    public function testMalformedDateThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cal->isBusinessDay('jp', '2026-13-40');
+    }
+
+    public function testNonExistentCalendarHasNoHolidays(): void
+    {
+        // Unknown calendar: weekdays are business days, weekends are not.
+        $this->assertTrue($this->cal->isBusinessDay('zz', '2026-01-01'));  // Thu, no holiday here
+        $this->assertFalse($this->cal->isBusinessDay('zz', '2026-01-03')); // Sat
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT266** — `Nene\Xion\BusinessCalendar`: a working-day calendar that excludes weekends and registered holidays, for SLA deadlines, due-date arithmetic, and "deliver in N working days" scheduling. Independent calendars coexist per `calKey` (country/office). Complements `SlaTracker` (FT237), which has no business-day notion today.

| Method | Description |
| --- | --- |
| `addHoliday/removeHoliday/isHoliday/holidays` | Manage & query the holiday set (cross-driver upsert; `[from,to)` listing). |
| `isBusinessDay(calKey, date): bool` | Mon–Fri and not a holiday. |
| `nextBusinessDay / previousBusinessDay` | Strictly after / before. |
| `addBusinessDays(calKey, date, days): string` | Move ±N working days (skips weekends + holidays). |
| `businessDaysBetween(calKey, from, to): int` | Count working days in half-open `[from, to)`. |

Key design points:
- **Half-open `[from, to)`** ranges so adjacent ranges compose without double-counting (date off-by-one trap).
- **Round-trip date validation** (`createFromFormat('!Y-m-d')->format('Y-m-d') === input`) rejects `2026-13-40` and silent overflow `2026-02-30`; avoids `getLastErrors()` and its `PhanTypeComparisonFromArray`.

## F-N findings

- **F-1** — none (clean trial). The FT265 scaffold-template fix (PR #719) held: generated stubs were namespace- and import-clean, no manual correction.

## Test plan

- [x] 24 unit tests / 34 assertions over a day-of-week-annotated reference week (two holidays); covers add/remove/scoping, isBusinessDay weekday/weekend/holiday, addBusinessDays forward/single/negative/zero, next/previous, businessDaysBetween end-exclusivity/holiday-span/empty/reversed, validation
- [x] `composer precommit` green (format → Phan → 4570 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)