### PR TITLE
feat(xion): TermGlossary — DB-backed term/definition glossary (FT278)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -84,6 +84,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `NoticeBoard` | admin-posted announcements with per-user read-acknowledgment. |
 | `Poll` | create polls with options and record per-user votes. |
 | `Post` | — |
+| `TermGlossary` | DB-backed glossary of terms and definitions. |
 | `TextTemplate` | DB-backed general-purpose text templates with variable substitution. |
 
 ---

--- a/class/xion/TermGlossary.php
+++ b/class/xion/TermGlossary.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * TermGlossary — DB-backed glossary of terms and definitions.
+ *
+ * A simple dictionary of domain terms with optional categories, for help
+ * pages, tooltips, onboarding, or "define this acronym" lookups. Terms are
+ * keyed by a normalised slug (lowercased, trimmed), so `API`, `api`, and
+ * ` Api ` collapse to one entry.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $g = new TermGlossary($pdo);
+ *
+ * $g->define('API', 'Application Programming Interface', 'tech');
+ * $g->define('SLA', 'Service Level Agreement', 'ops');
+ *
+ * $g->get('api');                 // ['term'=>'API','definition'=>'...','category'=>'tech']
+ * $g->has('API');                 // true
+ * $g->search('interface');        // matches term or definition
+ * $g->byCategory('tech');         // entries in a category
+ * $g->categories();               // ['ops', 'tech']
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE glossary_terms (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     slug       VARCHAR(190) NOT NULL,
+ *     term       VARCHAR(190) NOT NULL,
+ *     definition TEXT         NOT NULL,
+ *     category   VARCHAR(100) NOT NULL DEFAULT '',
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (slug)
+ * );
+ * ```
+ */
+final class TermGlossary
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Define (or redefine) a term. Idempotent per normalised term.
+     *
+     * @param  string $term       Display term (e.g. 'API').
+     * @param  string $definition Definition text.
+     * @param  string $category   Optional category.
+     * @throws \InvalidArgumentException on empty term or definition.
+     */
+    public function define(string $term, string $definition, string $category = ''): void
+    {
+        $slug = $this->slug($term);
+        $term = trim($term);
+        if (trim($definition) === '') {
+            throw new \InvalidArgumentException('Definition must not be empty.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'glossary_terms',
+            data:         ['slug' => $slug, 'term' => $term, 'definition' => $definition, 'category' => trim($category)],
+            conflictCols: ['slug'],
+            updateCols:   ['term', 'definition', 'category'],
+            updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    /**
+     * Look up a term (case-insensitive).
+     *
+     * @return array{term:string,definition:string,category:string}|null
+     */
+    public function get(string $term): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT term, definition, category FROM glossary_terms WHERE slug = ?');
+        $stmt->execute([$this->slug($term)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->hydrate($row);
+    }
+
+    /**
+     * Whether a term is defined (case-insensitive).
+     */
+    public function has(string $term): bool
+    {
+        $stmt = $this->db()->prepare('SELECT 1 FROM glossary_terms WHERE slug = ? LIMIT 1');
+        $stmt->execute([$this->slug($term)]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Search terms and definitions for a substring (case-insensitive), term order.
+     *
+     * @return array<int,array{term:string,definition:string,category:string}>
+     */
+    public function search(string $query): array
+    {
+        $query = trim($query);
+        if ($query === '') {
+            return [];
+        }
+        $like = '%' . $this->escapeLike(mb_strtolower($query)) . '%';
+
+        $stmt = $this->db()->prepare(
+            "SELECT term, definition, category FROM glossary_terms
+             WHERE LOWER(term) LIKE ? ESCAPE '\\' OR LOWER(definition) LIKE ? ESCAPE '\\'
+             ORDER BY term ASC"
+        );
+        $stmt->execute([$like, $like]);
+
+        return $this->hydrateRows($stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    /**
+     * List entries in a category, term order.
+     *
+     * @return array<int,array{term:string,definition:string,category:string}>
+     */
+    public function byCategory(string $category): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT term, definition, category FROM glossary_terms WHERE category = ? ORDER BY term ASC'
+        );
+        $stmt->execute([trim($category)]);
+
+        return $this->hydrateRows($stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    /**
+     * List distinct non-empty categories, alphabetically.
+     *
+     * @return array<int,string>
+     */
+    public function categories(): array
+    {
+        $stmt = $this->db()->query(
+            "SELECT DISTINCT category FROM glossary_terms WHERE category <> '' ORDER BY category ASC"
+        );
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        return array_map(static fn ($c): string => (string)$c, $rows);
+    }
+
+    /**
+     * List all entries, term order.
+     *
+     * @return array<int,array{term:string,definition:string,category:string}>
+     */
+    public function all(): array
+    {
+        $stmt = $this->db()->query('SELECT term, definition, category FROM glossary_terms ORDER BY term ASC');
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return $this->hydrateRows($rows);
+    }
+
+    /**
+     * Number of defined terms.
+     */
+    public function count(): int
+    {
+        $stmt = $this->db()->query('SELECT COUNT(*) FROM glossary_terms');
+
+        return $stmt === false ? 0 : (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Remove a term (case-insensitive). No-op if absent.
+     */
+    public function remove(string $term): void
+    {
+        $stmt = $this->db()->prepare('DELETE FROM glossary_terms WHERE slug = ?');
+        $stmt->execute([$this->slug($term)]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function slug(string $term): string
+    {
+        $slug = mb_strtolower(trim($term));
+        if ($slug === '') {
+            throw new \InvalidArgumentException('Term must not be empty.');
+        }
+
+        return $slug;
+    }
+
+    private function escapeLike(string $value): string
+    {
+        return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $value);
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>> $rows
+     * @return array<int,array{term:string,definition:string,category:string}>
+     */
+    private function hydrateRows(array $rows): array
+    {
+        $out = [];
+        foreach ($rows as $row) {
+            $out[] = $this->hydrate($row);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<string,mixed> $row
+     * @return array{term:string,definition:string,category:string}
+     */
+    private function hydrate(array $row): array
+    {
+        return [
+            'term'       => (string)$row['term'],
+            'definition' => (string)$row['definition'],
+            'category'   => (string)$row['category'],
+        ];
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-278.md
+++ b/docs/field-trials/2026-05-field-trial-278.md
@@ -1,0 +1,41 @@
+# Field Trial 278 — TermGlossary
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft278-term-glossary`
+**Baseline**: post FT277 merge
+
+## Goal
+
+Add `Nene\Xion\TermGlossary` — a DB-backed glossary of domain terms and definitions (help pages, tooltips, "define this acronym" lookups), with optional categories.
+
+## What was built
+
+### `Nene\Xion\TermGlossary` (`class/xion/TermGlossary.php`)
+
+| Method | Description |
+| --- | --- |
+| `define(term, definition, category='')` | Upsert by normalised slug. |
+| `get(term) / has(term)` | Case-insensitive lookup. |
+| `search(query)` | Substring match on term or definition. |
+| `byCategory(cat) / categories()` | Filter / distinct list. |
+| `all() / count() / remove(term)` | List / count / delete. |
+
+Key design points:
+
+- **Slug-keyed**: `mb_strtolower(trim(term))` is the unique key, so `API`/`api`/` Api ` collapse to one entry.
+- **Safe search**: query lowercased and `LIKE` wildcards (`% _ \`) escaped, so `search('%')` matches literally rather than everything.
+- **Cross-driver upsert**; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/TermGlossaryTest.php`)
+
+14 unit tests (24 assertions): define/get, case-insensitive get, idempotent-by-slug redefine, has, search (term/definition/none), empty-query empty, **literal wildcard (`search('%')` → none)**, byCategory, distinct sorted categories (excludes blank), all term-order, remove (+ missing no-op), validation (empty term, empty definition).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 14 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/TermGlossaryTest.php
+++ b/tests/Unit/Xion/TermGlossaryTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\TermGlossary;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for TermGlossary.
+ */
+final class TermGlossaryTest extends TestCase
+{
+    private PDO $db;
+    private TermGlossary $g;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE glossary_terms (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                slug       VARCHAR(190) NOT NULL,
+                term       VARCHAR(190) NOT NULL,
+                definition TEXT         NOT NULL,
+                category   VARCHAR(100) NOT NULL DEFAULT \'\',
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (slug)
+            )
+        ');
+        $this->g = new TermGlossary($this->db);
+    }
+
+    public function testDefineAndGet(): void
+    {
+        $this->g->define('API', 'Application Programming Interface', 'tech');
+        $e = $this->g->get('API');
+        $this->assertNotNull($e);
+        $this->assertSame('API', $e['term']);
+        $this->assertSame('Application Programming Interface', $e['definition']);
+        $this->assertSame('tech', $e['category']);
+    }
+
+    public function testGetIsCaseInsensitive(): void
+    {
+        $this->g->define('API', 'def');
+        $this->assertNotNull($this->g->get('api'));
+        $this->assertNotNull($this->g->get('  Api '));
+    }
+
+    public function testDefineIsIdempotentBySlug(): void
+    {
+        $this->g->define('API', 'first');
+        $this->g->define('api', 'second'); // same slug
+        $this->assertSame('second', $this->g->get('API')['definition']);
+        $this->assertSame(1, $this->g->count());
+    }
+
+    public function testHas(): void
+    {
+        $this->g->define('API', 'def');
+        $this->assertTrue($this->g->has('api'));
+        $this->assertFalse($this->g->has('SLA'));
+    }
+
+    public function testSearchMatchesTermOrDefinition(): void
+    {
+        $this->g->define('API', 'Application Programming Interface', 'tech');
+        $this->g->define('SLA', 'Service Level Agreement', 'ops');
+        $this->assertCount(1, $this->g->search('interface')); // in definition
+        $this->assertCount(1, $this->g->search('sla'));        // in term
+        $this->assertCount(0, $this->g->search('zzz'));
+    }
+
+    public function testSearchEmptyQueryReturnsEmpty(): void
+    {
+        $this->g->define('API', 'def');
+        $this->assertSame([], $this->g->search('   '));
+    }
+
+    public function testSearchTreatsWildcardLiterally(): void
+    {
+        $this->g->define('API', 'def');
+        // '%' must not act as a wildcard that matches everything
+        $this->assertSame([], $this->g->search('%'));
+    }
+
+    public function testByCategory(): void
+    {
+        $this->g->define('API', 'd', 'tech');
+        $this->g->define('TCP', 'd', 'tech');
+        $this->g->define('SLA', 'd', 'ops');
+        $this->assertCount(2, $this->g->byCategory('tech'));
+    }
+
+    public function testCategoriesDistinctSorted(): void
+    {
+        $this->g->define('API', 'd', 'tech');
+        $this->g->define('TCP', 'd', 'tech');
+        $this->g->define('SLA', 'd', 'ops');
+        $this->g->define('FYI', 'd'); // no category
+        $this->assertSame(['ops', 'tech'], $this->g->categories());
+    }
+
+    public function testAllTermOrder(): void
+    {
+        $this->g->define('TCP', 'd');
+        $this->g->define('API', 'd');
+        $all = $this->g->all();
+        $this->assertSame('API', $all[0]['term']);
+        $this->assertSame('TCP', $all[1]['term']);
+    }
+
+    public function testRemove(): void
+    {
+        $this->g->define('API', 'd');
+        $this->g->remove('api');
+        $this->assertFalse($this->g->has('API'));
+        $this->assertSame(0, $this->g->count());
+    }
+
+    public function testRemoveMissingIsNoop(): void
+    {
+        $this->g->remove('ghost');
+        $this->assertSame(0, $this->g->count());
+    }
+
+    public function testDefineRejectsEmptyTerm(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->g->define('   ', 'def');
+    }
+
+    public function testDefineRejectsEmptyDefinition(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->g->define('API', '   ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT278** — `Nene\Xion\TermGlossary`: a glossary of domain terms and definitions (help pages, tooltips, acronym lookups), with optional categories.

| Method | Description |
| --- | --- |
| `define(term, definition, category='')` | Upsert by normalised slug. |
| `get / has (term)` | Case-insensitive lookup. |
| `search(query)` | Substring match (term or definition). |
| `byCategory / categories / all / count / remove` | Filter / list / mutate. |

- Slug-keyed (case-insensitive collapse); `LIKE` wildcards escaped so `search('%')` is literal.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 14 tests / 24 assertions (define/get, case-insensitive, idempotent redefine, search term/def/none, literal `%`, byCategory, distinct categories, all order, remove, validation)
- [x] `composer precommit` green (format → Phan → 4743 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)