### PR TITLE
feat(kit): ShippingZone — region shipping rate with free-shipping threshold (FT290)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -184,6 +184,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `ProductReview` | entity reviews with ratings and helpfulness voting. |
 | `Quota` | plan-based resource quota management. |
 | `RecurringPayment` | Recurring payment schedule management. |
+| `ShippingZone` | region → shipping-zone rate lookup with free-shipping threshold. |
 | `ShoppingCart` | cart item management with quantity and price tracking. |
 | `Subscription` | track recurring subscription plans per user. |
 | `SubscriptionPlan` | user subscription lifecycle management. |

--- a/class/kit/ShippingZone.php
+++ b/class/kit/ShippingZone.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * ShippingZone — region → shipping-zone rate lookup with free-shipping threshold.
+ *
+ * Maps each delivery region to a named zone and a flat shipping rate (integer
+ * cents), with an optional per-region free-shipping threshold. Complements
+ * `TaxRate` (FT207, region tax lookup): same region-keyed, integer-cent shape,
+ * for the shipping side of checkout.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $sz = new ShippingZone($pdo);
+ *
+ * $sz->setRate('JP', 'domestic', 500);             // ¥5.00 flat
+ * $sz->setRate('US', 'intl', 2500, freeOverCents: 10000); // free over $100
+ *
+ * $sz->rateFor('JP');            // 500
+ * $sz->rateFor('US', 5000);      // 2500 (under threshold)
+ * $sz->rateFor('US', 10000);     // 0    (>= free-shipping threshold)
+ * $sz->rateFor('XX');            // null (unknown region)
+ *
+ * $sz->zoneOf('US');             // 'intl'
+ * $sz->regionsIn('intl');        // ['US', ...]
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE shipping_zones (
+ *     id              INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     region          VARCHAR(100) NOT NULL,
+ *     zone            VARCHAR(100) NOT NULL,
+ *     rate_cents      INTEGER      NOT NULL DEFAULT 0,
+ *     free_over_cents INTEGER      NOT NULL DEFAULT 0,
+ *     created_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (region)
+ * );
+ * ```
+ */
+final class ShippingZone
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set (or replace) the zone + rate for a region. Idempotent per region.
+     *
+     * @param  string $region        Region/country code.
+     * @param  string $zone          Zone name (e.g. 'domestic').
+     * @param  int    $rateCents      Flat shipping rate in cents (>= 0).
+     * @param  int    $freeOverCents Order total at/above which shipping is free
+     *                               (0 = no free-shipping threshold).
+     * @throws \InvalidArgumentException on empty region/zone or negative amounts.
+     */
+    public function setRate(string $region, string $zone, int $rateCents, int $freeOverCents = 0): void
+    {
+        $region = $this->validate($region, 'Region');
+        $zone   = $this->validate($zone, 'Zone');
+        if ($rateCents < 0 || $freeOverCents < 0) {
+            throw new \InvalidArgumentException('Amounts must not be negative.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'shipping_zones',
+            data:         ['region' => $region, 'zone' => $zone, 'rate_cents' => $rateCents, 'free_over_cents' => $freeOverCents],
+            conflictCols: ['region'],
+            updateCols:   ['zone', 'rate_cents', 'free_over_cents'],
+        );
+    }
+
+    /**
+     * Shipping cost for a region, applying the free-shipping threshold if an
+     * order total is given.
+     *
+     * @param  string   $region     Region code.
+     * @param  int|null $orderCents Order subtotal in cents; null skips the threshold.
+     * @return int|null             Shipping cents (0 if free), or null if region unknown.
+     */
+    public function rateFor(string $region, ?int $orderCents = null): ?int
+    {
+        $region = $this->validate($region, 'Region');
+
+        $stmt = $this->db()->prepare('SELECT rate_cents, free_over_cents FROM shipping_zones WHERE region = ?');
+        $stmt->execute([$region]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+
+        $free = (int)$row['free_over_cents'];
+        if ($free > 0 && $orderCents !== null && $orderCents >= $free) {
+            return 0;
+        }
+
+        return (int)$row['rate_cents'];
+    }
+
+    /**
+     * Zone name for a region, or null if unknown.
+     */
+    public function zoneOf(string $region): ?string
+    {
+        $region = $this->validate($region, 'Region');
+        $stmt   = $this->db()->prepare('SELECT zone FROM shipping_zones WHERE region = ?');
+        $stmt->execute([$region]);
+        $z = $stmt->fetchColumn();
+
+        return $z === false ? null : (string)$z;
+    }
+
+    /**
+     * Regions assigned to a zone, ascending.
+     *
+     * @return array<int,string>
+     */
+    public function regionsIn(string $zone): array
+    {
+        $zone = $this->validate($zone, 'Zone');
+        $stmt = $this->db()->prepare('SELECT region FROM shipping_zones WHERE zone = ? ORDER BY region ASC');
+        $stmt->execute([$zone]);
+
+        return array_map(static fn ($r): string => (string)$r, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    /**
+     * Distinct zone names, ascending.
+     *
+     * @return array<int,string>
+     */
+    public function zones(): array
+    {
+        $stmt = $this->db()->query('SELECT DISTINCT zone FROM shipping_zones ORDER BY zone ASC');
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        return array_map(static fn ($z): string => (string)$z, $rows);
+    }
+
+    /**
+     * Remove a region's rate. No-op if absent.
+     */
+    public function remove(string $region): void
+    {
+        $region = $this->validate($region, 'Region');
+        $stmt   = $this->db()->prepare('DELETE FROM shipping_zones WHERE region = ?');
+        $stmt->execute([$region]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-290.md
+++ b/docs/field-trials/2026-05-field-trial-290.md
@@ -1,0 +1,39 @@
+# Field Trial 290 — ShippingZone
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft290-shipping-zone`
+**Baseline**: post FT289 merge
+
+## Goal
+
+Add `Nene\Kit\ShippingZone` — region → shipping-zone rate lookup with integer-cent rates and an optional free-shipping threshold. Complements `TaxRate` (FT207) for the shipping side of checkout.
+
+## What was built
+
+### `Nene\Kit\ShippingZone` (`class/kit/ShippingZone.php`)
+
+| Method | Description |
+| --- | --- |
+| `setRate(region, zone, rateCents, freeOverCents=0)` | Upsert per region. |
+| `rateFor(region, orderCents=null): ?int` | Cost (0 if free, null if unknown). |
+| `zoneOf(region) / regionsIn(zone) / zones()` | Zone lookups. |
+| `remove(region)` | Delete. |
+
+Key design points:
+
+- **Integer-cent** rates (no floats); **free-shipping threshold** is inclusive (`orderCents >= freeOver` → 0); threshold ignored when no order total is given or when 0.
+- Region-keyed (cross-driver upsert), same shape as `TaxRate`.
+
+### Tests (`tests/Unit/Kit/ShippingZoneTest.php`)
+
+12 unit tests (18 assertions): set/rate, unknown→null, free threshold (under / exactly-at / over / no-total), no-threshold always charges, zoneOf, regionsIn, distinct zones, idempotent replace, remove (+ missing no-op), validation (negative, empty region).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/ShippingZoneTest.php
+++ b/tests/Unit/Kit/ShippingZoneTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\ShippingZone;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ShippingZone.
+ */
+final class ShippingZoneTest extends TestCase
+{
+    private PDO $db;
+    private ShippingZone $sz;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE shipping_zones (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                region          VARCHAR(100) NOT NULL,
+                zone            VARCHAR(100) NOT NULL,
+                rate_cents      INTEGER      NOT NULL DEFAULT 0,
+                free_over_cents INTEGER      NOT NULL DEFAULT 0,
+                created_at      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (region)
+            )
+        ');
+        $this->sz = new ShippingZone($this->db);
+    }
+
+    public function testSetAndRate(): void
+    {
+        $this->sz->setRate('JP', 'domestic', 500);
+        $this->assertSame(500, $this->sz->rateFor('JP'));
+    }
+
+    public function testRateUnknownRegionIsNull(): void
+    {
+        $this->assertNull($this->sz->rateFor('XX'));
+    }
+
+    public function testFreeShippingThreshold(): void
+    {
+        $this->sz->setRate('US', 'intl', 2500, freeOverCents: 10000);
+        $this->assertSame(2500, $this->sz->rateFor('US', 9999));   // under
+        $this->assertSame(0, $this->sz->rateFor('US', 10000));     // exactly at threshold → free
+        $this->assertSame(0, $this->sz->rateFor('US', 20000));     // over
+        $this->assertSame(2500, $this->sz->rateFor('US'));         // no order total → full rate
+    }
+
+    public function testNoThresholdAlwaysCharges(): void
+    {
+        $this->sz->setRate('JP', 'domestic', 500); // free_over = 0
+        $this->assertSame(500, $this->sz->rateFor('JP', 999999));
+    }
+
+    public function testZoneOf(): void
+    {
+        $this->sz->setRate('US', 'intl', 2500);
+        $this->assertSame('intl', $this->sz->zoneOf('US'));
+        $this->assertNull($this->sz->zoneOf('XX'));
+    }
+
+    public function testRegionsIn(): void
+    {
+        $this->sz->setRate('US', 'intl', 2500);
+        $this->sz->setRate('CA', 'intl', 2000);
+        $this->sz->setRate('JP', 'domestic', 500);
+        $this->assertSame(['CA', 'US'], $this->sz->regionsIn('intl'));
+    }
+
+    public function testZonesDistinct(): void
+    {
+        $this->sz->setRate('US', 'intl', 2500);
+        $this->sz->setRate('CA', 'intl', 2000);
+        $this->sz->setRate('JP', 'domestic', 500);
+        $this->assertSame(['domestic', 'intl'], $this->sz->zones());
+    }
+
+    public function testSetRateIsIdempotent(): void
+    {
+        $this->sz->setRate('JP', 'domestic', 500);
+        $this->sz->setRate('JP', 'express', 1200, freeOverCents: 5000);
+        $this->assertSame('express', $this->sz->zoneOf('JP'));
+        $this->assertSame(0, $this->sz->rateFor('JP', 5000));
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM shipping_zones')->fetchColumn());
+    }
+
+    public function testRemove(): void
+    {
+        $this->sz->setRate('JP', 'domestic', 500);
+        $this->sz->remove('JP');
+        $this->assertNull($this->sz->rateFor('JP'));
+    }
+
+    public function testRemoveMissingIsNoop(): void
+    {
+        $this->sz->remove('XX');
+        $this->assertSame([], $this->sz->zones());
+    }
+
+    public function testSetRateRejectsNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sz->setRate('JP', 'domestic', -1);
+    }
+
+    public function testSetRateRejectsEmptyRegion(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sz->setRate('  ', 'domestic', 500);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT290** — `Nene\Kit\ShippingZone`: region → shipping-zone rate lookup with integer-cent rates and an optional free-shipping threshold. Shipping-side counterpart to `TaxRate` (FT207).

| Method | Description |
| --- | --- |
| `setRate(region, zone, rateCents, freeOverCents=0)` | Upsert per region. |
| `rateFor(region, orderCents=null): ?int` | 0 if free, null if unknown. |
| `zoneOf / regionsIn / zones / remove` | Lookups / delete. |

- Integer cents; inclusive free-shipping threshold (`orderCents >= freeOver` → 0).

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 18 assertions (rate, unknown null, threshold under/at/over/no-total, no-threshold, zoneOf, regionsIn, distinct zones, idempotent, remove, validation)
- [x] `composer precommit` green (format → Phan → 4893 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)