### PR TITLE
feat(xion): ExchangeRate — effective-dated currency conversion (FT267)

### DIFF
--- a/class/xion/ExchangeRate.php
+++ b/class/xion/ExchangeRate.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ExchangeRate — effective-dated currency conversion rate table.
+ *
+ * Stores fixed-point conversion rates between currency pairs with an
+ * effective date, and converts integer-minor-unit amounts (cents) without
+ * floating point. Complements `Money` (FT49) and `TaxRate` (FT207): same
+ * integer-cent discipline, no `DECIMAL`/floats in the database.
+ *
+ * Rates are stored as integers scaled by {@see ExchangeRate::SCALE} (1e6, i.e.
+ * six decimal places). A rate of `1_500_000` means "× 1.5"; `150_000_000`
+ * means "× 150". `convertCents()` multiplies the amount by `rate / SCALE` and
+ * rounds half-up to the nearest minor unit. The caller is responsible for
+ * consistent minor-unit interpretation across the pair.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $fx = new ExchangeRate($pdo);
+ *
+ * // 1 USD = 1.5 (e.g. some quote currency); effective from a date
+ * $fx->setRate('USD', 'AUD', 1_500_000, '2026-01-01');
+ * $fx->setRate('USD', 'AUD', 1_550_000, '2026-02-01'); // later revision
+ *
+ * // Most recent rate on or before a date
+ * $fx->rateAt('USD', 'AUD', '2026-01-15'); // 1_500_000
+ * $fx->rateAt('USD', 'AUD', '2026-02-10'); // 1_550_000
+ * $fx->latest('USD', 'AUD');               // 1_550_000
+ *
+ * // Convert an integer-cent amount (returns null if no applicable rate)
+ * $fx->convertCents('USD', 'AUD', 1000, '2026-01-15'); // 1500
+ * $fx->convertCents('USD', 'AUD', 1000);               // uses latest → 1550
+ *
+ * $fx->history('USD', 'AUD'); // [['date'=>'2026-02-01','rate'=>1550000], ...]
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE exchange_rates (
+ *     id             INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     base           CHAR(3)  NOT NULL,
+ *     quote          CHAR(3)  NOT NULL,
+ *     rate           BIGINT   NOT NULL,
+ *     effective_date CHAR(10) NOT NULL,
+ *     created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (base, quote, effective_date)
+ * );
+ * ```
+ */
+final class ExchangeRate
+{
+    /** Fixed-point scale for stored rates (six decimal places). */
+    public const int SCALE = 1_000_000;
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set (or replace) the rate for a pair effective from a date.
+     *
+     * Idempotent per (base, quote, effective_date) — re-setting the same date
+     * overwrites the rate via cross-driver upsert.
+     *
+     * @param  string $base          Base currency code (e.g. 'USD').
+     * @param  string $quote         Quote currency code (e.g. 'AUD').
+     * @param  int    $rate          Rate scaled by SCALE (must be > 0).
+     * @param  string $effectiveDate Effective date 'Y-m-d'.
+     * @throws \InvalidArgumentException on empty code, $rate <= 0, or bad date.
+     */
+    public function setRate(string $base, string $quote, int $rate, string $effectiveDate): void
+    {
+        $base  = $this->validateCode($base);
+        $quote = $this->validateCode($quote);
+        if ($rate <= 0) {
+            throw new \InvalidArgumentException('Rate must be positive.');
+        }
+        $effectiveDate = $this->normalizeDate($effectiveDate);
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'exchange_rates',
+            data:         ['base' => $base, 'quote' => $quote, 'rate' => $rate, 'effective_date' => $effectiveDate],
+            conflictCols: ['base', 'quote', 'effective_date'],
+            updateCols:   ['rate'],
+        );
+    }
+
+    /**
+     * Return the rate in effect on or before a date (most recent applicable).
+     *
+     * @param  string $base  Base currency code.
+     * @param  string $quote Quote currency code.
+     * @param  string $date  As-of date 'Y-m-d'.
+     * @return int|null      Scaled rate, or null if no rate is effective yet.
+     */
+    public function rateAt(string $base, string $quote, string $date): ?int
+    {
+        $base  = $this->validateCode($base);
+        $quote = $this->validateCode($quote);
+        $date  = $this->normalizeDate($date);
+
+        $stmt = $this->db()->prepare(
+            'SELECT rate FROM exchange_rates
+             WHERE base = ? AND quote = ? AND effective_date <= ?
+             ORDER BY effective_date DESC LIMIT 1'
+        );
+        $stmt->execute([$base, $quote, $date]);
+        $rate = $stmt->fetchColumn();
+
+        return $rate === false ? null : (int)$rate;
+    }
+
+    /**
+     * Return the most recent rate for a pair regardless of date.
+     *
+     * @param  string $base  Base currency code.
+     * @param  string $quote Quote currency code.
+     * @return int|null      Scaled rate, or null if the pair has no rates.
+     */
+    public function latest(string $base, string $quote): ?int
+    {
+        $base  = $this->validateCode($base);
+        $quote = $this->validateCode($quote);
+
+        $stmt = $this->db()->prepare(
+            'SELECT rate FROM exchange_rates
+             WHERE base = ? AND quote = ?
+             ORDER BY effective_date DESC LIMIT 1'
+        );
+        $stmt->execute([$base, $quote]);
+        $rate = $stmt->fetchColumn();
+
+        return $rate === false ? null : (int)$rate;
+    }
+
+    /**
+     * Convert an integer-minor-unit amount using the applicable rate.
+     *
+     * Uses the rate effective on $date (most recent on or before), or the
+     * latest rate when $date is null. Rounds half-up to the nearest minor unit.
+     *
+     * @param  string      $base   Base currency code.
+     * @param  string      $quote  Quote currency code.
+     * @param  int         $amount Amount in base minor units (e.g. cents).
+     * @param  string|null $date   As-of date 'Y-m-d', or null for the latest rate.
+     * @return int|null            Converted amount in quote minor units, or null
+     *                             if no applicable rate exists.
+     */
+    public function convertCents(string $base, string $quote, int $amount, ?string $date = null): ?int
+    {
+        $rate = $date === null ? $this->latest($base, $quote) : $this->rateAt($base, $quote, $date);
+        if ($rate === null) {
+            return null;
+        }
+
+        $sign     = $amount < 0 ? -1 : 1;
+        $product  = abs($amount) * $rate;
+        $rounded  = intdiv($product + intdiv(self::SCALE, 2), self::SCALE);
+
+        return $sign * $rounded;
+    }
+
+    /**
+     * Return the full rate history for a pair, newest effective date first.
+     *
+     * @param  string $base  Base currency code.
+     * @param  string $quote Quote currency code.
+     * @return array<int,array{date:string,rate:int}>
+     */
+    public function history(string $base, string $quote): array
+    {
+        $base  = $this->validateCode($base);
+        $quote = $this->validateCode($quote);
+
+        $stmt = $this->db()->prepare(
+            'SELECT effective_date, rate FROM exchange_rates
+             WHERE base = ? AND quote = ?
+             ORDER BY effective_date DESC'
+        );
+        $stmt->execute([$base, $quote]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['date' => (string)$row['effective_date'], 'rate' => (int)$row['rate']];
+        }
+
+        return $out;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validateCode(string $code): string
+    {
+        $code = strtoupper(trim($code));
+        if ($code === '') {
+            throw new \InvalidArgumentException('Currency code must not be empty.');
+        }
+
+        return $code;
+    }
+
+    private function normalizeDate(string $date): string
+    {
+        $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', $date);
+        if ($parsed === false || $parsed->format('Y-m-d') !== $date) {
+            throw new \InvalidArgumentException("Invalid date (expected Y-m-d): {$date}");
+        }
+
+        return $parsed->format('Y-m-d');
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -173,6 +173,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `CouponCode` | Coupon / promo code management with usage limits and per-user redemption tracking. |
 | `CreditLedger` | append-only double-entry credit/debit ledger per user. |
 | `CreditNote` | financial credit notes / refund adjustments. |
+| `ExchangeRate` | effective-dated currency conversion rate table. |
 | `EventTicket` | event ticketing with capacity management and check-in tracking. |
 | `GiftCard` | prepaid gift card balance with partial redemption support. |
 | `InventoryStock` | product/SKU stock tracking with atomic reserve/release/commit. |

--- a/docs/field-trials/2026-05-field-trial-267.md
+++ b/docs/field-trials/2026-05-field-trial-267.md
@@ -1,0 +1,44 @@
+# Field Trial 267 — ExchangeRate
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft267-exchange-rate`
+**Baseline**: post FT266 merge
+
+## Goal
+
+Add `Nene\Xion\ExchangeRate` — effective-dated currency conversion rates with integer-cent conversion and no floating point. Rounds out the money helpers alongside `Money` (FT49) and `TaxRate` (FT207).
+
+## What was built
+
+### `Nene\Xion\ExchangeRate` (`class/xion/ExchangeRate.php`)
+
+Stores fixed-point rates per directed currency pair with an effective date. Rates are integers scaled by `SCALE = 1_000_000` (six decimal places); `1_500_000` means "× 1.5".
+
+| Method | Description |
+| --- | --- |
+| `setRate(base, quote, rate, effectiveDate)` | Upsert a scaled rate effective from a date (idempotent per date). |
+| `rateAt(base, quote, date): ?int` | Most recent rate on or before a date. |
+| `latest(base, quote): ?int` | Most recent rate regardless of date. |
+| `convertCents(base, quote, amount, date=null): ?int` | Convert minor units; half-up rounding; null if no rate. |
+| `history(base, quote): array` | Full rate history, newest effective date first. |
+
+Key design points:
+
+- **Integer-only fixed point**: rates stored as scaled `BIGINT`; `convertCents` uses `intdiv(amount*rate + SCALE/2, SCALE)` for half-up rounding, sign-corrected for negatives — no floats, consistent with the monetary-cents policy.
+- **Effective dating**: `rateAt` selects `effective_date <= date ORDER BY effective_date DESC LIMIT 1`, so historical conversions are reproducible; `convertCents(..., date=null)` uses `latest()`.
+- **Directed pairs**: `(base, quote)` is directional; the reverse pair is not implied (avoids silent precision loss from inversion).
+- **Round-trip date validation**; **cross-driver upsert** via `DbUpsert`; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/ExchangeRateTest.php`)
+
+19 unit tests (27 assertions): rateAt boundary (on/before/after revision, +1-day-before-effective null), latest, idempotent per-date overwrite, code upper-normalisation, directional pairs, convertCents (with date / latest / half-up / below-half / negative / zero / null-when-no-rate), history ordering, and validation (non-positive rate, empty code, overflow date).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 19 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/ExchangeRateTest.php
+++ b/tests/Unit/Xion/ExchangeRateTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ExchangeRate;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ExchangeRate.
+ */
+final class ExchangeRateTest extends TestCase
+{
+    private PDO $db;
+    private ExchangeRate $fx;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE exchange_rates (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                base           CHAR(3)  NOT NULL,
+                quote          CHAR(3)  NOT NULL,
+                rate           BIGINT   NOT NULL,
+                effective_date CHAR(10) NOT NULL,
+                created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (base, quote, effective_date)
+            )
+        ');
+        $this->fx = new ExchangeRate($this->db);
+    }
+
+    // ── rateAt / latest ─────────────────────────────────────────────────────────
+
+    public function testRateAtPicksMostRecentOnOrBeforeDate(): void
+    {
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-01-01');
+        $this->fx->setRate('USD', 'AUD', 1_550_000, '2026-02-01');
+
+        $this->assertSame(1_500_000, $this->fx->rateAt('USD', 'AUD', '2026-01-15')); // before 2nd revision
+        $this->assertSame(1_550_000, $this->fx->rateAt('USD', 'AUD', '2026-02-01')); // exactly on revision date
+        $this->assertSame(1_550_000, $this->fx->rateAt('USD', 'AUD', '2026-03-10')); // after
+    }
+
+    public function testRateAtReturnsNullBeforeAnyRate(): void
+    {
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-02-01');
+        $this->assertNull($this->fx->rateAt('USD', 'AUD', '2026-01-31')); // +1 day before effective
+    }
+
+    public function testLatestIgnoresDate(): void
+    {
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-01-01');
+        $this->fx->setRate('USD', 'AUD', 1_550_000, '2026-02-01');
+        $this->assertSame(1_550_000, $this->fx->latest('USD', 'AUD'));
+    }
+
+    public function testLatestNullForUnknownPair(): void
+    {
+        $this->assertNull($this->fx->latest('USD', 'JPY'));
+    }
+
+    public function testSetRateIsIdempotentPerDate(): void
+    {
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-01-01');
+        $this->fx->setRate('USD', 'AUD', 1_600_000, '2026-01-01'); // overwrite same date
+        $this->assertSame(1_600_000, $this->fx->rateAt('USD', 'AUD', '2026-01-01'));
+        $this->assertCount(1, $this->fx->history('USD', 'AUD'));
+    }
+
+    public function testCodesAreNormalisedToUpper(): void
+    {
+        $this->fx->setRate('usd', 'aud', 1_500_000, '2026-01-01');
+        $this->assertSame(1_500_000, $this->fx->latest('USD', 'AUD'));
+        $this->assertSame(1_500_000, $this->fx->rateAt('Usd', 'Aud', '2026-01-02'));
+    }
+
+    public function testPairsAreDirectional(): void
+    {
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-01-01');
+        $this->assertSame(1_500_000, $this->fx->latest('USD', 'AUD'));
+        $this->assertNull($this->fx->latest('AUD', 'USD')); // reverse not implied
+    }
+
+    // ── convertCents ──────────────────────────────────────────────────────────
+
+    public function testConvertCentsWithDate(): void
+    {
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-01-01'); // ×1.5
+        $this->assertSame(1500, $this->fx->convertCents('USD', 'AUD', 1000, '2026-01-15'));
+    }
+
+    public function testConvertCentsUsesLatestWhenDateNull(): void
+    {
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-01-01');
+        $this->fx->setRate('USD', 'AUD', 1_550_000, '2026-02-01'); // ×1.55
+        $this->assertSame(1550, $this->fx->convertCents('USD', 'AUD', 1000));
+    }
+
+    public function testConvertCentsRoundsHalfUp(): void
+    {
+        // ×1.005 on 100 cents = 100.5 → rounds half-up to 101
+        $this->fx->setRate('USD', 'AUD', 1_005_000, '2026-01-01');
+        $this->assertSame(101, $this->fx->convertCents('USD', 'AUD', 100));
+    }
+
+    public function testConvertCentsRoundsDownBelowHalf(): void
+    {
+        // ×1.004 on 100 cents = 100.4 → rounds to 100
+        $this->fx->setRate('USD', 'AUD', 1_004_000, '2026-01-01');
+        $this->assertSame(100, $this->fx->convertCents('USD', 'AUD', 100));
+    }
+
+    public function testConvertCentsNegativeAmount(): void
+    {
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-01-01');
+        $this->assertSame(-1500, $this->fx->convertCents('USD', 'AUD', -1000));
+    }
+
+    public function testConvertCentsZero(): void
+    {
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-01-01');
+        $this->assertSame(0, $this->fx->convertCents('USD', 'AUD', 0));
+    }
+
+    public function testConvertCentsNullWhenNoRate(): void
+    {
+        $this->assertNull($this->fx->convertCents('USD', 'AUD', 1000));
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-02-01');
+        $this->assertNull($this->fx->convertCents('USD', 'AUD', 1000, '2026-01-01')); // before effective
+    }
+
+    // ── history ─────────────────────────────────────────────────────────────────
+
+    public function testHistoryNewestFirst(): void
+    {
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-01-01');
+        $this->fx->setRate('USD', 'AUD', 1_550_000, '2026-02-01');
+        $hist = $this->fx->history('USD', 'AUD');
+        $this->assertSame('2026-02-01', $hist[0]['date']);
+        $this->assertSame(1_550_000, $hist[0]['rate']);
+        $this->assertSame('2026-01-01', $hist[1]['date']);
+    }
+
+    public function testHistoryEmptyForUnknownPair(): void
+    {
+        $this->assertSame([], $this->fx->history('USD', 'JPY'));
+    }
+
+    // ── validation ──────────────────────────────────────────────────────────────
+
+    public function testSetRateRejectsNonPositiveRate(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fx->setRate('USD', 'AUD', 0, '2026-01-01');
+    }
+
+    public function testSetRateRejectsEmptyCode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fx->setRate('', 'AUD', 1_500_000, '2026-01-01');
+    }
+
+    public function testSetRateRejectsBadDate(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->fx->setRate('USD', 'AUD', 1_500_000, '2026-02-30'); // overflow
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT267** — `Nene\Xion\ExchangeRate`: effective-dated, fixed-point currency conversion (no floats), alongside `Money` (FT49) / `TaxRate` (FT207). Rates are integers scaled by `SCALE = 1_000_000`.

| Method | Description |
| --- | --- |
| `setRate(base, quote, rate, effectiveDate)` | Upsert scaled rate (idempotent per date). |
| `rateAt / latest` | Rate on/before a date / most recent. |
| `convertCents(base, quote, amount, date=null): ?int` | Half-up integer conversion; null if no rate. |
| `history(base, quote)` | Newest effective date first. |

- Integer-only `intdiv(amount*rate + SCALE/2, SCALE)` rounding, sign-corrected.
- Effective dating → reproducible historical conversions; directed pairs (reverse not implied).

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 19 tests / 27 assertions (rateAt boundaries, convert half-up/below-half/negative/zero/null, idempotent overwrite, directional pairs, validation)
- [x] `composer precommit` green (format → Phan → 4589 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)