### PR TITLE
refactor(kit): migrate Files & Media helpers to Nene\Kit (ADR-0014 batch 1)

### DIFF
--- a/class/kit/Attachment.php
+++ b/class/kit/Attachment.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Xion;
+namespace Nene\Kit;
 
+use Nene\Xion\PdoConnection;
 use PDO;
 
 /**

--- a/class/kit/FileChunk.php
+++ b/class/kit/FileChunk.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Xion;
+namespace Nene\Kit;
 
+use Nene\Xion\PdoConnection;
 use PDO;
 
 /**

--- a/class/kit/FileMetadata.php
+++ b/class/kit/FileMetadata.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Xion;
+namespace Nene\Kit;
 
+use Nene\Xion\PdoConnection;
 use PDO;
 
 /**

--- a/class/kit/FileQuarantine.php
+++ b/class/kit/FileQuarantine.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Xion;
+namespace Nene\Kit;
 
+use Nene\Xion\PdoConnection;
 use PDO;
 
 /**

--- a/class/kit/MediaConversionJob.php
+++ b/class/kit/MediaConversionJob.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Xion;
+namespace Nene\Kit;
 
+use Nene\Xion\PdoConnection;
 use PDO;
 
 /**

--- a/class/kit/MediaGallery.php
+++ b/class/kit/MediaGallery.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Xion;
+namespace Nene\Kit;
 
+use Nene\Xion\PdoConnection;
 use PDO;
 
 /**

--- a/class/kit/MediaMetadata.php
+++ b/class/kit/MediaMetadata.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Xion;
+namespace Nene\Kit;
 
+use Nene\Xion\PdoConnection;
 use PDO;
 
 /**

--- a/class/kit/MediaProcessing.php
+++ b/class/kit/MediaProcessing.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Xion;
+namespace Nene\Kit;
 
+use Nene\Xion\PdoConnection;
 use PDO;
 
 /**

--- a/class/kit/SignedUrl.php
+++ b/class/kit/SignedUrl.php
@@ -15,7 +15,10 @@
 
 declare(strict_types=1);
 
-namespace Nene\Xion;
+namespace Nene\Kit;
+
+use Nene\Xion\HttpTermination;
+use Nene\Xion\JsonResponder;
 
 /**
  * Generates and verifies HMAC-SHA256-signed URLs with expiry.

--- a/class/kit/StorageQuota.php
+++ b/class/kit/StorageQuota.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Xion;
+namespace Nene\Kit;
 
+use Nene\Xion\PdoConnection;
 use PDO;
 
 /**

--- a/class/xion/INDEX.md
+++ b/class/xion/INDEX.md
@@ -156,17 +156,7 @@ Quick reference for all classes in `class/xion/`. Grouped by functional domain.
 
 | Class | Description |
 |-------|-------------|
-| `Attachment` | file attachments linked to any entity. |
-| `FileChunk` | chunked file upload tracking and reassembly coordination. |
-| `FileMetadata` | File storage metadata management. |
-| `FileQuarantine` | quarantine suspicious or policy-violating files with release/reject workflow. |
 | `FileUpload` | Safe wrapper for a single uploaded file ($_FILES entry). |
-| `MediaConversionJob` | async media processing job tracking. |
-| `MediaGallery` | ordered media item gallery attached to any entity. |
-| `MediaMetadata` | store and retrieve metadata for uploaded media files. |
-| `MediaProcessing` | track async media conversion/processing jobs. |
-| `SignedUrl` | — |
-| `StorageQuota` | per-owner storage usage tracking with configurable limits. |
 | `UploadedFile` | Typed wrapper around a single `$_FILES` entry. |
 
 ---

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
 			"Nene\\Model\\"     : "class/model/",
 			"Nene\\Database\\"  : "class/db/",
 			"Nene\\Func\\"      : "class/func/",
-			"Nene\\Xion\\"      : "class/xion/"
+			"Nene\\Xion\\"      : "class/xion/",
+			"Nene\\Kit\\"       : "class/kit/"
         }
     },
     "require": {

--- a/tests/Unit/Kit/AttachmentTest.php
+++ b/tests/Unit/Kit/AttachmentTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Kit;
 
-use Nene\Xion\Attachment;
+use Nene\Kit\Attachment;
 use PDO;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Kit/FileChunkTest.php
+++ b/tests/Unit/Kit/FileChunkTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Kit;
 
-use Nene\Xion\FileChunk;
+use Nene\Kit\FileChunk;
 use PDO;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Kit/FileMetadataTest.php
+++ b/tests/Unit/Kit/FileMetadataTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Kit;
 
-use Nene\Xion\FileMetadata;
+use Nene\Kit\FileMetadata;
 use PDO;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Kit/FileQuarantineTest.php
+++ b/tests/Unit/Kit/FileQuarantineTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Kit;
 
-use Nene\Xion\FileQuarantine;
+use Nene\Kit\FileQuarantine;
 use PDO;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Kit/MediaConversionJobTest.php
+++ b/tests/Unit/Kit/MediaConversionJobTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Kit;
 
-use Nene\Xion\MediaConversionJob;
+use Nene\Kit\MediaConversionJob;
 use PDO;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Kit/MediaGalleryTest.php
+++ b/tests/Unit/Kit/MediaGalleryTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Kit;
 
-use Nene\Xion\MediaGallery;
+use Nene\Kit\MediaGallery;
 use PDO;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Kit/MediaMetadataTest.php
+++ b/tests/Unit/Kit/MediaMetadataTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Kit;
 
-use Nene\Xion\MediaMetadata;
+use Nene\Kit\MediaMetadata;
 use PDO;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Kit/MediaProcessingTest.php
+++ b/tests/Unit/Kit/MediaProcessingTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Kit;
 
-use Nene\Xion\MediaProcessing;
+use Nene\Kit\MediaProcessing;
 use PDO;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Kit/SignedUrlTest.php
+++ b/tests/Unit/Kit/SignedUrlTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Kit;
 
-use Nene\Xion\SignedUrl;
+use Nene\Kit\SignedUrl;
 use PHPUnit\Framework\TestCase;
 
 final class SignedUrlTest extends TestCase

--- a/tests/Unit/Kit/StorageQuotaTest.php
+++ b/tests/Unit/Kit/StorageQuotaTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Nene\Tests\Unit\Xion;
+namespace Nene\Tests\Unit\Kit;
 
-use Nene\Xion\StorageQuota;
+use Nene\Kit\StorageQuota;
 use PDO;
 use PHPUnit\Framework\TestCase;
 

--- a/tools/migrate-to-kit.php
+++ b/tools/migrate-to-kit.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * One-off migration helper for ADR-0014: move application-domain helper classes
+ * out of Nene\Xion (class/xion/) into Nene\Kit (class/kit/), batch by batch.
+ *
+ * Usage:
+ *   php tools/migrate-to-kit.php preflight
+ *       List the full MOVE set (everything not in the STAY allowlist) and flag
+ *       any MOVE candidate that a STAY (core) class references by name — i.e. a
+ *       likely mis-classification that must stay in Xion.
+ *
+ *   php tools/migrate-to-kit.php move Foo Bar Baz
+ *       Move the named classes: git mv class/xion → class/kit, rewrite the
+ *       namespace to Nene\Kit, inject `use Nene\Xion\<core>;` for referenced
+ *       core symbols, and move + rewrite the matching test file.
+ *
+ * After a `move`, run: composer dump-autoload && composer format && composer test
+ */
+
+$root = dirname(__DIR__);
+
+/** Core + platform classes that REMAIN in Nene\Xion (framework, not helpers). */
+const STAY = [
+    // HTTP layer / runtime
+    'ControllerBase', 'Dispatcher', 'HttpEmitter', 'HttpResponse', 'HttpTermination',
+    'JsonResponder', 'RouteContext', 'QueryString', 'UrlParameter', 'RedirectGuard',
+    'RoleGuard', 'Request', 'RequestVariables', 'Post', 'View', 'Cursor', 'CursorPage',
+    'OffsetPage', 'ApiResponse', 'HttpCache', 'UploadedFile', 'FileUpload',
+    // DB base / schema / CLI
+    'PdoConnection', 'DataMapperBase', 'DataModelBase', 'ModelBase', 'TransactionManager',
+    'DbUpsert', 'SchemaDefinition', 'SchemaCompiler', 'SchemaDiffer', 'SchemaDiffCommand',
+    'GenerateSchemaSqlCommand', 'InitSqliteCommand', 'SetupDatabaseCommand', 'Command',
+    'EnvLoader', 'Initialize', 'DatabaseInstaller',
+    // errors / observability / mail / logging
+    'ErrorCode', 'DomainException', 'Log', 'LogFormatterFactory', 'AuditLogger',
+    'RequestId', 'ResponseDecorator', 'Mailer', 'MailMessage',
+    // auth / session plumbing
+    'AuthSession', 'CsrfProtectionPolicy', 'SessionHandlerFactory', 'RedisSessionHandler',
+    'BearerAuth', 'JwtCodec',
+    // cross-cutting platform services referenced by core
+    'ServerTiming',
+];
+
+/** Core symbols a helper may legitimately reference and therefore need a `use`. */
+const CORE_USABLE = [
+    'PdoConnection', 'DbUpsert', 'DomainException', 'TransactionManager',
+    'ErrorCode', 'ApiResponse', 'SchemaDefinition',
+];
+
+/** @return list<string> all class basenames in class/xion/ */
+function xionClasses(string $root): array
+{
+    $out = [];
+    foreach (glob($root . '/class/xion/*.php') ?: [] as $f) {
+        $out[] = basename($f, '.php');
+    }
+    sort($out);
+
+    return $out;
+}
+
+/** @return list<string> classes that should move to Kit */
+function moveSet(string $root): array
+{
+    return array_values(array_filter(
+        xionClasses($root),
+        static fn (string $c): bool => !in_array($c, STAY, true),
+    ));
+}
+
+/** Does $file reference identifier $name as code (rough word-boundary check)? */
+function referencesSymbol(string $file, string $name): bool
+{
+    $src = (string)file_get_contents($file);
+
+    return preg_match('/\b' . preg_quote($name, '/') . '\b/', $src) === 1;
+}
+
+$cmd  = $argv[1] ?? '';
+$args = array_slice($argv, 2);
+
+if ($cmd === 'preflight') {
+    $move = moveSet($root);
+    echo 'MOVE set: ' . count($move) . " classes (STAY: " . count(STAY) . ")\n\n";
+
+    $conflicts = [];
+    foreach ($move as $cls) {
+        foreach (STAY as $core) {
+            $coreFile = $root . "/class/xion/{$core}.php";
+            if (!is_file($coreFile)) {
+                continue;
+            }
+            if (referencesSymbol($coreFile, $cls)) {
+                $conflicts[$cls][] = $core;
+            }
+        }
+    }
+
+    if ($conflicts === []) {
+        echo "No conflicts: no STAY class references any MOVE candidate. Safe to batch.\n";
+    } else {
+        echo "⚠ CONFLICTS — these MOVE candidates are referenced by core (should likely STAY):\n";
+        foreach ($conflicts as $cls => $by) {
+            echo "  {$cls} ← " . implode(', ', $by) . "\n";
+        }
+    }
+    exit($conflicts === [] ? 0 : 1);
+}
+
+if ($cmd === 'move') {
+    if ($args === []) {
+        fwrite(STDERR, "Usage: move <Class> [Class...]\n");
+        exit(1);
+    }
+    $move = moveSet($root);
+
+    foreach ($args as $cls) {
+        if (in_array($cls, STAY, true)) {
+            fwrite(STDERR, "SKIP {$cls}: in STAY allowlist (core).\n");
+            continue;
+        }
+        if (!in_array($cls, $move, true)) {
+            fwrite(STDERR, "SKIP {$cls}: not found in class/xion/.\n");
+            continue;
+        }
+
+        // ── class file ──
+        $from = $root . "/class/xion/{$cls}.php";
+        $to   = $root . "/class/kit/{$cls}.php";
+        $src  = (string)file_get_contents($from);
+
+        $src = str_replace('namespace Nene\\Xion;', 'namespace Nene\\Kit;', $src);
+
+        // Determine needed core imports: any STAY class the moved body references
+        // must now be imported from Nene\Xion.
+        $imports = [];
+        foreach (STAY as $core) {
+            if (preg_match('/\b' . preg_quote($core, '/') . '\b/', $src) === 1) {
+                $imports[] = "use Nene\\Xion\\{$core};";
+            }
+        }
+        sort($imports);
+        if ($imports !== []) {
+            $importBlock = implode("\n", $imports) . "\n";
+            if (preg_match('/^use /m', $src) === 1) {
+                // Insert before the first existing `use ` line (CS Fixer sorts).
+                $src = preg_replace('/^use /m', $importBlock . 'use ', $src, 1) ?? $src;
+            } else {
+                // No existing imports: insert a use block after the namespace line.
+                $src = preg_replace(
+                    '/^(namespace Nene\\\\Kit;\n)/m',
+                    "$1\n" . $importBlock,
+                    $src,
+                    1,
+                ) ?? $src;
+            }
+        }
+
+        file_put_contents($to, $src);
+        exec('git -C ' . escapeshellarg($root) . ' rm -q ' . escapeshellarg($from));
+        exec('git -C ' . escapeshellarg($root) . ' add ' . escapeshellarg($to));
+        echo "moved class: {$cls}\n";
+
+        // ── test file ──
+        $tFrom = $root . "/tests/Unit/Xion/{$cls}Test.php";
+        $tTo   = $root . "/tests/Unit/Kit/{$cls}Test.php";
+        if (is_file($tFrom)) {
+            @mkdir(dirname($tTo), 0777, true);
+            $tsrc = (string)file_get_contents($tFrom);
+            // Normalise both historical test-namespace conventions to the
+            // canonical PSR-4 one under Kit.
+            $tsrc = str_replace(
+                ['namespace Nene\\Tests\\Unit\\Xion;', 'namespace Tests\\Unit\\Xion;'],
+                'namespace Nene\\Tests\\Unit\\Kit;',
+                $tsrc,
+            );
+            $tsrc = str_replace("use Nene\\Xion\\{$cls};", "use Nene\\Kit\\{$cls};", $tsrc);
+            file_put_contents($tTo, $tsrc);
+            exec('git -C ' . escapeshellarg($root) . ' rm -q ' . escapeshellarg($tFrom));
+            exec('git -C ' . escapeshellarg($root) . ' add ' . escapeshellarg($tTo));
+            echo "moved test:  {$cls}Test\n";
+        } else {
+            echo "  (no test file for {$cls})\n";
+        }
+    }
+    exit(0);
+}
+
+fwrite(STDERR, "Usage: php tools/migrate-to-kit.php {preflight|move <Class...>}\n");
+exit(1);


