### PR TITLE
feat(xion): EmailSuppression — do-not-send list for addresses (FT270)

### DIFF
--- a/class/xion/EmailSuppression.php
+++ b/class/xion/EmailSuppression.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * EmailSuppression — do-not-send list for email addresses.
+ *
+ * Tracks addresses that must not receive mail — hard bounces, spam
+ * complaints, explicit unsubscribes, or manual blocks — so a sender can skip
+ * them before dispatch and protect deliverability. Complements `EmailBounce`
+ * (FT253, which records bounce *events*): this is the derived, deduplicated
+ * suppression set keyed by address.
+ *
+ * Addresses are normalised to lowercase. The suppression set is the single
+ * source of truth a send pipeline consults via {@see EmailSuppression::filter()}.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $sup = new EmailSuppression($pdo);
+ *
+ * $sup->suppress('user@example.com', EmailSuppression::REASON_BOUNCE);
+ * $sup->suppress('spam@example.com', EmailSuppression::REASON_COMPLAINT);
+ *
+ * $sup->isSuppressed('USER@example.com'); // true (case-insensitive)
+ * $sup->reasonFor('user@example.com');    // 'bounce'
+ *
+ * // Before a batch send, keep only deliverable addresses
+ * $ok = $sup->filter(['a@x.com', 'user@example.com', 'b@x.com']);
+ * // → ['a@x.com', 'b@x.com']
+ *
+ * $sup->release('user@example.com'); // address recovered / re-subscribed
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE email_suppressions (
+ *     id            INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     email         VARCHAR(255) NOT NULL,
+ *     reason        VARCHAR(20)  NOT NULL,
+ *     suppressed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (email)
+ * );
+ * ```
+ */
+final class EmailSuppression
+{
+    public const string REASON_BOUNCE      = 'bounce';
+    public const string REASON_COMPLAINT   = 'complaint';
+    public const string REASON_UNSUBSCRIBE = 'unsubscribe';
+    public const string REASON_MANUAL      = 'manual';
+
+    private const array REASONS = [
+        self::REASON_BOUNCE,
+        self::REASON_COMPLAINT,
+        self::REASON_UNSUBSCRIBE,
+        self::REASON_MANUAL,
+    ];
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add (or update the reason for) a suppressed address. Idempotent per email.
+     *
+     * @param  string $email  Address (normalised to lowercase).
+     * @param  string $reason One of the REASON_* constants.
+     * @throws \InvalidArgumentException on empty email or unknown reason.
+     */
+    public function suppress(string $email, string $reason = self::REASON_MANUAL): void
+    {
+        $email = $this->normalize($email);
+        if (!in_array($reason, self::REASONS, true)) {
+            throw new \InvalidArgumentException("Unknown suppression reason: {$reason}");
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'email_suppressions',
+            data:         ['email' => $email, 'reason' => $reason],
+            conflictCols: ['email'],
+            updateCols:   ['reason'],
+            updateExprs:  ['suppressed_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    /**
+     * Whether an address is suppressed (case-insensitive).
+     */
+    public function isSuppressed(string $email): bool
+    {
+        $email = $this->normalize($email);
+        $stmt  = $this->db()->prepare('SELECT 1 FROM email_suppressions WHERE email = ? LIMIT 1');
+        $stmt->execute([$email]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Return the suppression reason for an address, or null if not suppressed.
+     */
+    public function reasonFor(string $email): ?string
+    {
+        $email = $this->normalize($email);
+        $stmt  = $this->db()->prepare('SELECT reason FROM email_suppressions WHERE email = ?');
+        $stmt->execute([$email]);
+        $reason = $stmt->fetchColumn();
+
+        return $reason === false ? null : (string)$reason;
+    }
+
+    /**
+     * Remove an address from the suppression list. No-op if absent.
+     */
+    public function release(string $email): void
+    {
+        $email = $this->normalize($email);
+        $stmt  = $this->db()->prepare('DELETE FROM email_suppressions WHERE email = ?');
+        $stmt->execute([$email]);
+    }
+
+    /**
+     * Filter a list of addresses down to the deliverable (non-suppressed) ones.
+     *
+     * Preserves input order and the original casing of each kept address.
+     * Performs a single query regardless of list size.
+     *
+     * @param  array<int,string> $emails Candidate addresses.
+     * @return array<int,string>         Addresses that are not suppressed.
+     */
+    public function filter(array $emails): array
+    {
+        if ($emails === []) {
+            return [];
+        }
+
+        $normalised = [];
+        foreach ($emails as $e) {
+            $normalised[] = strtolower(trim($e));
+        }
+        $unique = array_values(array_unique(array_filter($normalised, static fn (string $e): bool => $e !== '')));
+        if ($unique === []) {
+            return [];
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($unique), '?'));
+        $stmt         = $this->db()->prepare(
+            "SELECT email FROM email_suppressions WHERE email IN ({$placeholders})"
+        );
+        $stmt->execute($unique);
+
+        $suppressed = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $e) {
+            $suppressed[(string)$e] = true;
+        }
+
+        $out = [];
+        foreach ($emails as $original) {
+            $key = strtolower(trim($original));
+            if ($key !== '' && !isset($suppressed[$key])) {
+                $out[] = $original;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * List suppressed addresses, optionally filtered by reason, newest first.
+     *
+     * @param  string|null $reason One of the REASON_* constants, or null for all.
+     * @return array<int,array{email:string,reason:string,suppressed_at:string}>
+     * @throws \InvalidArgumentException on unknown reason.
+     */
+    public function all(?string $reason = null): array
+    {
+        if ($reason !== null && !in_array($reason, self::REASONS, true)) {
+            throw new \InvalidArgumentException("Unknown suppression reason: {$reason}");
+        }
+
+        if ($reason === null) {
+            $stmt = $this->db()->query(
+                'SELECT email, reason, suppressed_at FROM email_suppressions ORDER BY suppressed_at DESC, email ASC'
+            );
+            $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT email, reason, suppressed_at FROM email_suppressions WHERE reason = ? ORDER BY suppressed_at DESC, email ASC'
+            );
+            $stmt->execute([$reason]);
+            $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        }
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($rows as $row) {
+            $out[] = [
+                'email'         => (string)$row['email'],
+                'reason'        => (string)$row['reason'],
+                'suppressed_at' => (string)$row['suppressed_at'],
+            ];
+        }
+
+        return $out;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function normalize(string $email): string
+    {
+        $email = strtolower(trim($email));
+        if ($email === '') {
+            throw new \InvalidArgumentException('Email must not be empty.');
+        }
+
+        return $email;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -132,6 +132,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `DailyDigest` | per-user daily digest item accumulator. |
 | `EmailBounce` | email bounce and complaint tracking for delivery health management. |
 | `EmailQueue` | DB-backed outgoing email queue with retry and exponential backoff. |
+| `EmailSuppression` | do-not-send list for email addresses. |
 | `MailMessage` | Plain immutable description of one outgoing email. |
 | `Mailer` | Thin wrapper around Symfony Mailer (ADR-0006). |
 | `NewsletterSubscription` | Newsletter / mailing-list subscription manager with double opt-in support. |

--- a/docs/field-trials/2026-05-field-trial-270.md
+++ b/docs/field-trials/2026-05-field-trial-270.md
@@ -1,0 +1,41 @@
+# Field Trial 270 — EmailSuppression
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft270-email-suppression`
+**Baseline**: post FT269 merge
+
+## Goal
+
+Add `Nene\Xion\EmailSuppression` — a do-not-send list (bounce / complaint / unsubscribe / manual) consulted before dispatch to protect deliverability. Complements `EmailBounce` (FT253, raw bounce events): this is the deduplicated suppression set keyed by address.
+
+## What was built
+
+### `Nene\Xion\EmailSuppression` (`class/xion/EmailSuppression.php`)
+
+| Method | Description |
+| --- | --- |
+| `suppress(email, reason=MANUAL)` | Add/update (idempotent per address; validated reason). |
+| `isSuppressed(email) / reasonFor(email)` | Case-insensitive lookup. |
+| `release(email)` | Remove (recovery / re-subscribe). |
+| `filter(emails[]): array` | Keep only deliverable addresses (single `IN (...)` query, order + casing preserved). |
+| `all(reason=null): array` | List, optionally by reason, newest first. |
+
+Key design points:
+
+- **Normalisation**: addresses lowercased + trimmed on every path so lookups are case-insensitive; `UNIQUE (email)` dedupes.
+- **`filter()` for the send pipeline**: one query for the whole batch (not N), preserves input order and original casing of kept addresses, drops blanks/dupes internally.
+- **Reason constants** validated against an allow-list; **cross-driver upsert**; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/EmailSuppressionTest.php`)
+
+14 unit tests (19 assertions): suppress/check, case-insensitive + trim, default reason, idempotent reason-update, not-suppressed null, release (+ case-insensitive, + missing no-op), `filter` (deliverable kept with order/casing, empty list, blank entries dropped), `all` by reason, and validation (unknown reason on suppress + all, empty email).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 14 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/EmailSuppressionTest.php
+++ b/tests/Unit/Xion/EmailSuppressionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\EmailSuppression;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for EmailSuppression.
+ */
+final class EmailSuppressionTest extends TestCase
+{
+    private PDO $db;
+    private EmailSuppression $sup;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE email_suppressions (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                email         VARCHAR(255) NOT NULL,
+                reason        VARCHAR(20)  NOT NULL,
+                suppressed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (email)
+            )
+        ');
+        $this->sup = new EmailSuppression($this->db);
+    }
+
+    public function testSuppressAndCheck(): void
+    {
+        $this->sup->suppress('user@example.com', EmailSuppression::REASON_BOUNCE);
+        $this->assertTrue($this->sup->isSuppressed('user@example.com'));
+        $this->assertSame('bounce', $this->sup->reasonFor('user@example.com'));
+    }
+
+    public function testCaseInsensitiveAndTrimmed(): void
+    {
+        $this->sup->suppress('  USER@Example.COM ');
+        $this->assertTrue($this->sup->isSuppressed('user@example.com'));
+        $this->assertTrue($this->sup->isSuppressed('User@Example.com'));
+    }
+
+    public function testDefaultReasonIsManual(): void
+    {
+        $this->sup->suppress('user@example.com');
+        $this->assertSame('manual', $this->sup->reasonFor('user@example.com'));
+    }
+
+    public function testSuppressIsIdempotentAndUpdatesReason(): void
+    {
+        $this->sup->suppress('user@example.com', EmailSuppression::REASON_BOUNCE);
+        $this->sup->suppress('user@example.com', EmailSuppression::REASON_COMPLAINT);
+        $this->assertSame('complaint', $this->sup->reasonFor('user@example.com'));
+        $this->assertCount(1, $this->sup->all());
+    }
+
+    public function testNotSuppressedReturnsNull(): void
+    {
+        $this->assertFalse($this->sup->isSuppressed('nobody@example.com'));
+        $this->assertNull($this->sup->reasonFor('nobody@example.com'));
+    }
+
+    public function testRelease(): void
+    {
+        $this->sup->suppress('user@example.com');
+        $this->sup->release('USER@example.com'); // case-insensitive
+        $this->assertFalse($this->sup->isSuppressed('user@example.com'));
+    }
+
+    public function testReleaseMissingIsNoop(): void
+    {
+        $this->sup->release('ghost@example.com');
+        $this->assertSame([], $this->sup->all());
+    }
+
+    public function testFilterKeepsDeliverablePreservingOrderAndCasing(): void
+    {
+        $this->sup->suppress('user@example.com', EmailSuppression::REASON_BOUNCE);
+        $kept = $this->sup->filter(['A@x.com', 'USER@example.com', 'b@x.com']);
+        $this->assertSame(['A@x.com', 'b@x.com'], $kept); // suppressed dropped, casing kept
+    }
+
+    public function testFilterEmptyList(): void
+    {
+        $this->assertSame([], $this->sup->filter([]));
+    }
+
+    public function testFilterDropsBlankEntries(): void
+    {
+        $kept = $this->sup->filter(['  ', 'a@x.com']);
+        $this->assertSame(['a@x.com'], $kept);
+    }
+
+    public function testAllFilteredByReason(): void
+    {
+        $this->sup->suppress('a@x.com', EmailSuppression::REASON_BOUNCE);
+        $this->sup->suppress('b@x.com', EmailSuppression::REASON_COMPLAINT);
+        $this->sup->suppress('c@x.com', EmailSuppression::REASON_BOUNCE);
+        $this->assertCount(2, $this->sup->all(EmailSuppression::REASON_BOUNCE));
+        $this->assertCount(3, $this->sup->all());
+    }
+
+    public function testSuppressRejectsUnknownReason(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sup->suppress('user@example.com', 'explosion');
+    }
+
+    public function testSuppressRejectsEmptyEmail(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sup->suppress('   ');
+    }
+
+    public function testAllRejectsUnknownReason(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sup->all('bogus');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT270** — `Nene\Xion\EmailSuppression`: a do-not-send list (bounce/complaint/unsubscribe/manual) consulted before dispatch. Complements `EmailBounce` (FT253, raw events) as the deduplicated suppression set keyed by address.

| Method | Description |
| --- | --- |
| `suppress(email, reason=MANUAL)` | Idempotent per address; validated reason. |
| `isSuppressed / reasonFor` | Case-insensitive lookup. |
| `release(email)` | Recovery / re-subscribe. |
| `filter(emails[]): array` | Keep deliverable only — one `IN (...)` query, order + casing preserved. |
| `all(reason=null)` | List newest first. |

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 14 tests / 19 assertions (normalisation, idempotent reason-update, release, filter order/casing/blank/empty, all-by-reason, validation)
- [x] `composer precommit` green (format → Phan → 4632 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)