### PR TITLE
feat(xion): ChecksumRegistry — content integrity/tamper-detection (FT287)

### DIFF
--- a/class/xion/ChecksumRegistry.php
+++ b/class/xion/ChecksumRegistry.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Xion;
+
+use PDO;
+
+/**
+ * ChecksumRegistry — content integrity / tamper-detection registry.
+ *
+ * Stores a cryptographic checksum per key (a file path, config blob, exported
+ * artifact) so later reads can be verified against the recorded hash to detect
+ * corruption or tampering. Supports any algorithm reported by
+ * {@see hash_algos()}; defaults to SHA-256.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $cr = new ChecksumRegistry($pdo);
+ *
+ * $hash = $cr->put('config.json', $jsonString);   // store + return hash
+ * $cr->verify('config.json', $jsonString);         // true (unchanged)
+ * $cr->verify('config.json', $tampered);           // false
+ *
+ * $cr->putHash('big.iso', $precomputedSha256);     // store a known hash
+ * $cr->matches('big.iso', $precomputedSha256);     // true
+ *
+ * $cr->get('config.json');  // ['algo'=>'sha256','checksum'=>'...']
+ * $cr->forget('config.json');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE checksums (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     ref        VARCHAR(190) NOT NULL,
+ *     algo       VARCHAR(20)  NOT NULL DEFAULT 'sha256',
+ *     checksum   VARCHAR(128) NOT NULL,
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (ref)
+ * );
+ * ```
+ */
+final class ChecksumRegistry
+{
+    public const string DEFAULT_ALGO = 'sha256';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Hash content and store it under a key. Returns the computed checksum.
+     *
+     * @param  string $key   Registry key.
+     * @param  string $content Content to hash.
+     * @param  string $algo  Hash algorithm (default sha256).
+     * @return string        The stored checksum (lowercase hex).
+     * @throws \InvalidArgumentException on empty key or unknown algorithm.
+     */
+    public function put(string $key, string $content, string $algo = self::DEFAULT_ALGO): string
+    {
+        $algo     = $this->validateAlgo($algo);
+        $checksum = hash($algo, $content);
+        $this->store($key, $checksum, $algo);
+
+        return $checksum;
+    }
+
+    /**
+     * Store a pre-computed checksum under a key (no content hashing).
+     *
+     * @throws \InvalidArgumentException on empty key/checksum or unknown algorithm.
+     */
+    public function putHash(string $key, string $checksum, string $algo = self::DEFAULT_ALGO): void
+    {
+        $algo     = $this->validateAlgo($algo);
+        $checksum = strtolower(trim($checksum));
+        if ($checksum === '') {
+            throw new \InvalidArgumentException('Checksum must not be empty.');
+        }
+        $this->store($key, $checksum, $algo);
+    }
+
+    /**
+     * Verify content against the stored checksum for a key.
+     *
+     * @return bool True if a checksum is stored and matches; false otherwise
+     *              (including when the key is unknown).
+     */
+    public function verify(string $key, string $content): bool
+    {
+        $row = $this->get($key);
+        if ($row === null) {
+            return false;
+        }
+
+        $computed = hash($row['algo'], $content);
+
+        return hash_equals($row['checksum'], $computed);
+    }
+
+    /**
+     * Whether a given checksum equals the stored one for a key.
+     */
+    public function matches(string $key, string $checksum): bool
+    {
+        $row = $this->get($key);
+        if ($row === null) {
+            return false;
+        }
+
+        return hash_equals($row['checksum'], strtolower(trim($checksum)));
+    }
+
+    /**
+     * Return the stored algorithm and checksum for a key, or null.
+     *
+     * @return array{algo:string,checksum:string}|null
+     */
+    public function get(string $key): ?array
+    {
+        $key  = $this->validateKey($key);
+        $stmt = $this->db()->prepare('SELECT algo, checksum FROM checksums WHERE ref = ?');
+        $stmt->execute([$key]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : ['algo' => (string)$row['algo'], 'checksum' => (string)$row['checksum']];
+    }
+
+    /**
+     * Whether a checksum is registered for a key.
+     */
+    public function has(string $key): bool
+    {
+        return $this->get($key) !== null;
+    }
+
+    /**
+     * Remove a key's checksum. No-op if absent.
+     */
+    public function forget(string $key): void
+    {
+        $key  = $this->validateKey($key);
+        $stmt = $this->db()->prepare('DELETE FROM checksums WHERE ref = ?');
+        $stmt->execute([$key]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function store(string $key, string $checksum, string $algo): void
+    {
+        $key = $this->validateKey($key);
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'checksums',
+            data:         ['ref' => $key, 'algo' => $algo, 'checksum' => $checksum],
+            conflictCols: ['ref'],
+            updateCols:   ['algo', 'checksum'],
+            updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    private function validateAlgo(string $algo): string
+    {
+        $algo = strtolower(trim($algo));
+        if (!in_array($algo, hash_algos(), true)) {
+            throw new \InvalidArgumentException("Unknown hash algorithm: {$algo}");
+        }
+
+        return $algo;
+    }
+
+    private function validateKey(string $key): string
+    {
+        $key = trim($key);
+        if ($key === '') {
+            throw new \InvalidArgumentException('Key must not be empty.');
+        }
+
+        return $key;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -326,6 +326,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 | Class | Description |
 |-------|-------------|
 | `CacheEntry` | DB-backed key-value cache with optional TTL. |
+| `ChecksumRegistry` | content integrity / tamper-detection registry. |
 | `ConfigStore` | global application key-value configuration store. |
 | `DatabaseInstaller` | Database setup and health checks for the sample runtime. |
 | `Command` | — |

--- a/docs/field-trials/2026-05-field-trial-287.md
+++ b/docs/field-trials/2026-05-field-trial-287.md
@@ -1,0 +1,41 @@
+# Field Trial 287 — ChecksumRegistry
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft287-checksum-registry`
+**Baseline**: post FT286 merge
+
+## Goal
+
+Add `Nene\Xion\ChecksumRegistry` — a content integrity / tamper-detection registry: store a cryptographic checksum per key and verify content against it later.
+
+## What was built
+
+### `Nene\Xion\ChecksumRegistry` (`class/xion/ChecksumRegistry.php`)
+
+| Method | Description |
+| --- | --- |
+| `put(key, content, algo='sha256'): string` | Hash + store; returns checksum. |
+| `putHash(key, checksum, algo='sha256')` | Store a pre-computed hash. |
+| `verify(key, content): bool` | Re-hash and compare (false if unknown). |
+| `matches(key, checksum) / get(key) / has(key)` | Compare / read / exists. |
+| `forget(key)` | Remove. |
+
+Key design points:
+
+- **Any `hash_algos()` algorithm** (default sha256), validated against the runtime list; `verify` re-hashes with the *stored* algorithm.
+- **Timing-safe compare** via `hash_equals`; hex checksums normalised to lowercase so case never causes a false mismatch.
+- **Cross-driver upsert**; **PDO injection**.
+
+### Tests (`tests/Unit/Xion/ChecksumRegistryTest.php`)
+
+13 unit tests (20 assertions): put returns sha256, verify match + tamper detect, unknown-key false, idempotent update (old content no longer verifies), putHash + matches, case-insensitive hex, get algo+checksum, has, verify uses stored algo (md5), forget, validation (unknown algo, empty key, empty checksum).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Xion` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Xion/ChecksumRegistryTest.php
+++ b/tests/Unit/Xion/ChecksumRegistryTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Xion;
+
+use Nene\Xion\ChecksumRegistry;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ChecksumRegistry.
+ */
+final class ChecksumRegistryTest extends TestCase
+{
+    private PDO $db;
+    private ChecksumRegistry $cr;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE checksums (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                ref        VARCHAR(190) NOT NULL,
+                algo       VARCHAR(20)  NOT NULL DEFAULT \'sha256\',
+                checksum   VARCHAR(128) NOT NULL,
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (ref)
+            )
+        ');
+        $this->cr = new ChecksumRegistry($this->db);
+    }
+
+    public function testPutReturnsSha256(): void
+    {
+        $hash = $this->cr->put('f', 'hello');
+        $this->assertSame(hash('sha256', 'hello'), $hash);
+    }
+
+    public function testVerifyMatchesAndDetectsTamper(): void
+    {
+        $this->cr->put('config', 'original');
+        $this->assertTrue($this->cr->verify('config', 'original'));
+        $this->assertFalse($this->cr->verify('config', 'tampered'));
+    }
+
+    public function testVerifyUnknownKeyIsFalse(): void
+    {
+        $this->assertFalse($this->cr->verify('ghost', 'x'));
+    }
+
+    public function testPutIsIdempotentUpdate(): void
+    {
+        $this->cr->put('f', 'v1');
+        $this->cr->put('f', 'v2');
+        $this->assertTrue($this->cr->verify('f', 'v2'));
+        $this->assertFalse($this->cr->verify('f', 'v1'));
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM checksums')->fetchColumn());
+    }
+
+    public function testPutHashAndMatches(): void
+    {
+        $h = hash('sha256', 'data');
+        $this->cr->putHash('artifact', $h);
+        $this->assertTrue($this->cr->matches('artifact', $h));
+        $this->assertFalse($this->cr->matches('artifact', hash('sha256', 'other')));
+    }
+
+    public function testMatchesIsCaseInsensitiveOnHex(): void
+    {
+        $h = hash('sha256', 'data');
+        $this->cr->putHash('artifact', strtoupper($h));
+        $this->assertTrue($this->cr->matches('artifact', $h)); // stored lowercased
+    }
+
+    public function testGet(): void
+    {
+        $this->cr->put('f', 'x', 'sha1');
+        $row = $this->cr->get('f');
+        $this->assertNotNull($row);
+        $this->assertSame('sha1', $row['algo']);
+        $this->assertSame(hash('sha1', 'x'), $row['checksum']);
+    }
+
+    public function testHas(): void
+    {
+        $this->cr->put('f', 'x');
+        $this->assertTrue($this->cr->has('f'));
+        $this->assertFalse($this->cr->has('g'));
+    }
+
+    public function testVerifyUsesStoredAlgorithm(): void
+    {
+        $this->cr->put('f', 'payload', 'md5');
+        $this->assertTrue($this->cr->verify('f', 'payload')); // re-hashes with md5
+    }
+
+    public function testForget(): void
+    {
+        $this->cr->put('f', 'x');
+        $this->cr->forget('f');
+        $this->assertFalse($this->cr->has('f'));
+    }
+
+    public function testPutRejectsUnknownAlgo(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cr->put('f', 'x', 'notahash');
+    }
+
+    public function testPutRejectsEmptyKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cr->put('  ', 'x');
+    }
+
+    public function testPutHashRejectsEmptyChecksum(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->cr->putHash('f', '   ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT287** — `Nene\Xion\ChecksumRegistry`: a content integrity / tamper-detection registry. Store a checksum per key, verify content later.

| Method | Description |
| --- | --- |
| `put(key, content, algo='sha256'): string` | Hash + store. |
| `putHash(key, checksum, algo='sha256')` | Store precomputed. |
| `verify(key, content) / matches(key, checksum)` | Compare (stored algo). |
| `get / has / forget` | Read / exists / remove. |

- Any `hash_algos()` algorithm; `hash_equals` timing-safe; lowercase hex normalisation.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 20 assertions (sha256, verify match/tamper, unknown false, idempotent, putHash/matches, case-insensitive, get, verify-with-md5, forget, validation)
- [x] `composer precommit` green (format → Phan → 4856 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)