### PR TITLE
docs: mark FT277–FT286 complete (Xion wave)

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -54,6 +54,16 @@ The Xion helper wave (FT78–FT264) is ongoing as of 2026-05-28. Trigger-based a
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT286 — PinnedItem** (2026-05-29): `Nene\Xion\PinnedItem` — ordered pinned items per context; append-on-pin keeps position; moveToTop/moveToBottom reorder. PR #742.
+- **FT285 — Endorsement** (2026-05-29): `Nene\Xion\Endorsement` — peer skill endorsements; one per subject/skill/endorser; self-endorse rejected; topSkills by count. PR #741.
+- **FT284 — FunnelStep** (2026-05-29): `Nene\Xion\FunnelStep` — conversion-funnel step tracking; counts (distinct per step); conversionRate |F∩T|/|F|; drop-off analysis. PR #740.
+- **FT283 — UtmCampaign** (2026-05-29): `Nene\Xion\UtmCampaign` — UTM marketing attribution touch capture; first/last touch; countBy (whitelisted field); campaign analytics. PR #739.
+- **FT282 — AffiliateClick** (2026-05-29): `Nene\Xion\AffiliateClick` — affiliate click & conversion attribution; integer-cent revenue; convert() first-only; stats/conversionRate. PR #738.
+- **FT281 — FeatureTour** (2026-05-29): `Nene\Xion\FeatureTour` — per-user one-time UI tour/coachmark state; shouldShow/markSeen/complete/dismiss; no status regression; resetAll. PR #737.
+- **FT280 — IpReputation** (2026-05-29): `Nene\Xion\IpReputation` — running per-IP reputation score (atomic adjust); penalize/reward/isBad/worst/purgeBelow; feeds blocklist decisions. PR #736.
+- **FT279 — RedactionRule** (2026-05-29): `Nene\Xion\RedactionRule` — configurable PII/secret regex masking rules; priority order; validated patterns; preg_replace null-guarded. PR #735.
+- **FT278 — TermGlossary** (2026-05-29): `Nene\Xion\TermGlossary` — DB-backed term/definition glossary with categories; slug-keyed; LIKE-escaped search. PR #734.
+- **FT277 — WeightedPicker** (2026-05-29): `Nene\Xion\WeightedPicker` — weighted random selection from a named pool; deterministic roll for reproducibility; zero-weight retained but never picked. PR #733.
 - **FT276 — RoundRobinAssigner** (2026-05-29): `Nene\Xion\RoundRobinAssigner` — fair rotating pool assignment; persistent cursor; atomic next(); add/removeMember with cursor clamp. PR #731.
 - **FT275 — RetrySchedule** (2026-05-29): `Nene\Xion\RetrySchedule` — exponential-backoff retry tracking; arm/backoff/due; exhaustion terminal; hands off to DeadLetterQueue. PR #730.
 - **FT274 — DeadLetterQueue** (2026-05-29): `Nene\Xion\DeadLetterQueue` — parking lot for exhausted-retry messages; record/forQueue/requeue (atomic claim)/purgeOlderThan. PR #729.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT276 complete as of 2026-05-29 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT286 complete as of 2026-05-29 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,7 +6,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-29: all non-promotion Issues are closed; FT1–FT276 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-29: all non-promotion Issues are closed; FT1–FT286 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
 


### PR DESCRIPTION
## Summary

Batched post-merge documentation for the **FT277–FT286** Xion wave (PRs #733–#742), generated by `composer ft:done`.

- `docs/todo/current.md` + `docs/roadmap.md` — `FT1–FT276` → `FT1–FT286`
- `docs/field-trials/candidates.md` — ten archive entries prepended

| FT | Class | PR |
|----|-------|----|
| 277 | WeightedPicker | #733 |
| 278 | TermGlossary | #734 |
| 279 | RedactionRule | #735 |
| 280 | IpReputation | #736 |
| 281 | FeatureTour | #737 |
| 282 | AffiliateClick | #738 |
| 283 | UtmCampaign | #739 |
| 284 | FunnelStep | #740 |
| 285 | Endorsement | #741 |
| 286 | PinnedItem | #742 |

> Note: originally-queued TermsAcceptance/CookieConsent/AttributionTouch/AnnouncementRead were dropped as concept-duplicates of existing classes (TermConsent/ConsentLog/Referral/ReadProgress); FeatureTour and others replaced them.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)