### PR TITLE
feat(xion): Endorsement — peer skill endorsements between users (FT285)

### DIFF
--- a/class/xion/Endorsement.php
+++ b/class/xion/Endorsement.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * Endorsement — peer skill endorsements between users.
+ *
+ * Lets users endorse one another for named skills (LinkedIn-style), with one
+ * endorsement per (subject, skill, endorser) and self-endorsement disallowed.
+ * Supports per-skill counts and a user's top skills by endorsement volume.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $e = new Endorsement($pdo);
+ *
+ * $e->endorse(subjectUser: 1, skill: 'PHP', endorser: 2);
+ * $e->endorse(subjectUser: 1, skill: 'PHP', endorser: 3);
+ * $e->endorse(subjectUser: 1, skill: 'SQL', endorser: 2);
+ *
+ * $e->count(1, 'PHP');        // 2
+ * $e->hasEndorsed(1, 'PHP', 2); // true
+ * $e->topSkills(1);           // [['skill'=>'PHP','count'=>2], ['skill'=>'SQL','count'=>1]]
+ * $e->withdraw(1, 'PHP', 2);  // endorser 2 takes it back
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE endorsements (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     subject_user BIGINT       NOT NULL,
+ *     skill        VARCHAR(100) NOT NULL,
+ *     endorser     BIGINT       NOT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (subject_user, skill, endorser)
+ * );
+ * ```
+ */
+final class Endorsement
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Endorse a user for a skill. Idempotent per (subject, skill, endorser).
+     *
+     * @param  int    $subjectUser User being endorsed.
+     * @param  string $skill       Skill name.
+     * @param  int    $endorser    User giving the endorsement.
+     * @return bool                True if newly recorded; false if it already existed.
+     * @throws \InvalidArgumentException on empty skill or self-endorsement.
+     */
+    public function endorse(int $subjectUser, string $skill, int $endorser): bool
+    {
+        $skill = $this->validateSkill($skill);
+        if ($subjectUser === $endorser) {
+            throw new \InvalidArgumentException('A user cannot endorse themselves.');
+        }
+        if ($this->hasEndorsed($subjectUser, $skill, $endorser)) {
+            return false;
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO endorsements (subject_user, skill, endorser) VALUES (?, ?, ?)'
+        );
+        $stmt->execute([$subjectUser, $skill, $endorser]);
+
+        return true;
+    }
+
+    /**
+     * Whether a specific endorser has endorsed a subject's skill.
+     */
+    public function hasEndorsed(int $subjectUser, string $skill, int $endorser): bool
+    {
+        $skill = $this->validateSkill($skill);
+        $stmt  = $this->db()->prepare(
+            'SELECT 1 FROM endorsements WHERE subject_user = ? AND skill = ? AND endorser = ? LIMIT 1'
+        );
+        $stmt->execute([$subjectUser, $skill, $endorser]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Number of endorsements a subject has for a skill.
+     */
+    public function count(int $subjectUser, string $skill): int
+    {
+        $skill = $this->validateSkill($skill);
+        $stmt  = $this->db()->prepare(
+            'SELECT COUNT(*) FROM endorsements WHERE subject_user = ? AND skill = ?'
+        );
+        $stmt->execute([$subjectUser, $skill]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Endorser user ids for a subject's skill, ascending.
+     *
+     * @return array<int,int>
+     */
+    public function endorsers(int $subjectUser, string $skill): array
+    {
+        $skill = $this->validateSkill($skill);
+        $stmt  = $this->db()->prepare(
+            'SELECT endorser FROM endorsements WHERE subject_user = ? AND skill = ? ORDER BY endorser ASC'
+        );
+        $stmt->execute([$subjectUser, $skill]);
+
+        return array_map(static fn ($id): int => (int)$id, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    /**
+     * A subject's skills with endorsement counts, most-endorsed first.
+     *
+     * @param  int      $subjectUser Subject user.
+     * @param  int|null $limit       Optional cap.
+     * @return array<int,array{skill:string,count:int}>
+     */
+    public function topSkills(int $subjectUser, ?int $limit = null): array
+    {
+        $sql = 'SELECT skill, COUNT(*) AS c FROM endorsements WHERE subject_user = ?
+                GROUP BY skill ORDER BY c DESC, skill ASC';
+        if ($limit !== null) {
+            $sql .= ' LIMIT ' . max(0, $limit);
+        }
+        $stmt = $this->db()->prepare($sql);
+        $stmt->execute([$subjectUser]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['skill' => (string)$row['skill'], 'count' => (int)$row['c']];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Withdraw an endorsement. No-op if it does not exist.
+     */
+    public function withdraw(int $subjectUser, string $skill, int $endorser): void
+    {
+        $skill = $this->validateSkill($skill);
+        $stmt  = $this->db()->prepare(
+            'DELETE FROM endorsements WHERE subject_user = ? AND skill = ? AND endorser = ?'
+        );
+        $stmt->execute([$subjectUser, $skill, $endorser]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validateSkill(string $skill): string
+    {
+        $skill = trim($skill);
+        if ($skill === '') {
+            throw new \InvalidArgumentException('Skill must not be empty.');
+        }
+
+        return $skill;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -236,6 +236,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `AbTest` | A/B test variant assignment and conversion tracking. |
 | `Approval` | single-approver workflow (request → approve / reject). |
 | `ChangeRequest` | formal RFC / change-management approval workflow. |
+| `Endorsement` | peer skill endorsements between users. |
 | `EventRsvp` | event attendance management with accept/decline/maybe responses. |
 | `FaqItem` | FAQ articles with categories, ordering, and helpfulness voting. |
 | `FeatureRequest` | user-submitted feature requests with voting and status tracking. |

--- a/docs/field-trials/2026-05-field-trial-285.md
+++ b/docs/field-trials/2026-05-field-trial-285.md
@@ -1,0 +1,42 @@
+# Field Trial 285 — Endorsement
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft285-endorsement`
+**Baseline**: post FT284 merge
+
+## Goal
+
+Add `Nene\Xion\Endorsement` — peer skill endorsements between users (LinkedIn-style), with per-skill counts and top-skills ranking.
+
+## What was built
+
+### `Nene\Xion\Endorsement` (`class/xion/Endorsement.php`)
+
+| Method | Description |
+| --- | --- |
+| `endorse(subjectUser, skill, endorser): bool` | Record (idempotent; true only when new). |
+| `hasEndorsed(subjectUser, skill, endorser)` | Membership. |
+| `count(subjectUser, skill) / endorsers(...)` | Count / endorser ids. |
+| `topSkills(subjectUser, limit=null)` | Skills by endorsement count, desc. |
+| `withdraw(subjectUser, skill, endorser)` | Take back. |
+
+Key design points:
+
+- **One per (subject, skill, endorser)** via UNIQUE; re-endorse returns false, withdraw-then-re-endorse works.
+- **Self-endorsement rejected** (subject == endorser throws).
+- **topSkills** ranks by `COUNT(*)` desc for profile display.
+- **PDO injection**.
+
+### Tests (`tests/Unit/Xion/EndorsementTest.php`)
+
+12 unit tests (21 assertions): endorse + count, idempotent, hasEndorsed, endorsers list, topSkills ordering + limit, withdraw (+ missing no-op), withdraw-then-re-endorse, subject/skill scoping, **self-endorsement rejected**, empty-skill rejected.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/EndorsementTest.php
+++ b/tests/Unit/Xion/EndorsementTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\Endorsement;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Endorsement.
+ */
+final class EndorsementTest extends TestCase
+{
+    private PDO $db;
+    private Endorsement $e;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE endorsements (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                subject_user BIGINT       NOT NULL,
+                skill        VARCHAR(100) NOT NULL,
+                endorser     BIGINT       NOT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (subject_user, skill, endorser)
+            )
+        ');
+        $this->e = new Endorsement($this->db);
+    }
+
+    public function testEndorseAndCount(): void
+    {
+        $this->assertTrue($this->e->endorse(1, 'PHP', 2));
+        $this->assertTrue($this->e->endorse(1, 'PHP', 3));
+        $this->assertSame(2, $this->e->count(1, 'PHP'));
+    }
+
+    public function testEndorseIsIdempotent(): void
+    {
+        $this->assertTrue($this->e->endorse(1, 'PHP', 2));
+        $this->assertFalse($this->e->endorse(1, 'PHP', 2)); // already endorsed
+        $this->assertSame(1, $this->e->count(1, 'PHP'));
+    }
+
+    public function testHasEndorsed(): void
+    {
+        $this->e->endorse(1, 'PHP', 2);
+        $this->assertTrue($this->e->hasEndorsed(1, 'PHP', 2));
+        $this->assertFalse($this->e->hasEndorsed(1, 'PHP', 4));
+    }
+
+    public function testEndorsersListed(): void
+    {
+        $this->e->endorse(1, 'PHP', 5);
+        $this->e->endorse(1, 'PHP', 2);
+        $this->assertSame([2, 5], $this->e->endorsers(1, 'PHP'));
+    }
+
+    public function testTopSkillsOrderedByCount(): void
+    {
+        $this->e->endorse(1, 'PHP', 2);
+        $this->e->endorse(1, 'PHP', 3);
+        $this->e->endorse(1, 'SQL', 2);
+        $top = $this->e->topSkills(1);
+        $this->assertSame('PHP', $top[0]['skill']);
+        $this->assertSame(2, $top[0]['count']);
+        $this->assertSame('SQL', $top[1]['skill']);
+    }
+
+    public function testTopSkillsLimit(): void
+    {
+        $this->e->endorse(1, 'PHP', 2);
+        $this->e->endorse(1, 'SQL', 2);
+        $this->e->endorse(1, 'Go', 2);
+        $this->assertCount(2, $this->e->topSkills(1, 2));
+    }
+
+    public function testWithdraw(): void
+    {
+        $this->e->endorse(1, 'PHP', 2);
+        $this->e->withdraw(1, 'PHP', 2);
+        $this->assertSame(0, $this->e->count(1, 'PHP'));
+        $this->assertFalse($this->e->hasEndorsed(1, 'PHP', 2));
+    }
+
+    public function testWithdrawMissingIsNoop(): void
+    {
+        $this->e->withdraw(1, 'PHP', 2); // no throw
+        $this->assertSame(0, $this->e->count(1, 'PHP'));
+    }
+
+    public function testWithdrawThenReEndorse(): void
+    {
+        $this->e->endorse(1, 'PHP', 2);
+        $this->e->withdraw(1, 'PHP', 2);
+        $this->assertTrue($this->e->endorse(1, 'PHP', 2)); // can re-add
+    }
+
+    public function testSubjectsAndSkillsAreScoped(): void
+    {
+        $this->e->endorse(1, 'PHP', 2);
+        $this->assertSame(0, $this->e->count(99, 'PHP'));
+        $this->assertSame(0, $this->e->count(1, 'SQL'));
+    }
+
+    public function testSelfEndorsementRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->e->endorse(1, 'PHP', 1);
+    }
+
+    public function testEndorseRejectsEmptySkill(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->e->endorse(1, '  ', 2);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT285** — `Nene\Xion\Endorsement`: peer skill endorsements (LinkedIn-style), with per-skill counts and top-skills ranking.

| Method | Description |
| --- | --- |
| `endorse(subjectUser, skill, endorser): bool` | Idempotent; true only when new. |
| `hasEndorsed / count / endorsers` | Membership / count / ids. |
| `topSkills(subjectUser, limit=null)` | By count desc. |
| `withdraw(...)` | Take back. |

- One per (subject, skill, endorser); self-endorsement rejected; withdraw-then-re-endorse works.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 21 assertions (idempotent, hasEndorsed, endorsers, topSkills order+limit, withdraw+re-endorse, scoping, self-endorse reject, empty skill)
- [x] `composer precommit` green (format → Phan → 4831 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)