### PR TITLE
feat(xion): DataRetention — central table→TTL purge policy registry (FT268)

### DIFF
--- a/class/xion/DataRetention.php
+++ b/class/xion/DataRetention.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * DataRetention — central table→TTL retention policy registry and purge driver.
+ *
+ * Many Xion helpers ship their own `purgeOlderThan($days)` method; this class
+ * centralises *how long* each table is kept so a single retention cron can
+ * drive them. It records a TTL (in days) per table, computes the cutoff
+ * timestamp, and can execute the delete itself for tables with a standard
+ * timestamp column.
+ *
+ * The table name and date-column name are **developer-supplied identifiers**
+ * (from the policy registry / calling code), never end-user input. They are
+ * validated against a strict `^[A-Za-z_][A-Za-z0-9_]*$` pattern before being
+ * interpolated into SQL, since identifiers cannot be bound as parameters.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ret = new DataRetention($pdo);
+ *
+ * $ret->setPolicy('access_logs', 90);   // keep 90 days
+ * $ret->setPolicy('page_views', 30);
+ *
+ * $ret->policyFor('access_logs');        // 90
+ * $ret->policies();                      // [['table'=>'access_logs','ttlDays'=>90], ...]
+ *
+ * // For a retention cron: what should be purged, and to which cutoff?
+ * foreach ($ret->due() as $p) {
+ *     // $p = ['table'=>'access_logs','ttlDays'=>90,'cutoff'=>'2026-03-01 00:00:00']
+ * }
+ *
+ * // Execute the delete for a table with a timestamp column
+ * $deleted = $ret->purge('access_logs', 'created_at'); // rows removed
+ *
+ * $ret->removePolicy('page_views');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE retention_policies (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     table_name VARCHAR(100) NOT NULL,
+ *     ttl_days   INTEGER      NOT NULL,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (table_name)
+ * );
+ * ```
+ */
+final class DataRetention
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── policy management ───────────────────────────────────────────────────────
+
+    /**
+     * Set (or update) the retention TTL for a table. Idempotent per table.
+     *
+     * @param  string $table   Table name (identifier).
+     * @param  int    $ttlDays Days to retain (must be >= 1).
+     * @throws \InvalidArgumentException on bad identifier or $ttlDays < 1.
+     */
+    public function setPolicy(string $table, int $ttlDays): void
+    {
+        $table = $this->assertIdentifier($table);
+        if ($ttlDays < 1) {
+            throw new \InvalidArgumentException('TTL must be at least 1 day.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'retention_policies',
+            data:         ['table_name' => $table, 'ttl_days' => $ttlDays],
+            conflictCols: ['table_name'],
+            updateCols:   ['ttl_days'],
+            updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    /**
+     * Return the TTL (days) for a table, or null if no policy is set.
+     */
+    public function policyFor(string $table): ?int
+    {
+        $table = $this->assertIdentifier($table);
+
+        $stmt = $this->db()->prepare('SELECT ttl_days FROM retention_policies WHERE table_name = ?');
+        $stmt->execute([$table]);
+        $ttl = $stmt->fetchColumn();
+
+        return $ttl === false ? null : (int)$ttl;
+    }
+
+    /**
+     * Remove a table's policy. No-op if absent.
+     */
+    public function removePolicy(string $table): void
+    {
+        $table = $this->assertIdentifier($table);
+        $stmt  = $this->db()->prepare('DELETE FROM retention_policies WHERE table_name = ?');
+        $stmt->execute([$table]);
+    }
+
+    /**
+     * List all policies, ordered by table name.
+     *
+     * @return array<int,array{table:string,ttlDays:int}>
+     */
+    public function policies(): array
+    {
+        $stmt = $this->db()->query('SELECT table_name, ttl_days FROM retention_policies ORDER BY table_name ASC');
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($rows as $row) {
+            $out[] = ['table' => (string)$row['table_name'], 'ttlDays' => (int)$row['ttl_days']];
+        }
+
+        return $out;
+    }
+
+    // ── cutoff / purge ──────────────────────────────────────────────────────────
+
+    /**
+     * Compute the cutoff timestamp for a table: rows older than this are stale.
+     *
+     * @param  string      $table Table name (identifier).
+     * @param  string|null $asOf  Reference 'Y-m-d H:i:s' (or 'Y-m-d'); defaults to now.
+     * @return string|null        Cutoff as 'Y-m-d H:i:s', or null if no policy.
+     */
+    public function cutoff(string $table, ?string $asOf = null): ?string
+    {
+        $ttl = $this->policyFor($table);
+        if ($ttl === null) {
+            return null;
+        }
+
+        return $this->cutoffFor($ttl, $asOf);
+    }
+
+    /**
+     * Return every policy with its computed cutoff, for a retention cron to act on.
+     *
+     * @param  string|null $asOf Reference timestamp; defaults to now.
+     * @return array<int,array{table:string,ttlDays:int,cutoff:string}>
+     */
+    public function due(?string $asOf = null): array
+    {
+        $out = [];
+        foreach ($this->policies() as $p) {
+            $out[] = [
+                'table'   => $p['table'],
+                'ttlDays' => $p['ttlDays'],
+                'cutoff'  => $this->cutoffFor($p['ttlDays'], $asOf),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Delete rows older than the table's TTL by a timestamp column.
+     *
+     * @param  string      $table      Table to purge (identifier).
+     * @param  string      $dateColumn Timestamp column to compare (identifier).
+     * @param  string|null $asOf       Reference timestamp; defaults to now.
+     * @return int                     Number of rows deleted.
+     * @throws \InvalidArgumentException on bad identifier or missing policy.
+     */
+    public function purge(string $table, string $dateColumn, ?string $asOf = null): int
+    {
+        $table  = $this->assertIdentifier($table);
+        $column = $this->assertIdentifier($dateColumn);
+        $cutoff = $this->cutoff($table, $asOf);
+        if ($cutoff === null) {
+            throw new \InvalidArgumentException("No retention policy set for table: {$table}");
+        }
+
+        $stmt = $this->db()->prepare("DELETE FROM {$table} WHERE {$column} < ?");
+        $stmt->execute([$cutoff]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function cutoffFor(int $ttlDays, ?string $asOf): string
+    {
+        $base = $asOf === null
+            ? new \DateTimeImmutable()
+            : $this->parseTimestamp($asOf);
+
+        return $base->sub(new \DateInterval("P{$ttlDays}D"))->format('Y-m-d H:i:s');
+    }
+
+    private function parseTimestamp(string $value): \DateTimeImmutable
+    {
+        $ts = strtotime($value);
+        if ($ts === false) {
+            throw new \InvalidArgumentException("Invalid timestamp: {$value}");
+        }
+
+        return (new \DateTimeImmutable())->setTimestamp($ts);
+    }
+
+    private function assertIdentifier(string $name): string
+    {
+        $name = trim($name);
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name) !== 1) {
+            throw new \InvalidArgumentException("Invalid SQL identifier: {$name}");
+        }
+
+        return $name;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -315,6 +315,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `Command` | — |
 | `DataMapperBase` | — |
 | `DataModelBase` | — |
+| `DataRetention` | central table→TTL retention policy registry and purge driver. |
 | `DbUpsert` | Cross-driver upsert helper (MySQL + SQLite). |
 | `DomainException` | Throwable that carries a NeNe error code to the top-level request handler. |
 | `EnvLoader` | Minimal dotenv-style loader for CLI setup commands. |

--- a/docs/field-trials/2026-05-field-trial-268.md
+++ b/docs/field-trials/2026-05-field-trial-268.md
@@ -1,0 +1,43 @@
+# Field Trial 268 — DataRetention
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft268-data-retention`
+**Baseline**: post FT267 merge
+
+## Goal
+
+Add `Nene\Xion\DataRetention` — a central table→TTL retention policy registry and purge driver. Many Xion helpers ship their own `purgeOlderThan($days)`; this centralises *how long* each table is kept so one retention cron can drive them all.
+
+## What was built
+
+### `Nene\Xion\DataRetention` (`class/xion/DataRetention.php`)
+
+| Method | Description |
+| --- | --- |
+| `setPolicy(table, ttlDays)` | Upsert a per-table TTL (idempotent; ttl >= 1). |
+| `policyFor(table): ?int` / `policies(): array` | Read one / list all (ordered). |
+| `removePolicy(table)` | Drop a policy (no-op if absent). |
+| `cutoff(table, asOf=null): ?string` | Compute the stale-before timestamp. |
+| `due(asOf=null): array` | Every policy + its computed cutoff, for a cron. |
+| `purge(table, dateColumn, asOf=null): int` | Delete rows older than the cutoff; returns row count. |
+
+Key design points:
+
+- **Identifier safety**: `table`/`dateColumn` are developer-supplied identifiers (cannot be bound), validated against `^[A-Za-z_][A-Za-z0-9_]*$` before interpolation; user input never reaches them. Documented trust model.
+- **Strictly-older semantics**: `purge` deletes `WHERE col < cutoff`, so a row exactly at the cutoff is kept (matches the half-open convention used elsewhere).
+- **Testable time**: `asOf` parameter makes cutoff/purge deterministic without touching the clock.
+- **Cross-driver upsert** via `DbUpsert`; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/DataRetentionTest.php`)
+
+14 unit tests (20 assertions): set/get/update/remove/list ordering; cutoff arithmetic (90- and 30-day, annotated); `due()` per-policy cutoffs; `purge` strictly-older boundary (before/at/after cutoff → only "before" removed); purge-without-policy throws; identifier rejection for both table and column (`'; DROP TABLE'`, `col = 1 OR 1`); zero-TTL rejection.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 14 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/DataRetentionTest.php
+++ b/tests/Unit/Xion/DataRetentionTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\DataRetention;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for DataRetention.
+ */
+final class DataRetentionTest extends TestCase
+{
+    private PDO $db;
+    private DataRetention $ret;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE retention_policies (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                table_name VARCHAR(100) NOT NULL,
+                ttl_days   INTEGER      NOT NULL,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (table_name)
+            )
+        ');
+        $this->ret = new DataRetention($this->db);
+    }
+
+    // ── policy management ───────────────────────────────────────────────────────
+
+    public function testSetAndGetPolicy(): void
+    {
+        $this->ret->setPolicy('access_logs', 90);
+        $this->assertSame(90, $this->ret->policyFor('access_logs'));
+    }
+
+    public function testPolicyForUnknownIsNull(): void
+    {
+        $this->assertNull($this->ret->policyFor('nope'));
+    }
+
+    public function testSetPolicyIsIdempotentAndUpdates(): void
+    {
+        $this->ret->setPolicy('access_logs', 90);
+        $this->ret->setPolicy('access_logs', 30);
+        $this->assertSame(30, $this->ret->policyFor('access_logs'));
+        $this->assertCount(1, $this->ret->policies());
+    }
+
+    public function testRemovePolicy(): void
+    {
+        $this->ret->setPolicy('access_logs', 90);
+        $this->ret->removePolicy('access_logs');
+        $this->assertNull($this->ret->policyFor('access_logs'));
+    }
+
+    public function testRemovePolicyMissingIsNoop(): void
+    {
+        $this->ret->removePolicy('never'); // no throw
+        $this->assertSame([], $this->ret->policies());
+    }
+
+    public function testPoliciesOrderedByName(): void
+    {
+        $this->ret->setPolicy('page_views', 30);
+        $this->ret->setPolicy('access_logs', 90);
+        $list = $this->ret->policies();
+        $this->assertSame('access_logs', $list[0]['table']);
+        $this->assertSame('page_views', $list[1]['table']);
+    }
+
+    // ── cutoff / due ──────────────────────────────────────────────────────────
+
+    public function testCutoffSubtractsTtlDays(): void
+    {
+        $this->ret->setPolicy('access_logs', 90);
+        // asOf 2026-06-01 00:00:00 − 90 days = 2026-03-03 00:00:00
+        $this->assertSame('2026-03-03 00:00:00', $this->ret->cutoff('access_logs', '2026-06-01 00:00:00'));
+    }
+
+    public function testCutoffNullWhenNoPolicy(): void
+    {
+        $this->assertNull($this->ret->cutoff('access_logs', '2026-06-01'));
+    }
+
+    public function testDueReturnsAllPoliciesWithCutoff(): void
+    {
+        $this->ret->setPolicy('access_logs', 90);
+        $this->ret->setPolicy('page_views', 30);
+        $due = $this->ret->due('2026-06-01 00:00:00');
+        $this->assertCount(2, $due);
+        // ordered by name → access_logs first; 90-day cutoff
+        $this->assertSame('access_logs', $due[0]['table']);
+        $this->assertSame('2026-03-03 00:00:00', $due[0]['cutoff']);
+        // page_views: 2026-06-01 − 30 days = 2026-05-02
+        $this->assertSame('2026-05-02 00:00:00', $due[1]['cutoff']);
+    }
+
+    // ── purge ─────────────────────────────────────────────────────────────────
+
+    public function testPurgeDeletesOnlyRowsOlderThanCutoff(): void
+    {
+        $this->db->exec('CREATE TABLE access_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, created_at DATETIME)');
+        // TTL 30 days, asOf 2026-06-01 → cutoff 2026-05-02 00:00:00 (strictly-older purged)
+        $this->ret->setPolicy('access_logs', 30);
+        $ins = $this->db->prepare('INSERT INTO access_logs (created_at) VALUES (?)');
+        $ins->execute(['2026-05-01 12:00:00']); // before cutoff  → purged
+        $ins->execute(['2026-05-02 00:00:00']); // exactly cutoff → kept (not strictly <)
+        $ins->execute(['2026-05-15 00:00:00']); // after cutoff   → kept
+
+        $deleted = $this->ret->purge('access_logs', 'created_at', '2026-06-01 00:00:00');
+
+        $this->assertSame(1, $deleted);
+        $this->assertSame(2, (int)$this->db->query('SELECT COUNT(*) FROM access_logs')->fetchColumn());
+    }
+
+    public function testPurgeThrowsWithoutPolicy(): void
+    {
+        $this->db->exec('CREATE TABLE foo (id INTEGER PRIMARY KEY, created_at DATETIME)');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ret->purge('foo', 'created_at', '2026-06-01');
+    }
+
+    // ── identifier validation ───────────────────────────────────────────────────
+
+    public function testSetPolicyRejectsBadIdentifier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ret->setPolicy('access_logs; DROP TABLE users', 30);
+    }
+
+    public function testPurgeRejectsBadColumnIdentifier(): void
+    {
+        $this->ret->setPolicy('access_logs', 30);
+        $this->db->exec('CREATE TABLE access_logs (id INTEGER PRIMARY KEY, created_at DATETIME)');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ret->purge('access_logs', 'created_at = 1 OR 1', '2026-06-01');
+    }
+
+    public function testSetPolicyRejectsZeroTtl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ret->setPolicy('access_logs', 0);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT268** — `Nene\Xion\DataRetention`: a central table→TTL retention registry and purge driver, so one retention cron can drive the many per-class `purgeOlderThan()` helpers.

| Method | Description |
| --- | --- |
| `setPolicy / policyFor / policies / removePolicy` | Manage per-table TTLs. |
| `cutoff(table, asOf=null) / due(asOf=null)` | Compute stale-before timestamp(s). |
| `purge(table, dateColumn, asOf=null): int` | Delete rows strictly older than cutoff. |

- **Identifier safety**: `table`/`dateColumn` validated against `^[A-Za-z_][A-Za-z0-9_]*$` before interpolation (cannot be bound; never user input).
- **Strictly-older** (`col < cutoff`) so a row exactly at the cutoff is kept.
- `asOf` makes cutoff/purge deterministic in tests.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 14 tests / 20 assertions (CRUD + ordering, cutoff arithmetic, due(), purge boundary before/at/after, no-policy throw, identifier injection rejection, zero-TTL reject)
- [x] `composer precommit` green (format → Phan → 4603 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)