### PR TITLE
feat(xion): PasswordPolicy — per-scope password complexity rules (FT271)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -25,6 +25,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `OtpChallenge` | one-time password (OTP) challenge issuance and verification. |
 | `PasswordExpiry` | Password expiry policy enforcement. |
 | `PasswordHistory` | Password history — prevent users from reusing recent passwords. |
+| `PasswordPolicy` | configurable password complexity rules per scope. |
 | `PasswordResetToken` | Cryptographic helpers for password-reset token workflows. |
 | `PersonalAccessToken` | Personal Access Token (PAT) management for user-facing dashboards. |
 | `PinCode` | short PIN / OTP issuance with attempt limiting and expiry. |

--- a/class/xion/PasswordPolicy.php
+++ b/class/xion/PasswordPolicy.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * PasswordPolicy — configurable password complexity rules per scope.
+ *
+ * Stores complexity requirements (minimum length and character-class flags)
+ * per named scope and validates candidate passwords against them. Distinct
+ * from `PasswordExpiry` (FT264, *when* a password must change) and
+ * `PasswordHistory` (FT91, preventing *reuse*): this governs *what makes a
+ * password acceptable* at set-time.
+ *
+ * When no policy row exists for a scope, the built-in defaults apply
+ * (min length {@see PasswordPolicy::DEFAULT_MIN_LENGTH}, no character-class
+ * requirements), so `validate()` is always safe to call.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $pp = new PasswordPolicy($pdo);
+ *
+ * $pp->setPolicy('admin', minLength: 12, requireUpper: true, requireDigit: true, requireSymbol: true);
+ *
+ * $pp->validate('admin', 'short');
+ * // ['too_short', 'need_upper', 'need_digit', 'need_symbol']
+ *
+ * $pp->isValid('admin', 'Sup3rSecret!');   // true
+ * $pp->validate('unconfigured', 'abcdefgh'); // [] — default min-8 satisfied
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE password_policies (
+ *     id             INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     scope          VARCHAR(100) NOT NULL,
+ *     min_length     INTEGER      NOT NULL DEFAULT 8,
+ *     require_upper  INTEGER      NOT NULL DEFAULT 0,
+ *     require_lower  INTEGER      NOT NULL DEFAULT 0,
+ *     require_digit  INTEGER      NOT NULL DEFAULT 0,
+ *     require_symbol INTEGER      NOT NULL DEFAULT 0,
+ *     updated_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (scope)
+ * );
+ * ```
+ */
+final class PasswordPolicy
+{
+    public const int DEFAULT_MIN_LENGTH = 8;
+
+    public const string VIOLATION_TOO_SHORT   = 'too_short';
+    public const string VIOLATION_NEED_UPPER  = 'need_upper';
+    public const string VIOLATION_NEED_LOWER  = 'need_lower';
+    public const string VIOLATION_NEED_DIGIT  = 'need_digit';
+    public const string VIOLATION_NEED_SYMBOL = 'need_symbol';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set (or replace) the policy for a scope. Idempotent per scope.
+     *
+     * @param  string $scope         Policy scope (e.g. 'admin').
+     * @param  int    $minLength     Minimum length (>= 1).
+     * @param  bool   $requireUpper  Require an uppercase letter.
+     * @param  bool   $requireLower  Require a lowercase letter.
+     * @param  bool   $requireDigit  Require a digit.
+     * @param  bool   $requireSymbol Require a non-alphanumeric character.
+     * @throws \InvalidArgumentException on empty scope or $minLength < 1.
+     */
+    public function setPolicy(
+        string $scope,
+        int $minLength = self::DEFAULT_MIN_LENGTH,
+        bool $requireUpper = false,
+        bool $requireLower = false,
+        bool $requireDigit = false,
+        bool $requireSymbol = false,
+    ): void {
+        $scope = $this->validateScope($scope);
+        if ($minLength < 1) {
+            throw new \InvalidArgumentException('Minimum length must be at least 1.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'password_policies',
+            data:         [
+                'scope'          => $scope,
+                'min_length'     => $minLength,
+                'require_upper'  => $requireUpper ? 1 : 0,
+                'require_lower'  => $requireLower ? 1 : 0,
+                'require_digit'  => $requireDigit ? 1 : 0,
+                'require_symbol' => $requireSymbol ? 1 : 0,
+            ],
+            conflictCols: ['scope'],
+            updateCols:   ['min_length', 'require_upper', 'require_lower', 'require_digit', 'require_symbol'],
+            updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    /**
+     * Return the effective policy for a scope (stored or built-in default).
+     *
+     * @param  string $scope Policy scope.
+     * @return array{min_length:int,require_upper:bool,require_lower:bool,require_digit:bool,require_symbol:bool}
+     */
+    public function getPolicy(string $scope): array
+    {
+        $scope = $this->validateScope($scope);
+
+        $stmt = $this->db()->prepare(
+            'SELECT min_length, require_upper, require_lower, require_digit, require_symbol
+             FROM password_policies WHERE scope = ?'
+        );
+        $stmt->execute([$scope]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return [
+                'min_length'     => self::DEFAULT_MIN_LENGTH,
+                'require_upper'  => false,
+                'require_lower'  => false,
+                'require_digit'  => false,
+                'require_symbol' => false,
+            ];
+        }
+
+        return [
+            'min_length'     => (int)$row['min_length'],
+            'require_upper'  => (bool)$row['require_upper'],
+            'require_lower'  => (bool)$row['require_lower'],
+            'require_digit'  => (bool)$row['require_digit'],
+            'require_symbol' => (bool)$row['require_symbol'],
+        ];
+    }
+
+    /**
+     * Validate a password against a scope's policy.
+     *
+     * @param  string $scope    Policy scope.
+     * @param  string $password Candidate password.
+     * @return array<int,string> Violation codes (empty = valid).
+     */
+    public function validate(string $scope, string $password): array
+    {
+        $policy     = $this->getPolicy($scope);
+        $violations = [];
+
+        if (mb_strlen($password) < $policy['min_length']) {
+            $violations[] = self::VIOLATION_TOO_SHORT;
+        }
+        if ($policy['require_upper'] && preg_match('/[A-Z]/', $password) !== 1) {
+            $violations[] = self::VIOLATION_NEED_UPPER;
+        }
+        if ($policy['require_lower'] && preg_match('/[a-z]/', $password) !== 1) {
+            $violations[] = self::VIOLATION_NEED_LOWER;
+        }
+        if ($policy['require_digit'] && preg_match('/[0-9]/', $password) !== 1) {
+            $violations[] = self::VIOLATION_NEED_DIGIT;
+        }
+        if ($policy['require_symbol'] && preg_match('/[^A-Za-z0-9]/', $password) !== 1) {
+            $violations[] = self::VIOLATION_NEED_SYMBOL;
+        }
+
+        return $violations;
+    }
+
+    /**
+     * Whether a password satisfies a scope's policy.
+     */
+    public function isValid(string $scope, string $password): bool
+    {
+        return $this->validate($scope, $password) === [];
+    }
+
+    /**
+     * Remove a scope's policy (reverts it to the built-in default). No-op if absent.
+     */
+    public function remove(string $scope): void
+    {
+        $scope = $this->validateScope($scope);
+        $stmt  = $this->db()->prepare('DELETE FROM password_policies WHERE scope = ?');
+        $stmt->execute([$scope]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validateScope(string $scope): string
+    {
+        $scope = trim($scope);
+        if ($scope === '') {
+            throw new \InvalidArgumentException('Scope must not be empty.');
+        }
+
+        return $scope;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-271.md
+++ b/docs/field-trials/2026-05-field-trial-271.md
@@ -1,0 +1,42 @@
+# Field Trial 271 — PasswordPolicy
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft271-password-policy`
+**Baseline**: post FT270 merge
+
+## Goal
+
+Add `Nene\Xion\PasswordPolicy` — configurable password complexity rules per scope, validating candidate passwords at set-time. Completes the password trio with `PasswordExpiry` (FT264, when to change) and `PasswordHistory` (FT91, no reuse).
+
+## What was built
+
+### `Nene\Xion\PasswordPolicy` (`class/xion/PasswordPolicy.php`)
+
+| Method | Description |
+| --- | --- |
+| `setPolicy(scope, minLength, requireUpper, requireLower, requireDigit, requireSymbol)` | Upsert a per-scope rule set. |
+| `getPolicy(scope): array` | Effective policy (stored row or built-in default). |
+| `validate(scope, password): array` | Violation codes (`too_short`/`need_upper`/`need_lower`/`need_digit`/`need_symbol`); empty = valid. |
+| `isValid(scope, password): bool` | Convenience over `validate`. |
+| `remove(scope)` | Revert a scope to the default. |
+
+Key design points:
+
+- **Safe default**: with no policy row, defaults apply (min length 8, no class requirements), so `validate()` never errors on an unconfigured scope.
+- **All violations returned** (not first-fail) so a UI can show every problem at once.
+- **Multibyte-correct length** via `mb_strlen`; symbol = any non-alphanumeric (`/[^A-Za-z0-9]/`).
+- **Cross-driver upsert**; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/PasswordPolicyTest.php`)
+
+12 unit tests (26 assertions): default-policy behaviour + shape, set/get, all-violations collection, strong-password pass, min-length boundary (9 vs 10 at min 10), symbol detection, multibyte length (パスワード counts as chars), idempotent upsert, remove→default, validation (empty scope, zero min length).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/PasswordPolicyTest.php
+++ b/tests/Unit/Xion/PasswordPolicyTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\PasswordPolicy;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PasswordPolicy.
+ */
+final class PasswordPolicyTest extends TestCase
+{
+    private PDO $db;
+    private PasswordPolicy $pp;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE password_policies (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                scope          VARCHAR(100) NOT NULL,
+                min_length     INTEGER      NOT NULL DEFAULT 8,
+                require_upper  INTEGER      NOT NULL DEFAULT 0,
+                require_lower  INTEGER      NOT NULL DEFAULT 0,
+                require_digit  INTEGER      NOT NULL DEFAULT 0,
+                require_symbol INTEGER      NOT NULL DEFAULT 0,
+                updated_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (scope)
+            )
+        ');
+        $this->pp = new PasswordPolicy($this->db);
+    }
+
+    public function testDefaultPolicyWhenNoneSet(): void
+    {
+        // Default = min length 8, no class requirements.
+        $this->assertSame([], $this->pp->validate('web', 'abcdefgh')); // exactly 8 → ok
+        $this->assertSame(
+            [PasswordPolicy::VIOLATION_TOO_SHORT],
+            $this->pp->validate('web', 'abcdefg') // 7 → too short
+        );
+    }
+
+    public function testGetPolicyReturnsDefaultShape(): void
+    {
+        $p = $this->pp->getPolicy('web');
+        $this->assertSame(8, $p['min_length']);
+        $this->assertFalse($p['require_upper']);
+    }
+
+    public function testSetAndGetPolicy(): void
+    {
+        $this->pp->setPolicy('admin', minLength: 12, requireUpper: true, requireDigit: true, requireSymbol: true);
+        $p = $this->pp->getPolicy('admin');
+        $this->assertSame(12, $p['min_length']);
+        $this->assertTrue($p['require_upper']);
+        $this->assertTrue($p['require_digit']);
+        $this->assertTrue($p['require_symbol']);
+        $this->assertFalse($p['require_lower']);
+    }
+
+    public function testValidateCollectsAllViolations(): void
+    {
+        $this->pp->setPolicy('admin', minLength: 12, requireUpper: true, requireDigit: true, requireSymbol: true);
+        $v = $this->pp->validate('admin', 'short');
+        $this->assertContains(PasswordPolicy::VIOLATION_TOO_SHORT, $v);
+        $this->assertContains(PasswordPolicy::VIOLATION_NEED_UPPER, $v);
+        $this->assertContains(PasswordPolicy::VIOLATION_NEED_DIGIT, $v);
+        $this->assertContains(PasswordPolicy::VIOLATION_NEED_SYMBOL, $v);
+        $this->assertNotContains(PasswordPolicy::VIOLATION_NEED_LOWER, $v); // 'short' has lowercase
+    }
+
+    public function testIsValidPassesStrongPassword(): void
+    {
+        $this->pp->setPolicy('admin', minLength: 12, requireUpper: true, requireLower: true, requireDigit: true, requireSymbol: true);
+        $this->assertTrue($this->pp->isValid('admin', 'Sup3rSecret!'));
+    }
+
+    public function testMinLengthBoundary(): void
+    {
+        $this->pp->setPolicy('x', minLength: 10);
+        $this->assertFalse($this->pp->isValid('x', '123456789'));   // 9  → too short
+        $this->assertTrue($this->pp->isValid('x', '1234567890'));   // 10 → exactly at minimum, ok
+    }
+
+    public function testRequireSymbolDetectsNonAlnum(): void
+    {
+        $this->pp->setPolicy('x', minLength: 1, requireSymbol: true);
+        $this->assertFalse($this->pp->isValid('x', 'abc123'));
+        $this->assertTrue($this->pp->isValid('x', 'abc-123'));
+    }
+
+    public function testMultibyteLengthCountedByCharacters(): void
+    {
+        $this->pp->setPolicy('x', minLength: 4);
+        $this->assertTrue($this->pp->isValid('x', 'パスワード')); // 5 chars
+        $this->assertFalse($this->pp->isValid('x', 'パス'));      // 2 chars
+    }
+
+    public function testSetPolicyIsIdempotent(): void
+    {
+        $this->pp->setPolicy('admin', minLength: 10);
+        $this->pp->setPolicy('admin', minLength: 16, requireUpper: true);
+        $this->assertSame(16, $this->pp->getPolicy('admin')['min_length']);
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM password_policies')->fetchColumn());
+    }
+
+    public function testRemoveRevertsToDefault(): void
+    {
+        $this->pp->setPolicy('admin', minLength: 20);
+        $this->pp->remove('admin');
+        $this->assertSame(8, $this->pp->getPolicy('admin')['min_length']); // back to default
+    }
+
+    public function testSetPolicyRejectsEmptyScope(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pp->setPolicy('  ', minLength: 8);
+    }
+
+    public function testSetPolicyRejectsZeroMinLength(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pp->setPolicy('x', minLength: 0);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT271** — `Nene\Xion\PasswordPolicy`: configurable password complexity rules per scope, validated at set-time. Completes the password trio with `PasswordExpiry` (FT264) and `PasswordHistory` (FT91).

| Method | Description |
| --- | --- |
| `setPolicy(scope, minLength, requireUpper, requireLower, requireDigit, requireSymbol)` | Upsert rule set. |
| `getPolicy(scope)` | Stored row or built-in default. |
| `validate(scope, pw): array` / `isValid` | All violation codes / bool. |
| `remove(scope)` | Revert to default. |

- Safe default (min 8, no class reqs) when unconfigured; all violations returned; `mb_strlen` length.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 26 assertions (default behaviour, set/get, all-violations, boundary 9-vs-10, symbol, multibyte, idempotent, remove→default, validation)
- [x] `composer precommit` green (format → Phan → 4644 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)