### PR TITLE
feat(xion): MaintenanceWindow — scheduled per-scope maintenance windows (FT269)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -323,6 +323,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `GenerateSchemaSqlCommand` | — |
 | `InitSqliteCommand` | — |
 | `Initialize` | — |
+| `MaintenanceWindow` | scheduled maintenance windows per service scope. |
 | `PdoConnection` | — |
 | `SchemaCompiler` | Compile {@see SchemaDefinition} into MySQL and SQLite DDL. |
 | `SchemaDefinition` | NeNe's sample-schema source of truth. |

--- a/class/xion/MaintenanceWindow.php
+++ b/class/xion/MaintenanceWindow.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * MaintenanceWindow — scheduled maintenance windows per service scope.
+ *
+ * Records planned maintenance intervals so an app can show a banner, return
+ * 503 during the window, or gate background jobs. Distinct from
+ * `MaintenanceMode` (FT87), which is a single global on/off flag: this models
+ * *time-bounded, scheduled* windows, can hold several upcoming entries, and is
+ * scoped (e.g. one per service or region).
+ *
+ * A window is "active" during the half-open interval `[starts_at, ends_at)`.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $mw = new MaintenanceWindow($pdo);
+ *
+ * $id = $mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 04:00:00', 'DB upgrade');
+ *
+ * $mw->isActive('api', '2026-06-01 03:00:00');   // true
+ * $mw->isActive('api', '2026-06-01 04:00:00');   // false (end exclusive)
+ * $mw->activeWindow('api', '2026-06-01 03:00:00'); // ['id'=>.., 'reason'=>'DB upgrade', ...]
+ *
+ * $mw->upcoming('api', '2026-05-30 00:00:00');   // windows starting after the ref time
+ *
+ * $mw->cancel($id);
+ * $mw->purgeEnded('2026-07-01 00:00:00');        // drop windows that ended before a date
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE maintenance_windows (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     scope      VARCHAR(100) NOT NULL,
+ *     starts_at  DATETIME     NOT NULL,
+ *     ends_at    DATETIME     NOT NULL,
+ *     reason     VARCHAR(255) NOT NULL DEFAULT '',
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class MaintenanceWindow
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Schedule a maintenance window.
+     *
+     * @param  string $scope    Service scope (e.g. 'api').
+     * @param  string $startsAt Start timestamp ('Y-m-d H:i:s' or parseable).
+     * @param  string $endsAt   End timestamp; must be strictly after $startsAt.
+     * @param  string $reason   Optional human reason.
+     * @return int              New window id.
+     * @throws \InvalidArgumentException on empty scope, bad timestamps, or end <= start.
+     */
+    public function schedule(string $scope, string $startsAt, string $endsAt, string $reason = ''): int
+    {
+        $scope = $this->validateScope($scope);
+        $start = $this->parse($startsAt);
+        $end   = $this->parse($endsAt);
+        if ($end <= $start) {
+            throw new \InvalidArgumentException('End must be strictly after start.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO maintenance_windows (scope, starts_at, ends_at, reason)
+             VALUES (?, ?, ?, ?)'
+        );
+        $stmt->execute([$scope, $start, $end, $reason]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Whether a maintenance window is active at a point in time.
+     *
+     * @param string      $scope Service scope.
+     * @param string|null $asOf  Reference timestamp; defaults to now.
+     */
+    public function isActive(string $scope, ?string $asOf = null): bool
+    {
+        return $this->activeWindow($scope, $asOf) !== null;
+    }
+
+    /**
+     * Return the active window at a point in time, or null.
+     *
+     * If windows overlap, the one ending soonest is returned.
+     *
+     * @param  string      $scope Service scope.
+     * @param  string|null $asOf  Reference timestamp; defaults to now.
+     * @return array{id:int,scope:string,starts_at:string,ends_at:string,reason:string}|null
+     */
+    public function activeWindow(string $scope, ?string $asOf = null): ?array
+    {
+        $scope = $this->validateScope($scope);
+        $now   = $this->parse($asOf ?? 'now');
+
+        $stmt = $this->db()->prepare(
+            'SELECT id, scope, starts_at, ends_at, reason FROM maintenance_windows
+             WHERE scope = ? AND starts_at <= ? AND ends_at > ?
+             ORDER BY ends_at ASC LIMIT 1'
+        );
+        $stmt->execute([$scope, $now, $now]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->hydrate($row);
+    }
+
+    /**
+     * List windows starting strictly after a reference time, soonest first.
+     *
+     * @param  string      $scope Service scope.
+     * @param  string|null $asOf  Reference timestamp; defaults to now.
+     * @return array<int,array{id:int,scope:string,starts_at:string,ends_at:string,reason:string}>
+     */
+    public function upcoming(string $scope, ?string $asOf = null): array
+    {
+        $scope = $this->validateScope($scope);
+        $now   = $this->parse($asOf ?? 'now');
+
+        $stmt = $this->db()->prepare(
+            'SELECT id, scope, starts_at, ends_at, reason FROM maintenance_windows
+             WHERE scope = ? AND starts_at > ?
+             ORDER BY starts_at ASC'
+        );
+        $stmt->execute([$scope, $now]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = $this->hydrate($row);
+        }
+
+        return $out;
+    }
+
+    /**
+     * Cancel (delete) a scheduled window by id. No-op if absent.
+     */
+    public function cancel(int $id): void
+    {
+        $stmt = $this->db()->prepare('DELETE FROM maintenance_windows WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+
+    /**
+     * Delete windows that ended on or before a reference time.
+     *
+     * @param  string|null $asOf Reference timestamp; defaults to now.
+     * @return int               Number of windows removed.
+     */
+    public function purgeEnded(?string $asOf = null): int
+    {
+        $now  = $this->parse($asOf ?? 'now');
+        $stmt = $this->db()->prepare('DELETE FROM maintenance_windows WHERE ends_at <= ?');
+        $stmt->execute([$now]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @param  array<string,mixed> $row
+     * @return array{id:int,scope:string,starts_at:string,ends_at:string,reason:string}
+     */
+    private function hydrate(array $row): array
+    {
+        return [
+            'id'        => (int)$row['id'],
+            'scope'     => (string)$row['scope'],
+            'starts_at' => (string)$row['starts_at'],
+            'ends_at'   => (string)$row['ends_at'],
+            'reason'    => (string)$row['reason'],
+        ];
+    }
+
+    private function validateScope(string $scope): string
+    {
+        $scope = trim($scope);
+        if ($scope === '') {
+            throw new \InvalidArgumentException('Scope must not be empty.');
+        }
+
+        return $scope;
+    }
+
+    private function parse(string $value): string
+    {
+        $ts = strtotime($value);
+        if ($ts === false) {
+            throw new \InvalidArgumentException("Invalid timestamp: {$value}");
+        }
+
+        return date('Y-m-d H:i:s', $ts);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-269.md
+++ b/docs/field-trials/2026-05-field-trial-269.md
@@ -1,0 +1,45 @@
+# Field Trial 269 — MaintenanceWindow
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft269-maintenance-window`
+**Baseline**: post FT268 merge
+
+## Goal
+
+Add `Nene\Xion\MaintenanceWindow` — scheduled, time-bounded maintenance windows per service scope. Distinct from `MaintenanceMode` (FT87), a single global on/off flag: this models scheduled intervals, holds several upcoming entries, and is scoped.
+
+## What was built
+
+### `Nene\Xion\MaintenanceWindow` (`class/xion/MaintenanceWindow.php`)
+
+A window is active during the half-open interval `[starts_at, ends_at)`.
+
+| Method | Description |
+| --- | --- |
+| `schedule(scope, startsAt, endsAt, reason='') : int` | Create a window (end must be strictly after start). |
+| `isActive(scope, asOf=null): bool` | Whether a window covers the instant. |
+| `activeWindow(scope, asOf=null): ?array` | The covering window (soonest-ending if overlapping). |
+| `upcoming(scope, asOf=null): array` | Future windows, soonest first. |
+| `cancel(id)` | Delete a window (no-op if absent). |
+| `purgeEnded(asOf=null): int` | Drop windows that already ended. |
+
+Key design points:
+
+- **Half-open `[start, end)`**: start inclusive, end exclusive (consistent with the wave's range convention).
+- **Overlap resolution**: `activeWindow` returns the soonest-ending covering window (`ORDER BY ends_at`).
+- **Deterministic time**: `asOf` parameter for testable, reproducible queries.
+- **PDO injection**; timestamps normalised via `strtotime` → `'Y-m-d H:i:s'`.
+
+### Tests (`tests/Unit/Xion/MaintenanceWindowTest.php`)
+
+15 unit tests (23 assertions): schedule returns id; isActive within / half-open boundaries (start incl, end excl, just-before) / scoped; activeWindow details / null / soonest-ending preference; upcoming ordering and exclusion of active+past; cancel + missing no-op; purgeEnded removes only finished windows; validation (end<start, end==start, empty scope).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 15 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/MaintenanceWindowTest.php
+++ b/tests/Unit/Xion/MaintenanceWindowTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\MaintenanceWindow;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for MaintenanceWindow.
+ */
+final class MaintenanceWindowTest extends TestCase
+{
+    private PDO $db;
+    private MaintenanceWindow $mw;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE maintenance_windows (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                scope      VARCHAR(100) NOT NULL,
+                starts_at  DATETIME     NOT NULL,
+                ends_at    DATETIME     NOT NULL,
+                reason     VARCHAR(255) NOT NULL DEFAULT \'\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->mw = new MaintenanceWindow($this->db);
+    }
+
+    public function testScheduleReturnsId(): void
+    {
+        $id = $this->mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 04:00:00', 'DB upgrade');
+        $this->assertGreaterThan(0, $id);
+    }
+
+    public function testIsActiveWithinWindow(): void
+    {
+        $this->mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 04:00:00');
+        $this->assertTrue($this->mw->isActive('api', '2026-06-01 03:00:00'));
+    }
+
+    public function testIsActiveBoundariesAreHalfOpen(): void
+    {
+        $this->mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 04:00:00');
+        $this->assertTrue($this->mw->isActive('api', '2026-06-01 02:00:00'));  // start inclusive
+        $this->assertFalse($this->mw->isActive('api', '2026-06-01 04:00:00')); // end exclusive
+        $this->assertFalse($this->mw->isActive('api', '2026-06-01 01:59:59')); // just before
+    }
+
+    public function testIsActiveScoped(): void
+    {
+        $this->mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 04:00:00');
+        $this->assertFalse($this->mw->isActive('web', '2026-06-01 03:00:00'));
+    }
+
+    public function testActiveWindowReturnsDetails(): void
+    {
+        $this->mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 04:00:00', 'DB upgrade');
+        $w = $this->mw->activeWindow('api', '2026-06-01 03:00:00');
+        $this->assertNotNull($w);
+        $this->assertSame('DB upgrade', $w['reason']);
+        $this->assertSame('2026-06-01 02:00:00', $w['starts_at']);
+    }
+
+    public function testActiveWindowNullWhenNone(): void
+    {
+        $this->assertNull($this->mw->activeWindow('api', '2026-06-01 03:00:00'));
+    }
+
+    public function testActiveWindowPrefersSoonestEnding(): void
+    {
+        $this->mw->schedule('api', '2026-06-01 01:00:00', '2026-06-01 06:00:00', 'long');
+        $this->mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 04:00:00', 'short');
+        $w = $this->mw->activeWindow('api', '2026-06-01 03:00:00');
+        $this->assertNotNull($w);
+        $this->assertSame('short', $w['reason']);
+    }
+
+    public function testUpcomingListsFutureSoonestFirst(): void
+    {
+        $this->mw->schedule('api', '2026-06-10 02:00:00', '2026-06-10 03:00:00', 'later');
+        $this->mw->schedule('api', '2026-06-05 02:00:00', '2026-06-05 03:00:00', 'sooner');
+        $up = $this->mw->upcoming('api', '2026-06-01 00:00:00');
+        $this->assertCount(2, $up);
+        $this->assertSame('sooner', $up[0]['reason']);
+        $this->assertSame('later', $up[1]['reason']);
+    }
+
+    public function testUpcomingExcludesActiveAndPast(): void
+    {
+        $this->mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 04:00:00', 'active');
+        $up = $this->mw->upcoming('api', '2026-06-01 03:00:00'); // currently inside this window
+        $this->assertSame([], $up);
+    }
+
+    public function testCancel(): void
+    {
+        $id = $this->mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 04:00:00');
+        $this->mw->cancel($id);
+        $this->assertFalse($this->mw->isActive('api', '2026-06-01 03:00:00'));
+    }
+
+    public function testCancelMissingIsNoop(): void
+    {
+        $this->mw->cancel(999); // no throw
+        $this->assertNull($this->mw->activeWindow('api', '2026-06-01 03:00:00'));
+    }
+
+    public function testPurgeEndedRemovesOnlyFinishedWindows(): void
+    {
+        $this->mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 04:00:00', 'past');
+        $this->mw->schedule('api', '2026-06-10 02:00:00', '2026-06-10 04:00:00', 'future');
+        $removed = $this->mw->purgeEnded('2026-06-05 00:00:00');
+        $this->assertSame(1, $removed);
+        $this->assertCount(1, $this->mw->upcoming('api', '2026-06-01 00:00:00'));
+    }
+
+    public function testScheduleRejectsEndBeforeStart(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mw->schedule('api', '2026-06-01 04:00:00', '2026-06-01 02:00:00');
+    }
+
+    public function testScheduleRejectsEqualStartEnd(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mw->schedule('api', '2026-06-01 02:00:00', '2026-06-01 02:00:00');
+    }
+
+    public function testScheduleRejectsEmptyScope(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mw->schedule('  ', '2026-06-01 02:00:00', '2026-06-01 04:00:00');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT269** — `Nene\Xion\MaintenanceWindow`: scheduled, time-bounded maintenance windows per service scope. Unlike `MaintenanceMode` (FT87, a global flag), this holds scheduled intervals, several upcoming entries, scoped per service. Active during half-open `[starts_at, ends_at)`.

| Method | Description |
| --- | --- |
| `schedule(scope, startsAt, endsAt, reason='') : int` | Create (end strictly after start). |
| `isActive / activeWindow (asOf=null)` | Covering window (soonest-ending if overlapping). |
| `upcoming(scope, asOf=null)` | Future windows, soonest first. |
| `cancel(id) / purgeEnded(asOf=null): int` | Delete one / drop finished. |

- Half-open `[start, end)`; `asOf` for deterministic tests.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 15 tests / 23 assertions (half-open boundaries, scoping, overlap resolution, upcoming ordering/exclusion, cancel, purgeEnded, validation)
- [x] `composer precommit` green (format → Phan → 4618 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)