### PR TITLE
ci: retry `docker compose up` against transient Docker Hub pull failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,20 @@ jobs:
         run: docker tag nene-app:ci nene-app
 
       - name: Start app
-        run: docker compose up -d app
+        # Retry: `docker compose up` pulls dependency images (mysql, redis) from
+        # Docker Hub, which intermittently fails with a transient registry error
+        # ("Head .../manifests/...: unknown"). Retry a few times before failing
+        # the job so a Hub blip doesn't force a manual re-run.
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose up -d app; then
+              exit 0
+            fi
+            echo "compose up failed (attempt ${attempt}/3) — retrying in 15s…"
+            sleep 15
+          done
+          echo "compose up failed after 3 attempts" >&2
+          exit 1
 
       - name: Wait for /health to report healthStatus=ok
         run: |


### PR DESCRIPTION
## Summary

The `HTTP runtime smoke (Docker)` job's **Start app** step (`docker compose up -d app`) pulls dependency images (mysql, redis) from Docker Hub. Hub intermittently returns a transient registry error:

```
redis Error Head "https://registry-1.docker.io/v2/library/redis/manifests/7-alpine": unknown
```

…which fails the job and forces a **manual re-run** (hit this ~3–4× during the recent wave). This wraps the step in a **3-attempt retry with 15s backoff** so a Hub blip self-heals.

Lowest-risk fix — no change to test semantics or compose topology.

## Test plan
- [x] YAML step is a plain retry loop around the existing command; exits 0 on first success, fails after 3 attempts
- [x] CI runs on this PR (the retry path itself is exercised by the smoke job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)