### PR TITLE
feat(xion): PercentageRollout — sticky percentage feature rollout (FT272)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -273,6 +273,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `Cors` | CORS (Cross-Origin Resource Sharing) header utility. |
 | `ExportJob` | async data export job tracking. |
 | `FeatureFlag` | DB-backed feature flags with global on/off and per-user overrides. |
+| `PercentageRollout` | gradual feature rollout by percentage with sticky bucketing. |
 | `HealthCheck` | service/component health monitoring log. |
 | `HttpCache` | HTTP cache header utilities for REST endpoints. |
 | `IdempotencyStore` | DB-backed idempotency key store for POST endpoints. |

--- a/class/xion/PercentageRollout.php
+++ b/class/xion/PercentageRollout.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * PercentageRollout — gradual feature rollout by percentage with sticky bucketing.
+ *
+ * Enables a feature for a deterministic percentage of keys (user ids, account
+ * ids, …). Distinct from `FeatureFlag` (FT124, a global on/off toggle): here a
+ * flag carries a 0–100 percentage and membership is decided by hashing the
+ * `(flag, key)` pair, so:
+ *
+ * - the same key always gets the same answer for a given percentage (sticky —
+ *   no flicker between requests), and
+ * - raising the percentage only *adds* keys (a key enabled at 20% stays
+ *   enabled at 50%), because the bucket is derived from the key, not random.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ro = new PercentageRollout($pdo);
+ *
+ * $ro->setPercentage('new_ui', 25);       // 25% rollout
+ * $ro->isEnabled('new_ui', 'user-42');    // deterministic true/false
+ * $ro->percentageFor('new_ui');           // 25
+ *
+ * $ro->enableFully('new_ui');             // 100% — everyone
+ * $ro->disable('new_ui');                 // 0% — no one
+ * $ro->remove('new_ui');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE rollout_flags (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     flag       VARCHAR(100) NOT NULL,
+ *     percentage INTEGER      NOT NULL DEFAULT 0,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (flag)
+ * );
+ * ```
+ */
+final class PercentageRollout
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set the rollout percentage for a flag (0–100). Idempotent per flag.
+     *
+     * @param  string $flag    Flag name.
+     * @param  int    $percent Rollout percentage, 0–100 inclusive.
+     * @throws \InvalidArgumentException on empty flag or out-of-range percent.
+     */
+    public function setPercentage(string $flag, int $percent): void
+    {
+        $flag = $this->validateFlag($flag);
+        if ($percent < 0 || $percent > 100) {
+            throw new \InvalidArgumentException('Percentage must be between 0 and 100.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'rollout_flags',
+            data:         ['flag' => $flag, 'percentage' => $percent],
+            conflictCols: ['flag'],
+            updateCols:   ['percentage'],
+            updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    /**
+     * Return the rollout percentage for a flag (0 if not configured).
+     */
+    public function percentageFor(string $flag): int
+    {
+        $flag = $this->validateFlag($flag);
+        $stmt = $this->db()->prepare('SELECT percentage FROM rollout_flags WHERE flag = ?');
+        $stmt->execute([$flag]);
+        $pct = $stmt->fetchColumn();
+
+        return $pct === false ? 0 : (int)$pct;
+    }
+
+    /**
+     * Whether the feature is enabled for a given key under the current percentage.
+     *
+     * Deterministic and sticky: depends only on `(flag, key)` and the stored
+     * percentage. A key in the enabled set at percentage P stays enabled for
+     * any P' >= P.
+     *
+     * @param string $flag Flag name.
+     * @param string $key  Stable identity (e.g. user id).
+     */
+    public function isEnabled(string $flag, string $key): bool
+    {
+        $pct = $this->percentageFor($flag);
+        if ($pct <= 0) {
+            return false;
+        }
+        if ($pct >= 100) {
+            return true;
+        }
+
+        return $this->bucket($flag, $key) < $pct;
+    }
+
+    /**
+     * Set the flag to 100%.
+     */
+    public function enableFully(string $flag): void
+    {
+        $this->setPercentage($flag, 100);
+    }
+
+    /**
+     * Set the flag to 0%.
+     */
+    public function disable(string $flag): void
+    {
+        $this->setPercentage($flag, 0);
+    }
+
+    /**
+     * Remove a flag entirely (subsequent `isEnabled` is false). No-op if absent.
+     */
+    public function remove(string $flag): void
+    {
+        $flag = $this->validateFlag($flag);
+        $stmt = $this->db()->prepare('DELETE FROM rollout_flags WHERE flag = ?');
+        $stmt->execute([$flag]);
+    }
+
+    /**
+     * List all flags and their percentages, ordered by flag name.
+     *
+     * @return array<int,array{flag:string,percentage:int}>
+     */
+    public function flags(): array
+    {
+        $stmt = $this->db()->query('SELECT flag, percentage FROM rollout_flags ORDER BY flag ASC');
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($rows as $row) {
+            $out[] = ['flag' => (string)$row['flag'], 'percentage' => (int)$row['percentage']];
+        }
+
+        return $out;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * Map (flag, key) to a stable bucket in 0–99.
+     */
+    private function bucket(string $flag, string $key): int
+    {
+        return crc32($flag . ':' . $key) % 100;
+    }
+
+    private function validateFlag(string $flag): string
+    {
+        $flag = trim($flag);
+        if ($flag === '') {
+            throw new \InvalidArgumentException('Flag must not be empty.');
+        }
+
+        return $flag;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-272.md
+++ b/docs/field-trials/2026-05-field-trial-272.md
@@ -1,0 +1,41 @@
+# Field Trial 272 — PercentageRollout
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft272-percentage-rollout`
+**Baseline**: post FT271 merge
+
+## Goal
+
+Add `Nene\Xion\PercentageRollout` — gradual feature rollout to a deterministic percentage of keys, with sticky bucketing. Distinct from `FeatureFlag` (FT124, global on/off): membership is hashed from `(flag, key)`.
+
+## What was built
+
+### `Nene\Xion\PercentageRollout` (`class/xion/PercentageRollout.php`)
+
+| Method | Description |
+| --- | --- |
+| `setPercentage(flag, 0..100)` | Upsert rollout percentage. |
+| `percentageFor(flag): int` | Current percentage (0 if unset). |
+| `isEnabled(flag, key): bool` | Deterministic, sticky membership. |
+| `enableFully / disable / remove (flag)` | 100% / 0% / delete. |
+| `flags(): array` | List flags + percentages. |
+
+Key design points:
+
+- **Sticky + monotonic**: bucket = `crc32(flag.':'.key) % 100`; `isEnabled` is `bucket < pct`. The same key always gets the same answer for a given pct (no per-request flicker), and raising pct only *adds* keys — a key live at 30% stays live at 60%.
+- **Cheap fast-paths**: 0% short-circuits to false, 100% to true (no hashing).
+- **Cross-driver upsert**; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/PercentageRolloutTest.php`)
+
+16 unit tests (259 assertions), mostly property-based (hash output not hard-coded): default 0; 0%→nobody, 100%→everybody; unconfigured→false; determinism for a key; **monotonic membership** (30% ⊆ 60% ⊆ 90% over 200 keys); approximate distribution (~40% over 2000 keys within slack); enableFully/disable; idempotent set; remove; ordered flags(); range validation (101, -1, empty flag).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 16 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/PercentageRolloutTest.php
+++ b/tests/Unit/Xion/PercentageRolloutTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\PercentageRollout;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PercentageRollout.
+ *
+ * Bucketing is a deterministic hash, so most tests assert *properties*
+ * (determinism, monotonicity, full/empty rollout, approximate distribution)
+ * rather than hard-coded crc32 outputs.
+ */
+final class PercentageRolloutTest extends TestCase
+{
+    private PDO $db;
+    private PercentageRollout $ro;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE rollout_flags (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                flag       VARCHAR(100) NOT NULL,
+                percentage INTEGER      NOT NULL DEFAULT 0,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (flag)
+            )
+        ');
+        $this->ro = new PercentageRollout($this->db);
+    }
+
+    public function testPercentageDefaultsToZero(): void
+    {
+        $this->assertSame(0, $this->ro->percentageFor('new_ui'));
+    }
+
+    public function testSetAndGetPercentage(): void
+    {
+        $this->ro->setPercentage('new_ui', 25);
+        $this->assertSame(25, $this->ro->percentageFor('new_ui'));
+    }
+
+    public function testZeroPercentEnablesNobody(): void
+    {
+        $this->ro->setPercentage('new_ui', 0);
+        for ($i = 0; $i < 50; $i++) {
+            $this->assertFalse($this->ro->isEnabled('new_ui', "user-{$i}"));
+        }
+    }
+
+    public function testHundredPercentEnablesEveryone(): void
+    {
+        $this->ro->setPercentage('new_ui', 100);
+        for ($i = 0; $i < 50; $i++) {
+            $this->assertTrue($this->ro->isEnabled('new_ui', "user-{$i}"));
+        }
+    }
+
+    public function testUnconfiguredFlagIsDisabled(): void
+    {
+        $this->assertFalse($this->ro->isEnabled('ghost', 'user-1'));
+    }
+
+    public function testDeterministicForSameKey(): void
+    {
+        $this->ro->setPercentage('new_ui', 50);
+        $first = $this->ro->isEnabled('new_ui', 'user-42');
+        for ($i = 0; $i < 5; $i++) {
+            $this->assertSame($first, $this->ro->isEnabled('new_ui', 'user-42'));
+        }
+    }
+
+    public function testMonotonicMembershipAsPercentageGrows(): void
+    {
+        // Every key enabled at 30% must remain enabled at 60% and 90%.
+        $keys = array_map(static fn (int $i): string => "user-{$i}", range(0, 199));
+
+        $this->ro->setPercentage('f', 30);
+        $at30 = array_filter($keys, fn (string $k): bool => $this->ro->isEnabled('f', $k));
+
+        $this->ro->setPercentage('f', 60);
+        foreach ($at30 as $k) {
+            $this->assertTrue($this->ro->isEnabled('f', $k), "key {$k} dropped out at 60%");
+        }
+
+        $this->ro->setPercentage('f', 90);
+        foreach ($at30 as $k) {
+            $this->assertTrue($this->ro->isEnabled('f', $k), "key {$k} dropped out at 90%");
+        }
+    }
+
+    public function testApproximateDistribution(): void
+    {
+        $this->ro->setPercentage('f', 40);
+        $enabled = 0;
+        $n       = 2000;
+        for ($i = 0; $i < $n; $i++) {
+            if ($this->ro->isEnabled('f', "user-{$i}")) {
+                $enabled++;
+            }
+        }
+        $ratio = $enabled / $n;
+        // 40% target; allow generous slack for hash distribution.
+        $this->assertGreaterThan(0.32, $ratio);
+        $this->assertLessThan(0.48, $ratio);
+    }
+
+    public function testDifferentFlagsBucketIndependently(): void
+    {
+        // Same key, same percentage, different flag → not necessarily the same
+        // membership; but each flag is internally consistent.
+        $this->ro->setPercentage('a', 50);
+        $this->ro->setPercentage('b', 50);
+        $this->assertSame($this->ro->isEnabled('a', 'k'), $this->ro->isEnabled('a', 'k'));
+        $this->assertSame($this->ro->isEnabled('b', 'k'), $this->ro->isEnabled('b', 'k'));
+    }
+
+    public function testEnableFullyAndDisable(): void
+    {
+        $this->ro->enableFully('f');
+        $this->assertSame(100, $this->ro->percentageFor('f'));
+        $this->assertTrue($this->ro->isEnabled('f', 'anyone'));
+
+        $this->ro->disable('f');
+        $this->assertSame(0, $this->ro->percentageFor('f'));
+        $this->assertFalse($this->ro->isEnabled('f', 'anyone'));
+    }
+
+    public function testSetPercentageIsIdempotent(): void
+    {
+        $this->ro->setPercentage('f', 10);
+        $this->ro->setPercentage('f', 80);
+        $this->assertSame(80, $this->ro->percentageFor('f'));
+        $this->assertCount(1, $this->ro->flags());
+    }
+
+    public function testRemove(): void
+    {
+        $this->ro->setPercentage('f', 100);
+        $this->ro->remove('f');
+        $this->assertSame(0, $this->ro->percentageFor('f'));
+        $this->assertFalse($this->ro->isEnabled('f', 'anyone'));
+    }
+
+    public function testFlagsListOrdered(): void
+    {
+        $this->ro->setPercentage('zeta', 10);
+        $this->ro->setPercentage('alpha', 20);
+        $list = $this->ro->flags();
+        $this->assertSame('alpha', $list[0]['flag']);
+        $this->assertSame('zeta', $list[1]['flag']);
+    }
+
+    public function testSetPercentageRejectsOutOfRange(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ro->setPercentage('f', 101);
+    }
+
+    public function testSetPercentageRejectsNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ro->setPercentage('f', -1);
+    }
+
+    public function testSetPercentageRejectsEmptyFlag(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ro->setPercentage('  ', 10);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT272** — `Nene\Xion\PercentageRollout`: gradual feature rollout to a deterministic percentage of keys with sticky bucketing. Distinct from `FeatureFlag` (FT124, global on/off).

| Method | Description |
| --- | --- |
| `setPercentage(flag, 0..100)` / `percentageFor` | Upsert / read. |
| `isEnabled(flag, key): bool` | Deterministic, sticky membership. |
| `enableFully / disable / remove / flags` | 100% / 0% / delete / list. |

- bucket = `crc32(flag:key) % 100`, `isEnabled = bucket < pct` → sticky (no flicker) and **monotonic** (30% ⊆ 60%). 0%/100% fast-paths.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 16 tests / 259 assertions, property-based: 0%/100%, determinism, monotonic membership over 200 keys, ~40% distribution over 2000, enableFully/disable/remove, ordered flags, range validation
- [x] `composer precommit` green (format → Phan → 4660 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)