### PR TITLE
feat(xion): AffiliateClick — affiliate click & conversion attribution (FT282)

### DIFF
--- a/class/xion/AffiliateClick.php
+++ b/class/xion/AffiliateClick.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * AffiliateClick — affiliate click tracking and conversion attribution.
+ *
+ * Records affiliate referral clicks (each with a unique tracking id) and later
+ * marks which ones converted, with an integer-cent value, so payouts and
+ * conversion rates can be computed per affiliate. Distinct from `Referral`
+ * (FT85, user-to-user referral codes): this is partner/affiliate-program
+ * click→conversion attribution.
+ *
+ * Conversion values are stored as **integer cents** (no floats), consistent
+ * with the framework's monetary policy.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ac = new AffiliateClick($pdo);
+ *
+ * $ac->recordClick('partner-7', 'clk_abc123', '/pricing');
+ *
+ * // Later, when the visitor purchases
+ * $ac->convert('clk_abc123', 4990); // $49.90
+ *
+ * $ac->isConverted('clk_abc123');     // true
+ * $ac->stats('partner-7');            // ['clicks'=>1,'conversions'=>1,'revenue'=>4990,'rate'=>1.0]
+ * $ac->revenueFor('partner-7');       // 4990
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE affiliate_clicks (
+ *     id               INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     affiliate        VARCHAR(100) NOT NULL,
+ *     click_id         VARCHAR(190) NOT NULL,
+ *     landing          VARCHAR(255) NOT NULL DEFAULT '',
+ *     converted        INTEGER      NOT NULL DEFAULT 0,
+ *     conversion_value INTEGER      NOT NULL DEFAULT 0,
+ *     clicked_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     converted_at     DATETIME     NULL,
+ *     UNIQUE (click_id)
+ * );
+ * ```
+ */
+final class AffiliateClick
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record an affiliate click. Idempotent per click id (re-recording is ignored).
+     *
+     * @param  string      $affiliate Affiliate identifier.
+     * @param  string      $clickId   Unique click/tracking id.
+     * @param  string      $landing   Optional landing path/URL.
+     * @param  string|null $asOf      Click time; defaults to now.
+     * @throws \InvalidArgumentException on empty affiliate or click id.
+     */
+    public function recordClick(string $affiliate, string $clickId, string $landing = '', ?string $asOf = null): void
+    {
+        $affiliate = $this->validate($affiliate, 'Affiliate');
+        $clickId   = $this->validate($clickId, 'Click id');
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'affiliate_clicks',
+            data:         ['affiliate' => $affiliate, 'click_id' => $clickId, 'landing' => $landing, 'clicked_at' => $this->ts($asOf)],
+            conflictCols: ['click_id'],
+            // No updateCols/updateExprs → INSERT ... ON CONFLICT DO NOTHING.
+        );
+    }
+
+    /**
+     * Mark a click as converted with an integer-cent value.
+     *
+     * @param  string      $clickId    Click id.
+     * @param  int         $valueCents Conversion value in cents (>= 0).
+     * @param  string|null $asOf       Conversion time; defaults to now.
+     * @return bool                    True if newly converted; false if unknown or already converted.
+     * @throws \InvalidArgumentException on negative value.
+     */
+    public function convert(string $clickId, int $valueCents = 0, ?string $asOf = null): bool
+    {
+        $clickId = $this->validate($clickId, 'Click id');
+        if ($valueCents < 0) {
+            throw new \InvalidArgumentException('Conversion value must not be negative.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'UPDATE affiliate_clicks SET converted = 1, conversion_value = ?, converted_at = ?
+             WHERE click_id = ? AND converted = 0'
+        );
+        $stmt->execute([$valueCents, $this->ts($asOf), $clickId]);
+
+        return $stmt->rowCount() === 1;
+    }
+
+    /**
+     * Whether a click has converted.
+     */
+    public function isConverted(string $clickId): bool
+    {
+        $clickId = $this->validate($clickId, 'Click id');
+        $stmt    = $this->db()->prepare('SELECT converted FROM affiliate_clicks WHERE click_id = ?');
+        $stmt->execute([$clickId]);
+        $v = $stmt->fetchColumn();
+
+        return $v !== false && (int)$v === 1;
+    }
+
+    /**
+     * Number of clicks recorded for an affiliate.
+     */
+    public function clicksFor(string $affiliate): int
+    {
+        return $this->scalar('SELECT COUNT(*) FROM affiliate_clicks WHERE affiliate = ?', $affiliate);
+    }
+
+    /**
+     * Number of converted clicks for an affiliate.
+     */
+    public function conversionsFor(string $affiliate): int
+    {
+        return $this->scalar('SELECT COUNT(*) FROM affiliate_clicks WHERE affiliate = ? AND converted = 1', $affiliate);
+    }
+
+    /**
+     * Total conversion revenue (cents) for an affiliate.
+     */
+    public function revenueFor(string $affiliate): int
+    {
+        return $this->scalar('SELECT COALESCE(SUM(conversion_value), 0) FROM affiliate_clicks WHERE affiliate = ?', $affiliate);
+    }
+
+    /**
+     * Per-affiliate summary: clicks, conversions, revenue (cents), and rate.
+     *
+     * @return array{clicks:int,conversions:int,revenue:int,rate:float}
+     */
+    public function stats(string $affiliate): array
+    {
+        $clicks      = $this->clicksFor($affiliate);
+        $conversions = $this->conversionsFor($affiliate);
+        $revenue     = $this->revenueFor($affiliate);
+        $rate        = $clicks === 0 ? 0.0 : round($conversions / $clicks, 4);
+
+        return ['clicks' => $clicks, 'conversions' => $conversions, 'revenue' => $revenue, 'rate' => $rate];
+    }
+
+    /**
+     * Delete clicks older than $days. Returns the number removed.
+     *
+     * @param  int         $days Age threshold (>= 0).
+     * @param  string|null $asOf Reference time; defaults to now.
+     */
+    public function purgeOlderThan(int $days, ?string $asOf = null): int
+    {
+        if ($days < 0) {
+            throw new \InvalidArgumentException('Days must not be negative.');
+        }
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid reference time.');
+        }
+        $cutoff = date('Y-m-d H:i:s', $epoch - $days * 86400);
+
+        $stmt = $this->db()->prepare('DELETE FROM affiliate_clicks WHERE clicked_at < ?');
+        $stmt->execute([$cutoff]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function scalar(string $sql, string $affiliate): int
+    {
+        $affiliate = $this->validate($affiliate, 'Affiliate');
+        $stmt      = $this->db()->prepare($sql);
+        $stmt->execute([$affiliate]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function ts(?string $asOf): string
+    {
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid timestamp.');
+        }
+
+        return date('Y-m-d H:i:s', $epoch);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -206,6 +206,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | Class | Description |
 |-------|-------------|
 | `AccessLog` | Security-focused resource access log. |
+| `AffiliateClick` | affiliate click tracking and conversion attribution. |
 | `AlertRule` | metric-based alert rules with threshold evaluation and event log. |
 | `ApiUsageLog` | per-API-key request tracking with endpoint and status logging. |
 | `AuditLog` | compliance-grade record of who changed what on any entity. |

--- a/docs/field-trials/2026-05-field-trial-282.md
+++ b/docs/field-trials/2026-05-field-trial-282.md
@@ -1,0 +1,42 @@
+# Field Trial 282 — AffiliateClick
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft282-affiliate-click`
+**Baseline**: post FT281 merge
+
+## Goal
+
+Add `Nene\Xion\AffiliateClick` — affiliate click tracking with conversion attribution and integer-cent revenue, for partner-program payouts and conversion-rate reporting. Distinct from `Referral` (FT85, user-to-user codes).
+
+## What was built
+
+### `Nene\Xion\AffiliateClick` (`class/xion/AffiliateClick.php`)
+
+| Method | Description |
+| --- | --- |
+| `recordClick(affiliate, clickId, landing='')` | Log a click (idempotent per click id). |
+| `convert(clickId, valueCents=0): bool` | Mark converted; true only on the first conversion. |
+| `isConverted(clickId)` | Conversion check. |
+| `clicksFor / conversionsFor / revenueFor (affiliate)` | Counts / cents. |
+| `stats(affiliate)` | `{clicks, conversions, revenue, rate}`. |
+| `purgeOlderThan(days, asOf=null)` | Housekeeping. |
+
+Key design points:
+
+- **Idempotent clicks** via `ON CONFLICT DO NOTHING` (unique click id); **convert() guarded** with `WHERE converted = 0` so a re-conversion returns false and never overwrites the recorded value.
+- **Integer-cent revenue** (no floats); `rate` rounded to 4 dp, 0.0 when no clicks.
+- **PDO injection**; `asOf` for deterministic time.
+
+### Tests (`tests/Unit/Xion/AffiliateClickTest.php`)
+
+13 unit tests (24 assertions): record + count, idempotent click, convert + revenue, convert unknown false, **double-convert returns false + value unchanged**, conversions/revenue sums, stats rate (0.25), zero-clicks rate 0.0, affiliate separation, purgeOlderThan, validation (negative value, empty affiliate/click id).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/AffiliateClickTest.php
+++ b/tests/Unit/Xion/AffiliateClickTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\AffiliateClick;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for AffiliateClick.
+ */
+final class AffiliateClickTest extends TestCase
+{
+    private PDO $db;
+    private AffiliateClick $ac;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE affiliate_clicks (
+                id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                affiliate        VARCHAR(100) NOT NULL,
+                click_id         VARCHAR(190) NOT NULL,
+                landing          VARCHAR(255) NOT NULL DEFAULT \'\',
+                converted        INTEGER      NOT NULL DEFAULT 0,
+                conversion_value INTEGER      NOT NULL DEFAULT 0,
+                clicked_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                converted_at     DATETIME     NULL,
+                UNIQUE (click_id)
+            )
+        ');
+        $this->ac = new AffiliateClick($this->db);
+    }
+
+    public function testRecordClickAndCount(): void
+    {
+        $this->ac->recordClick('p7', 'clk1', '/pricing');
+        $this->ac->recordClick('p7', 'clk2');
+        $this->assertSame(2, $this->ac->clicksFor('p7'));
+    }
+
+    public function testRecordClickIdempotentPerClickId(): void
+    {
+        $this->ac->recordClick('p7', 'clk1');
+        $this->ac->recordClick('p7', 'clk1'); // ignored
+        $this->assertSame(1, $this->ac->clicksFor('p7'));
+    }
+
+    public function testConvert(): void
+    {
+        $this->ac->recordClick('p7', 'clk1');
+        $this->assertTrue($this->ac->convert('clk1', 4990));
+        $this->assertTrue($this->ac->isConverted('clk1'));
+        $this->assertSame(4990, $this->ac->revenueFor('p7'));
+    }
+
+    public function testConvertUnknownClickReturnsFalse(): void
+    {
+        $this->assertFalse($this->ac->convert('ghost', 100));
+    }
+
+    public function testConvertTwiceReturnsFalseSecondTime(): void
+    {
+        $this->ac->recordClick('p7', 'clk1');
+        $this->assertTrue($this->ac->convert('clk1', 1000));
+        $this->assertFalse($this->ac->convert('clk1', 2000)); // already converted
+        $this->assertSame(1000, $this->ac->revenueFor('p7')); // value unchanged
+    }
+
+    public function testConversionsAndRevenue(): void
+    {
+        $this->ac->recordClick('p7', 'a');
+        $this->ac->recordClick('p7', 'b');
+        $this->ac->recordClick('p7', 'c');
+        $this->ac->convert('a', 1000);
+        $this->ac->convert('b', 2000);
+        $this->assertSame(2, $this->ac->conversionsFor('p7'));
+        $this->assertSame(3000, $this->ac->revenueFor('p7'));
+    }
+
+    public function testStats(): void
+    {
+        $this->ac->recordClick('p7', 'a');
+        $this->ac->recordClick('p7', 'b');
+        $this->ac->recordClick('p7', 'c');
+        $this->ac->recordClick('p7', 'd');
+        $this->ac->convert('a', 5000);
+        $stats = $this->ac->stats('p7');
+        $this->assertSame(4, $stats['clicks']);
+        $this->assertSame(1, $stats['conversions']);
+        $this->assertSame(5000, $stats['revenue']);
+        $this->assertSame(0.25, $stats['rate']);
+    }
+
+    public function testStatsZeroClicksRateZero(): void
+    {
+        $stats = $this->ac->stats('nobody');
+        $this->assertSame(0, $stats['clicks']);
+        $this->assertSame(0.0, $stats['rate']);
+    }
+
+    public function testAffiliatesAreSeparate(): void
+    {
+        $this->ac->recordClick('p7', 'a');
+        $this->ac->recordClick('p8', 'b');
+        $this->assertSame(1, $this->ac->clicksFor('p7'));
+        $this->assertSame(1, $this->ac->clicksFor('p8'));
+    }
+
+    public function testPurgeOlderThan(): void
+    {
+        $this->ac->recordClick('p7', 'old', '', '2026-01-01 00:00:00');
+        $this->ac->recordClick('p7', 'new', '', '2026-05-29 00:00:00');
+        $removed = $this->ac->purgeOlderThan(90, '2026-05-29 00:00:00');
+        $this->assertSame(1, $removed);
+        $this->assertSame(1, $this->ac->clicksFor('p7'));
+    }
+
+    public function testConvertRejectsNegativeValue(): void
+    {
+        $this->ac->recordClick('p7', 'clk1');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ac->convert('clk1', -1);
+    }
+
+    public function testRecordClickRejectsEmptyAffiliate(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ac->recordClick('  ', 'clk1');
+    }
+
+    public function testRecordClickRejectsEmptyClickId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ac->recordClick('p7', '  ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT282** — `Nene\Xion\AffiliateClick`: affiliate click tracking with conversion attribution and integer-cent revenue. Distinct from `Referral` (FT85, user-to-user codes).

| Method | Description |
| --- | --- |
| `recordClick(affiliate, clickId, landing='')` | Idempotent per click id. |
| `convert(clickId, valueCents=0): bool` | First-only; value immutable after. |
| `isConverted / clicksFor / conversionsFor / revenueFor` | Read. |
| `stats(affiliate)` | `{clicks, conversions, revenue, rate}`. |
| `purgeOlderThan(days, asOf=null)` | Housekeeping. |

- `ON CONFLICT DO NOTHING` clicks; `convert` guarded by `WHERE converted=0`; integer cents.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 24 assertions (idempotent click, convert+revenue, double-convert false/immutable, sums, stats rate, zero-clicks, separation, purge, validation)
- [x] `composer precommit` green (format → Phan → 4796 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)