### PR DESCRIPTION
## Summary

First batch of the **ADR-0014** framework-core / helper-catalogue split. Establishes the migration machinery and moves the Files & Media helper domain.

- Adds `"Nene\\Kit\\": "class/kit/"` to the composer PSR-4 map.
- Adds `tools/migrate-to-kit.php` — a one-off helper with a **`preflight`** check (lists the 227-class MOVE set and flags any candidate referenced by a STAY/core class) and a **`move`** command (git mv + namespace rewrite + `use Nene\Xion\…` injection + test move/namespace-normalise).
- Moves **10** helpers `Nene\Xion → Nene\Kit`: Attachment, FileChunk, FileMetadata, FileQuarantine, MediaConversionJob, MediaGallery, MediaMetadata, MediaProcessing, SignedUrl, StorageQuota.
- **Stays in core:** `UploadedFile`, `FileUpload` (request/file-handling plumbing).

Preflight confirmed the full split is conflict-free after adding `JwtCodec` and `ServerTiming` to the STAY allowlist (both referenced by core).

## Notes
- Kit catalogue `INDEX.md` + `make:kit`/`kit:index` tooling land in the final batch; `class/xion/INDEX.md` is regenerated each batch (moved classes drop off).
- Pure mechanical move — no logic changes.

## Test plan
- [x] `composer format` + `composer analyze` (Phan) clean
- [x] `vendor/bin/phpunit` green — 4902 tests, 8681 assertions (46 pre-existing HTTP skips)
- [x] `tools/migrate-to-kit.php preflight` → "No conflicts"

🤖 Generated with [Claude Code](https://claude.com/claude-code)