### PR TITLE
feat(xion): PinnedItem — ordered pinned items per context (FT286)

### DIFF
--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -109,6 +109,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | `Mention` | track @-mentions of users within content items. |
 | `NotificationPreference` | Notification preference manager — per-user channel × type opt-in/opt-out. |
 | `OnlineStatus` | track user presence with heartbeat-based online/idle/offline states. |
+| `PinnedItem` | pin entities to the top of a context, in an ordered list. |
 | `PresenceChannel` | track which users are currently "in" a named channel. |
 | `PresenceTracker` | user online presence and last-seen tracking. |
 | `ProfileBadge` | Gamification badge award and management. |

--- a/class/xion/PinnedItem.php
+++ b/class/xion/PinnedItem.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * PinnedItem — pin entities to the top of a context, in an ordered list.
+ *
+ * Maintains a small ordered set of "pinned" items per context (pinned posts in
+ * a forum, pinned messages in a channel, featured products on a page). New
+ * pins append to the end; `moveToTop()` / `moveToBottom()` reorder. Distinct
+ * from `Bookmark` (FT72, private saved items) and `Watchlist` (FT80): this is
+ * a shared, ordered, curated list.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $p = new PinnedItem($pdo);
+ *
+ * $p->pin('channel:5', 'msg-100', pinnedBy: 7);
+ * $p->pin('channel:5', 'msg-200');
+ *
+ * $p->items('channel:5');          // ['msg-100', 'msg-200'] (pin order)
+ * $p->moveToTop('channel:5', 'msg-200'); // ['msg-200', 'msg-100']
+ * $p->isPinned('channel:5', 'msg-100');  // true
+ * $p->unpin('channel:5', 'msg-100');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE pinned_items (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     context    VARCHAR(150) NOT NULL,
+ *     item       VARCHAR(190) NOT NULL,
+ *     position   INTEGER      NOT NULL DEFAULT 0,
+ *     pinned_by  BIGINT       NOT NULL DEFAULT 0,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (context, item)
+ * );
+ * ```
+ */
+final class PinnedItem
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Pin an item to a context (appended to the end). Idempotent: re-pinning an
+     * existing item keeps its position.
+     *
+     * @param  string $context  Context key.
+     * @param  string $item     Item identifier.
+     * @param  int    $pinnedBy Optional user id who pinned it.
+     * @throws \InvalidArgumentException on empty context or item.
+     */
+    public function pin(string $context, string $item, int $pinnedBy = 0): void
+    {
+        $context = $this->validate($context, 'Context');
+        $item    = $this->validate($item, 'Item');
+        if ($this->isPinned($context, $item)) {
+            return;
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO pinned_items (context, item, position, pinned_by) VALUES (?, ?, ?, ?)'
+        );
+        $stmt->execute([$context, $item, $this->maxPosition($context) + 1, $pinnedBy]);
+    }
+
+    /**
+     * Unpin an item. No-op if not pinned.
+     */
+    public function unpin(string $context, string $item): void
+    {
+        $context = $this->validate($context, 'Context');
+        $item    = $this->validate($item, 'Item');
+        $stmt    = $this->db()->prepare('DELETE FROM pinned_items WHERE context = ? AND item = ?');
+        $stmt->execute([$context, $item]);
+    }
+
+    /**
+     * Whether an item is pinned in a context.
+     */
+    public function isPinned(string $context, string $item): bool
+    {
+        $context = $this->validate($context, 'Context');
+        $item    = $this->validate($item, 'Item');
+        $stmt    = $this->db()->prepare('SELECT 1 FROM pinned_items WHERE context = ? AND item = ? LIMIT 1');
+        $stmt->execute([$context, $item]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Pinned items for a context, in pin order (position asc).
+     *
+     * @return array<int,string>
+     */
+    public function items(string $context): array
+    {
+        $context = $this->validate($context, 'Context');
+        $stmt    = $this->db()->prepare(
+            'SELECT item FROM pinned_items WHERE context = ? ORDER BY position ASC, id ASC'
+        );
+        $stmt->execute([$context]);
+
+        return array_map(static fn ($i): string => (string)$i, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    /**
+     * Number of pinned items in a context.
+     */
+    public function count(string $context): int
+    {
+        $context = $this->validate($context, 'Context');
+        $stmt    = $this->db()->prepare('SELECT COUNT(*) FROM pinned_items WHERE context = ?');
+        $stmt->execute([$context]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Move a pinned item to the top of its context. No-op if not pinned.
+     */
+    public function moveToTop(string $context, string $item): void
+    {
+        $this->moveTo($context, $item, $this->minPosition($context) - 1);
+    }
+
+    /**
+     * Move a pinned item to the bottom of its context. No-op if not pinned.
+     */
+    public function moveToBottom(string $context, string $item): void
+    {
+        $this->moveTo($context, $item, $this->maxPosition($context) + 1);
+    }
+
+    /**
+     * Remove all pins in a context. Returns the number removed.
+     */
+    public function clear(string $context): int
+    {
+        $context = $this->validate($context, 'Context');
+        $stmt    = $this->db()->prepare('DELETE FROM pinned_items WHERE context = ?');
+        $stmt->execute([$context]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function moveTo(string $context, string $item, int $position): void
+    {
+        $context = $this->validate($context, 'Context');
+        $item    = $this->validate($item, 'Item');
+        $stmt    = $this->db()->prepare('UPDATE pinned_items SET position = ? WHERE context = ? AND item = ?');
+        $stmt->execute([$position, $context, $item]);
+    }
+
+    private function maxPosition(string $context): int
+    {
+        $stmt = $this->db()->prepare('SELECT COALESCE(MAX(position), -1) FROM pinned_items WHERE context = ?');
+        $stmt->execute([$context]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function minPosition(string $context): int
+    {
+        $stmt = $this->db()->prepare('SELECT COALESCE(MIN(position), 0) FROM pinned_items WHERE context = ?');
+        $stmt->execute([$context]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-286.md
+++ b/docs/field-trials/2026-05-field-trial-286.md
@@ -1,0 +1,41 @@
+# Field Trial 286 — PinnedItem
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft286-pinned-item`
+**Baseline**: post FT285 merge
+
+## Goal
+
+Add `Nene\Xion\PinnedItem` — an ordered set of pinned items per context (pinned posts/messages, featured products). Distinct from `Bookmark` (FT72, private) and `Watchlist` (FT80): a shared, ordered, curated list.
+
+## What was built
+
+### `Nene\Xion\PinnedItem` (`class/xion/PinnedItem.php`)
+
+| Method | Description |
+| --- | --- |
+| `pin(context, item, pinnedBy=0)` | Append (idempotent; keeps position on re-pin). |
+| `unpin(context, item) / isPinned(...)` | Remove / check. |
+| `items(context)` | Pinned items in order. |
+| `moveToTop / moveToBottom (context, item)` | Reorder. |
+| `count(context) / clear(context): int` | Size / wipe. |
+
+Key design points:
+
+- **Append-on-pin**: new pins get `MAX(position)+1`; **idempotent re-pin keeps position** (no jump back to the end).
+- **Reorder primitives** `moveToTop` (`MIN-1`) / `moveToBottom` (`MAX+1`) avoid full renumbering.
+- **PDO injection**; UNIQUE (context, item).
+
+### Tests (`tests/Unit/Xion/PinnedItemTest.php`)
+
+12 unit tests (15 assertions): pin append order, idempotent pin, isPinned, unpin (+ missing no-op), moveToTop, moveToBottom, **idempotent re-pin keeps reordered position**, context separation, clear, validation (empty context/item).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/PinnedItemTest.php
+++ b/tests/Unit/Xion/PinnedItemTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\PinnedItem;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PinnedItem.
+ */
+final class PinnedItemTest extends TestCase
+{
+    private PDO $db;
+    private PinnedItem $p;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE pinned_items (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                context    VARCHAR(150) NOT NULL,
+                item       VARCHAR(190) NOT NULL,
+                position   INTEGER      NOT NULL DEFAULT 0,
+                pinned_by  BIGINT       NOT NULL DEFAULT 0,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (context, item)
+            )
+        ');
+        $this->p = new PinnedItem($this->db);
+    }
+
+    public function testPinAppendsInOrder(): void
+    {
+        $this->p->pin('c', 'a');
+        $this->p->pin('c', 'b');
+        $this->p->pin('c', 'd');
+        $this->assertSame(['a', 'b', 'd'], $this->p->items('c'));
+    }
+
+    public function testPinIsIdempotent(): void
+    {
+        $this->p->pin('c', 'a');
+        $this->p->pin('c', 'a');
+        $this->assertSame(1, $this->p->count('c'));
+    }
+
+    public function testIsPinned(): void
+    {
+        $this->p->pin('c', 'a');
+        $this->assertTrue($this->p->isPinned('c', 'a'));
+        $this->assertFalse($this->p->isPinned('c', 'z'));
+    }
+
+    public function testUnpin(): void
+    {
+        $this->p->pin('c', 'a');
+        $this->p->pin('c', 'b');
+        $this->p->unpin('c', 'a');
+        $this->assertSame(['b'], $this->p->items('c'));
+    }
+
+    public function testUnpinMissingIsNoop(): void
+    {
+        $this->p->unpin('c', 'ghost');
+        $this->assertSame(0, $this->p->count('c'));
+    }
+
+    public function testMoveToTop(): void
+    {
+        $this->p->pin('c', 'a');
+        $this->p->pin('c', 'b');
+        $this->p->pin('c', 'd');
+        $this->p->moveToTop('c', 'd');
+        $this->assertSame(['d', 'a', 'b'], $this->p->items('c'));
+    }
+
+    public function testMoveToBottom(): void
+    {
+        $this->p->pin('c', 'a');
+        $this->p->pin('c', 'b');
+        $this->p->pin('c', 'd');
+        $this->p->moveToBottom('c', 'a');
+        $this->assertSame(['b', 'd', 'a'], $this->p->items('c'));
+    }
+
+    public function testIdempotentPinKeepsPosition(): void
+    {
+        $this->p->pin('c', 'a');
+        $this->p->pin('c', 'b');
+        $this->p->moveToTop('c', 'b');
+        $this->p->pin('c', 'b'); // re-pin should not move it back
+        $this->assertSame(['b', 'a'], $this->p->items('c'));
+    }
+
+    public function testContextsAreSeparate(): void
+    {
+        $this->p->pin('c1', 'a');
+        $this->p->pin('c2', 'b');
+        $this->assertSame(['a'], $this->p->items('c1'));
+        $this->assertSame(['b'], $this->p->items('c2'));
+    }
+
+    public function testClear(): void
+    {
+        $this->p->pin('c', 'a');
+        $this->p->pin('c', 'b');
+        $removed = $this->p->clear('c');
+        $this->assertSame(2, $removed);
+        $this->assertSame([], $this->p->items('c'));
+    }
+
+    public function testPinRejectsEmptyContext(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->p->pin('  ', 'a');
+    }
+
+    public function testPinRejectsEmptyItem(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->p->pin('c', '  ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT286** — `Nene\Xion\PinnedItem`: an ordered set of pinned items per context (pinned posts/messages, featured products). Distinct from `Bookmark` (FT72, private) and `Watchlist` (FT80).

| Method | Description |
| --- | --- |
| `pin(context, item, pinnedBy=0)` | Append (idempotent; keeps position). |
| `unpin / isPinned` | Remove / check. |
| `items(context)` | In order. |
| `moveToTop / moveToBottom` | Reorder. |
| `count / clear` | Size / wipe. |

- Append `MAX+1`; reorder via `MIN-1` / `MAX+1`; idempotent re-pin keeps position.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 15 assertions (append order, idempotent, isPinned, unpin, move top/bottom, re-pin keeps position, separation, clear, validation)
- [x] `composer precommit` green (format → Phan → 4843 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)