### PR TITLE
feat(xion): DeadLetterQueue — parking lot for exhausted-retry messages (FT274)

### DIFF
--- a/class/xion/DeadLetterQueue.php
+++ b/class/xion/DeadLetterQueue.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * DeadLetterQueue — parking lot for messages that exhausted their retries.
+ *
+ * When a job or message fails terminally (max attempts reached, poison
+ * payload, unrecoverable error), the worker `record()`s it here with the
+ * failing payload and error. Operators can then inspect, count, purge, or
+ * `requeue()` entries for replay after a fix. Complements `JobQueue` (FT73)
+ * and `NotificationQueue` (FT217), which handle live, retryable work — this
+ * holds the *terminal failures* those queues give up on.
+ *
+ * Payloads are opaque strings (the caller JSON-encodes structured data). The
+ * class never interprets them.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $dlq = new DeadLetterQueue($pdo);
+ *
+ * $id = $dlq->record('emails', json_encode($msg), 'SMTP 550', attempts: 5);
+ *
+ * $dlq->count('emails');             // how many parked
+ * $dlq->forQueue('emails');          // inspect (newest first)
+ * $dlq->queues();                    // [['queue'=>'emails','count'=>3], ...]
+ *
+ * // After fixing the bug, claim one for replay (returns it and removes it)
+ * if ($entry = $dlq->requeue($id)) {
+ *     // re-dispatch $entry['payload'] ...
+ * }
+ *
+ * $dlq->purgeOlderThan(90);          // housekeeping
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE dead_letters (
+ *     id        INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     queue     VARCHAR(100) NOT NULL,
+ *     payload   TEXT         NOT NULL,
+ *     error     TEXT         NOT NULL DEFAULT '',
+ *     attempts  INTEGER      NOT NULL DEFAULT 0,
+ *     failed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class DeadLetterQueue
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Park a terminally-failed message.
+     *
+     * @param  string $queue    Originating queue name.
+     * @param  string $payload  Opaque payload (caller-encoded).
+     * @param  string $error    Failure reason / last error.
+     * @param  int    $attempts How many attempts were made (>= 0).
+     * @return int              New dead-letter id.
+     * @throws \InvalidArgumentException on empty queue or negative attempts.
+     */
+    public function record(string $queue, string $payload, string $error = '', int $attempts = 0): int
+    {
+        $queue = $this->validateQueue($queue);
+        if ($attempts < 0) {
+            throw new \InvalidArgumentException('Attempts must not be negative.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO dead_letters (queue, payload, error, attempts) VALUES (?, ?, ?, ?)'
+        );
+        $stmt->execute([$queue, $payload, $error, $attempts]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Fetch a single dead letter by id.
+     *
+     * @return array{id:int,queue:string,payload:string,error:string,attempts:int,failed_at:string}|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, queue, payload, error, attempts, failed_at FROM dead_letters WHERE id = ?'
+        );
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->hydrate($row);
+    }
+
+    /**
+     * List dead letters for a queue, newest failure first.
+     *
+     * @param  string   $queue Queue name.
+     * @param  int|null $limit Optional cap on rows returned.
+     * @return array<int,array{id:int,queue:string,payload:string,error:string,attempts:int,failed_at:string}>
+     */
+    public function forQueue(string $queue, ?int $limit = null): array
+    {
+        $queue = $this->validateQueue($queue);
+
+        $sql = 'SELECT id, queue, payload, error, attempts, failed_at FROM dead_letters WHERE queue = ? ORDER BY id DESC';
+        if ($limit !== null) {
+            $sql .= ' LIMIT ' . max(0, $limit);
+        }
+        $stmt = $this->db()->prepare($sql);
+        $stmt->execute([$queue]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = $this->hydrate($row);
+        }
+
+        return $out;
+    }
+
+    /**
+     * Count dead letters, optionally for a single queue.
+     */
+    public function count(?string $queue = null): int
+    {
+        if ($queue === null) {
+            $stmt = $this->db()->query('SELECT COUNT(*) FROM dead_letters');
+
+            return $stmt === false ? 0 : (int)$stmt->fetchColumn();
+        }
+
+        $queue = $this->validateQueue($queue);
+        $stmt  = $this->db()->prepare('SELECT COUNT(*) FROM dead_letters WHERE queue = ?');
+        $stmt->execute([$queue]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Per-queue summary counts, busiest first.
+     *
+     * @return array<int,array{queue:string,count:int}>
+     */
+    public function queues(): array
+    {
+        $stmt = $this->db()->query(
+            'SELECT queue, COUNT(*) AS c FROM dead_letters GROUP BY queue ORDER BY c DESC, queue ASC'
+        );
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($rows as $row) {
+            $out[] = ['queue' => (string)$row['queue'], 'count' => (int)$row['c']];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Remove a dead letter by id (e.g. discarded after review). No-op if absent.
+     */
+    public function remove(int $id): void
+    {
+        $stmt = $this->db()->prepare('DELETE FROM dead_letters WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+
+    /**
+     * Claim a dead letter for replay: returns it and removes it atomically.
+     *
+     * @param  int $id Dead-letter id.
+     * @return array{id:int,queue:string,payload:string,error:string,attempts:int,failed_at:string}|null
+     *               The entry, or null if it does not exist.
+     */
+    public function requeue(int $id): ?array
+    {
+        $db             = $this->db();
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+
+        try {
+            $entry = $this->get($id);
+            if ($entry !== null) {
+                $stmt = $db->prepare('DELETE FROM dead_letters WHERE id = ?');
+                $stmt->execute([$id]);
+            }
+            if ($ownTransaction) {
+                $db->commit();
+            }
+
+            return $entry;
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Delete dead letters older than $days. Returns the number removed.
+     *
+     * @param  int         $days Age threshold in days (>= 0).
+     * @param  string|null $asOf Reference time; defaults to now.
+     */
+    public function purgeOlderThan(int $days, ?string $asOf = null): int
+    {
+        if ($days < 0) {
+            throw new \InvalidArgumentException('Days must not be negative.');
+        }
+        $ref = strtotime($asOf ?? 'now');
+        if ($ref === false) {
+            throw new \InvalidArgumentException('Invalid reference time.');
+        }
+        $cutoff = date('Y-m-d H:i:s', $ref - $days * 86400);
+
+        $stmt = $this->db()->prepare('DELETE FROM dead_letters WHERE failed_at < ?');
+        $stmt->execute([$cutoff]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @param  array<string,mixed> $row
+     * @return array{id:int,queue:string,payload:string,error:string,attempts:int,failed_at:string}
+     */
+    private function hydrate(array $row): array
+    {
+        return [
+            'id'        => (int)$row['id'],
+            'queue'     => (string)$row['queue'],
+            'payload'   => (string)$row['payload'],
+            'error'     => (string)$row['error'],
+            'attempts'  => (int)$row['attempts'],
+            'failed_at' => (string)$row['failed_at'],
+        ];
+    }
+
+    private function validateQueue(string $queue): string
+    {
+        $queue = trim($queue);
+        if ($queue === '') {
+            throw new \InvalidArgumentException('Queue must not be empty.');
+        }
+
+        return $queue;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -298,6 +298,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `BatchResult` | Accumulates per-item results for a batch operation. |
 | `CircuitBreaker` | — |
 | `DataImportJob` | CSV/data import job tracking with per-row error recording. |
+| `DeadLetterQueue` | parking lot for messages that exhausted their retries. |
 | `DistributedLock` | DB-backed distributed lock with TTL, owner enforcement, and stale-lock reclaim. |
 | `DocumentLock` | optimistic editing lock for collaborative document editing. |
 | `DocumentSignature` | e-signature request workflow with multi-signatory support. |

--- a/docs/field-trials/2026-05-field-trial-274.md
+++ b/docs/field-trials/2026-05-field-trial-274.md
@@ -1,0 +1,42 @@
+# Field Trial 274 — DeadLetterQueue
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft274-dead-letter-queue`
+**Baseline**: post FT273 merge
+
+## Goal
+
+Add `Nene\Xion\DeadLetterQueue` — a parking lot for messages that exhausted their retries. Complements `JobQueue` (FT73) and `NotificationQueue` (FT217), which handle live retryable work; this holds the terminal failures they give up on, for inspection and replay.
+
+## What was built
+
+### `Nene\Xion\DeadLetterQueue` (`class/xion/DeadLetterQueue.php`)
+
+| Method | Description |
+| --- | --- |
+| `record(queue, payload, error='', attempts=0): int` | Park a failed message. |
+| `get(id) / forQueue(queue, limit=null)` | Inspect one / list newest-first. |
+| `count(queue=null) / queues()` | Totals / per-queue summary (busiest first). |
+| `remove(id)` | Discard after review. |
+| `requeue(id): ?array` | Claim for replay — returns and deletes atomically. |
+| `purgeOlderThan(days, asOf=null): int` | Housekeeping. |
+
+Key design points:
+
+- **Opaque payloads**: stored as TEXT, never interpreted (caller JSON-encodes).
+- **`requeue()` is atomic** (transaction, reuses an open one): returns the entry and removes it so a replay can't double-process.
+- **`asOf` purge** for deterministic tests; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/DeadLetterQueueTest.php`)
+
+14 unit tests (29 assertions): record/get, missing null, forQueue newest-first + limit, count total/per-queue, queues summary busiest-first, remove (+ missing no-op), requeue returns+removes + missing null, purgeOlderThan aged rows, validation (empty queue, negative attempts, negative days).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 14 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/DeadLetterQueueTest.php
+++ b/tests/Unit/Xion/DeadLetterQueueTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\DeadLetterQueue;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for DeadLetterQueue.
+ */
+final class DeadLetterQueueTest extends TestCase
+{
+    private PDO $db;
+    private DeadLetterQueue $dlq;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE dead_letters (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                queue     VARCHAR(100) NOT NULL,
+                payload   TEXT         NOT NULL,
+                error     TEXT         NOT NULL DEFAULT \'\',
+                attempts  INTEGER      NOT NULL DEFAULT 0,
+                failed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->dlq = new DeadLetterQueue($this->db);
+    }
+
+    public function testRecordAndGet(): void
+    {
+        $id    = $this->dlq->record('emails', '{"to":"x@y.com"}', 'SMTP 550', 5);
+        $entry = $this->dlq->get($id);
+        $this->assertNotNull($entry);
+        $this->assertSame('emails', $entry['queue']);
+        $this->assertSame('{"to":"x@y.com"}', $entry['payload']);
+        $this->assertSame('SMTP 550', $entry['error']);
+        $this->assertSame(5, $entry['attempts']);
+    }
+
+    public function testGetMissingIsNull(): void
+    {
+        $this->assertNull($this->dlq->get(999));
+    }
+
+    public function testForQueueNewestFirst(): void
+    {
+        $this->dlq->record('emails', 'a');
+        $this->dlq->record('emails', 'b');
+        $this->dlq->record('sms', 'c');
+        $list = $this->dlq->forQueue('emails');
+        $this->assertCount(2, $list);
+        $this->assertSame('b', $list[0]['payload']); // newest (higher id) first
+    }
+
+    public function testForQueueLimit(): void
+    {
+        $this->dlq->record('emails', 'a');
+        $this->dlq->record('emails', 'b');
+        $this->dlq->record('emails', 'c');
+        $this->assertCount(2, $this->dlq->forQueue('emails', 2));
+    }
+
+    public function testCountTotalAndPerQueue(): void
+    {
+        $this->dlq->record('emails', 'a');
+        $this->dlq->record('emails', 'b');
+        $this->dlq->record('sms', 'c');
+        $this->assertSame(3, $this->dlq->count());
+        $this->assertSame(2, $this->dlq->count('emails'));
+        $this->assertSame(0, $this->dlq->count('push'));
+    }
+
+    public function testQueuesSummaryBusiestFirst(): void
+    {
+        $this->dlq->record('emails', 'a');
+        $this->dlq->record('emails', 'b');
+        $this->dlq->record('sms', 'c');
+        $q = $this->dlq->queues();
+        $this->assertSame('emails', $q[0]['queue']);
+        $this->assertSame(2, $q[0]['count']);
+        $this->assertSame('sms', $q[1]['queue']);
+    }
+
+    public function testRemove(): void
+    {
+        $id = $this->dlq->record('emails', 'a');
+        $this->dlq->remove($id);
+        $this->assertNull($this->dlq->get($id));
+        $this->assertSame(0, $this->dlq->count());
+    }
+
+    public function testRemoveMissingIsNoop(): void
+    {
+        $this->dlq->remove(999);
+        $this->assertSame(0, $this->dlq->count());
+    }
+
+    public function testRequeueReturnsAndRemoves(): void
+    {
+        $id    = $this->dlq->record('emails', 'payload-x', 'boom', 3);
+        $entry = $this->dlq->requeue($id);
+        $this->assertNotNull($entry);
+        $this->assertSame('payload-x', $entry['payload']);
+        $this->assertSame(3, $entry['attempts']);
+        // It is gone after claiming.
+        $this->assertNull($this->dlq->get($id));
+        $this->assertSame(0, $this->dlq->count());
+    }
+
+    public function testRequeueMissingIsNull(): void
+    {
+        $this->assertNull($this->dlq->requeue(999));
+    }
+
+    public function testPurgeOlderThanRemovesAgedRows(): void
+    {
+        $this->db->exec("INSERT INTO dead_letters (queue, payload, failed_at) VALUES ('q', 'old', '2026-01-01 00:00:00')");
+        $this->db->exec("INSERT INTO dead_letters (queue, payload, failed_at) VALUES ('q', 'new', '2026-05-29 00:00:00')");
+        // asOf 2026-05-29, purge older than 90 days → cutoff ~2026-02-28; 'old' removed
+        $removed = $this->dlq->purgeOlderThan(90, '2026-05-29 00:00:00');
+        $this->assertSame(1, $removed);
+        $this->assertSame(1, $this->dlq->count());
+    }
+
+    public function testRecordRejectsEmptyQueue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->dlq->record('  ', 'x');
+    }
+
+    public function testRecordRejectsNegativeAttempts(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->dlq->record('emails', 'x', '', -1);
+    }
+
+    public function testPurgeRejectsNegativeDays(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->dlq->purgeOlderThan(-1);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT274** — `Nene\Xion\DeadLetterQueue`: a parking lot for messages that exhausted their retries. Complements `JobQueue` (FT73) / `NotificationQueue` (FT217) — holds the terminal failures they give up on, for inspection and replay.

| Method | Description |
| --- | --- |
| `record(queue, payload, error='', attempts=0): int` | Park a failure. |
| `get / forQueue(queue, limit=null)` | Inspect / list newest-first. |
| `count(queue=null) / queues()` | Totals / per-queue summary. |
| `requeue(id): ?array` | Claim for replay (return + delete atomically). |
| `remove(id) / purgeOlderThan(days, asOf=null)` | Discard / housekeeping. |

- Opaque payloads; `requeue` atomic in a transaction (no double-process).

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 14 tests / 29 assertions (record/get, newest-first + limit, counts, queues summary, requeue return+remove, purge, validation)
- [x] `composer precommit` green (format → Phan → 4687 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)