### PR TITLE
feat(kit): Payout — accrue and settle marketplace payouts (FT291)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -176,6 +176,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `InventoryStock` | product/SKU stock tracking with atomic reserve/release/commit. |
 | `OrderLine` | e-commerce order header with line items. |
 | `PaymentRecord` | simple payment/transaction ledger. |
+| `Payout` | accrue amounts owed to payees and settle them in payout runs. |
 | `PointBalance` | user loyalty/reward points with append-only ledger. |
 | `PointLedger` | Append-only point / loyalty system with negative-balance prevention. |
 | `PriceHistory` | append-only price change log for products or any priced entity. |

--- a/class/kit/Payout.php
+++ b/class/kit/Payout.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * Payout — accrue amounts owed to payees and settle them in payout runs.
+ *
+ * Tracks money owed to sellers / affiliates / creators as individual
+ * integer-cent line items, then settles a payee's outstanding balance in a
+ * payout run. Distinct from `PaymentRecord` (incoming customer payments) and
+ * `CreditLedger` (general double-entry): this is the *outbound* marketplace
+ * payout side.
+ *
+ * Each accrual is an immutable line with a status: `pending` → `paid`
+ * (settled in a run) or `failed` (e.g. transfer bounced; can be retried by
+ * re-accruing or reopening out of band).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $p = new Payout($pdo);
+ *
+ * $p->accrue('seller-7', 1500, 'order-100');  // owe $15.00
+ * $p->accrue('seller-7', 800,  'order-101');  // owe $8.00
+ *
+ * $p->pendingTotal('seller-7');   // 2300
+ * $paid = $p->pay('seller-7');    // settle pending → 2300, lines marked paid
+ * $p->pendingTotal('seller-7');   // 0
+ * $p->paidTotal('seller-7');      // 2300
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE payouts (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     payee        VARCHAR(190) NOT NULL,
+ *     amount_cents INTEGER      NOT NULL,
+ *     status       VARCHAR(10)  NOT NULL DEFAULT 'pending',
+ *     reference    VARCHAR(190) NOT NULL DEFAULT '',
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     paid_at      DATETIME     NULL
+ * );
+ * ```
+ */
+final class Payout
+{
+    public const string STATUS_PENDING = 'pending';
+    public const string STATUS_PAID    = 'paid';
+    public const string STATUS_FAILED  = 'failed';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Accrue an amount owed to a payee (a pending line item).
+     *
+     * @param  string $payee      Payee identifier.
+     * @param  int    $amountCents Amount owed in cents (> 0).
+     * @param  string $reference  Optional source reference (order id, etc.).
+     * @return int                New line item id.
+     * @throws \InvalidArgumentException on empty payee or non-positive amount.
+     */
+    public function accrue(string $payee, int $amountCents, string $reference = ''): int
+    {
+        $payee = $this->validate($payee, 'Payee');
+        if ($amountCents <= 0) {
+            throw new \InvalidArgumentException('Amount must be positive.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO payouts (payee, amount_cents, status, reference) VALUES (?, ?, ?, ?)'
+        );
+        $stmt->execute([$payee, $amountCents, self::STATUS_PENDING, $reference]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Total pending (unsettled) cents owed to a payee.
+     */
+    public function pendingTotal(string $payee): int
+    {
+        return $this->sum($payee, self::STATUS_PENDING);
+    }
+
+    /**
+     * Total settled cents paid to a payee.
+     */
+    public function paidTotal(string $payee): int
+    {
+        return $this->sum($payee, self::STATUS_PAID);
+    }
+
+    /**
+     * Settle a payee's pending balance: mark all pending lines paid.
+     *
+     * @param  string      $payee Payee identifier.
+     * @param  string|null $asOf  Settlement time; defaults to now.
+     * @return int                Total cents settled in this run (0 if nothing pending).
+     */
+    public function pay(string $payee, ?string $asOf = null): int
+    {
+        $payee = $this->validate($payee, 'Payee');
+        $total = $this->pendingTotal($payee);
+        if ($total === 0) {
+            return 0;
+        }
+
+        $stmt = $this->db()->prepare(
+            'UPDATE payouts SET status = ?, paid_at = ? WHERE payee = ? AND status = ?'
+        );
+        $stmt->execute([self::STATUS_PAID, $this->ts($asOf), $payee, self::STATUS_PENDING]);
+
+        return $total;
+    }
+
+    /**
+     * Mark a single line item failed. Returns true if it was pending.
+     */
+    public function markFailed(int $id): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE payouts SET status = ? WHERE id = ? AND status = ?'
+        );
+        $stmt->execute([self::STATUS_FAILED, $id, self::STATUS_PENDING]);
+
+        return $stmt->rowCount() === 1;
+    }
+
+    /**
+     * List a payee's line items (optionally filtered by status), newest first.
+     *
+     * @param  string      $payee  Payee identifier.
+     * @param  string|null $status One of the STATUS_* constants, or null for all.
+     * @return array<int,array{id:int,amount_cents:int,status:string,reference:string}>
+     * @throws \InvalidArgumentException on unknown status.
+     */
+    public function items(string $payee, ?string $status = null): array
+    {
+        $payee = $this->validate($payee, 'Payee');
+        if ($status !== null && !in_array($status, [self::STATUS_PENDING, self::STATUS_PAID, self::STATUS_FAILED], true)) {
+            throw new \InvalidArgumentException("Unknown status: {$status}");
+        }
+
+        if ($status === null) {
+            $stmt = $this->db()->prepare(
+                'SELECT id, amount_cents, status, reference FROM payouts WHERE payee = ? ORDER BY id DESC'
+            );
+            $stmt->execute([$payee]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT id, amount_cents, status, reference FROM payouts WHERE payee = ? AND status = ? ORDER BY id DESC'
+            );
+            $stmt->execute([$payee, $status]);
+        }
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = [
+                'id'           => (int)$row['id'],
+                'amount_cents' => (int)$row['amount_cents'],
+                'status'       => (string)$row['status'],
+                'reference'    => (string)$row['reference'],
+            ];
+        }
+
+        return $out;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function sum(string $payee, string $status): int
+    {
+        $payee = $this->validate($payee, 'Payee');
+        $stmt  = $this->db()->prepare(
+            'SELECT COALESCE(SUM(amount_cents), 0) FROM payouts WHERE payee = ? AND status = ?'
+        );
+        $stmt->execute([$payee, $status]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function ts(?string $asOf): string
+    {
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid timestamp.');
+        }
+
+        return date('Y-m-d H:i:s', $epoch);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-291.md
+++ b/docs/field-trials/2026-05-field-trial-291.md
@@ -1,0 +1,41 @@
+# Field Trial 291 — Payout
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft291-payout`
+**Baseline**: post FT290 merge
+
+## Goal
+
+Add `Nene\Kit\Payout` — accrue integer-cent amounts owed to payees (sellers / affiliates / creators) and settle them in payout runs. The outbound marketplace counterpart to `PaymentRecord` (incoming) and `CreditLedger` (general).
+
+## What was built
+
+### `Nene\Kit\Payout` (`class/kit/Payout.php`)
+
+| Method | Description |
+| --- | --- |
+| `accrue(payee, amountCents, reference=''): int` | Record a pending line item (amount > 0). |
+| `pendingTotal / paidTotal (payee)` | Sum by status. |
+| `pay(payee, asOf=null): int` | Settle all pending → paid; returns total settled. |
+| `markFailed(id): bool` | Pending → failed (true only if it was pending). |
+| `items(payee, status=null)` | List lines, newest first. |
+
+Key design points:
+
+- **Integer-cent line items** with `pending → paid | failed` status; `pay()` settles only pending lines (failed excluded) and returns the settled total.
+- `markFailed`/`pay` guard on the prior status in the WHERE clause (no regressions).
+- Append-only accrual; `asOf` for deterministic settlement time.
+
+### Tests (`tests/Unit/Kit/PayoutTest.php`)
+
+12 unit tests (19 assertions): accrue + pendingTotal, pay settles, pay-nothing → 0, accrue-after-pay fresh pending, markFailed excludes from pending, markFailed only on pending, pay skips failed, items all/filtered, payee separation, validation (non-positive, empty payee, unknown status).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/PayoutTest.php
+++ b/tests/Unit/Kit/PayoutTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\Payout;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Payout.
+ */
+final class PayoutTest extends TestCase
+{
+    private PDO $db;
+    private Payout $p;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE payouts (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                payee        VARCHAR(190) NOT NULL,
+                amount_cents INTEGER      NOT NULL,
+                status       VARCHAR(10)  NOT NULL DEFAULT \'pending\',
+                reference    VARCHAR(190) NOT NULL DEFAULT \'\',
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                paid_at      DATETIME     NULL
+            )
+        ');
+        $this->p = new Payout($this->db);
+    }
+
+    public function testAccrueAndPendingTotal(): void
+    {
+        $this->p->accrue('s7', 1500, 'order-100');
+        $this->p->accrue('s7', 800, 'order-101');
+        $this->assertSame(2300, $this->p->pendingTotal('s7'));
+    }
+
+    public function testPaySettlesPending(): void
+    {
+        $this->p->accrue('s7', 1500);
+        $this->p->accrue('s7', 800);
+        $settled = $this->p->pay('s7');
+        $this->assertSame(2300, $settled);
+        $this->assertSame(0, $this->p->pendingTotal('s7'));
+        $this->assertSame(2300, $this->p->paidTotal('s7'));
+    }
+
+    public function testPayWithNothingPendingReturnsZero(): void
+    {
+        $this->assertSame(0, $this->p->pay('nobody'));
+    }
+
+    public function testAccrueAfterPayStartsFreshPending(): void
+    {
+        $this->p->accrue('s7', 1000);
+        $this->p->pay('s7');
+        $this->p->accrue('s7', 500); // new pending after settlement
+        $this->assertSame(500, $this->p->pendingTotal('s7'));
+        $this->assertSame(1000, $this->p->paidTotal('s7'));
+    }
+
+    public function testMarkFailedExcludesFromPending(): void
+    {
+        $id = $this->p->accrue('s7', 1500);
+        $this->p->accrue('s7', 800);
+        $this->assertTrue($this->p->markFailed($id));
+        $this->assertSame(800, $this->p->pendingTotal('s7')); // failed line excluded
+    }
+
+    public function testMarkFailedOnlyAffectsPending(): void
+    {
+        $id = $this->p->accrue('s7', 1000);
+        $this->p->pay('s7'); // now paid
+        $this->assertFalse($this->p->markFailed($id)); // can't fail a paid line
+    }
+
+    public function testPayDoesNotSettleFailedLines(): void
+    {
+        $id = $this->p->accrue('s7', 1500);
+        $this->p->accrue('s7', 800);
+        $this->p->markFailed($id);
+        $this->assertSame(800, $this->p->pay('s7')); // only the pending 800
+    }
+
+    public function testItemsAllAndFiltered(): void
+    {
+        $this->p->accrue('s7', 1500, 'a');
+        $id = $this->p->accrue('s7', 800, 'b');
+        $this->p->markFailed($id);
+        $this->assertCount(2, $this->p->items('s7'));
+        $this->assertCount(1, $this->p->items('s7', Payout::STATUS_PENDING));
+        $this->assertCount(1, $this->p->items('s7', Payout::STATUS_FAILED));
+    }
+
+    public function testPayeesAreSeparate(): void
+    {
+        $this->p->accrue('s7', 1000);
+        $this->p->accrue('s8', 500);
+        $this->assertSame(1000, $this->p->pendingTotal('s7'));
+        $this->assertSame(500, $this->p->pendingTotal('s8'));
+    }
+
+    public function testAccrueRejectsNonPositive(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->p->accrue('s7', 0);
+    }
+
+    public function testAccrueRejectsEmptyPayee(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->p->accrue('  ', 1000);
+    }
+
+    public function testItemsRejectsUnknownStatus(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->p->items('s7', 'bogus');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT291** — `Nene\Kit\Payout`: accrue integer-cent amounts owed to payees (sellers/affiliates/creators) and settle them in payout runs. Outbound counterpart to `PaymentRecord` (incoming) / `CreditLedger` (general).

| Method | Description |
| --- | --- |
| `accrue(payee, amountCents, reference=''): int` | Pending line (amount > 0). |
| `pendingTotal / paidTotal (payee)` | Sum by status. |
| `pay(payee, asOf=null): int` | Settle pending → paid; returns total. |
| `markFailed(id): bool` | Pending → failed. |
| `items(payee, status=null)` | List newest-first. |

- `pending → paid | failed`; `pay()` settles only pending (failed excluded); status guards in WHERE.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 19 assertions (accrue/total, pay settles, nothing→0, fresh-after-pay, markFailed excl/guard, pay skips failed, items all/filtered, separation, validation)
- [x] `composer precommit` green (format → Phan → 4905 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)