### PR TITLE
feat(xion): WeightedPicker — weighted random selection from a pool (FT277)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -341,6 +341,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `SetupDatabaseCommand` | — |
 | `SystemSetting` | typed global application settings store. |
 | `TenantConfig` | per-tenant key-value configuration store. |
+| `WeightedPicker` | weighted random selection from a named pool. |
 
 ---
 

--- a/class/xion/WeightedPicker.php
+++ b/class/xion/WeightedPicker.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * WeightedPicker — weighted random selection from a named pool.
+ *
+ * Stores items with integer weights per pool and picks one with probability
+ * proportional to its weight. Useful for weighted A/B variant assignment,
+ * ad/creative rotation, prize draws, or load distribution favouring more
+ * capable workers. Items with weight 0 are retained but never selected.
+ *
+ * `pick()` uses a random roll; `pick($pool, $roll)` accepts an explicit roll
+ * in `[0, totalWeight)` for deterministic/reproducible selection (and tests).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $wp = new WeightedPicker($pdo);
+ *
+ * $wp->setWeight('variant', 'A', 70);
+ * $wp->setWeight('variant', 'B', 30);
+ *
+ * $wp->pick('variant');        // 'A' ~70% of the time, 'B' ~30%
+ * $wp->pick('variant', 0);     // 'A' (deterministic: roll 0)
+ * $wp->pick('variant', 70);    // 'B' (roll 70 lands in B's band)
+ *
+ * $wp->totalWeight('variant'); // 100
+ * $wp->weights('variant');     // [['item'=>'A','weight'=>70], ...]
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE weighted_entries (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     pool       VARCHAR(100) NOT NULL,
+ *     item       VARCHAR(190) NOT NULL,
+ *     weight     INTEGER      NOT NULL DEFAULT 0,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (pool, item)
+ * );
+ * ```
+ */
+final class WeightedPicker
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set (or update) an item's weight in a pool. Idempotent per (pool, item).
+     *
+     * @param  string $pool   Pool name.
+     * @param  string $item   Item identifier.
+     * @param  int    $weight Selection weight (>= 0; 0 = never picked).
+     * @throws \InvalidArgumentException on empty pool/item or negative weight.
+     */
+    public function setWeight(string $pool, string $item, int $weight): void
+    {
+        $pool = $this->validate($pool, 'Pool');
+        $item = $this->validate($item, 'Item');
+        if ($weight < 0) {
+            throw new \InvalidArgumentException('Weight must not be negative.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'weighted_entries',
+            data:         ['pool' => $pool, 'item' => $item, 'weight' => $weight],
+            conflictCols: ['pool', 'item'],
+            updateCols:   ['weight'],
+        );
+    }
+
+    /**
+     * Pick an item from a pool with probability proportional to weight.
+     *
+     * @param  string   $pool Pool name.
+     * @param  int|null  $roll Explicit roll in [0, totalWeight) for deterministic
+     *                         selection; null picks a random roll.
+     * @return string|null     Selected item, or null if the pool has no positive weight.
+     * @throws \InvalidArgumentException on empty pool or out-of-range roll.
+     */
+    public function pick(string $pool, ?int $roll = null): ?string
+    {
+        $pool    = $this->validate($pool, 'Pool');
+        $entries = $this->positiveEntries($pool);
+        $total   = 0;
+        foreach ($entries as $e) {
+            $total += $e['weight'];
+        }
+        if ($total === 0) {
+            return null;
+        }
+
+        if ($roll === null) {
+            $roll = random_int(0, $total - 1);
+        } elseif ($roll < 0 || $roll >= $total) {
+            throw new \InvalidArgumentException("Roll must be in [0, {$total}).");
+        }
+
+        $acc = 0;
+        foreach ($entries as $e) {
+            $acc += $e['weight'];
+            if ($roll < $acc) {
+                return $e['item'];
+            }
+        }
+
+        return $entries[count($entries) - 1]['item']; // unreachable; defensive
+    }
+
+    /**
+     * Total weight of a pool.
+     */
+    public function totalWeight(string $pool): int
+    {
+        $pool = $this->validate($pool, 'Pool');
+        $stmt = $this->db()->prepare('SELECT COALESCE(SUM(weight), 0) FROM weighted_entries WHERE pool = ?');
+        $stmt->execute([$pool]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * List a pool's items and weights, item order.
+     *
+     * @return array<int,array{item:string,weight:int}>
+     */
+    public function weights(string $pool): array
+    {
+        $pool = $this->validate($pool, 'Pool');
+        $stmt = $this->db()->prepare('SELECT item, weight FROM weighted_entries WHERE pool = ? ORDER BY item ASC');
+        $stmt->execute([$pool]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['item' => (string)$row['item'], 'weight' => (int)$row['weight']];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Remove an item from a pool. No-op if absent.
+     */
+    public function remove(string $pool, string $item): void
+    {
+        $pool = $this->validate($pool, 'Pool');
+        $item = $this->validate($item, 'Item');
+        $stmt = $this->db()->prepare('DELETE FROM weighted_entries WHERE pool = ? AND item = ?');
+        $stmt->execute([$pool, $item]);
+    }
+
+    /**
+     * Remove all items from a pool. No-op if empty.
+     */
+    public function clear(string $pool): void
+    {
+        $pool = $this->validate($pool, 'Pool');
+        $stmt = $this->db()->prepare('DELETE FROM weighted_entries WHERE pool = ?');
+        $stmt->execute([$pool]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * Pool entries with positive weight, in stable id order.
+     *
+     * @return array<int,array{item:string,weight:int}>
+     */
+    private function positiveEntries(string $pool): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT item, weight FROM weighted_entries WHERE pool = ? AND weight > 0 ORDER BY id ASC'
+        );
+        $stmt->execute([$pool]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['item' => (string)$row['item'], 'weight' => (int)$row['weight']];
+        }
+
+        return $out;
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-277.md
+++ b/docs/field-trials/2026-05-field-trial-277.md
@@ -1,0 +1,41 @@
+# Field Trial 277 — WeightedPicker
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft277-weighted-picker`
+**Baseline**: post FT276 merge
+
+## Goal
+
+Add `Nene\Xion\WeightedPicker` — weighted random selection from a named pool (weighted A/B variants, creative rotation, prize draws, capability-weighted load distribution).
+
+## What was built
+
+### `Nene\Xion\WeightedPicker` (`class/xion/WeightedPicker.php`)
+
+| Method | Description |
+| --- | --- |
+| `setWeight(pool, item, weight)` | Upsert an item's weight (>= 0). |
+| `pick(pool, roll=null): ?string` | Weighted pick; `roll` gives deterministic selection. |
+| `totalWeight(pool) / weights(pool)` | Sum / list. |
+| `remove(pool, item) / clear(pool)` | Mutate. |
+
+Key design points:
+
+- **Deterministic-or-random**: `pick($pool, $roll)` selects via an explicit roll in `[0, total)` (reproducible / testable); `pick($pool)` rolls `random_int`.
+- **Zero-weight items retained but never selected**; `pick` returns null when no positive weight exists.
+- **Stable banding**: entries walked in insertion (id) order so bands are predictable.
+- **Cross-driver upsert**; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/WeightedPickerTest.php`)
+
+13 unit tests (27 assertions): deterministic roll bands (A=[0,70), B=[70,100)); totalWeight; null when no positive weight; zero-weight never picked; idempotent update; weights listing; out-of-range roll throws; ~80/20 random distribution over 2000 draws; remove; clear; independent pools; validation (negative weight, empty item).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/WeightedPickerTest.php
+++ b/tests/Unit/Xion/WeightedPickerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\WeightedPicker;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for WeightedPicker.
+ *
+ * Items are walked in insertion (id) order, so with A (70) then B (30) the
+ * bands are A = [0, 70) and B = [70, 100).
+ */
+final class WeightedPickerTest extends TestCase
+{
+    private PDO $db;
+    private WeightedPicker $wp;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE weighted_entries (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                pool       VARCHAR(100) NOT NULL,
+                item       VARCHAR(190) NOT NULL,
+                weight     INTEGER      NOT NULL DEFAULT 0,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (pool, item)
+            )
+        ');
+        $this->wp = new WeightedPicker($this->db);
+    }
+
+    public function testDeterministicRollBands(): void
+    {
+        $this->wp->setWeight('v', 'A', 70);
+        $this->wp->setWeight('v', 'B', 30);
+        $this->assertSame('A', $this->wp->pick('v', 0));   // start of A
+        $this->assertSame('A', $this->wp->pick('v', 69));  // end of A band
+        $this->assertSame('B', $this->wp->pick('v', 70));  // start of B band
+        $this->assertSame('B', $this->wp->pick('v', 99));  // end of B band
+    }
+
+    public function testTotalWeight(): void
+    {
+        $this->wp->setWeight('v', 'A', 70);
+        $this->wp->setWeight('v', 'B', 30);
+        $this->assertSame(100, $this->wp->totalWeight('v'));
+    }
+
+    public function testPickNullWhenNoPositiveWeight(): void
+    {
+        $this->assertNull($this->wp->pick('empty'));
+        $this->wp->setWeight('v', 'A', 0);
+        $this->assertNull($this->wp->pick('v'));
+    }
+
+    public function testZeroWeightItemNeverPicked(): void
+    {
+        $this->wp->setWeight('v', 'A', 0);
+        $this->wp->setWeight('v', 'B', 5);
+        for ($roll = 0; $roll < 5; $roll++) {
+            $this->assertSame('B', $this->wp->pick('v', $roll));
+        }
+    }
+
+    public function testSetWeightIsIdempotentUpdate(): void
+    {
+        $this->wp->setWeight('v', 'A', 10);
+        $this->wp->setWeight('v', 'A', 40);
+        $this->assertSame(40, $this->wp->totalWeight('v'));
+        $this->assertCount(1, $this->wp->weights('v'));
+    }
+
+    public function testWeightsListed(): void
+    {
+        $this->wp->setWeight('v', 'B', 30);
+        $this->wp->setWeight('v', 'A', 70);
+        $w = $this->wp->weights('v');
+        $this->assertSame('A', $w[0]['item']); // item order
+        $this->assertSame(70, $w[0]['weight']);
+    }
+
+    public function testRollOutOfRangeThrows(): void
+    {
+        $this->wp->setWeight('v', 'A', 10);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wp->pick('v', 10); // total is 10 → valid rolls 0..9
+    }
+
+    public function testRandomPickDistribution(): void
+    {
+        $this->wp->setWeight('v', 'A', 80);
+        $this->wp->setWeight('v', 'B', 20);
+        $a = 0;
+        $n = 2000;
+        for ($i = 0; $i < $n; $i++) {
+            if ($this->wp->pick('v') === 'A') {
+                $a++;
+            }
+        }
+        $ratio = $a / $n;
+        $this->assertGreaterThan(0.72, $ratio); // ~80% with slack
+        $this->assertLessThan(0.88, $ratio);
+    }
+
+    public function testRemoveItem(): void
+    {
+        $this->wp->setWeight('v', 'A', 70);
+        $this->wp->setWeight('v', 'B', 30);
+        $this->wp->remove('v', 'A');
+        $this->assertSame(30, $this->wp->totalWeight('v'));
+        $this->assertSame('B', $this->wp->pick('v', 0));
+    }
+
+    public function testClear(): void
+    {
+        $this->wp->setWeight('v', 'A', 70);
+        $this->wp->setWeight('v', 'B', 30);
+        $this->wp->clear('v');
+        $this->assertSame(0, $this->wp->totalWeight('v'));
+        $this->assertNull($this->wp->pick('v'));
+    }
+
+    public function testPoolsIndependent(): void
+    {
+        $this->wp->setWeight('p1', 'A', 10);
+        $this->wp->setWeight('p2', 'X', 5);
+        $this->assertSame(10, $this->wp->totalWeight('p1'));
+        $this->assertSame(5, $this->wp->totalWeight('p2'));
+    }
+
+    public function testSetWeightRejectsNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wp->setWeight('v', 'A', -1);
+    }
+
+    public function testSetWeightRejectsEmptyItem(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->wp->setWeight('v', '  ', 10);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT277** — `Nene\Xion\WeightedPicker`: weighted random selection from a named pool (weighted A/B variants, creative rotation, prize draws, capability-weighted load).

| Method | Description |
| --- | --- |
| `setWeight(pool, item, weight)` | Upsert weight (>= 0). |
| `pick(pool, roll=null): ?string` | Weighted pick; `roll` → deterministic. |
| `totalWeight / weights / remove / clear` | Inspect / mutate. |

- `roll` in `[0, total)` for reproducible selection; zero-weight retained but never picked; stable banding (id order).

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 27 assertions (deterministic bands A=[0,70)/B=[70,100), zero-weight skip, out-of-range throw, ~80/20 distribution over 2000, remove/clear, validation)
- [x] `composer precommit` green (format → Phan → 4729 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)