### PR TITLE
feat(xion): FunnelStep — conversion-funnel step tracking (FT284)

### DIFF
--- a/class/xion/FunnelStep.php
+++ b/class/xion/FunnelStep.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * FunnelStep — conversion-funnel step completion tracking.
+ *
+ * Records when a subject (user, session, visitor) reaches a named step in a
+ * funnel (`signup → verify → onboard → activate`) so drop-off and
+ * step-to-step conversion can be computed. Each step carries an order for
+ * sorting the funnel visualisation.
+ *
+ * Recording a step is idempotent per `(funnel, subject, step)` — reaching the
+ * same step twice does not double-count.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $f = new FunnelStep($pdo);
+ *
+ * $f->reach('signup', 'user-1', 'visit',    1);
+ * $f->reach('signup', 'user-1', 'register', 2);
+ * $f->reach('signup', 'user-2', 'visit',    1);
+ *
+ * $f->hasReached('signup', 'user-1', 'register'); // true
+ * $f->reachedSteps('signup', 'user-1');           // ['visit','register']
+ * $f->counts('signup');                           // [['step'=>'visit','order'=>1,'subjects'=>2], ...]
+ * $f->conversionRate('signup', 'visit', 'register'); // 0.5
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE funnel_steps (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     funnel     VARCHAR(100) NOT NULL,
+ *     subject    VARCHAR(190) NOT NULL,
+ *     step       VARCHAR(100) NOT NULL,
+ *     step_order INTEGER      NOT NULL DEFAULT 0,
+ *     reached_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (funnel, subject, step)
+ * );
+ * ```
+ */
+final class FunnelStep
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record that a subject reached a funnel step. Idempotent per subject+step.
+     *
+     * @param  string      $funnel Funnel name.
+     * @param  string      $subject Subject id (user/session/visitor).
+     * @param  string      $step    Step name.
+     * @param  int         $order   Sort order of the step within the funnel.
+     * @param  string|null $asOf    Reach time; defaults to now.
+     * @throws \InvalidArgumentException on empty funnel/subject/step.
+     */
+    public function reach(string $funnel, string $subject, string $step, int $order = 0, ?string $asOf = null): void
+    {
+        $funnel  = $this->validate($funnel, 'Funnel');
+        $subject = $this->validate($subject, 'Subject');
+        $step    = $this->validate($step, 'Step');
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'funnel_steps',
+            data:         ['funnel' => $funnel, 'subject' => $subject, 'step' => $step, 'step_order' => $order, 'reached_at' => $this->ts($asOf)],
+            conflictCols: ['funnel', 'subject', 'step'],
+            updateCols:   ['step_order'],
+        );
+    }
+
+    /**
+     * Whether a subject reached a step.
+     */
+    public function hasReached(string $funnel, string $subject, string $step): bool
+    {
+        $funnel  = $this->validate($funnel, 'Funnel');
+        $subject = $this->validate($subject, 'Subject');
+        $step    = $this->validate($step, 'Step');
+
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM funnel_steps WHERE funnel = ? AND subject = ? AND step = ? LIMIT 1'
+        );
+        $stmt->execute([$funnel, $subject, $step]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Steps a subject reached, in funnel order.
+     *
+     * @return array<int,string>
+     */
+    public function reachedSteps(string $funnel, string $subject): array
+    {
+        $funnel  = $this->validate($funnel, 'Funnel');
+        $subject = $this->validate($subject, 'Subject');
+
+        $stmt = $this->db()->prepare(
+            'SELECT step FROM funnel_steps WHERE funnel = ? AND subject = ? ORDER BY step_order ASC, reached_at ASC, id ASC'
+        );
+        $stmt->execute([$funnel, $subject]);
+
+        return array_map(static fn ($s): string => (string)$s, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    /**
+     * Distinct-subject counts per step, in funnel order — the funnel chart data.
+     *
+     * @return array<int,array{step:string,order:int,subjects:int}>
+     */
+    public function counts(string $funnel): array
+    {
+        $funnel = $this->validate($funnel, 'Funnel');
+
+        $stmt = $this->db()->prepare(
+            'SELECT step, MIN(step_order) AS ord, COUNT(DISTINCT subject) AS subjects
+             FROM funnel_steps WHERE funnel = ?
+             GROUP BY step ORDER BY ord ASC, step ASC'
+        );
+        $stmt->execute([$funnel]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['step' => (string)$row['step'], 'order' => (int)$row['ord'], 'subjects' => (int)$row['subjects']];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Step-to-step conversion rate: of subjects who reached $fromStep, the
+     * fraction that also reached $toStep. Returns 0.0 if none reached $fromStep.
+     *
+     * @return float Rounded to 4 decimal places.
+     */
+    public function conversionRate(string $funnel, string $fromStep, string $toStep): float
+    {
+        $funnel   = $this->validate($funnel, 'Funnel');
+        $fromStep = $this->validate($fromStep, 'From step');
+        $toStep   = $this->validate($toStep, 'To step');
+
+        $denomStmt = $this->db()->prepare(
+            'SELECT COUNT(DISTINCT subject) FROM funnel_steps WHERE funnel = ? AND step = ?'
+        );
+        $denomStmt->execute([$funnel, $fromStep]);
+        $denom = (int)$denomStmt->fetchColumn();
+        if ($denom === 0) {
+            return 0.0;
+        }
+
+        $numStmt = $this->db()->prepare(
+            'SELECT COUNT(DISTINCT subject) FROM funnel_steps
+             WHERE funnel = ? AND step = ?
+             AND subject IN (SELECT subject FROM funnel_steps WHERE funnel = ? AND step = ?)'
+        );
+        $numStmt->execute([$funnel, $toStep, $funnel, $fromStep]);
+        $num = (int)$numStmt->fetchColumn();
+
+        return round($num / $denom, 4);
+    }
+
+    /**
+     * Delete funnel records older than $days. Returns rows removed.
+     */
+    public function purgeOlderThan(int $days, ?string $asOf = null): int
+    {
+        if ($days < 0) {
+            throw new \InvalidArgumentException('Days must not be negative.');
+        }
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid reference time.');
+        }
+        $cutoff = date('Y-m-d H:i:s', $epoch - $days * 86400);
+
+        $stmt = $this->db()->prepare('DELETE FROM funnel_steps WHERE reached_at < ?');
+        $stmt->execute([$cutoff]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function ts(?string $asOf): string
+    {
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid timestamp.');
+        }
+
+        return date('Y-m-d H:i:s', $epoch);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -219,6 +219,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `CronLog` | scheduled task execution log. |
 | `DownloadCounter` | Download counter — track file/asset download events. |
 | `EventLog` | append-only domain event log for event sourcing–lite patterns. |
+| `FunnelStep` | conversion-funnel step completion tracking. |
 | `IncidentLog` | IT/service incident tracking with severity and lifecycle. |
 | `IntegrationLog` | outbound/inbound API call log with request and response data. |
 | `KpiTracker` | KPI / OKR metric tracking with target vs. actual comparison. |

--- a/docs/field-trials/2026-05-field-trial-284.md
+++ b/docs/field-trials/2026-05-field-trial-284.md
@@ -1,0 +1,43 @@
+# Field Trial 284 — FunnelStep
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft284-funnel-step`
+**Baseline**: post FT283 merge
+
+## Goal
+
+Add `Nene\Xion\FunnelStep` — conversion-funnel step completion tracking so drop-off and step-to-step conversion can be computed (signup → verify → onboard → activate).
+
+## What was built
+
+### `Nene\Xion\FunnelStep` (`class/xion/FunnelStep.php`)
+
+| Method | Description |
+| --- | --- |
+| `reach(funnel, subject, step, order=0, asOf=null)` | Record reaching a step (idempotent). |
+| `hasReached(funnel, subject, step)` | Membership. |
+| `reachedSteps(funnel, subject)` | Steps reached, in funnel order. |
+| `counts(funnel)` | Distinct-subject count per step (chart data). |
+| `conversionRate(funnel, fromStep, toStep): float` | Of those reaching from, fraction reaching to. |
+| `purgeOlderThan(days, asOf=null)` | Housekeeping. |
+
+Key design points:
+
+- **Idempotent per (funnel, subject, step)** so re-reaching never double-counts.
+- **`conversionRate`** = `|F ∩ T| / |F|` via a subquery; 0.0 when the from-step has no subjects (no divide-by-zero).
+- **`counts` uses `COUNT(DISTINCT subject)`** ordered by step order for direct funnel-chart rendering.
+- **PDO injection**; `asOf` for deterministic time.
+
+### Tests (`tests/Unit/Xion/FunnelStepTest.php`)
+
+11 unit tests (18 assertions): reach + hasReached, idempotent, reachedSteps ordering, counts distinct-per-step, conversionRate 0.5 / full 1.0 / zero (no to) / zero (no from), funnel separation, purgeOlderThan, validation (empty funnel/step).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 11 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/FunnelStepTest.php
+++ b/tests/Unit/Xion/FunnelStepTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\FunnelStep;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for FunnelStep.
+ */
+final class FunnelStepTest extends TestCase
+{
+    private PDO $db;
+    private FunnelStep $f;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE funnel_steps (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                funnel     VARCHAR(100) NOT NULL,
+                subject    VARCHAR(190) NOT NULL,
+                step       VARCHAR(100) NOT NULL,
+                step_order INTEGER      NOT NULL DEFAULT 0,
+                reached_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (funnel, subject, step)
+            )
+        ');
+        $this->f = new FunnelStep($this->db);
+    }
+
+    public function testReachAndHasReached(): void
+    {
+        $this->f->reach('signup', 'u1', 'visit', 1);
+        $this->assertTrue($this->f->hasReached('signup', 'u1', 'visit'));
+        $this->assertFalse($this->f->hasReached('signup', 'u1', 'register'));
+    }
+
+    public function testReachIsIdempotent(): void
+    {
+        $this->f->reach('signup', 'u1', 'visit', 1);
+        $this->f->reach('signup', 'u1', 'visit', 1);
+        $this->assertCount(1, $this->f->reachedSteps('signup', 'u1'));
+    }
+
+    public function testReachedStepsInOrder(): void
+    {
+        $this->f->reach('signup', 'u1', 'register', 2);
+        $this->f->reach('signup', 'u1', 'visit', 1);
+        $this->f->reach('signup', 'u1', 'activate', 3);
+        $this->assertSame(['visit', 'register', 'activate'], $this->f->reachedSteps('signup', 'u1'));
+    }
+
+    public function testCountsDistinctSubjectsPerStep(): void
+    {
+        $this->f->reach('signup', 'u1', 'visit', 1);
+        $this->f->reach('signup', 'u2', 'visit', 1);
+        $this->f->reach('signup', 'u1', 'register', 2);
+        $counts = $this->f->counts('signup');
+        $this->assertSame('visit', $counts[0]['step']);
+        $this->assertSame(2, $counts[0]['subjects']);
+        $this->assertSame('register', $counts[1]['step']);
+        $this->assertSame(1, $counts[1]['subjects']);
+    }
+
+    public function testConversionRate(): void
+    {
+        // 2 reach visit, 1 of them reaches register → 0.5
+        $this->f->reach('signup', 'u1', 'visit', 1);
+        $this->f->reach('signup', 'u2', 'visit', 1);
+        $this->f->reach('signup', 'u1', 'register', 2);
+        $this->assertSame(0.5, $this->f->conversionRate('signup', 'visit', 'register'));
+    }
+
+    public function testConversionRateFullAndZero(): void
+    {
+        $this->f->reach('signup', 'u1', 'visit', 1);
+        $this->f->reach('signup', 'u1', 'register', 2);
+        $this->assertSame(1.0, $this->f->conversionRate('signup', 'visit', 'register'));
+        // nobody reached 'activate' among visitors
+        $this->assertSame(0.0, $this->f->conversionRate('signup', 'visit', 'activate'));
+    }
+
+    public function testConversionRateZeroWhenNoFrom(): void
+    {
+        $this->assertSame(0.0, $this->f->conversionRate('signup', 'visit', 'register'));
+    }
+
+    public function testFunnelsAreSeparate(): void
+    {
+        $this->f->reach('a', 'u1', 'visit', 1);
+        $this->f->reach('b', 'u1', 'visit', 1);
+        $this->assertCount(1, $this->f->counts('a'));
+        $this->assertFalse($this->f->hasReached('a', 'u2', 'visit'));
+    }
+
+    public function testPurgeOlderThan(): void
+    {
+        $this->f->reach('signup', 'u1', 'visit', 1, '2026-01-01 00:00:00');
+        $this->f->reach('signup', 'u2', 'visit', 1, '2026-05-29 00:00:00');
+        $removed = $this->f->purgeOlderThan(90, '2026-05-29 00:00:00');
+        $this->assertSame(1, $removed);
+        $this->assertSame(1, $this->f->counts('signup')[0]['subjects']);
+    }
+
+    public function testReachRejectsEmptyFunnel(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->f->reach('  ', 'u1', 'visit', 1);
+    }
+
+    public function testReachRejectsEmptyStep(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->f->reach('signup', 'u1', '  ', 1);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT284** — `Nene\Xion\FunnelStep`: conversion-funnel step completion tracking for drop-off and step-to-step conversion (signup → verify → onboard → activate).

| Method | Description |
| --- | --- |
| `reach(funnel, subject, step, order=0, asOf=null)` | Idempotent record. |
| `hasReached / reachedSteps` | Membership / ordered path. |
| `counts(funnel)` | Distinct subjects per step (chart data). |
| `conversionRate(funnel, from, to): float` | `|F∩T|/|F|`, 0.0 when no from. |
| `purgeOlderThan(days, asOf=null)` | Housekeeping. |

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 11 tests / 18 assertions (idempotent, ordering, distinct counts, conversion 0.5/1.0/zero×2, separation, purge, validation)
- [x] `composer precommit` green (format → Phan → 4819 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)