### PR TITLE
feat(xion): RedactionRule — configurable PII/secret masking rules (FT279)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -52,6 +52,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `ImpersonationLog` | Admin impersonation session audit log. |
 | `IpAllowlist` | per-resource IP allowlist with CIDR range support. |
 | `IpBlocklist` | global IP address blocklist with optional expiry. |
+| `RedactionRule` | configurable PII/secret masking rules for text. |
 | `RedirectGuard` | Open-redirect guard for controllers that need to redirect to an |
 | `ResourceLock` | advisory lock on any entity to prevent concurrent edits. |
 | `RoleGuard` | — |

--- a/class/xion/RedactionRule.php
+++ b/class/xion/RedactionRule.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * RedactionRule — configurable PII/secret masking rules for text.
+ *
+ * Holds a registry of named regular-expression rules and applies them to mask
+ * sensitive data (card numbers, emails, tokens) before text is logged, shown
+ * to support staff, or exported. Rules are applied in priority order so more
+ * specific patterns can run first.
+ *
+ * Patterns are **operator-supplied** PCRE regular expressions (including
+ * delimiters, e.g. `'/\b\d{13,16}\b/'`), validated for compilability when
+ * added — they are configuration, never end-user input.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $r = new RedactionRule($pdo);
+ *
+ * $r->addRule('card', '/\b\d{13,16}\b/', '[CARD]', priority: 10);
+ * $r->addRule('email', '/[\w.+-]+@[\w-]+\.[\w.-]+/', '[EMAIL]');
+ *
+ * $r->redact('pay 4111111111111111 or mail a@b.com');
+ * // 'pay [CARD] or mail [EMAIL]'
+ *
+ * $r->disable('email');
+ * $r->redact('mail a@b.com'); // unchanged — rule disabled
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE redaction_rules (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     name        VARCHAR(100) NOT NULL,
+ *     pattern     TEXT         NOT NULL,
+ *     replacement VARCHAR(255) NOT NULL DEFAULT '[REDACTED]',
+ *     priority    INTEGER      NOT NULL DEFAULT 0,
+ *     enabled     INTEGER      NOT NULL DEFAULT 1,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (name)
+ * );
+ * ```
+ */
+final class RedactionRule
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add or update a redaction rule. Idempotent per name.
+     *
+     * @param  string $name        Rule name.
+     * @param  string $pattern     PCRE pattern with delimiters (must compile).
+     * @param  string $replacement Replacement string.
+     * @param  int    $priority    Higher runs first (default 0).
+     * @throws \InvalidArgumentException on empty name or invalid pattern.
+     */
+    public function addRule(string $name, string $pattern, string $replacement = '[REDACTED]', int $priority = 0): void
+    {
+        $name = $this->validateName($name);
+        $this->assertValidPattern($pattern);
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'redaction_rules',
+            data:         [
+                'name'        => $name,
+                'pattern'     => $pattern,
+                'replacement' => $replacement,
+                'priority'    => $priority,
+                'enabled'     => 1,
+            ],
+            conflictCols: ['name'],
+            updateCols:   ['pattern', 'replacement', 'priority', 'enabled'],
+        );
+    }
+
+    /**
+     * Apply all enabled rules to a string, in priority (then name) order.
+     *
+     * @param  string $text Input text.
+     * @return string       Redacted text.
+     */
+    public function redact(string $text): string
+    {
+        foreach ($this->enabledRules() as $rule) {
+            $result = preg_replace($rule['pattern'], $rule['replacement'], $text);
+            if ($result !== null) {
+                $text = $result;
+            }
+        }
+
+        return $text;
+    }
+
+    /**
+     * Apply a single named rule (ignores enabled flag). Returns text unchanged
+     * if the rule does not exist.
+     */
+    public function applyRule(string $name, string $text): string
+    {
+        $name = $this->validateName($name);
+        $stmt = $this->db()->prepare('SELECT pattern, replacement FROM redaction_rules WHERE name = ?');
+        $stmt->execute([$name]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return $text;
+        }
+
+        $result = preg_replace((string)$row['pattern'], (string)$row['replacement'], $text);
+
+        return $result ?? $text;
+    }
+
+    /**
+     * Enable a rule. No-op if absent.
+     */
+    public function enable(string $name): void
+    {
+        $this->setEnabled($name, true);
+    }
+
+    /**
+     * Disable a rule without deleting it. No-op if absent.
+     */
+    public function disable(string $name): void
+    {
+        $this->setEnabled($name, false);
+    }
+
+    /**
+     * Remove a rule. No-op if absent.
+     */
+    public function remove(string $name): void
+    {
+        $name = $this->validateName($name);
+        $stmt = $this->db()->prepare('DELETE FROM redaction_rules WHERE name = ?');
+        $stmt->execute([$name]);
+    }
+
+    /**
+     * List all rules in application order (priority desc, name asc).
+     *
+     * @return array<int,array{name:string,pattern:string,replacement:string,priority:int,enabled:bool}>
+     */
+    public function rules(): array
+    {
+        $stmt = $this->db()->query(
+            'SELECT name, pattern, replacement, priority, enabled FROM redaction_rules
+             ORDER BY priority DESC, name ASC'
+        );
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($rows as $row) {
+            $out[] = [
+                'name'        => (string)$row['name'],
+                'pattern'     => (string)$row['pattern'],
+                'replacement' => (string)$row['replacement'],
+                'priority'    => (int)$row['priority'],
+                'enabled'     => (bool)$row['enabled'],
+            ];
+        }
+
+        return $out;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array<int,array{pattern:string,replacement:string}>
+     */
+    private function enabledRules(): array
+    {
+        $stmt = $this->db()->query(
+            'SELECT pattern, replacement FROM redaction_rules WHERE enabled = 1
+             ORDER BY priority DESC, name ASC'
+        );
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($rows as $row) {
+            $out[] = ['pattern' => (string)$row['pattern'], 'replacement' => (string)$row['replacement']];
+        }
+
+        return $out;
+    }
+
+    private function setEnabled(string $name, bool $enabled): void
+    {
+        $name = $this->validateName($name);
+        $stmt = $this->db()->prepare('UPDATE redaction_rules SET enabled = ? WHERE name = ?');
+        $stmt->execute([$enabled ? 1 : 0, $name]);
+    }
+
+    private function assertValidPattern(string $pattern): void
+    {
+        $subject = '';
+        if (@preg_match($pattern, $subject) === false) {
+            throw new \InvalidArgumentException('Invalid regular expression pattern.');
+        }
+    }
+
+    private function validateName(string $name): string
+    {
+        $name = trim($name);
+        if ($name === '') {
+            throw new \InvalidArgumentException('Name must not be empty.');
+        }
+
+        return $name;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-279.md
+++ b/docs/field-trials/2026-05-field-trial-279.md
@@ -1,0 +1,42 @@
+# Field Trial 279 — RedactionRule
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft279-redaction-rule`
+**Baseline**: post FT278 merge
+
+## Goal
+
+Add `Nene\Xion\RedactionRule` — a registry of named regex masking rules applied to text before it is logged, shown to support, or exported (mask card numbers, emails, tokens).
+
+## What was built
+
+### `Nene\Xion\RedactionRule` (`class/xion/RedactionRule.php`)
+
+| Method | Description |
+| --- | --- |
+| `addRule(name, pattern, replacement='[REDACTED]', priority=0)` | Upsert; pattern validated for compilability. |
+| `redact(text): string` | Apply all enabled rules in priority order. |
+| `applyRule(name, text): string` | Apply one rule (ignores enabled flag). |
+| `enable / disable / remove (name)` | Toggle / delete. |
+| `rules()` | List in application order. |
+
+Key design points:
+
+- **Operator-supplied PCRE patterns** (config, not user input), validated at add-time via `@preg_match($pattern, $subject)` — the subject is a variable to keep Phan's arg-order check happy.
+- **Priority then name ordering** so specific rules can run before broad ones.
+- **`preg_replace` null-guarded**: on a runtime regex failure the text passes through unchanged rather than becoming null.
+- **Cross-driver upsert**; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/RedactionRuleTest.php`)
+
+13 unit tests (14 assertions): single + multiple rule redaction; priority ordering (broad-after-specific); disabled not applied; re-enable; applyRule ignores enabled flag + missing returns unchanged; idempotent add; rules ordered by priority then name; remove; no-rules passthrough; validation (invalid pattern, empty name).
+
+## Findings
+
+### F-1 — process note: `preg_match` arg-order
+
+`@preg_match($pattern, '')` tripped `PhanParamSuspiciousOrder` (variable pattern + literal subject). Resolved cleanly by binding the subject to a variable — no suppression needed. Worth remembering for other regex-validation helpers.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/RedactionRuleTest.php
+++ b/tests/Unit/Xion/RedactionRuleTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\RedactionRule;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for RedactionRule.
+ */
+final class RedactionRuleTest extends TestCase
+{
+    private PDO $db;
+    private RedactionRule $r;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE redaction_rules (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                name        VARCHAR(100) NOT NULL,
+                pattern     TEXT         NOT NULL,
+                replacement VARCHAR(255) NOT NULL DEFAULT \'[REDACTED]\',
+                priority    INTEGER      NOT NULL DEFAULT 0,
+                enabled     INTEGER      NOT NULL DEFAULT 1,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (name)
+            )
+        ');
+        $this->r = new RedactionRule($this->db);
+    }
+
+    public function testRedactAppliesRule(): void
+    {
+        $this->r->addRule('card', '/\b\d{13,16}\b/', '[CARD]');
+        $this->assertSame('pay [CARD] now', $this->r->redact('pay 4111111111111111 now'));
+    }
+
+    public function testRedactAppliesMultipleRules(): void
+    {
+        $this->r->addRule('card', '/\b\d{13,16}\b/', '[CARD]');
+        $this->r->addRule('email', '/[\w.+-]+@[\w-]+\.[\w.-]+/', '[EMAIL]');
+        $this->assertSame(
+            'card [CARD] mail [EMAIL]',
+            $this->r->redact('card 4111111111111111 mail a@b.com')
+        );
+    }
+
+    public function testPriorityOrder(): void
+    {
+        // Higher priority runs first.
+        $this->r->addRule('digits', '/\d+/', 'N', priority: 1);
+        $this->r->addRule('specific', '/4111/', 'CARD', priority: 10);
+        // 'specific' (pri 10) first → 'CARD111111111111', then digits → 'CARDN'
+        $this->assertSame('CARDN', $this->r->redact('4111111111111111'));
+    }
+
+    public function testDisabledRuleNotApplied(): void
+    {
+        $this->r->addRule('email', '/[\w.+-]+@[\w-]+\.[\w.-]+/', '[EMAIL]');
+        $this->r->disable('email');
+        $this->assertSame('mail a@b.com', $this->r->redact('mail a@b.com'));
+    }
+
+    public function testReEnable(): void
+    {
+        $this->r->addRule('email', '/[\w.+-]+@[\w-]+\.[\w.-]+/', '[EMAIL]');
+        $this->r->disable('email');
+        $this->r->enable('email');
+        $this->assertSame('mail [EMAIL]', $this->r->redact('mail a@b.com'));
+    }
+
+    public function testApplyRuleIgnoresEnabledFlag(): void
+    {
+        $this->r->addRule('email', '/[\w.+-]+@[\w-]+\.[\w.-]+/', '[EMAIL]');
+        $this->r->disable('email');
+        $this->assertSame('mail [EMAIL]', $this->r->applyRule('email', 'mail a@b.com'));
+    }
+
+    public function testApplyRuleMissingReturnsUnchanged(): void
+    {
+        $this->assertSame('hello', $this->r->applyRule('ghost', 'hello'));
+    }
+
+    public function testAddRuleIsIdempotent(): void
+    {
+        $this->r->addRule('card', '/\d{16}/', '[A]');
+        $this->r->addRule('card', '/\d{16}/', '[B]');
+        $this->assertCount(1, $this->r->rules());
+        $this->assertSame('[B]', $this->r->rules()[0]['replacement']);
+    }
+
+    public function testRulesOrderedByPriorityThenName(): void
+    {
+        $this->r->addRule('b', '/x/', 'X', priority: 5);
+        $this->r->addRule('a', '/y/', 'Y', priority: 5);
+        $this->r->addRule('c', '/z/', 'Z', priority: 10);
+        $names = array_map(static fn (array $rr): string => $rr['name'], $this->r->rules());
+        $this->assertSame(['c', 'a', 'b'], $names);
+    }
+
+    public function testRemove(): void
+    {
+        $this->r->addRule('card', '/\d{16}/', '[CARD]');
+        $this->r->remove('card');
+        $this->assertSame([], $this->r->rules());
+    }
+
+    public function testRedactWithNoRulesReturnsInput(): void
+    {
+        $this->assertSame('untouched', $this->r->redact('untouched'));
+    }
+
+    public function testAddRuleRejectsInvalidPattern(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->addRule('bad', '/unterminated(');
+    }
+
+    public function testAddRuleRejectsEmptyName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->addRule('  ', '/x/');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT279** — `Nene\Xion\RedactionRule`: a registry of named regex masking rules applied to text before it is logged, shown to support, or exported.

| Method | Description |
| --- | --- |
| `addRule(name, pattern, replacement='[REDACTED]', priority=0)` | Upsert (pattern validated). |
| `redact(text)` | Apply enabled rules in priority order. |
| `applyRule(name, text)` | Apply one (ignores enabled flag). |
| `enable / disable / remove / rules` | Toggle / list. |

- Operator-supplied PCRE (config, not user input), validated at add-time; `preg_replace` null-guarded.

## F-N findings
- **F-1** (process note): `@preg_match($pattern, '')` tripped `PhanParamSuspiciousOrder`; resolved by binding the subject to a variable (no suppression).

## Test plan
- [x] 13 tests / 14 assertions (single/multi redaction, priority order, disable/enable, applyRule, idempotent, ordering, remove, passthrough, validation)
- [x] `composer precommit` green (format → Phan → 4756 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)