### PR TITLE
feat(xion): UtmCampaign — UTM marketing attribution touch capture (FT283)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -224,6 +224,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `KpiTracker` | KPI / OKR metric tracking with target vs. actual comparison. |
 | `PageView` | page and resource view analytics tracking. |
 | `SlaTracker` | SLA/SLO breach detection for timed work items. |
+| `UtmCampaign` | UTM marketing-attribution touch capture. |
 
 ---
 

--- a/class/xion/UtmCampaign.php
+++ b/class/xion/UtmCampaign.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * UtmCampaign — UTM marketing-attribution touch capture.
+ *
+ * Records UTM parameters (`utm_source`, `utm_medium`, `utm_campaign`,
+ * `utm_term`, `utm_content`) seen on a visit, keyed by an opaque visitor id,
+ * so marketing can attribute conversions to campaigns and analyse first- vs
+ * last-touch. Distinct from `AffiliateClick` (FT282, partner click→conversion)
+ * and `Referral` (FT85, user codes): this is campaign-parameter analytics.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $utm = new UtmCampaign($pdo);
+ *
+ * $utm->record('visitor-1', ['source' => 'google', 'medium' => 'cpc', 'campaign' => 'spring']);
+ * $utm->record('visitor-1', ['source' => 'newsletter', 'medium' => 'email', 'campaign' => 'spring']);
+ *
+ * $utm->firstTouch('visitor-1');     // google/cpc touch
+ * $utm->lastTouch('visitor-1');      // newsletter/email touch
+ * $utm->touchesFor('visitor-1');     // full attribution path
+ * $utm->countBy('source');           // ['google'=>1,'newsletter'=>1]
+ * $utm->campaignTouches('spring');   // 2
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE utm_touches (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     visitor    VARCHAR(190) NOT NULL,
+ *     source     VARCHAR(150) NOT NULL,
+ *     medium     VARCHAR(150) NOT NULL DEFAULT '',
+ *     campaign   VARCHAR(150) NOT NULL DEFAULT '',
+ *     term       VARCHAR(150) NOT NULL DEFAULT '',
+ *     content    VARCHAR(150) NOT NULL DEFAULT '',
+ *     landed_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class UtmCampaign
+{
+    private const array FIELDS = ['source', 'medium', 'campaign', 'term', 'content'];
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record a UTM touch for a visitor.
+     *
+     * @param  string                $visitor Opaque visitor id.
+     * @param  array<string,string>  $params  UTM fields (source required;
+     *                                         medium/campaign/term/content optional).
+     * @param  string|null           $asOf    Touch time; defaults to now.
+     * @return int                            New touch id.
+     * @throws \InvalidArgumentException on empty visitor or empty source.
+     */
+    public function record(string $visitor, array $params, ?string $asOf = null): int
+    {
+        $visitor = $this->validate($visitor, 'Visitor');
+        $source  = trim($params['source'] ?? '');
+        if ($source === '') {
+            throw new \InvalidArgumentException('UTM source must not be empty.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO utm_touches (visitor, source, medium, campaign, term, content, landed_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            $visitor,
+            $source,
+            trim($params['medium'] ?? ''),
+            trim($params['campaign'] ?? ''),
+            trim($params['term'] ?? ''),
+            trim($params['content'] ?? ''),
+            $this->ts($asOf),
+        ]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Full attribution path for a visitor, oldest touch first.
+     *
+     * @return array<int,array{source:string,medium:string,campaign:string,term:string,content:string,landed_at:string}>
+     */
+    public function touchesFor(string $visitor): array
+    {
+        $visitor = $this->validate($visitor, 'Visitor');
+        $stmt    = $this->db()->prepare(
+            'SELECT source, medium, campaign, term, content, landed_at FROM utm_touches
+             WHERE visitor = ? ORDER BY id ASC'
+        );
+        $stmt->execute([$visitor]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = $this->hydrate($row);
+        }
+
+        return $out;
+    }
+
+    /**
+     * The visitor's first (acquisition) touch, or null.
+     *
+     * @return array{source:string,medium:string,campaign:string,term:string,content:string,landed_at:string}|null
+     */
+    public function firstTouch(string $visitor): ?array
+    {
+        return $this->edgeTouch($visitor, 'ASC');
+    }
+
+    /**
+     * The visitor's most recent touch, or null.
+     *
+     * @return array{source:string,medium:string,campaign:string,term:string,content:string,landed_at:string}|null
+     */
+    public function lastTouch(string $visitor): ?array
+    {
+        return $this->edgeTouch($visitor, 'DESC');
+    }
+
+    /**
+     * Number of touches recorded for a campaign.
+     */
+    public function campaignTouches(string $campaign): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM utm_touches WHERE campaign = ?');
+        $stmt->execute([trim($campaign)]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Group touches by a UTM field and count them, busiest first.
+     *
+     * @param  string $field One of source|medium|campaign|term|content.
+     * @return array<string,int> value → count
+     * @throws \InvalidArgumentException on an unknown field.
+     */
+    public function countBy(string $field): array
+    {
+        if (!in_array($field, self::FIELDS, true)) {
+            throw new \InvalidArgumentException("Unknown UTM field: {$field}");
+        }
+
+        // $field is whitelisted above, safe to interpolate.
+        $stmt = $this->db()->query(
+            "SELECT {$field} AS k, COUNT(*) AS c FROM utm_touches GROUP BY {$field} ORDER BY c DESC, k ASC"
+        );
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($rows as $row) {
+            $out[(string)$row['k']] = (int)$row['c'];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Delete touches older than $days. Returns the number removed.
+     */
+    public function purgeOlderThan(int $days, ?string $asOf = null): int
+    {
+        if ($days < 0) {
+            throw new \InvalidArgumentException('Days must not be negative.');
+        }
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid reference time.');
+        }
+        $cutoff = date('Y-m-d H:i:s', $epoch - $days * 86400);
+
+        $stmt = $this->db()->prepare('DELETE FROM utm_touches WHERE landed_at < ?');
+        $stmt->execute([$cutoff]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array{source:string,medium:string,campaign:string,term:string,content:string,landed_at:string}|null
+     */
+    private function edgeTouch(string $visitor, string $dir): ?array
+    {
+        $visitor = $this->validate($visitor, 'Visitor');
+        $stmt    = $this->db()->prepare(
+            "SELECT source, medium, campaign, term, content, landed_at FROM utm_touches
+             WHERE visitor = ? ORDER BY id {$dir} LIMIT 1"
+        );
+        $stmt->execute([$visitor]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->hydrate($row);
+    }
+
+    /**
+     * @param  array<string,mixed> $row
+     * @return array{source:string,medium:string,campaign:string,term:string,content:string,landed_at:string}
+     */
+    private function hydrate(array $row): array
+    {
+        return [
+            'source'    => (string)$row['source'],
+            'medium'    => (string)$row['medium'],
+            'campaign'  => (string)$row['campaign'],
+            'term'      => (string)$row['term'],
+            'content'   => (string)$row['content'],
+            'landed_at' => (string)$row['landed_at'],
+        ];
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function ts(?string $asOf): string
+    {
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid timestamp.');
+        }
+
+        return date('Y-m-d H:i:s', $epoch);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-283.md
+++ b/docs/field-trials/2026-05-field-trial-283.md
@@ -1,0 +1,43 @@
+# Field Trial 283 — UtmCampaign
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft283-utm-campaign`
+**Baseline**: post FT282 merge
+
+## Goal
+
+Add `Nene\Xion\UtmCampaign` — capture UTM marketing parameters per visit for campaign attribution and first/last-touch analysis. Distinct from `AffiliateClick` (FT282) and `Referral` (FT85).
+
+## What was built
+
+### `Nene\Xion\UtmCampaign` (`class/xion/UtmCampaign.php`)
+
+| Method | Description |
+| --- | --- |
+| `record(visitor, params[], asOf=null): int` | Store a UTM touch (source required). |
+| `touchesFor(visitor)` | Full attribution path, oldest first. |
+| `firstTouch / lastTouch (visitor)` | Acquisition / most recent touch. |
+| `campaignTouches(campaign)` | Touch count for a campaign. |
+| `countBy(field)` | Group counts by source/medium/campaign/term/content. |
+| `purgeOlderThan(days, asOf=null)` | Housekeeping. |
+
+Key design points:
+
+- **First/last touch** derived by `id ASC/DESC` — supports both common attribution models.
+- **`countBy` field whitelist**: the grouped column is validated against a fixed field list before interpolation (the rest is parameter-bound), so it is injection-safe.
+- **Optional UTM fields default to `''`**; only `source` is required.
+- **PDO injection**; `asOf` for deterministic time.
+
+### Tests (`tests/Unit/Xion/UtmCampaignTest.php`)
+
+12 unit tests (22 assertions): record + read, first/last touch, edge-null when none, oldest-first ordering, optional fields default empty, campaignTouches, countBy busiest-first, **countBy rejects unknown field (`evil; DROP TABLE`)**, visitor separation, purgeOlderThan, validation (empty visitor, empty source).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/UtmCampaignTest.php
+++ b/tests/Unit/Xion/UtmCampaignTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\UtmCampaign;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for UtmCampaign.
+ */
+final class UtmCampaignTest extends TestCase
+{
+    private PDO $db;
+    private UtmCampaign $utm;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE utm_touches (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                visitor   VARCHAR(190) NOT NULL,
+                source    VARCHAR(150) NOT NULL,
+                medium    VARCHAR(150) NOT NULL DEFAULT \'\',
+                campaign  VARCHAR(150) NOT NULL DEFAULT \'\',
+                term      VARCHAR(150) NOT NULL DEFAULT \'\',
+                content   VARCHAR(150) NOT NULL DEFAULT \'\',
+                landed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->utm = new UtmCampaign($this->db);
+    }
+
+    public function testRecordAndTouches(): void
+    {
+        $this->utm->record('v1', ['source' => 'google', 'medium' => 'cpc', 'campaign' => 'spring']);
+        $touches = $this->utm->touchesFor('v1');
+        $this->assertCount(1, $touches);
+        $this->assertSame('google', $touches[0]['source']);
+        $this->assertSame('cpc', $touches[0]['medium']);
+        $this->assertSame('spring', $touches[0]['campaign']);
+    }
+
+    public function testFirstAndLastTouch(): void
+    {
+        $this->utm->record('v1', ['source' => 'google', 'medium' => 'cpc']);
+        $this->utm->record('v1', ['source' => 'newsletter', 'medium' => 'email']);
+        $this->assertSame('google', $this->utm->firstTouch('v1')['source']);
+        $this->assertSame('newsletter', $this->utm->lastTouch('v1')['source']);
+    }
+
+    public function testEdgeTouchesNullWhenNone(): void
+    {
+        $this->assertNull($this->utm->firstTouch('nobody'));
+        $this->assertNull($this->utm->lastTouch('nobody'));
+    }
+
+    public function testTouchesOldestFirst(): void
+    {
+        $this->utm->record('v1', ['source' => 'a']);
+        $this->utm->record('v1', ['source' => 'b']);
+        $this->utm->record('v1', ['source' => 'c']);
+        $sources = array_map(static fn (array $t): string => $t['source'], $this->utm->touchesFor('v1'));
+        $this->assertSame(['a', 'b', 'c'], $sources);
+    }
+
+    public function testOptionalFieldsDefaultEmpty(): void
+    {
+        $this->utm->record('v1', ['source' => 'direct']);
+        $t = $this->utm->firstTouch('v1');
+        $this->assertSame('', $t['medium']);
+        $this->assertSame('', $t['campaign']);
+    }
+
+    public function testCampaignTouches(): void
+    {
+        $this->utm->record('v1', ['source' => 'google', 'campaign' => 'spring']);
+        $this->utm->record('v2', ['source' => 'fb', 'campaign' => 'spring']);
+        $this->utm->record('v3', ['source' => 'fb', 'campaign' => 'summer']);
+        $this->assertSame(2, $this->utm->campaignTouches('spring'));
+    }
+
+    public function testCountBy(): void
+    {
+        $this->utm->record('v1', ['source' => 'google']);
+        $this->utm->record('v2', ['source' => 'google']);
+        $this->utm->record('v3', ['source' => 'fb']);
+        $counts = $this->utm->countBy('source');
+        $this->assertSame(2, $counts['google']);
+        $this->assertSame(1, $counts['fb']);
+        // busiest first
+        $this->assertSame('google', array_key_first($counts));
+    }
+
+    public function testCountByRejectsUnknownField(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->utm->countBy('evil; DROP TABLE');
+    }
+
+    public function testVisitorsAreSeparate(): void
+    {
+        $this->utm->record('v1', ['source' => 'a']);
+        $this->utm->record('v2', ['source' => 'b']);
+        $this->assertCount(1, $this->utm->touchesFor('v1'));
+        $this->assertCount(1, $this->utm->touchesFor('v2'));
+    }
+
+    public function testPurgeOlderThan(): void
+    {
+        $this->utm->record('v1', ['source' => 'old'], '2026-01-01 00:00:00');
+        $this->utm->record('v1', ['source' => 'new'], '2026-05-29 00:00:00');
+        $removed = $this->utm->purgeOlderThan(90, '2026-05-29 00:00:00');
+        $this->assertSame(1, $removed);
+        $this->assertCount(1, $this->utm->touchesFor('v1'));
+    }
+
+    public function testRecordRejectsEmptyVisitor(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->utm->record('  ', ['source' => 'google']);
+    }
+
+    public function testRecordRejectsEmptySource(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->utm->record('v1', ['medium' => 'cpc']);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT283** — `Nene\Xion\UtmCampaign`: capture UTM parameters per visit for campaign attribution and first/last-touch analysis. Distinct from `AffiliateClick` (FT282) and `Referral` (FT85).

| Method | Description |
| --- | --- |
| `record(visitor, params[], asOf=null): int` | Store a touch (source required). |
| `touchesFor / firstTouch / lastTouch` | Path / acquisition / latest. |
| `campaignTouches(campaign)` | Count for a campaign. |
| `countBy(field)` | Grouped counts (whitelisted field). |
| `purgeOlderThan(days, asOf=null)` | Housekeeping. |

- First/last via `id ASC/DESC`; `countBy` field whitelisted (injection-safe); optional fields default `''`.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 22 assertions (record/read, first/last, edge-null, ordering, defaults, campaignTouches, countBy busiest + unknown-field reject, separation, purge, validation)
- [x] `composer precommit` green (format → Phan → 4808 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)