### PR TITLE
feat(xion): Heartbeat — liveness / dead-man-switch per service (FT273)

### DIFF
--- a/class/xion/Heartbeat.php
+++ b/class/xion/Heartbeat.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Heartbeat — liveness / dead-man-switch tracking per service.
+ *
+ * Each worker, cron, or service records a periodic `beat()`; monitoring then
+ * asks whether a service is still alive (beat within a freshness window) or
+ * has gone `stale()`. Distinct from `HealthCheck` (FT225), which logs rich
+ * check results (status, latency) over time — this is a single
+ * last-seen-timestamp per service, optimised for "is X still running?".
+ *
+ * Timestamps are stored as `'Y-m-d H:i:s'` (lexicographically comparable). An
+ * `$asOf` parameter on the time-sensitive methods keeps tests deterministic.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $hb = new Heartbeat($pdo);
+ *
+ * $hb->beat('cron.cleanup');               // record a beat now
+ * $hb->lastBeat('cron.cleanup');           // '2026-05-29 12:00:00'
+ *
+ * $hb->isAlive('cron.cleanup', 300);       // beat within last 5 min?
+ * $hb->stale(300);                         // services with no recent beat
+ * $hb->alive(300);                         // services beating recently
+ *
+ * $hb->forget('cron.cleanup');             // deregister
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE heartbeats (
+ *     id        INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     service   VARCHAR(150) NOT NULL,
+ *     last_beat DATETIME     NOT NULL,
+ *     UNIQUE (service)
+ * );
+ * ```
+ */
+final class Heartbeat
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record a heartbeat for a service (upsert of its last-seen timestamp).
+     *
+     * @param  string      $service Service identifier.
+     * @param  string|null $asOf    Beat time; defaults to now.
+     * @throws \InvalidArgumentException on empty service or bad timestamp.
+     */
+    public function beat(string $service, ?string $asOf = null): void
+    {
+        $service = $this->validateService($service);
+        $now     = $this->parse($asOf ?? 'now');
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'heartbeats',
+            data:         ['service' => $service, 'last_beat' => $now],
+            conflictCols: ['service'],
+            updateCols:   ['last_beat'],
+        );
+    }
+
+    /**
+     * Return a service's last beat timestamp, or null if never seen.
+     */
+    public function lastBeat(string $service): ?string
+    {
+        $service = $this->validateService($service);
+        $stmt    = $this->db()->prepare('SELECT last_beat FROM heartbeats WHERE service = ?');
+        $stmt->execute([$service]);
+        $beat = $stmt->fetchColumn();
+
+        return $beat === false ? null : (string)$beat;
+    }
+
+    /**
+     * Whether a service has beaten within the freshness window.
+     *
+     * A service never seen is not alive.
+     *
+     * @param string      $service       Service identifier.
+     * @param int         $withinSeconds Freshness window (must be >= 1).
+     * @param string|null $asOf          Reference time; defaults to now.
+     */
+    public function isAlive(string $service, int $withinSeconds, ?string $asOf = null): bool
+    {
+        $last = $this->lastBeat($service);
+        if ($last === null) {
+            return false;
+        }
+
+        return $last >= $this->cutoff($withinSeconds, $asOf);
+    }
+
+    /**
+     * List services whose most recent beat is within the window, freshest first.
+     *
+     * @param  int         $withinSeconds Freshness window (>= 1).
+     * @param  string|null $asOf          Reference time; defaults to now.
+     * @return array<int,array{service:string,last_beat:string}>
+     */
+    public function alive(int $withinSeconds, ?string $asOf = null): array
+    {
+        return $this->query('last_beat >= ?', $this->cutoff($withinSeconds, $asOf), 'DESC');
+    }
+
+    /**
+     * List services whose most recent beat is older than the window (or, by
+     * definition, services that have stopped beating), oldest first.
+     *
+     * @param  int         $withinSeconds Freshness window (>= 1).
+     * @param  string|null $asOf          Reference time; defaults to now.
+     * @return array<int,array{service:string,last_beat:string}>
+     */
+    public function stale(int $withinSeconds, ?string $asOf = null): array
+    {
+        return $this->query('last_beat < ?', $this->cutoff($withinSeconds, $asOf), 'ASC');
+    }
+
+    /**
+     * Remove a service's heartbeat record. No-op if absent.
+     */
+    public function forget(string $service): void
+    {
+        $service = $this->validateService($service);
+        $stmt    = $this->db()->prepare('DELETE FROM heartbeats WHERE service = ?');
+        $stmt->execute([$service]);
+    }
+
+    /**
+     * List all known services and their last beat, freshest first.
+     *
+     * @return array<int,array{service:string,last_beat:string}>
+     */
+    public function all(): array
+    {
+        $stmt = $this->db()->query('SELECT service, last_beat FROM heartbeats ORDER BY last_beat DESC');
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return $this->hydrateRows($rows);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array<int,array{service:string,last_beat:string}>
+     */
+    private function query(string $where, string $cutoff, string $dir): array
+    {
+        $stmt = $this->db()->prepare(
+            "SELECT service, last_beat FROM heartbeats WHERE {$where} ORDER BY last_beat {$dir}"
+        );
+        $stmt->execute([$cutoff]);
+
+        return $this->hydrateRows($stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>> $rows
+     * @return array<int,array{service:string,last_beat:string}>
+     */
+    private function hydrateRows(array $rows): array
+    {
+        $out = [];
+        foreach ($rows as $row) {
+            $out[] = ['service' => (string)$row['service'], 'last_beat' => (string)$row['last_beat']];
+        }
+
+        return $out;
+    }
+
+    private function cutoff(int $withinSeconds, ?string $asOf): string
+    {
+        if ($withinSeconds < 1) {
+            throw new \InvalidArgumentException('Window must be at least 1 second.');
+        }
+        $ref = strtotime($asOf ?? 'now');
+        if ($ref === false) {
+            throw new \InvalidArgumentException('Invalid reference time.');
+        }
+
+        return date('Y-m-d H:i:s', $ref - $withinSeconds);
+    }
+
+    private function parse(string $value): string
+    {
+        $ts = strtotime($value);
+        if ($ts === false) {
+            throw new \InvalidArgumentException("Invalid timestamp: {$value}");
+        }
+
+        return date('Y-m-d H:i:s', $ts);
+    }
+
+    private function validateService(string $service): string
+    {
+        $service = trim($service);
+        if ($service === '') {
+            throw new \InvalidArgumentException('Service must not be empty.');
+        }
+
+        return $service;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -275,6 +275,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `FeatureFlag` | DB-backed feature flags with global on/off and per-user overrides. |
 | `PercentageRollout` | gradual feature rollout by percentage with sticky bucketing. |
 | `HealthCheck` | service/component health monitoring log. |
+| `Heartbeat` | liveness / dead-man-switch tracking per service. |
 | `HttpCache` | HTTP cache header utilities for REST endpoints. |
 | `IdempotencyStore` | DB-backed idempotency key store for POST endpoints. |
 | `MaintenanceMode` | Maintenance mode — global on/off flag with allowlist for bypass users. |

--- a/docs/field-trials/2026-05-field-trial-273.md
+++ b/docs/field-trials/2026-05-field-trial-273.md
@@ -1,0 +1,42 @@
+# Field Trial 273 — Heartbeat
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft273-heartbeat`
+**Baseline**: post FT272 merge
+
+## Goal
+
+Add `Nene\Xion\Heartbeat` — liveness / dead-man-switch tracking per service. A single last-seen timestamp per service, optimised for "is X still running?". Distinct from `HealthCheck` (FT225), which logs rich check results over time.
+
+## What was built
+
+### `Nene\Xion\Heartbeat` (`class/xion/Heartbeat.php`)
+
+| Method | Description |
+| --- | --- |
+| `beat(service, asOf=null)` | Upsert the service's last-seen timestamp. |
+| `lastBeat(service): ?string` | Last beat, or null. |
+| `isAlive(service, withinSeconds, asOf=null): bool` | Beat within the freshness window? |
+| `alive(withinSeconds, asOf=null) / stale(...)` | Services in / past the window. |
+| `forget(service) / all()` | Deregister / list. |
+
+Key design points:
+
+- **Inclusive freshness boundary**: alive iff `last_beat >= asOf - withinSeconds`; a beat exactly at the cutoff counts as alive (`>=`).
+- **alive/stale partition** the known services exactly at a given window.
+- **Sortable timestamps**: `'Y-m-d H:i:s'` string comparison; `asOf` keeps tests deterministic.
+- **Cross-driver upsert**; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/HeartbeatTest.php`)
+
+13 unit tests (18 assertions): beat + lastBeat, beat upsert, null when unseen, isAlive within window, **boundary (exactly 300s inclusive vs 301s dead)**, isAlive false when unseen, stale list, alive freshest-first, alive+stale partition, forget (+ missing no-op), validation (empty service, zero window).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/HeartbeatTest.php
+++ b/tests/Unit/Xion/HeartbeatTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\Heartbeat;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Heartbeat.
+ */
+final class HeartbeatTest extends TestCase
+{
+    private PDO $db;
+    private Heartbeat $hb;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE heartbeats (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                service   VARCHAR(150) NOT NULL,
+                last_beat DATETIME     NOT NULL,
+                UNIQUE (service)
+            )
+        ');
+        $this->hb = new Heartbeat($this->db);
+    }
+
+    public function testBeatAndLastBeat(): void
+    {
+        $this->hb->beat('cron', '2026-05-29 12:00:00');
+        $this->assertSame('2026-05-29 12:00:00', $this->hb->lastBeat('cron'));
+    }
+
+    public function testBeatIsUpsert(): void
+    {
+        $this->hb->beat('cron', '2026-05-29 12:00:00');
+        $this->hb->beat('cron', '2026-05-29 12:05:00');
+        $this->assertSame('2026-05-29 12:05:00', $this->hb->lastBeat('cron'));
+        $this->assertCount(1, $this->hb->all());
+    }
+
+    public function testLastBeatNullWhenUnseen(): void
+    {
+        $this->assertNull($this->hb->lastBeat('ghost'));
+    }
+
+    public function testIsAliveWithinWindow(): void
+    {
+        $this->hb->beat('cron', '2026-05-29 12:00:00');
+        // 200s later, window 300s → still alive
+        $this->assertTrue($this->hb->isAlive('cron', 300, '2026-05-29 12:03:20'));
+    }
+
+    public function testIsAliveBoundaryInclusive(): void
+    {
+        $this->hb->beat('cron', '2026-05-29 12:00:00');
+        // exactly 300s later, window 300s → last_beat == cutoff → alive (>=)
+        $this->assertTrue($this->hb->isAlive('cron', 300, '2026-05-29 12:05:00'));
+        // 301s later → cutoff is 12:00:01, last_beat 12:00:00 < cutoff → dead
+        $this->assertFalse($this->hb->isAlive('cron', 300, '2026-05-29 12:05:01'));
+    }
+
+    public function testIsAliveFalseWhenUnseen(): void
+    {
+        $this->assertFalse($this->hb->isAlive('ghost', 300, '2026-05-29 12:00:00'));
+    }
+
+    public function testStaleListsServicesPastWindow(): void
+    {
+        $this->hb->beat('fresh', '2026-05-29 12:04:00');
+        $this->hb->beat('old', '2026-05-29 11:00:00');
+        // asOf 12:05:00, window 300s → cutoff 12:00:00; 'old' is stale, 'fresh' is not
+        $stale = $this->hb->stale(300, '2026-05-29 12:05:00');
+        $this->assertCount(1, $stale);
+        $this->assertSame('old', $stale[0]['service']);
+    }
+
+    public function testAliveListsServicesWithinWindowFreshestFirst(): void
+    {
+        $this->hb->beat('a', '2026-05-29 12:04:00');
+        $this->hb->beat('b', '2026-05-29 12:04:30');
+        $this->hb->beat('old', '2026-05-29 11:00:00');
+        $alive = $this->hb->alive(300, '2026-05-29 12:05:00');
+        $this->assertCount(2, $alive);
+        $this->assertSame('b', $alive[0]['service']); // freshest first
+        $this->assertSame('a', $alive[1]['service']);
+    }
+
+    public function testAliveAndStaleArePartition(): void
+    {
+        $this->hb->beat('a', '2026-05-29 12:04:00');
+        $this->hb->beat('old', '2026-05-29 11:00:00');
+        $alive = $this->hb->alive(300, '2026-05-29 12:05:00');
+        $stale = $this->hb->stale(300, '2026-05-29 12:05:00');
+        $this->assertSame(2, count($alive) + count($stale));
+    }
+
+    public function testForget(): void
+    {
+        $this->hb->beat('cron', '2026-05-29 12:00:00');
+        $this->hb->forget('cron');
+        $this->assertNull($this->hb->lastBeat('cron'));
+    }
+
+    public function testForgetMissingIsNoop(): void
+    {
+        $this->hb->forget('ghost');
+        $this->assertSame([], $this->hb->all());
+    }
+
+    public function testBeatRejectsEmptyService(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->hb->beat('  ', '2026-05-29 12:00:00');
+    }
+
+    public function testIsAliveRejectsZeroWindow(): void
+    {
+        $this->hb->beat('cron', '2026-05-29 12:00:00');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->hb->isAlive('cron', 0, '2026-05-29 12:00:00');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT273** — `Nene\Xion\Heartbeat`: liveness / dead-man-switch tracking per service. A single last-seen timestamp, optimised for "is X still running?". Distinct from `HealthCheck` (FT225) rich logging.

| Method | Description |
| --- | --- |
| `beat(service, asOf=null)` | Upsert last-seen. |
| `isAlive(service, withinSeconds, asOf=null)` | Beat within window (inclusive)? |
| `alive / stale (withinSeconds, asOf=null)` | Partition services in/past window. |
| `lastBeat / forget / all` | Read / deregister / list. |

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 18 assertions (upsert, boundary 300s inclusive vs 301s dead, alive/stale partition, freshest-first, validation)
- [x] `composer precommit` green (format → Phan → 4673 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)