### PR TITLE
feat(kit): QuietHours — per-user do-not-disturb window (FT288)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -135,6 +135,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `NotificationInbox` | User notification inbox: push, list, mark-as-read, unread count. |
 | `NotificationQueue` | channel-agnostic outbox-pattern notification queue. |
 | `PushSubscription` | Web Push notification subscription registry. |
+| `QuietHours` | per-user do-not-disturb time-of-day window. |
 | `RecipientGroup` | mailing list / recipient group management. |
 | `Reminder` | user-set future reminders. |
 | `SessionFlash` | one-time flash messages stored in DB, consumed on next read. |
@@ -315,5 +316,5 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 
 ---
 
-*Generated from PHPDoc descriptions. Run `composer xion:index` to refresh after adding classes.*
+*Generated from PHPDoc descriptions. Run `composer kit:index` to refresh after adding classes.*
 

--- a/class/kit/QuietHours.php
+++ b/class/kit/QuietHours.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * QuietHours — per-user do-not-disturb time-of-day window.
+ *
+ * Stores a recurring daily quiet window per user (e.g. 22:00–07:00) so a
+ * notification pipeline can suppress or defer non-urgent messages during it.
+ * Distinct from `MaintenanceWindow` (FT269), which models absolute,
+ * service-scoped one-off intervals: this is a recurring per-user time-of-day
+ * range.
+ *
+ * Windows are stored as minutes-from-midnight `[start, end)`. Overnight
+ * windows (start > end, e.g. 22:00–07:00) are supported and wrap across
+ * midnight. A zero-length window (start == end) is treated as "never quiet".
+ * The time zone is stored as metadata; callers pass the user's local
+ * wall-clock time to {@see QuietHours::isQuiet()}.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $qh = new QuietHours($pdo);
+ *
+ * $qh->set(42, '22:00', '07:00', 'Asia/Tokyo'); // overnight window
+ *
+ * $qh->isQuiet(42, '23:30'); // true
+ * $qh->isQuiet(42, '06:59'); // true
+ * $qh->isQuiet(42, '07:00'); // false (end exclusive)
+ * $qh->isQuiet(42, '12:00'); // false
+ *
+ * $qh->window(42);   // ['start' => '22:00', 'end' => '07:00', 'tz' => 'Asia/Tokyo']
+ * $qh->clear(42);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE quiet_hours (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id    BIGINT      NOT NULL,
+ *     start_min  INTEGER     NOT NULL,
+ *     end_min    INTEGER     NOT NULL,
+ *     tz         VARCHAR(64) NOT NULL DEFAULT 'UTC',
+ *     updated_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (user_id)
+ * );
+ * ```
+ */
+final class QuietHours
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set (or replace) a user's quiet window. Idempotent per user.
+     *
+     * @param  int    $userId User id.
+     * @param  string $start  Window start as 'HH:MM' (inclusive).
+     * @param  string $end    Window end as 'HH:MM' (exclusive); may be < start (overnight).
+     * @param  string $tz     IANA time zone metadata (default 'UTC').
+     * @throws \InvalidArgumentException on malformed time or empty tz.
+     */
+    public function set(int $userId, string $start, string $end, string $tz = 'UTC'): void
+    {
+        $startMin = $this->toMinutes($start);
+        $endMin   = $this->toMinutes($end);
+        $tz       = trim($tz);
+        if ($tz === '') {
+            throw new \InvalidArgumentException('Time zone must not be empty.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'quiet_hours',
+            data:         ['user_id' => $userId, 'start_min' => $startMin, 'end_min' => $endMin, 'tz' => $tz],
+            conflictCols: ['user_id'],
+            updateCols:   ['start_min', 'end_min', 'tz'],
+            updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    /**
+     * Whether a local wall-clock time falls inside the user's quiet window.
+     *
+     * Returns false if the user has no window. The window is half-open
+     * `[start, end)`; overnight windows wrap; a zero-length window is never quiet.
+     *
+     * @param int    $userId User id.
+     * @param string $at     Local time as 'HH:MM'.
+     */
+    public function isQuiet(int $userId, string $at): bool
+    {
+        $row = $this->fetch($userId);
+        if ($row === null) {
+            return false;
+        }
+
+        $t     = $this->toMinutes($at);
+        $start = (int)$row['start_min'];
+        $end   = (int)$row['end_min'];
+
+        if ($start === $end) {
+            return false; // zero-length window
+        }
+        if ($start < $end) {
+            return $t >= $start && $t < $end;
+        }
+
+        // Overnight window (wraps past midnight).
+        return $t >= $start || $t < $end;
+    }
+
+    /**
+     * Whether the user has a quiet window configured.
+     */
+    public function hasWindow(int $userId): bool
+    {
+        return $this->fetch($userId) !== null;
+    }
+
+    /**
+     * Return the user's window as 'HH:MM' strings + tz, or null.
+     *
+     * @return array{start:string,end:string,tz:string}|null
+     */
+    public function window(int $userId): ?array
+    {
+        $row = $this->fetch($userId);
+        if ($row === null) {
+            return null;
+        }
+
+        return [
+            'start' => $this->toClock((int)$row['start_min']),
+            'end'   => $this->toClock((int)$row['end_min']),
+            'tz'    => (string)$row['tz'],
+        ];
+    }
+
+    /**
+     * Remove a user's quiet window. No-op if absent.
+     */
+    public function clear(int $userId): void
+    {
+        $stmt = $this->db()->prepare('DELETE FROM quiet_hours WHERE user_id = ?');
+        $stmt->execute([$userId]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function fetch(int $userId): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT start_min, end_min, tz FROM quiet_hours WHERE user_id = ?');
+        $stmt->execute([$userId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    private function toMinutes(string $clock): int
+    {
+        if (preg_match('/^([01]\d|2[0-3]):([0-5]\d)$/', trim($clock), $m) !== 1) {
+            throw new \InvalidArgumentException("Invalid time (expected HH:MM 00:00–23:59): {$clock}");
+        }
+
+        return ((int)$m[1]) * 60 + (int)$m[2];
+    }
+
+    private function toClock(int $minutes): string
+    {
+        return sprintf('%02d:%02d', intdiv($minutes, 60), $minutes % 60);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-288.md
+++ b/docs/field-trials/2026-05-field-trial-288.md
@@ -1,0 +1,41 @@
+# Field Trial 288 — QuietHours
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft288-quiet-hours`
+**Baseline**: post FT287 merge — **first helper scaffolded into `Nene\Kit` (ADR-0014)**
+
+## Goal
+
+Add `Nene\Kit\QuietHours` — per-user do-not-disturb time-of-day windows so a notification pipeline can defer non-urgent messages. Distinct from `MaintenanceWindow` (FT269, absolute service-scoped intervals): this is a recurring per-user time-of-day range.
+
+## What was built
+
+### `Nene\Kit\QuietHours` (`class/kit/QuietHours.php`)
+
+| Method | Description |
+| --- | --- |
+| `set(userId, 'HH:MM', 'HH:MM', tz='UTC')` | Upsert the quiet window (idempotent per user). |
+| `isQuiet(userId, 'HH:MM'): bool` | Whether a local time is inside the window. |
+| `window(userId): ?array` | `{start, end, tz}` as clock strings. |
+| `hasWindow / clear (userId)` | Exists / remove. |
+
+Key design points:
+
+- **Minutes-from-midnight, half-open `[start, end)`**: start inclusive, end exclusive.
+- **Overnight wrap**: when `start > end` (e.g. 22:00–07:00) the window spans midnight (`t >= start || t < end`); `start == end` is "never quiet".
+- **tz stored as metadata**; caller passes local wall-clock time.
+- First class created with `composer make:kit` — landed in `Nene\Kit` with `use Nene\Xion\PdoConnection;`/`DbUpsert;` cross-namespace imports.
+
+### Tests (`tests/Unit/Kit/QuietHoursTest.php`)
+
+13 unit tests (28 assertions): no-window never quiet; same-day half-open boundaries; overnight wrap (incl. past-midnight + end-exclusive); zero-length never quiet; window clock strings; idempotent per user; user separation; clear (+ missing no-op); default tz UTC; malformed-time rejection (set start/end, isQuiet).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper; the make:kit scaffold produced correct namespace/imports. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/QuietHoursTest.php
+++ b/tests/Unit/Kit/QuietHoursTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\QuietHours;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for QuietHours.
+ */
+final class QuietHoursTest extends TestCase
+{
+    private PDO $db;
+    private QuietHours $qh;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE quiet_hours (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    BIGINT      NOT NULL,
+                start_min  INTEGER     NOT NULL,
+                end_min    INTEGER     NOT NULL,
+                tz         VARCHAR(64) NOT NULL DEFAULT \'UTC\',
+                updated_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (user_id)
+            )
+        ');
+        $this->qh = new QuietHours($this->db);
+    }
+
+    public function testNoWindowIsNeverQuiet(): void
+    {
+        $this->assertFalse($this->qh->hasWindow(42));
+        $this->assertFalse($this->qh->isQuiet(42, '03:00'));
+        $this->assertNull($this->qh->window(42));
+    }
+
+    public function testSameDayWindowHalfOpen(): void
+    {
+        $this->qh->set(42, '09:00', '17:00');
+        $this->assertFalse($this->qh->isQuiet(42, '08:59')); // before
+        $this->assertTrue($this->qh->isQuiet(42, '09:00'));  // start inclusive
+        $this->assertTrue($this->qh->isQuiet(42, '12:00'));
+        $this->assertFalse($this->qh->isQuiet(42, '17:00')); // end exclusive
+        $this->assertFalse($this->qh->isQuiet(42, '18:00'));
+    }
+
+    public function testOvernightWindowWraps(): void
+    {
+        $this->qh->set(42, '22:00', '07:00');
+        $this->assertTrue($this->qh->isQuiet(42, '22:00'));  // start inclusive
+        $this->assertTrue($this->qh->isQuiet(42, '23:30'));
+        $this->assertTrue($this->qh->isQuiet(42, '00:00'));  // past midnight
+        $this->assertTrue($this->qh->isQuiet(42, '06:59'));
+        $this->assertFalse($this->qh->isQuiet(42, '07:00')); // end exclusive
+        $this->assertFalse($this->qh->isQuiet(42, '12:00'));
+    }
+
+    public function testZeroLengthWindowNeverQuiet(): void
+    {
+        $this->qh->set(42, '09:00', '09:00');
+        $this->assertFalse($this->qh->isQuiet(42, '09:00'));
+        $this->assertFalse($this->qh->isQuiet(42, '00:00'));
+    }
+
+    public function testWindowReturnsClockStrings(): void
+    {
+        $this->qh->set(42, '22:00', '07:00', 'Asia/Tokyo');
+        $w = $this->qh->window(42);
+        $this->assertSame(['start' => '22:00', 'end' => '07:00', 'tz' => 'Asia/Tokyo'], $w);
+    }
+
+    public function testSetIsIdempotentPerUser(): void
+    {
+        $this->qh->set(42, '22:00', '07:00');
+        $this->qh->set(42, '23:00', '06:00');
+        $this->assertSame('23:00', $this->qh->window(42)['start']);
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM quiet_hours')->fetchColumn());
+    }
+
+    public function testUsersAreSeparate(): void
+    {
+        $this->qh->set(1, '22:00', '07:00');
+        $this->assertTrue($this->qh->isQuiet(1, '23:00'));
+        $this->assertFalse($this->qh->hasWindow(2));
+    }
+
+    public function testClear(): void
+    {
+        $this->qh->set(42, '22:00', '07:00');
+        $this->qh->clear(42);
+        $this->assertFalse($this->qh->hasWindow(42));
+        $this->assertFalse($this->qh->isQuiet(42, '23:00'));
+    }
+
+    public function testClearMissingIsNoop(): void
+    {
+        $this->qh->clear(99); // no throw
+        $this->assertFalse($this->qh->hasWindow(99));
+    }
+
+    public function testDefaultTimezoneIsUtc(): void
+    {
+        $this->qh->set(42, '09:00', '17:00');
+        $this->assertSame('UTC', $this->qh->window(42)['tz']);
+    }
+
+    public function testSetRejectsMalformedTime(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->qh->set(42, '25:00', '07:00');
+    }
+
+    public function testSetRejectsNonClockString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->qh->set(42, '9am', '5pm');
+    }
+
+    public function testIsQuietRejectsMalformedTime(): void
+    {
+        $this->qh->set(42, '22:00', '07:00');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->qh->isQuiet(42, '99:99');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT288** — `Nene\Kit\QuietHours`: per-user do-not-disturb time-of-day windows. **First helper scaffolded into `Nene\Kit`** via `composer make:kit` (post ADR-0014). Distinct from `MaintenanceWindow` (FT269, absolute service intervals).

| Method | Description |
| --- | --- |
| `set(userId, 'HH:MM', 'HH:MM', tz='UTC')` | Upsert window (idempotent per user). |
| `isQuiet(userId, 'HH:MM'): bool` | Local time inside the window? |
| `window / hasWindow / clear` | Read / exists / remove. |

- Minutes-from-midnight, half-open `[start, end)`; overnight wrap; zero-length = never quiet.

## F-N findings
- **F-1** — none. make:kit scaffold produced correct `Nene\Kit` namespace + cross-namespace imports.

## Test plan
- [x] 13 tests / 28 assertions (half-open, overnight wrap incl. past-midnight, zero-length, idempotent, separation, clear, default tz, malformed-time rejection)
- [x] `composer precommit` green (format → Phan → 4869 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)