### PR TITLE
feat(xion): FeatureTour — per-user one-time UI tour/coachmark state (FT281)

### DIFF
--- a/class/xion/FeatureTour.php
+++ b/class/xion/FeatureTour.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * FeatureTour — per-user state for one-time UI tours / coachmarks.
+ *
+ * Tracks whether each user has seen, advanced through, completed, or dismissed
+ * a guided product tour, so the front-end shows each tour only when
+ * appropriate. A user with no record for a tour is "pristine" and should be
+ * shown the tour; once any interaction is recorded, auto-display stops.
+ *
+ * `resetAll()` clears a tour for everyone — useful when the tour content
+ * changes and should be re-shown.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ft = new FeatureTour($pdo);
+ *
+ * if ($ft->shouldShow(42, 'editor-v2')) {
+ *     $ft->markSeen(42, 'editor-v2');   // begin; auto-display stops
+ * }
+ * $ft->advance(42, 'editor-v2', 3);     // user reached step 3
+ * $ft->complete(42, 'editor-v2');       // finished
+ * // or: $ft->dismiss(42, 'editor-v2'); // skipped
+ *
+ * $ft->status(42, 'editor-v2');         // 'completed'
+ * $ft->completedCount('editor-v2');     // analytics
+ * $ft->resetAll('editor-v2');           // re-show to everyone after a rewrite
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE feature_tours (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id    BIGINT       NOT NULL,
+ *     tour       VARCHAR(100) NOT NULL,
+ *     status     VARCHAR(20)  NOT NULL DEFAULT 'seen',
+ *     step       INTEGER      NOT NULL DEFAULT 0,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (user_id, tour)
+ * );
+ * ```
+ */
+final class FeatureTour
+{
+    public const string STATUS_SEEN      = 'seen';
+    public const string STATUS_COMPLETED = 'completed';
+    public const string STATUS_DISMISSED = 'dismissed';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Whether a tour should be auto-shown to a user (no prior interaction).
+     */
+    public function shouldShow(int $userId, string $tour): bool
+    {
+        return $this->row($userId, $this->validateTour($tour)) === null;
+    }
+
+    /**
+     * Mark a tour as seen (begun) for a user, at an optional step. Idempotent;
+     * does not regress a completed/dismissed tour back to seen.
+     */
+    public function markSeen(int $userId, string $tour, int $step = 0): void
+    {
+        $this->upsert($userId, $tour, self::STATUS_SEEN, $step, regressStatus: false);
+    }
+
+    /**
+     * Record progress to a step (implies the tour is in progress / seen).
+     *
+     * @throws \InvalidArgumentException on negative step.
+     */
+    public function advance(int $userId, string $tour, int $step): void
+    {
+        if ($step < 0) {
+            throw new \InvalidArgumentException('Step must not be negative.');
+        }
+        $this->upsert($userId, $tour, self::STATUS_SEEN, $step, regressStatus: false);
+    }
+
+    /**
+     * Mark a tour completed for a user.
+     */
+    public function complete(int $userId, string $tour): void
+    {
+        $this->upsert($userId, $tour, self::STATUS_COMPLETED, null, regressStatus: true);
+    }
+
+    /**
+     * Mark a tour dismissed (skipped) for a user.
+     */
+    public function dismiss(int $userId, string $tour): void
+    {
+        $this->upsert($userId, $tour, self::STATUS_DISMISSED, null, regressStatus: true);
+    }
+
+    /**
+     * Current status for a user+tour, or null if pristine.
+     */
+    public function status(int $userId, string $tour): ?string
+    {
+        $row = $this->row($userId, $this->validateTour($tour));
+
+        return $row === null ? null : (string)$row['status'];
+    }
+
+    /**
+     * Current step for a user+tour (0 if pristine).
+     */
+    public function step(int $userId, string $tour): int
+    {
+        $row = $this->row($userId, $this->validateTour($tour));
+
+        return $row === null ? 0 : (int)$row['step'];
+    }
+
+    /**
+     * Clear one user's record for a tour (auto-display resumes). No-op if absent.
+     */
+    public function reset(int $userId, string $tour): void
+    {
+        $tour = $this->validateTour($tour);
+        $stmt = $this->db()->prepare('DELETE FROM feature_tours WHERE user_id = ? AND tour = ?');
+        $stmt->execute([$userId, $tour]);
+    }
+
+    /**
+     * Clear a tour for every user (re-show to all). Returns rows removed.
+     */
+    public function resetAll(string $tour): int
+    {
+        $tour = $this->validateTour($tour);
+        $stmt = $this->db()->prepare('DELETE FROM feature_tours WHERE tour = ?');
+        $stmt->execute([$tour]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Count users with a given status for a tour.
+     */
+    public function completedCount(string $tour): int
+    {
+        return $this->countByStatus($tour, self::STATUS_COMPLETED);
+    }
+
+    /**
+     * Count users who dismissed a tour.
+     */
+    public function dismissedCount(string $tour): int
+    {
+        return $this->countByStatus($tour, self::STATUS_DISMISSED);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function upsert(int $userId, string $tour, string $status, ?int $step, bool $regressStatus): void
+    {
+        $tour = $this->validateTour($tour);
+        $db   = $this->db();
+
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+
+        try {
+            $existing = $this->row($userId, $tour);
+            $newStep  = $step ?? ($existing === null ? 0 : (int)$existing['step']);
+
+            // Do not regress a terminal status back to 'seen'.
+            $newStatus = $status;
+            if (!$regressStatus && $existing !== null && $status === self::STATUS_SEEN) {
+                $current = (string)$existing['status'];
+                if ($current === self::STATUS_COMPLETED || $current === self::STATUS_DISMISSED) {
+                    $newStatus = $current;
+                }
+            }
+
+            DbUpsert::run(
+                $db,
+                table:        'feature_tours',
+                data:         ['user_id' => $userId, 'tour' => $tour, 'status' => $newStatus, 'step' => $newStep],
+                conflictCols: ['user_id', 'tour'],
+                updateCols:   ['status', 'step'],
+                updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+            );
+
+            if ($ownTransaction) {
+                $db->commit();
+            }
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    private function countByStatus(string $tour, string $status): int
+    {
+        $tour = $this->validateTour($tour);
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM feature_tours WHERE tour = ? AND status = ?');
+        $stmt->execute([$tour, $status]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function row(int $userId, string $tour): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT status, step FROM feature_tours WHERE user_id = ? AND tour = ?');
+        $stmt->execute([$userId, $tour]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    private function validateTour(string $tour): string
+    {
+        $tour = trim($tour);
+        if ($tour === '') {
+            throw new \InvalidArgumentException('Tour must not be empty.');
+        }
+
+        return $tour;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -102,6 +102,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `ConsentLog` | immutable record of user consent grants and withdrawals. |
 | `DailyStreak` | Track per-user daily activity streaks. |
 | `EntityAlias` | multiple identifier aliases for an entity. |
+| `FeatureTour` | per-user state for one-time UI tours / coachmarks. |
 | `FollowRelation` | User follow/unfollow relationship management. |
 | `FriendRequest` | friend request lifecycle with pending/accepted/declined/cancelled states. |
 | `GdprRequest` | GDPR data-subject request tracking. |

--- a/docs/field-trials/2026-05-field-trial-281.md
+++ b/docs/field-trials/2026-05-field-trial-281.md
@@ -1,0 +1,47 @@
+# Field Trial 281 — FeatureTour
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft281-feature-tour`
+**Baseline**: post FT280 merge
+
+## Goal
+
+Add `Nene\Xion\FeatureTour` — per-user state for one-time UI tours / coachmarks, so the front-end shows each guided tour only when appropriate.
+
+> **Process note (dup avoided):** the originally-queued FT281 *TermsAcceptance* was dropped — `TermConsent` already covers versioned ToS/privacy acceptance. The name-only duplicate check had missed the conceptual overlap; pivoted to FeatureTour after a concept-scan of the INDEX. Lesson folded into the wave: scan INDEX *descriptions*, not just class names.
+
+## What was built
+
+### `Nene\Xion\FeatureTour` (`class/xion/FeatureTour.php`)
+
+| Method | Description |
+| --- | --- |
+| `shouldShow(userId, tour): bool` | True when pristine (no prior interaction). |
+| `markSeen / advance(step)` | Begin / record progress (status `seen`). |
+| `complete / dismiss (userId, tour)` | Terminal states. |
+| `status / step (userId, tour)` | Read state. |
+| `reset(userId, tour) / resetAll(tour): int` | Re-show to one / everyone. |
+| `completedCount / dismissedCount (tour)` | Analytics. |
+
+Key design points:
+
+- **Pristine = auto-show**: `shouldShow` is true only when no row exists; any interaction stops auto-display.
+- **No status regression**: `markSeen`/`advance` will not pull a `completed`/`dismissed` tour back to `seen` (status compare inside the upsert transaction).
+- **`resetAll` re-shows after a rewrite**; per-user `reset` resumes for one.
+- **Cross-driver upsert**; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/FeatureTourTest.php`)
+
+14 unit tests (23 assertions): pristine shouldShow; markSeen stops display; advance records step + creates record; complete/dismiss; **no regression from completed/dismissed**; reset; resetAll (re-show all, scoped to tour); counts by status; per-user separation; validation (negative step, empty tour).
+
+## Findings
+
+### F-1 — process-gap: concept-level duplicate slipped past name check
+
+**Kind**: process-gap · **Severity**: low · **Decision**: document
+
+Name-only dedup let a conceptual duplicate (TermsAcceptance vs existing TermConsent) into the queue. Caught before any PR by scanning INDEX descriptions. Mitigation applied to the rest of the wave: concept-scan, not just name-scan.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/FeatureTourTest.php
+++ b/tests/Unit/Xion/FeatureTourTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\FeatureTour;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for FeatureTour.
+ */
+final class FeatureTourTest extends TestCase
+{
+    private PDO $db;
+    private FeatureTour $ft;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE feature_tours (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    BIGINT       NOT NULL,
+                tour       VARCHAR(100) NOT NULL,
+                status     VARCHAR(20)  NOT NULL DEFAULT \'seen\',
+                step       INTEGER      NOT NULL DEFAULT 0,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (user_id, tour)
+            )
+        ');
+        $this->ft = new FeatureTour($this->db);
+    }
+
+    public function testShouldShowWhenPristine(): void
+    {
+        $this->assertTrue($this->ft->shouldShow(42, 'editor'));
+        $this->assertNull($this->ft->status(42, 'editor'));
+        $this->assertSame(0, $this->ft->step(42, 'editor'));
+    }
+
+    public function testMarkSeenStopsAutoDisplay(): void
+    {
+        $this->ft->markSeen(42, 'editor');
+        $this->assertFalse($this->ft->shouldShow(42, 'editor'));
+        $this->assertSame('seen', $this->ft->status(42, 'editor'));
+    }
+
+    public function testAdvanceRecordsStep(): void
+    {
+        $this->ft->markSeen(42, 'editor');
+        $this->ft->advance(42, 'editor', 3);
+        $this->assertSame(3, $this->ft->step(42, 'editor'));
+        $this->assertSame('seen', $this->ft->status(42, 'editor'));
+    }
+
+    public function testAdvanceCreatesRecord(): void
+    {
+        $this->ft->advance(42, 'editor', 2);
+        $this->assertFalse($this->ft->shouldShow(42, 'editor'));
+        $this->assertSame(2, $this->ft->step(42, 'editor'));
+    }
+
+    public function testComplete(): void
+    {
+        $this->ft->markSeen(42, 'editor');
+        $this->ft->complete(42, 'editor');
+        $this->assertSame('completed', $this->ft->status(42, 'editor'));
+    }
+
+    public function testDismiss(): void
+    {
+        $this->ft->dismiss(42, 'editor');
+        $this->assertSame('dismissed', $this->ft->status(42, 'editor'));
+    }
+
+    public function testMarkSeenDoesNotRegressCompleted(): void
+    {
+        $this->ft->complete(42, 'editor');
+        $this->ft->markSeen(42, 'editor'); // should not pull back to 'seen'
+        $this->assertSame('completed', $this->ft->status(42, 'editor'));
+    }
+
+    public function testMarkSeenDoesNotRegressDismissed(): void
+    {
+        $this->ft->dismiss(42, 'editor');
+        $this->ft->advance(42, 'editor', 5);
+        $this->assertSame('dismissed', $this->ft->status(42, 'editor'));
+    }
+
+    public function testReset(): void
+    {
+        $this->ft->complete(42, 'editor');
+        $this->ft->reset(42, 'editor');
+        $this->assertTrue($this->ft->shouldShow(42, 'editor'));
+    }
+
+    public function testResetAllReShowsToEveryone(): void
+    {
+        $this->ft->complete(1, 'editor');
+        $this->ft->dismiss(2, 'editor');
+        $this->ft->markSeen(3, 'other');
+        $removed = $this->ft->resetAll('editor');
+        $this->assertSame(2, $removed);
+        $this->assertTrue($this->ft->shouldShow(1, 'editor'));
+        $this->assertTrue($this->ft->shouldShow(2, 'editor'));
+        $this->assertFalse($this->ft->shouldShow(3, 'other')); // untouched
+    }
+
+    public function testCountsByStatus(): void
+    {
+        $this->ft->complete(1, 'editor');
+        $this->ft->complete(2, 'editor');
+        $this->ft->dismiss(3, 'editor');
+        $this->assertSame(2, $this->ft->completedCount('editor'));
+        $this->assertSame(1, $this->ft->dismissedCount('editor'));
+    }
+
+    public function testToursAreSeparatePerUser(): void
+    {
+        $this->ft->complete(1, 'editor');
+        $this->assertTrue($this->ft->shouldShow(2, 'editor'));
+    }
+
+    public function testAdvanceRejectsNegativeStep(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ft->advance(42, 'editor', -1);
+    }
+
+    public function testMarkSeenRejectsEmptyTour(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ft->markSeen(42, '  ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT281** — `Nene\Xion\FeatureTour`: per-user state for one-time UI tours / coachmarks, so the front-end shows each guided tour only when appropriate.

> Replaces the originally-queued *TermsAcceptance*, which duplicated the existing `TermConsent` (caught by a concept-scan of the INDEX before any PR).

| Method | Description |
| --- | --- |
| `shouldShow(userId, tour)` | True when pristine. |
| `markSeen / advance(step)` | Begin / progress. |
| `complete / dismiss` | Terminal states (no regression). |
| `status / step / reset / resetAll / completedCount / dismissedCount` | Read / reset / analytics. |

## F-N findings
- **F-1** (low, process-gap): name-only dedup missed a concept duplicate; mitigated by scanning INDEX descriptions for the rest of the wave.

## Test plan
- [x] 14 tests / 23 assertions (pristine show, markSeen/advance, complete/dismiss, no regression, reset/resetAll scoped, counts, per-user separation, validation)
- [x] `composer precommit` green (format → Phan → 4783 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)