### PR TITLE
feat(xion): RoundRobinAssigner — fair rotating pool assignment (FT276)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -305,6 +305,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `JobQueue` | simple DB-backed background job queue. |
 | `OptimisticLock` | — |
 | `RetrySchedule` | exponential-backoff retry tracking for arbitrary operations. |
+| `RoundRobinAssigner` | fair rotating assignment across a named pool. |
 | `ScheduledTask` | cron-style task schedule registry with last-run tracking. |
 | `TokenBucket` | DB-backed token bucket algorithm for flexible rate limiting. |
 | `TransactionManager` | — |

--- a/class/xion/RoundRobinAssigner.php
+++ b/class/xion/RoundRobinAssigner.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * RoundRobinAssigner — fair rotating assignment across a named pool.
+ *
+ * Hands out members of a pool in rotation so work is distributed evenly:
+ * support tickets to agents, leads to reps, jobs to workers. Each pool keeps
+ * an ordered member list and a persistent cursor, so the rotation survives
+ * across requests and processes.
+ *
+ * `next()` advances the cursor atomically (read + pick + advance inside a
+ * transaction), so concurrent callers never receive the same slot twice in a
+ * row from one cycle.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $rr = new RoundRobinAssigner($pdo);
+ *
+ * $rr->setMembers('support', ['alice', 'bob', 'carol']);
+ *
+ * $rr->next('support'); // 'alice'
+ * $rr->next('support'); // 'bob'
+ * $rr->next('support'); // 'carol'
+ * $rr->next('support'); // 'alice'  (wraps)
+ *
+ * $rr->peek('support');             // next without advancing
+ * $rr->addMember('support', 'dave');
+ * $rr->removeMember('support', 'bob');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE round_robin_pools (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     pool       VARCHAR(100) NOT NULL,
+ *     members    TEXT         NOT NULL DEFAULT '[]',
+ *     cursor     INTEGER      NOT NULL DEFAULT 0,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (pool)
+ * );
+ * ```
+ */
+final class RoundRobinAssigner
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set the full member list for a pool (resets the cursor to the start).
+     *
+     * Duplicate and blank members are dropped; order is preserved.
+     *
+     * @param  string             $pool    Pool name.
+     * @param  array<int,string>  $members Ordered member identifiers.
+     * @throws \InvalidArgumentException on empty pool name.
+     */
+    public function setMembers(string $pool, array $members): void
+    {
+        $pool  = $this->validatePool($pool);
+        $clean = $this->cleanMembers($members);
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'round_robin_pools',
+            data:         ['pool' => $pool, 'members' => $this->encode($clean), 'cursor' => 0],
+            conflictCols: ['pool'],
+            updateCols:   ['members', 'cursor'],
+            updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    /**
+     * Return the current member list for a pool.
+     *
+     * @return array<int,string>
+     */
+    public function members(string $pool): array
+    {
+        $row = $this->fetch($this->validatePool($pool));
+
+        return $row === null ? [] : $this->decode((string)$row['members']);
+    }
+
+    /**
+     * Return the next member and advance the cursor (atomic).
+     *
+     * @param  string $pool Pool name.
+     * @return string|null  The assigned member, or null if the pool is empty/unknown.
+     */
+    public function next(string $pool): ?string
+    {
+        $pool           = $this->validatePool($pool);
+        $db             = $this->db();
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+
+        try {
+            $row = $this->fetch($pool);
+            if ($row === null) {
+                if ($ownTransaction) {
+                    $db->commit();
+                }
+
+                return null;
+            }
+
+            $members = $this->decode((string)$row['members']);
+            $count   = count($members);
+            if ($count === 0) {
+                if ($ownTransaction) {
+                    $db->commit();
+                }
+
+                return null;
+            }
+
+            $cursor = (int)$row['cursor'] % $count;
+            $member = $members[$cursor];
+            $next   = ($cursor + 1) % $count;
+
+            $stmt = $db->prepare('UPDATE round_robin_pools SET cursor = ? WHERE pool = ?');
+            $stmt->execute([$next, $pool]);
+
+            if ($ownTransaction) {
+                $db->commit();
+            }
+
+            return $member;
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Return the member that `next()` would assign, without advancing.
+     */
+    public function peek(string $pool): ?string
+    {
+        $row = $this->fetch($this->validatePool($pool));
+        if ($row === null) {
+            return null;
+        }
+        $members = $this->decode((string)$row['members']);
+        $count   = count($members);
+        if ($count === 0) {
+            return null;
+        }
+
+        return $members[(int)$row['cursor'] % $count];
+    }
+
+    /**
+     * Append a member to the pool if not already present. Creates the pool if new.
+     */
+    public function addMember(string $pool, string $member): void
+    {
+        $pool   = $this->validatePool($pool);
+        $member = trim($member);
+        if ($member === '') {
+            throw new \InvalidArgumentException('Member must not be empty.');
+        }
+
+        $members = $this->members($pool);
+        if (!in_array($member, $members, true)) {
+            $members[] = $member;
+            $this->persistMembers($pool, $members);
+        }
+    }
+
+    /**
+     * Remove a member from the pool. No-op if absent.
+     */
+    public function removeMember(string $pool, string $member): void
+    {
+        $pool   = $this->validatePool($pool);
+        $member = trim($member);
+
+        $members = $this->members($pool);
+        $filtered = array_values(array_filter($members, static fn (string $m): bool => $m !== $member));
+        if (count($filtered) !== count($members)) {
+            $this->persistMembers($pool, $filtered);
+        }
+    }
+
+    /**
+     * Reset the rotation cursor to the start. No-op if the pool is unknown.
+     */
+    public function reset(string $pool): void
+    {
+        $pool = $this->validatePool($pool);
+        $stmt = $this->db()->prepare('UPDATE round_robin_pools SET cursor = 0 WHERE pool = ?');
+        $stmt->execute([$pool]);
+    }
+
+    /**
+     * Delete a pool entirely. No-op if absent.
+     */
+    public function remove(string $pool): void
+    {
+        $pool = $this->validatePool($pool);
+        $stmt = $this->db()->prepare('DELETE FROM round_robin_pools WHERE pool = ?');
+        $stmt->execute([$pool]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * Persist a member list, clamping the cursor into range (preserves position).
+     *
+     * @param array<int,string> $members
+     */
+    private function persistMembers(string $pool, array $members): void
+    {
+        $row    = $this->fetch($pool);
+        $cursor = $row === null ? 0 : (int)$row['cursor'];
+        $count  = count($members);
+        $cursor = $count === 0 ? 0 : $cursor % $count;
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'round_robin_pools',
+            data:         ['pool' => $pool, 'members' => $this->encode($members), 'cursor' => $cursor],
+            conflictCols: ['pool'],
+            updateCols:   ['members', 'cursor'],
+            updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function fetch(string $pool): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT members, cursor FROM round_robin_pools WHERE pool = ?');
+        $stmt->execute([$pool]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * @param  array<int,string> $members
+     * @return array<int,string>
+     */
+    private function cleanMembers(array $members): array
+    {
+        $out = [];
+        foreach ($members as $m) {
+            $m = trim($m);
+            if ($m !== '' && !in_array($m, $out, true)) {
+                $out[] = $m;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<int,string> $members
+     */
+    private function encode(array $members): string
+    {
+        return json_encode(array_values($members), JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function decode(string $json): array
+    {
+        /** @var mixed $decoded */
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($decoded as $m) {
+            $out[] = (string)$m;
+        }
+
+        return $out;
+    }
+
+    private function validatePool(string $pool): string
+    {
+        $pool = trim($pool);
+        if ($pool === '') {
+            throw new \InvalidArgumentException('Pool must not be empty.');
+        }
+
+        return $pool;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-276.md
+++ b/docs/field-trials/2026-05-field-trial-276.md
@@ -1,0 +1,42 @@
+# Field Trial 276 — RoundRobinAssigner
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft276-round-robin-assigner`
+**Baseline**: post FT275 merge
+
+## Goal
+
+Add `Nene\Xion\RoundRobinAssigner` — fair rotating assignment across a named pool (tickets→agents, leads→reps, jobs→workers). Each pool keeps an ordered member list and a persistent cursor that survives across requests.
+
+## What was built
+
+### `Nene\Xion\RoundRobinAssigner` (`class/xion/RoundRobinAssigner.php`)
+
+| Method | Description |
+| --- | --- |
+| `setMembers(pool, members[])` | Set the list (dedupes/trims, resets cursor). |
+| `next(pool): ?string` | Return next member and advance the cursor (atomic). |
+| `peek(pool): ?string` | Next without advancing. |
+| `addMember / removeMember (pool, member)` | Mutate the list (cursor clamped). |
+| `members / reset / remove (pool)` | Read / rewind / delete. |
+
+Key design points:
+
+- **Persistent cursor** stored per pool → rotation continues across requests/processes.
+- **Atomic `next()`**: read + pick + advance inside a transaction (reuses an open one), so concurrent callers don't collide.
+- **Cursor clamped** on member removal (`cursor % count`) so the rotation stays valid; `addMember` creates the pool on demand.
+- **Cross-driver upsert**; **PDO injection**; members stored as JSON.
+
+### Tests (`tests/Unit/Xion/RoundRobinAssignerTest.php`)
+
+16 unit tests (27 assertions): rotation + wrap; empty/unknown pool → null; peek non-advancing; setMembers dedupe/trim + cursor reset; addMember append/create/idempotent; removeMember + cursor clamp; reset; remove; independent pools; validation (empty pool, empty member).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 16 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/RoundRobinAssignerTest.php
+++ b/tests/Unit/Xion/RoundRobinAssignerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\RoundRobinAssigner;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for RoundRobinAssigner.
+ */
+final class RoundRobinAssignerTest extends TestCase
+{
+    private PDO $db;
+    private RoundRobinAssigner $rr;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE round_robin_pools (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                pool       VARCHAR(100) NOT NULL,
+                members    TEXT         NOT NULL DEFAULT \'[]\',
+                cursor     INTEGER      NOT NULL DEFAULT 0,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (pool)
+            )
+        ');
+        $this->rr = new RoundRobinAssigner($this->db);
+    }
+
+    public function testNextRotatesAndWraps(): void
+    {
+        $this->rr->setMembers('support', ['alice', 'bob', 'carol']);
+        $this->assertSame('alice', $this->rr->next('support'));
+        $this->assertSame('bob', $this->rr->next('support'));
+        $this->assertSame('carol', $this->rr->next('support'));
+        $this->assertSame('alice', $this->rr->next('support')); // wraps
+        $this->assertSame('bob', $this->rr->next('support'));
+    }
+
+    public function testNextEmptyPoolReturnsNull(): void
+    {
+        $this->rr->setMembers('empty', []);
+        $this->assertNull($this->rr->next('empty'));
+    }
+
+    public function testNextUnknownPoolReturnsNull(): void
+    {
+        $this->assertNull($this->rr->next('ghost'));
+    }
+
+    public function testPeekDoesNotAdvance(): void
+    {
+        $this->rr->setMembers('p', ['a', 'b']);
+        $this->assertSame('a', $this->rr->peek('p'));
+        $this->assertSame('a', $this->rr->peek('p'));
+        $this->assertSame('a', $this->rr->next('p'));
+        $this->assertSame('b', $this->rr->peek('p'));
+    }
+
+    public function testSetMembersDedupesAndTrims(): void
+    {
+        $this->rr->setMembers('p', ['  a  ', 'b', 'a', '', 'b']);
+        $this->assertSame(['a', 'b'], $this->rr->members('p'));
+    }
+
+    public function testSetMembersResetsCursor(): void
+    {
+        $this->rr->setMembers('p', ['a', 'b', 'c']);
+        $this->rr->next('p'); // cursor → 1
+        $this->rr->setMembers('p', ['x', 'y']); // reset
+        $this->assertSame('x', $this->rr->next('p'));
+    }
+
+    public function testAddMemberAppends(): void
+    {
+        $this->rr->setMembers('p', ['a', 'b']);
+        $this->rr->addMember('p', 'c');
+        $this->assertSame(['a', 'b', 'c'], $this->rr->members('p'));
+    }
+
+    public function testAddMemberCreatesPool(): void
+    {
+        $this->rr->addMember('fresh', 'a');
+        $this->assertSame(['a'], $this->rr->members('fresh'));
+        $this->assertSame('a', $this->rr->next('fresh'));
+    }
+
+    public function testAddMemberIdempotent(): void
+    {
+        $this->rr->setMembers('p', ['a']);
+        $this->rr->addMember('p', 'a');
+        $this->assertSame(['a'], $this->rr->members('p'));
+    }
+
+    public function testRemoveMember(): void
+    {
+        $this->rr->setMembers('p', ['a', 'b', 'c']);
+        $this->rr->removeMember('p', 'b');
+        $this->assertSame(['a', 'c'], $this->rr->members('p'));
+    }
+
+    public function testRemoveMemberClampsCursor(): void
+    {
+        $this->rr->setMembers('p', ['a', 'b', 'c']);
+        $this->rr->next('p'); // a, cursor → 1
+        $this->rr->next('p'); // b, cursor → 2
+        $this->rr->removeMember('p', 'c'); // now 2 members, cursor 2 % 2 = 0
+        $this->assertSame('a', $this->rr->next('p'));
+    }
+
+    public function testReset(): void
+    {
+        $this->rr->setMembers('p', ['a', 'b']);
+        $this->rr->next('p'); // a
+        $this->rr->reset('p');
+        $this->assertSame('a', $this->rr->next('p'));
+    }
+
+    public function testRemovePool(): void
+    {
+        $this->rr->setMembers('p', ['a']);
+        $this->rr->remove('p');
+        $this->assertSame([], $this->rr->members('p'));
+        $this->assertNull($this->rr->next('p'));
+    }
+
+    public function testPoolsAreIndependent(): void
+    {
+        $this->rr->setMembers('p1', ['a', 'b']);
+        $this->rr->setMembers('p2', ['x', 'y']);
+        $this->assertSame('a', $this->rr->next('p1'));
+        $this->assertSame('x', $this->rr->next('p2'));
+        $this->assertSame('b', $this->rr->next('p1'));
+    }
+
+    public function testSetMembersRejectsEmptyPool(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rr->setMembers('  ', ['a']);
+    }
+
+    public function testAddMemberRejectsEmptyMember(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rr->addMember('p', '   ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT276** — `Nene\Xion\RoundRobinAssigner`: fair rotating assignment across a named pool (tickets→agents, leads→reps, jobs→workers). Persistent per-pool cursor survives across requests.

| Method | Description |
| --- | --- |
| `setMembers(pool, members[])` | Set list (dedupe/trim, reset cursor). |
| `next(pool): ?string` | Next member, advance atomically. |
| `peek(pool)` | Next without advancing. |
| `addMember / removeMember / reset / remove / members` | Manage. |

- Atomic `next()` (transaction); cursor clamped on removal; JSON member storage.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 16 tests / 27 assertions (rotation+wrap, empty/unknown null, peek, dedupe/trim+reset, add create/idempotent, remove+clamp, reset, independent pools, validation)
- [x] `composer precommit` green (format → Phan → 4716 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)