### PR TITLE
feat(xion): IpReputation — running reputation score per IP (FT280)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -52,6 +52,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `ImpersonationLog` | Admin impersonation session audit log. |
 | `IpAllowlist` | per-resource IP allowlist with CIDR range support. |
 | `IpBlocklist` | global IP address blocklist with optional expiry. |
+| `IpReputation` | running reputation score per IP address. |
 | `RedactionRule` | configurable PII/secret masking rules for text. |
 | `RedirectGuard` | Open-redirect guard for controllers that need to redirect to an |
 | `ResourceLock` | advisory lock on any entity to prevent concurrent edits. |

--- a/class/xion/IpReputation.php
+++ b/class/xion/IpReputation.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * IpReputation — running reputation score per IP address.
+ *
+ * Accumulates a numeric score per IP from observed behaviour: failed logins,
+ * spammy posts, or rate-limit hits push it up (worse); good behaviour or
+ * decay can pull it down. Callers then gate on a threshold. Distinct from
+ * `IpAllowlist` / `IpBlocklist` (FT121/FT148), which are hard binary lists —
+ * this is the soft, additive signal that can *feed* a blocklist decision.
+ *
+ * Higher score = worse reputation. Score adjustments are applied atomically so
+ * concurrent observers accumulate correctly.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $rep = new IpReputation($pdo);
+ *
+ * $rep->penalize('203.0.113.5', 10);   // failed login
+ * $rep->penalize('203.0.113.5', 5);    // another → score 15
+ * $rep->reward('203.0.113.5', 3);      // good behaviour → score 12
+ *
+ * $rep->score('203.0.113.5');          // 12
+ * $rep->isBad('203.0.113.5', 20);      // false (below threshold)
+ * $rep->worst(10);                     // worst offenders
+ * $rep->purgeBelow(1);                 // housekeeping: drop near-zero scores
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE ip_reputation (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     ip         VARCHAR(45) NOT NULL,
+ *     score      INTEGER     NOT NULL DEFAULT 0,
+ *     updated_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (ip)
+ * );
+ * ```
+ */
+final class IpReputation
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add $delta to an IP's score (may be negative) and return the new score.
+     *
+     * Applied atomically (read-modify-write in a transaction).
+     *
+     * @param  string $ip    IP address.
+     * @param  int    $delta Amount to add (negative to improve reputation).
+     * @return int           The resulting score.
+     * @throws \InvalidArgumentException on empty IP.
+     */
+    public function adjust(string $ip, int $delta): int
+    {
+        $ip             = $this->validateIp($ip);
+        $db             = $this->db();
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+
+        try {
+            $current = $this->rawScore($ip);
+            $new     = $current + $delta;
+
+            DbUpsert::run(
+                $db,
+                table:        'ip_reputation',
+                data:         ['ip' => $ip, 'score' => $new],
+                conflictCols: ['ip'],
+                updateCols:   ['score'],
+                updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+            );
+
+            if ($ownTransaction) {
+                $db->commit();
+            }
+
+            return $new;
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Increase an IP's score (worse reputation).
+     *
+     * @param int $points Positive number of points to add (>= 1).
+     */
+    public function penalize(string $ip, int $points = 1): int
+    {
+        if ($points < 1) {
+            throw new \InvalidArgumentException('Points must be at least 1.');
+        }
+
+        return $this->adjust($ip, $points);
+    }
+
+    /**
+     * Decrease an IP's score (better reputation).
+     *
+     * @param int $points Positive number of points to subtract (>= 1).
+     */
+    public function reward(string $ip, int $points = 1): int
+    {
+        if ($points < 1) {
+            throw new \InvalidArgumentException('Points must be at least 1.');
+        }
+
+        return $this->adjust($ip, -$points);
+    }
+
+    /**
+     * Current score for an IP (0 if unknown).
+     */
+    public function score(string $ip): int
+    {
+        return $this->rawScore($this->validateIp($ip));
+    }
+
+    /**
+     * Whether an IP's score is at or above a threshold.
+     */
+    public function isBad(string $ip, int $threshold): bool
+    {
+        return $this->score($ip) >= $threshold;
+    }
+
+    /**
+     * Worst-scoring IPs, highest first.
+     *
+     * @param  int $limit Maximum rows (>= 1).
+     * @return array<int,array{ip:string,score:int}>
+     */
+    public function worst(int $limit = 10): array
+    {
+        $limit = max(1, $limit);
+        $stmt  = $this->db()->prepare(
+            'SELECT ip, score FROM ip_reputation ORDER BY score DESC, ip ASC LIMIT ?'
+        );
+        $stmt->bindValue(1, $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['ip' => (string)$row['ip'], 'score' => (int)$row['score']];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Reset an IP's score to zero (keeps the row). No-op if absent.
+     */
+    public function reset(string $ip): void
+    {
+        $ip   = $this->validateIp($ip);
+        $stmt = $this->db()->prepare('UPDATE ip_reputation SET score = 0, updated_at = CURRENT_TIMESTAMP WHERE ip = ?');
+        $stmt->execute([$ip]);
+    }
+
+    /**
+     * Remove an IP's row entirely. No-op if absent.
+     */
+    public function remove(string $ip): void
+    {
+        $ip   = $this->validateIp($ip);
+        $stmt = $this->db()->prepare('DELETE FROM ip_reputation WHERE ip = ?');
+        $stmt->execute([$ip]);
+    }
+
+    /**
+     * Delete rows scoring below a threshold (decay housekeeping). Returns count removed.
+     */
+    public function purgeBelow(int $threshold): int
+    {
+        $stmt = $this->db()->prepare('DELETE FROM ip_reputation WHERE score < ?');
+        $stmt->execute([$threshold]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function rawScore(string $ip): int
+    {
+        $stmt = $this->db()->prepare('SELECT score FROM ip_reputation WHERE ip = ?');
+        $stmt->execute([$ip]);
+        $score = $stmt->fetchColumn();
+
+        return $score === false ? 0 : (int)$score;
+    }
+
+    private function validateIp(string $ip): string
+    {
+        $ip = trim($ip);
+        if ($ip === '') {
+            throw new \InvalidArgumentException('IP must not be empty.');
+        }
+
+        return $ip;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-280.md
+++ b/docs/field-trials/2026-05-field-trial-280.md
@@ -1,0 +1,43 @@
+# Field Trial 280 — IpReputation
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft280-ip-reputation`
+**Baseline**: post FT279 merge
+
+## Goal
+
+Add `Nene\Xion\IpReputation` — a running reputation score per IP from observed behaviour. The soft, additive signal that can feed a blocklist decision; distinct from `IpAllowlist`/`IpBlocklist` (FT121/FT148) hard binary lists.
+
+## What was built
+
+### `Nene\Xion\IpReputation` (`class/xion/IpReputation.php`)
+
+Higher score = worse reputation.
+
+| Method | Description |
+| --- | --- |
+| `adjust(ip, delta): int` | Atomic add (may be negative); returns new score. |
+| `penalize(ip, points=1) / reward(ip, points=1)` | Convenience +/- (points >= 1). |
+| `score(ip) / isBad(ip, threshold)` | Read / threshold check (>= inclusive). |
+| `worst(limit=10)` | Worst offenders, highest first. |
+| `reset(ip) / remove(ip) / purgeBelow(threshold)` | Zero / delete / decay housekeeping. |
+
+Key design points:
+
+- **Atomic accumulation**: `adjust` does read-modify-write inside a transaction (reuses an open one), so concurrent observers don't lose increments.
+- **Feeds, not replaces, blocklists**: a soft score; the app decides when a threshold escalates to a hard block.
+- **Cross-driver upsert**; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/IpReputationTest.php`)
+
+13 unit tests (21 assertions): penalize accumulation, reward decrease, negative adjust, unknown→0, isBad threshold (inclusive boundary), worst desc + limit, reset, remove, purgeBelow, adjust within an existing transaction, validation (zero penalize/reward points, empty IP).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/IpReputationTest.php
+++ b/tests/Unit/Xion/IpReputationTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\IpReputation;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for IpReputation.
+ */
+final class IpReputationTest extends TestCase
+{
+    private PDO $db;
+    private IpReputation $rep;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE ip_reputation (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                ip         VARCHAR(45) NOT NULL,
+                score      INTEGER     NOT NULL DEFAULT 0,
+                updated_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (ip)
+            )
+        ');
+        $this->rep = new IpReputation($this->db);
+    }
+
+    public function testPenalizeAccumulates(): void
+    {
+        $this->assertSame(10, $this->rep->penalize('1.1.1.1', 10));
+        $this->assertSame(15, $this->rep->penalize('1.1.1.1', 5));
+        $this->assertSame(15, $this->rep->score('1.1.1.1'));
+    }
+
+    public function testRewardDecreases(): void
+    {
+        $this->rep->penalize('1.1.1.1', 15);
+        $this->assertSame(12, $this->rep->reward('1.1.1.1', 3));
+    }
+
+    public function testAdjustNegative(): void
+    {
+        $this->rep->penalize('1.1.1.1', 5);
+        $this->assertSame(2, $this->rep->adjust('1.1.1.1', -3));
+    }
+
+    public function testScoreUnknownIsZero(): void
+    {
+        $this->assertSame(0, $this->rep->score('9.9.9.9'));
+    }
+
+    public function testIsBadThreshold(): void
+    {
+        $this->rep->penalize('1.1.1.1', 20);
+        $this->assertTrue($this->rep->isBad('1.1.1.1', 20));  // >= inclusive
+        $this->assertTrue($this->rep->isBad('1.1.1.1', 19));
+        $this->assertFalse($this->rep->isBad('1.1.1.1', 21));
+    }
+
+    public function testWorstOrderedDesc(): void
+    {
+        $this->rep->penalize('a', 5);
+        $this->rep->penalize('b', 50);
+        $this->rep->penalize('c', 20);
+        $worst = $this->rep->worst(2);
+        $this->assertCount(2, $worst);
+        $this->assertSame('b', $worst[0]['ip']);
+        $this->assertSame('c', $worst[1]['ip']);
+    }
+
+    public function testReset(): void
+    {
+        $this->rep->penalize('1.1.1.1', 30);
+        $this->rep->reset('1.1.1.1');
+        $this->assertSame(0, $this->rep->score('1.1.1.1'));
+    }
+
+    public function testRemove(): void
+    {
+        $this->rep->penalize('1.1.1.1', 30);
+        $this->rep->remove('1.1.1.1');
+        $this->assertSame(0, $this->rep->score('1.1.1.1'));
+        $this->assertSame([], $this->rep->worst());
+    }
+
+    public function testPurgeBelow(): void
+    {
+        $this->rep->penalize('a', 100);
+        $this->rep->penalize('b', 2);
+        $this->rep->penalize('c', 50);
+        $removed = $this->rep->purgeBelow(50); // a(100),c(50) kept; b(2) removed
+        $this->assertSame(1, $removed);
+        $this->assertCount(2, $this->rep->worst());
+    }
+
+    public function testAdjustWithinExistingTransaction(): void
+    {
+        $this->db->beginTransaction();
+        $this->rep->penalize('1.1.1.1', 5);
+        $this->rep->penalize('1.1.1.1', 5);
+        $this->db->commit();
+        $this->assertSame(10, $this->rep->score('1.1.1.1'));
+    }
+
+    public function testPenalizeRejectsZeroPoints(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rep->penalize('1.1.1.1', 0);
+    }
+
+    public function testRewardRejectsZeroPoints(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rep->reward('1.1.1.1', 0);
+    }
+
+    public function testAdjustRejectsEmptyIp(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rep->adjust('  ', 5);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT280** — `Nene\Xion\IpReputation`: a running per-IP reputation score from observed behaviour. Soft signal that feeds a blocklist decision; distinct from `IpAllowlist`/`IpBlocklist` (FT121/FT148) hard lists. Higher = worse.

| Method | Description |
| --- | --- |
| `adjust(ip, delta): int` | Atomic add; returns new score. |
| `penalize / reward (ip, points=1)` | +/- convenience. |
| `score / isBad(ip, threshold)` | Read / threshold (>= inclusive). |
| `worst(limit) / reset / remove / purgeBelow` | Offenders / housekeeping. |

- Atomic read-modify-write (transaction); soft score feeds, not replaces, blocklists.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 21 assertions (accumulate, reward, negative, unknown→0, isBad boundary, worst desc+limit, reset/remove/purgeBelow, in-transaction, validation)
- [x] `composer precommit` green (format → Phan → 4769 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)