### PR TITLE
feat(xion): RetrySchedule — exponential-backoff retry tracking (FT275)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -304,6 +304,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `DocumentSignature` | e-signature request workflow with multi-signatory support. |
 | `JobQueue` | simple DB-backed background job queue. |
 | `OptimisticLock` | — |
+| `RetrySchedule` | exponential-backoff retry tracking for arbitrary operations. |
 | `ScheduledTask` | cron-style task schedule registry with last-run tracking. |
 | `TokenBucket` | DB-backed token bucket algorithm for flexible rate limiting. |
 | `TransactionManager` | — |

--- a/class/xion/RetrySchedule.php
+++ b/class/xion/RetrySchedule.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * RetrySchedule — exponential-backoff retry tracking for arbitrary operations.
+ *
+ * Tracks the retry state of any named operation (`ref`) — an outbound webhook,
+ * a third-party sync, a flaky import — independent of how the work is
+ * executed. `arm()` registers an operation, `backoff()` records a failed
+ * attempt and computes the next eligible time with exponential backoff, and
+ * `due()` lists operations ready to retry now. When attempts reach the
+ * maximum the operation is marked exhausted (hand off to
+ * {@see DeadLetterQueue} (FT274) at that point).
+ *
+ * Next attempt delay = `baseSeconds * 2^(attempts - 1)`, capped to keep the
+ * exponent sane.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $rs = new RetrySchedule($pdo);
+ *
+ * $rs->arm('webhook:42', baseSeconds: 60, maxAttempts: 5); // due now
+ *
+ * // On failure: schedule the next attempt (60s, 120s, 240s, …)
+ * $next = $rs->backoff('webhook:42'); // '2026-05-29 12:01:00' or null if exhausted
+ *
+ * // A worker polls for ready operations
+ * foreach ($rs->due() as $r) { /* retry $r['ref'] *\/ }
+ *
+ * if ($rs->isExhausted('webhook:42')) { /* give up / dead-letter *\/ }
+ *
+ * $rs->clear('webhook:42'); // success or abandon
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE retry_schedule (
+ *     id              INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     ref             VARCHAR(190) NOT NULL,
+ *     attempts        INTEGER      NOT NULL DEFAULT 0,
+ *     max_attempts    INTEGER      NOT NULL DEFAULT 5,
+ *     base_seconds    INTEGER      NOT NULL DEFAULT 60,
+ *     next_attempt_at DATETIME     NOT NULL,
+ *     exhausted       INTEGER      NOT NULL DEFAULT 0,
+ *     UNIQUE (ref)
+ * );
+ * ```
+ */
+final class RetrySchedule
+{
+    /** Maximum backoff exponent, to avoid overflow / absurd delays. */
+    private const int MAX_EXPONENT = 16;
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Register (or reset) an operation for retry tracking; due immediately.
+     *
+     * @param  string      $ref         Operation identifier.
+     * @param  int         $baseSeconds Base backoff unit (>= 1).
+     * @param  int         $maxAttempts Maximum attempts before exhaustion (>= 1).
+     * @param  string|null $asOf        Reference time; defaults to now.
+     * @throws \InvalidArgumentException on empty ref or non-positive bounds.
+     */
+    public function arm(string $ref, int $baseSeconds = 60, int $maxAttempts = 5, ?string $asOf = null): void
+    {
+        $ref = $this->validateRef($ref);
+        if ($baseSeconds < 1) {
+            throw new \InvalidArgumentException('Base seconds must be at least 1.');
+        }
+        if ($maxAttempts < 1) {
+            throw new \InvalidArgumentException('Max attempts must be at least 1.');
+        }
+        $now = $this->ts($asOf);
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'retry_schedule',
+            data:         [
+                'ref'             => $ref,
+                'attempts'        => 0,
+                'max_attempts'    => $maxAttempts,
+                'base_seconds'    => $baseSeconds,
+                'next_attempt_at' => $now,
+                'exhausted'       => 0,
+            ],
+            conflictCols: ['ref'],
+            updateCols:   ['attempts', 'max_attempts', 'base_seconds', 'next_attempt_at', 'exhausted'],
+        );
+    }
+
+    /**
+     * Record a failed attempt and schedule the next one with exponential backoff.
+     *
+     * @param  string      $ref  Operation identifier (must be armed).
+     * @param  string|null $asOf Reference time; defaults to now.
+     * @return string|null       Next attempt timestamp, or null if now exhausted.
+     * @throws \InvalidArgumentException if $ref is not armed.
+     */
+    public function backoff(string $ref, ?string $asOf = null): ?string
+    {
+        $ref = $this->validateRef($ref);
+        $row = $this->fetch($ref);
+        if ($row === null) {
+            throw new \InvalidArgumentException("Ref is not armed: {$ref}");
+        }
+
+        $attempts = (int)$row['attempts'] + 1;
+        $max      = (int)$row['max_attempts'];
+
+        if ($attempts >= $max) {
+            $stmt = $this->db()->prepare(
+                'UPDATE retry_schedule SET attempts = ?, exhausted = 1 WHERE ref = ?'
+            );
+            $stmt->execute([$attempts, $ref]);
+
+            return null;
+        }
+
+        $base  = (int)$row['base_seconds'];
+        $exp   = min($attempts - 1, self::MAX_EXPONENT);
+        $delay = $base * (2 ** $exp);
+        $next  = date('Y-m-d H:i:s', $this->epoch($asOf) + (int)$delay);
+
+        $stmt = $this->db()->prepare(
+            'UPDATE retry_schedule SET attempts = ?, next_attempt_at = ? WHERE ref = ?'
+        );
+        $stmt->execute([$attempts, $next, $ref]);
+
+        return $next;
+    }
+
+    /**
+     * List operations eligible to retry now (not exhausted, next attempt due),
+     * soonest first.
+     *
+     * @param  string|null $asOf Reference time; defaults to now.
+     * @return array<int,array{ref:string,attempts:int,next_attempt_at:string}>
+     */
+    public function due(?string $asOf = null): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT ref, attempts, next_attempt_at FROM retry_schedule
+             WHERE exhausted = 0 AND next_attempt_at <= ?
+             ORDER BY next_attempt_at ASC'
+        );
+        $stmt->execute([$this->ts($asOf)]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = [
+                'ref'             => (string)$row['ref'],
+                'attempts'        => (int)$row['attempts'],
+                'next_attempt_at' => (string)$row['next_attempt_at'],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Number of recorded failed attempts for an operation (0 if unknown).
+     */
+    public function attempts(string $ref): int
+    {
+        $row = $this->fetch($this->validateRef($ref));
+
+        return $row === null ? 0 : (int)$row['attempts'];
+    }
+
+    /**
+     * Next scheduled attempt time, or null if unknown.
+     */
+    public function nextAttemptAt(string $ref): ?string
+    {
+        $row = $this->fetch($this->validateRef($ref));
+
+        return $row === null ? null : (string)$row['next_attempt_at'];
+    }
+
+    /**
+     * Whether an operation has exhausted its attempts.
+     */
+    public function isExhausted(string $ref): bool
+    {
+        $row = $this->fetch($this->validateRef($ref));
+
+        return $row !== null && (int)$row['exhausted'] === 1;
+    }
+
+    /**
+     * Remove an operation's retry state (success or abandonment). No-op if absent.
+     */
+    public function clear(string $ref): void
+    {
+        $ref  = $this->validateRef($ref);
+        $stmt = $this->db()->prepare('DELETE FROM retry_schedule WHERE ref = ?');
+        $stmt->execute([$ref]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function fetch(string $ref): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT attempts, max_attempts, base_seconds, next_attempt_at, exhausted
+             FROM retry_schedule WHERE ref = ?'
+        );
+        $stmt->execute([$ref]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    private function epoch(?string $asOf): int
+    {
+        $ts = strtotime($asOf ?? 'now');
+        if ($ts === false) {
+            throw new \InvalidArgumentException('Invalid reference time.');
+        }
+
+        return $ts;
+    }
+
+    private function ts(?string $asOf): string
+    {
+        return date('Y-m-d H:i:s', $this->epoch($asOf));
+    }
+
+    private function validateRef(string $ref): string
+    {
+        $ref = trim($ref);
+        if ($ref === '') {
+            throw new \InvalidArgumentException('Ref must not be empty.');
+        }
+
+        return $ref;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-275.md
+++ b/docs/field-trials/2026-05-field-trial-275.md
@@ -1,0 +1,44 @@
+# Field Trial 275 — RetrySchedule
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft275-retry-schedule`
+**Baseline**: post FT274 merge
+
+## Goal
+
+Add `Nene\Xion\RetrySchedule` — exponential-backoff retry tracking for arbitrary named operations (webhooks, syncs, imports), independent of how the work executes. Hands off to `DeadLetterQueue` (FT274) on exhaustion.
+
+## What was built
+
+### `Nene\Xion\RetrySchedule` (`class/xion/RetrySchedule.php`)
+
+Next delay = `baseSeconds * 2^(attempts-1)`, exponent capped at 16.
+
+| Method | Description |
+| --- | --- |
+| `arm(ref, baseSeconds=60, maxAttempts=5, asOf=null)` | Register/reset; due now. |
+| `backoff(ref, asOf=null): ?string` | Record failure; schedule next (null when exhausted). |
+| `due(asOf=null): array` | Operations ready to retry now, soonest first. |
+| `attempts / nextAttemptAt / isExhausted (ref)` | State accessors. |
+| `clear(ref)` | Success / abandon. |
+
+Key design points:
+
+- **Exponential backoff with cap** to avoid overflow / absurd delays.
+- **Exhaustion is terminal**: at `attempts >= maxAttempts` the row is flagged `exhausted` and excluded from `due()`.
+- **`due()` boundary inclusive** (`next_attempt_at <= asOf`); `asOf` makes the whole schedule deterministic in tests.
+- **Cross-driver upsert** (arm); **PDO injection**.
+
+### Tests (`tests/Unit/Xion/RetryScheduleTest.php`)
+
+13 unit tests (27 assertions): arm due-now; **exponential sequence 60→120→240s** asserted exactly; exhaustion at max; exhausted excluded from due; due time boundary (too-early vs exactly-due); soonest-first ordering; arm resets exhausted state; clear (+ missing no-op); backoff-on-unarmed throws; validation (empty ref, zero base, zero max).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/RetryScheduleTest.php
+++ b/tests/Unit/Xion/RetryScheduleTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\RetrySchedule;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for RetrySchedule.
+ */
+final class RetryScheduleTest extends TestCase
+{
+    private PDO $db;
+    private RetrySchedule $rs;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE retry_schedule (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                ref             VARCHAR(190) NOT NULL,
+                attempts        INTEGER      NOT NULL DEFAULT 0,
+                max_attempts    INTEGER      NOT NULL DEFAULT 5,
+                base_seconds    INTEGER      NOT NULL DEFAULT 60,
+                next_attempt_at DATETIME     NOT NULL,
+                exhausted       INTEGER      NOT NULL DEFAULT 0,
+                UNIQUE (ref)
+            )
+        ');
+        $this->rs = new RetrySchedule($this->db);
+    }
+
+    public function testArmIsDueImmediately(): void
+    {
+        $this->rs->arm('w', 60, 3, '2026-05-29 12:00:00');
+        $this->assertSame(0, $this->rs->attempts('w'));
+        $this->assertSame('2026-05-29 12:00:00', $this->rs->nextAttemptAt('w'));
+        $due = $this->rs->due('2026-05-29 12:00:00');
+        $this->assertCount(1, $due);
+        $this->assertSame('w', $due[0]['ref']);
+    }
+
+    public function testBackoffExponential(): void
+    {
+        $this->rs->arm('w', 60, 5, '2026-05-29 12:00:00');
+        // attempt 1: delay 60*2^0 = 60s
+        $this->assertSame('2026-05-29 12:01:00', $this->rs->backoff('w', '2026-05-29 12:00:00'));
+        $this->assertSame(1, $this->rs->attempts('w'));
+        // attempt 2: delay 60*2^1 = 120s
+        $this->assertSame('2026-05-29 12:03:00', $this->rs->backoff('w', '2026-05-29 12:01:00'));
+        // attempt 3: delay 60*2^2 = 240s
+        $this->assertSame('2026-05-29 12:07:00', $this->rs->backoff('w', '2026-05-29 12:03:00'));
+    }
+
+    public function testBackoffReachesExhaustion(): void
+    {
+        $this->rs->arm('w', 60, 3, '2026-05-29 12:00:00');
+        $this->assertNotNull($this->rs->backoff('w', '2026-05-29 12:00:00')); // attempt 1
+        $this->assertNotNull($this->rs->backoff('w', '2026-05-29 12:01:00')); // attempt 2
+        $this->assertNull($this->rs->backoff('w', '2026-05-29 12:03:00'));    // attempt 3 → exhausted
+        $this->assertTrue($this->rs->isExhausted('w'));
+        $this->assertSame(3, $this->rs->attempts('w'));
+    }
+
+    public function testExhaustedIsNotDue(): void
+    {
+        $this->rs->arm('w', 60, 1, '2026-05-29 12:00:00');
+        $this->rs->backoff('w', '2026-05-29 12:00:00'); // attempt 1 == max → exhausted
+        $this->assertSame([], $this->rs->due('2026-05-29 13:00:00'));
+    }
+
+    public function testDueRespectsNextAttemptTime(): void
+    {
+        $this->rs->arm('w', 60, 5, '2026-05-29 12:00:00');
+        $this->rs->backoff('w', '2026-05-29 12:00:00'); // next at 12:01:00
+        $this->assertSame([], $this->rs->due('2026-05-29 12:00:30')); // too early
+        $this->assertCount(1, $this->rs->due('2026-05-29 12:01:00')); // exactly due (<=)
+    }
+
+    public function testDueSoonestFirst(): void
+    {
+        $this->rs->arm('a', 60, 5, '2026-05-29 12:00:00');
+        $this->rs->arm('b', 60, 5, '2026-05-29 11:00:00');
+        $due = $this->rs->due('2026-05-29 12:00:00');
+        $this->assertSame('b', $due[0]['ref']); // earlier next_attempt_at first
+    }
+
+    public function testArmResetsState(): void
+    {
+        $this->rs->arm('w', 60, 1, '2026-05-29 12:00:00');
+        $this->rs->backoff('w', '2026-05-29 12:00:00'); // exhausted
+        $this->assertTrue($this->rs->isExhausted('w'));
+        $this->rs->arm('w', 60, 3, '2026-05-29 13:00:00'); // re-arm
+        $this->assertFalse($this->rs->isExhausted('w'));
+        $this->assertSame(0, $this->rs->attempts('w'));
+    }
+
+    public function testClear(): void
+    {
+        $this->rs->arm('w', 60, 3, '2026-05-29 12:00:00');
+        $this->rs->clear('w');
+        $this->assertSame(0, $this->rs->attempts('w'));
+        $this->assertNull($this->rs->nextAttemptAt('w'));
+    }
+
+    public function testClearMissingIsNoop(): void
+    {
+        $this->rs->clear('ghost'); // no throw
+        $this->assertFalse($this->rs->isExhausted('ghost'));
+    }
+
+    public function testBackoffOnUnarmedThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rs->backoff('never', '2026-05-29 12:00:00');
+    }
+
+    public function testArmRejectsEmptyRef(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rs->arm('  ');
+    }
+
+    public function testArmRejectsZeroBase(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rs->arm('w', 0, 3);
+    }
+
+    public function testArmRejectsZeroMaxAttempts(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rs->arm('w', 60, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT275** — `Nene\Xion\RetrySchedule`: exponential-backoff retry tracking for arbitrary named operations (webhooks, syncs, imports), independent of execution. Hands off to `DeadLetterQueue` (FT274) on exhaustion.

| Method | Description |
| --- | --- |
| `arm(ref, baseSeconds=60, maxAttempts=5, asOf=null)` | Register/reset; due now. |
| `backoff(ref, asOf=null): ?string` | Record failure; next = base*2^(attempts-1); null when exhausted. |
| `due(asOf=null)` | Ready-to-retry, soonest first. |
| `attempts / nextAttemptAt / isExhausted / clear` | State / cleanup. |

- Exponential backoff (exponent capped); exhaustion terminal & excluded from `due()`; `asOf` deterministic.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 27 assertions (exact 60→120→240s sequence, exhaustion, due boundary, soonest-first, re-arm reset, validation)
- [x] `composer precommit` green (format → Phan → 4700 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)