### PR TITLE
feat(kit): Snooze — defer an item until a wake-up time (FT289)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -139,6 +139,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `RecipientGroup` | mailing list / recipient group management. |
 | `Reminder` | user-set future reminders. |
 | `SessionFlash` | one-time flash messages stored in DB, consumed on next read. |
+| `Snooze` | temporarily hide an item until a wake-up time. |
 | `TopicSubscription` | user subscriptions to named topics for notification routing. |
 
 ---
@@ -317,4 +318,5 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 ---
 
 *Generated from PHPDoc descriptions. Run `composer kit:index` to refresh after adding classes.*
+
 

--- a/class/kit/Snooze.php
+++ b/class/kit/Snooze.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * Snooze — temporarily hide an item until a wake-up time.
+ *
+ * "Snooze this until tomorrow 9am": hides a notification, task, ticket, or any
+ * keyed item from an owner's active view until `wake_at`, after which it
+ * resurfaces via {@see Snooze::due()}. One snooze per `(owner, item)`;
+ * re-snoozing updates the wake time. Distinct from `Reminder` (FT184, which
+ * creates a *new* future reminder): Snooze defers an *existing* item.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $s = new Snooze($pdo);
+ *
+ * $s->snooze('user-1', 'ticket-42', '2026-05-30 09:00:00');
+ *
+ * $s->isSnoozed('user-1', 'ticket-42');   // true (before wake)
+ * $s->snoozed('user-1');                  // still-hidden items, soonest wake first
+ * $s->due('user-1');                      // items whose wake time has passed
+ *
+ * $s->unsnooze('user-1', 'ticket-42');    // cancel early
+ * $s->clearWoken('user-1');               // drop woken rows after resurfacing
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE snoozes (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     owner      VARCHAR(190) NOT NULL,
+ *     item       VARCHAR(190) NOT NULL,
+ *     wake_at    DATETIME     NOT NULL,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (owner, item)
+ * );
+ * ```
+ */
+final class Snooze
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Snooze an item until a wake time. Idempotent per (owner, item) — re-snoozing
+     * replaces the wake time.
+     *
+     * @param  string $owner Owner key (user/session).
+     * @param  string $item  Item identifier.
+     * @param  string $until Wake time ('Y-m-d H:i:s' or parseable).
+     * @throws \InvalidArgumentException on empty owner/item or bad time.
+     */
+    public function snooze(string $owner, string $item, string $until): void
+    {
+        $owner = $this->validate($owner, 'Owner');
+        $item  = $this->validate($item, 'Item');
+        $wake  = $this->ts($until);
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'snoozes',
+            data:         ['owner' => $owner, 'item' => $item, 'wake_at' => $wake],
+            conflictCols: ['owner', 'item'],
+            updateCols:   ['wake_at'],
+        );
+    }
+
+    /**
+     * Whether an item is currently snoozed (wake time still in the future).
+     *
+     * @param string      $owner Owner key.
+     * @param string      $item  Item id.
+     * @param string|null $asOf  Reference time; defaults to now.
+     */
+    public function isSnoozed(string $owner, string $item, ?string $asOf = null): bool
+    {
+        $owner = $this->validate($owner, 'Owner');
+        $item  = $this->validate($item, 'Item');
+
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM snoozes WHERE owner = ? AND item = ? AND wake_at > ? LIMIT 1'
+        );
+        $stmt->execute([$owner, $item, $this->ts($asOf ?? 'now')]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Wake time for an item, or null if not snoozed.
+     */
+    public function wakeAt(string $owner, string $item): ?string
+    {
+        $owner = $this->validate($owner, 'Owner');
+        $item  = $this->validate($item, 'Item');
+
+        $stmt = $this->db()->prepare('SELECT wake_at FROM snoozes WHERE owner = ? AND item = ?');
+        $stmt->execute([$owner, $item]);
+        $w = $stmt->fetchColumn();
+
+        return $w === false ? null : (string)$w;
+    }
+
+    /**
+     * Still-snoozed items for an owner (wake time in the future), soonest first.
+     *
+     * @param  string      $owner Owner key.
+     * @param  string|null $asOf  Reference time; defaults to now.
+     * @return array<int,array{item:string,wake_at:string}>
+     */
+    public function snoozed(string $owner, ?string $asOf = null): array
+    {
+        return $this->query($owner, 'wake_at > ?', $asOf, 'ASC');
+    }
+
+    /**
+     * Items whose wake time has passed (ready to resurface), oldest wake first.
+     *
+     * @param  string      $owner Owner key.
+     * @param  string|null $asOf  Reference time; defaults to now.
+     * @return array<int,array{item:string,wake_at:string}>
+     */
+    public function due(string $owner, ?string $asOf = null): array
+    {
+        return $this->query($owner, 'wake_at <= ?', $asOf, 'ASC');
+    }
+
+    /**
+     * Cancel a snooze. No-op if absent.
+     */
+    public function unsnooze(string $owner, string $item): void
+    {
+        $owner = $this->validate($owner, 'Owner');
+        $item  = $this->validate($item, 'Item');
+        $stmt  = $this->db()->prepare('DELETE FROM snoozes WHERE owner = ? AND item = ?');
+        $stmt->execute([$owner, $item]);
+    }
+
+    /**
+     * Delete woken rows (wake time passed) for an owner, after resurfacing them.
+     *
+     * @param  string      $owner Owner key.
+     * @param  string|null $asOf  Reference time; defaults to now.
+     * @return int                Number of rows removed.
+     */
+    public function clearWoken(string $owner, ?string $asOf = null): int
+    {
+        $owner = $this->validate($owner, 'Owner');
+        $stmt  = $this->db()->prepare('DELETE FROM snoozes WHERE owner = ? AND wake_at <= ?');
+        $stmt->execute([$owner, $this->ts($asOf ?? 'now')]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array<int,array{item:string,wake_at:string}>
+     */
+    private function query(string $owner, string $cond, ?string $asOf, string $dir): array
+    {
+        $owner = $this->validate($owner, 'Owner');
+        $stmt  = $this->db()->prepare(
+            "SELECT item, wake_at FROM snoozes WHERE owner = ? AND {$cond} ORDER BY wake_at {$dir}"
+        );
+        $stmt->execute([$owner, $this->ts($asOf ?? 'now')]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['item' => (string)$row['item'], 'wake_at' => (string)$row['wake_at']];
+        }
+
+        return $out;
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function ts(string $value): string
+    {
+        $epoch = strtotime($value);
+        if ($epoch === false) {
+            throw new \InvalidArgumentException("Invalid time: {$value}");
+        }
+
+        return date('Y-m-d H:i:s', $epoch);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-289.md
+++ b/docs/field-trials/2026-05-field-trial-289.md
@@ -1,0 +1,42 @@
+# Field Trial 289 — Snooze
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft289-snooze`
+**Baseline**: post FT288 merge
+
+## Goal
+
+Add `Nene\Kit\Snooze` — temporarily hide an existing item (notification, task, ticket) from an owner's active view until a wake time, after which it resurfaces. Distinct from `Reminder` (FT184, which creates a *new* future reminder): Snooze defers an *existing* item.
+
+## What was built
+
+### `Nene\Kit\Snooze` (`class/kit/Snooze.php`)
+
+| Method | Description |
+| --- | --- |
+| `snooze(owner, item, until)` | Hide until a wake time (idempotent; re-snooze replaces). |
+| `isSnoozed(owner, item, asOf=null)` | Still hidden (wake in the future)? |
+| `wakeAt(owner, item): ?string` | The wake time, or null. |
+| `snoozed(owner, asOf=null)` | Still-hidden items, soonest wake first. |
+| `due(owner, asOf=null)` | Woken items (wake passed), ready to resurface. |
+| `unsnooze(owner, item) / clearWoken(owner, asOf=null): int` | Cancel / cleanup. |
+
+Key design points:
+
+- **`snoozed` + `due` partition** an owner's rows at a given instant (`wake_at > now` vs `<= now`).
+- **Boundary**: at exactly `wake_at` the item is *due*, not snoozed (`isSnoozed` uses `>`).
+- One snooze per `(owner, item)` (cross-driver upsert); `asOf` for deterministic time.
+
+### Tests (`tests/Unit/Kit/SnoozeTest.php`)
+
+12 unit tests (23 assertions): snooze/isSnoozed boundary (before/at/after wake), wakeAt, re-snooze replaces, snoozed soonest-first, due woken items, snoozed+due partition, unsnooze (+ missing no-op), clearWoken removes only woken, owner separation, validation (empty owner, bad time).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/SnoozeTest.php
+++ b/tests/Unit/Kit/SnoozeTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\Snooze;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Snooze.
+ */
+final class SnoozeTest extends TestCase
+{
+    private PDO $db;
+    private Snooze $s;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE snoozes (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                owner      VARCHAR(190) NOT NULL,
+                item       VARCHAR(190) NOT NULL,
+                wake_at    DATETIME     NOT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (owner, item)
+            )
+        ');
+        $this->s = new Snooze($this->db);
+    }
+
+    public function testSnoozeAndIsSnoozed(): void
+    {
+        $this->s->snooze('u1', 'ticket-42', '2026-05-30 09:00:00');
+        $this->assertTrue($this->s->isSnoozed('u1', 'ticket-42', '2026-05-29 12:00:00'));  // before wake
+        $this->assertFalse($this->s->isSnoozed('u1', 'ticket-42', '2026-05-30 09:00:00')); // at wake (not > )
+        $this->assertFalse($this->s->isSnoozed('u1', 'ticket-42', '2026-05-30 10:00:00')); // after
+    }
+
+    public function testWakeAt(): void
+    {
+        $this->s->snooze('u1', 'x', '2026-05-30 09:00:00');
+        $this->assertSame('2026-05-30 09:00:00', $this->s->wakeAt('u1', 'x'));
+        $this->assertNull($this->s->wakeAt('u1', 'missing'));
+    }
+
+    public function testReSnoozeReplacesWakeTime(): void
+    {
+        $this->s->snooze('u1', 'x', '2026-05-30 09:00:00');
+        $this->s->snooze('u1', 'x', '2026-06-01 09:00:00');
+        $this->assertSame('2026-06-01 09:00:00', $this->s->wakeAt('u1', 'x'));
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM snoozes')->fetchColumn());
+    }
+
+    public function testSnoozedListsFutureSoonestFirst(): void
+    {
+        $this->s->snooze('u1', 'later', '2026-06-10 09:00:00');
+        $this->s->snooze('u1', 'soon', '2026-06-02 09:00:00');
+        $snoozed = $this->s->snoozed('u1', '2026-06-01 00:00:00');
+        $this->assertCount(2, $snoozed);
+        $this->assertSame('soon', $snoozed[0]['item']);
+        $this->assertSame('later', $snoozed[1]['item']);
+    }
+
+    public function testDueReturnsWokenItems(): void
+    {
+        $this->s->snooze('u1', 'woken', '2026-05-29 08:00:00');
+        $this->s->snooze('u1', 'still', '2026-06-10 09:00:00');
+        // asOf 2026-05-29 12:00 → 'woken' is due, 'still' is not
+        $due = $this->s->due('u1', '2026-05-29 12:00:00');
+        $this->assertCount(1, $due);
+        $this->assertSame('woken', $due[0]['item']);
+    }
+
+    public function testSnoozedAndDuePartition(): void
+    {
+        $this->s->snooze('u1', 'a', '2026-05-29 08:00:00'); // woken
+        $this->s->snooze('u1', 'b', '2026-06-10 00:00:00'); // future
+        $asOf    = '2026-05-29 12:00:00';
+        $snoozed = $this->s->snoozed('u1', $asOf);
+        $due     = $this->s->due('u1', $asOf);
+        $this->assertSame(2, count($snoozed) + count($due));
+        $this->assertCount(1, $snoozed);
+        $this->assertCount(1, $due);
+    }
+
+    public function testUnsnooze(): void
+    {
+        $this->s->snooze('u1', 'x', '2026-06-10 09:00:00');
+        $this->s->unsnooze('u1', 'x');
+        $this->assertFalse($this->s->isSnoozed('u1', 'x', '2026-06-01 00:00:00'));
+        $this->assertNull($this->s->wakeAt('u1', 'x'));
+    }
+
+    public function testUnsnoozeMissingIsNoop(): void
+    {
+        $this->s->unsnooze('u1', 'ghost');
+        $this->assertNull($this->s->wakeAt('u1', 'ghost'));
+    }
+
+    public function testClearWokenRemovesOnlyWoken(): void
+    {
+        $this->s->snooze('u1', 'woken', '2026-05-29 08:00:00');
+        $this->s->snooze('u1', 'future', '2026-06-10 09:00:00');
+        $removed = $this->s->clearWoken('u1', '2026-05-29 12:00:00');
+        $this->assertSame(1, $removed);
+        $this->assertTrue($this->s->isSnoozed('u1', 'future', '2026-05-29 12:00:00'));
+    }
+
+    public function testOwnersAreSeparate(): void
+    {
+        $this->s->snooze('u1', 'x', '2026-06-10 09:00:00');
+        $this->assertSame([], $this->s->snoozed('u2', '2026-06-01 00:00:00'));
+    }
+
+    public function testSnoozeRejectsEmptyOwner(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->s->snooze('  ', 'x', '2026-06-10 09:00:00');
+    }
+
+    public function testSnoozeRejectsBadTime(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->s->snooze('u1', 'x', 'not-a-time');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT289** — `Nene\Kit\Snooze`: temporarily hide an existing item (notification/task/ticket) until a wake time, after which it resurfaces. Distinct from `Reminder` (FT184, a *new* future reminder).

| Method | Description |
| --- | --- |
| `snooze(owner, item, until)` | Hide until wake (idempotent; replaces). |
| `isSnoozed / wakeAt` | Still hidden? / wake time. |
| `snoozed / due (owner, asOf=null)` | Still-hidden / woken (partition). |
| `unsnooze / clearWoken` | Cancel / cleanup. |

- At exactly `wake_at` the item is *due*, not snoozed; `snoozed`+`due` partition the owner's rows.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 23 assertions (boundary before/at/after, re-snooze replace, soonest-first, partition, clearWoken, separation, validation)
- [x] `composer precommit` green (format → Phan → 4881 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)