### PR TITLE
feat(kit): QuizAttempt — record and score quiz attempts per user (FT292)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -231,6 +231,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `FeatureRequest` | user-submitted feature requests with voting and status tracking. |
 | `Label` | colored label definitions with entity assignment. |
 | `Leaderboard` | Score-based leaderboard with best-score retention, ranking, and personal rank lookup. |
+| `QuizAttempt` | record and score quiz / assessment attempts per user. |
 | `Reaction` | emoji / symbol reactions on any entity. |
 | `ReactionCounter` | emoji/type reactions on any entity with per-user state. |
 | `Referral` | referral code generation, attribution, and conversion tracking. |

--- a/class/kit/QuizAttempt.php
+++ b/class/kit/QuizAttempt.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * QuizAttempt — record and score quiz / assessment attempts per user.
+ *
+ * Logs each attempt at a named quiz with a raw score, the maximum possible
+ * score, and whether it met the pass mark. Supports best-score, has-passed,
+ * attempt history, and a per-quiz pass rate. Distinct from `SurveyResponse`
+ * (FT215, un-scored form answers) and `VotePoll` (FT239, voting).
+ *
+ * Attempts are append-only; a user may attempt a quiz many times.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $q = new QuizAttempt($pdo);
+ *
+ * $q->record('php-basics', userId: 1, score: 7, maxScore: 10, passMark: 6); // passed
+ * $q->record('php-basics', userId: 1, score: 5, maxScore: 10, passMark: 6); // failed
+ *
+ * $q->bestScore('php-basics', 1);   // 7
+ * $q->hasPassed('php-basics', 1);   // true (one attempt passed)
+ * $q->attemptCount('php-basics', 1);// 2
+ * $q->passRate('php-basics');       // 0.5 (1 of 2 attempts passed)
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE quiz_attempts (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     quiz       VARCHAR(150) NOT NULL,
+ *     user_id    BIGINT       NOT NULL,
+ *     score      INTEGER      NOT NULL,
+ *     max_score  INTEGER      NOT NULL,
+ *     passed     INTEGER      NOT NULL DEFAULT 0,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class QuizAttempt
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Record a quiz attempt. Pass/fail is `score >= passMark`.
+     *
+     * @param  string $quiz     Quiz identifier.
+     * @param  int    $userId   User id.
+     * @param  int    $score    Raw score (0 <= score <= maxScore).
+     * @param  int    $maxScore Maximum possible score (> 0).
+     * @param  int    $passMark Minimum score to pass (0 <= passMark <= maxScore).
+     * @return int              New attempt id.
+     * @throws \InvalidArgumentException on empty quiz or out-of-range scores.
+     */
+    public function record(string $quiz, int $userId, int $score, int $maxScore, int $passMark): int
+    {
+        $quiz = $this->validate($quiz);
+        if ($maxScore <= 0) {
+            throw new \InvalidArgumentException('Max score must be positive.');
+        }
+        if ($score < 0 || $score > $maxScore) {
+            throw new \InvalidArgumentException('Score must be between 0 and max score.');
+        }
+        if ($passMark < 0 || $passMark > $maxScore) {
+            throw new \InvalidArgumentException('Pass mark must be between 0 and max score.');
+        }
+
+        $passed = $score >= $passMark ? 1 : 0;
+        $stmt   = $this->db()->prepare(
+            'INSERT INTO quiz_attempts (quiz, user_id, score, max_score, passed) VALUES (?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([$quiz, $userId, $score, $maxScore, $passed]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Best (highest) score a user achieved on a quiz, or null if no attempts.
+     */
+    public function bestScore(string $quiz, int $userId): ?int
+    {
+        $quiz = $this->validate($quiz);
+        $stmt = $this->db()->prepare('SELECT MAX(score) FROM quiz_attempts WHERE quiz = ? AND user_id = ?');
+        $stmt->execute([$quiz, $userId]);
+        $best = $stmt->fetchColumn();
+
+        return $best === null || $best === false ? null : (int)$best;
+    }
+
+    /**
+     * Whether the user has passed the quiz in any attempt.
+     */
+    public function hasPassed(string $quiz, int $userId): bool
+    {
+        $quiz = $this->validate($quiz);
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM quiz_attempts WHERE quiz = ? AND user_id = ? AND passed = 1 LIMIT 1'
+        );
+        $stmt->execute([$quiz, $userId]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Number of attempts a user made on a quiz.
+     */
+    public function attemptCount(string $quiz, int $userId): int
+    {
+        $quiz = $this->validate($quiz);
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM quiz_attempts WHERE quiz = ? AND user_id = ?');
+        $stmt->execute([$quiz, $userId]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * A user's attempts on a quiz, newest first.
+     *
+     * @return array<int,array{score:int,max_score:int,passed:bool}>
+     */
+    public function attempts(string $quiz, int $userId): array
+    {
+        $quiz = $this->validate($quiz);
+        $stmt = $this->db()->prepare(
+            'SELECT score, max_score, passed FROM quiz_attempts WHERE quiz = ? AND user_id = ? ORDER BY id DESC'
+        );
+        $stmt->execute([$quiz, $userId]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = [
+                'score'     => (int)$row['score'],
+                'max_score' => (int)$row['max_score'],
+                'passed'    => (bool)$row['passed'],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Fraction of attempts on a quiz that passed (0.0–1.0), rounded to 4 dp.
+     * Returns 0.0 when there are no attempts.
+     */
+    public function passRate(string $quiz): float
+    {
+        $quiz  = $this->validate($quiz);
+        $stmt  = $this->db()->prepare('SELECT COUNT(*) AS total, COALESCE(SUM(passed), 0) AS passed FROM quiz_attempts WHERE quiz = ?');
+        $stmt->execute([$quiz]);
+        $row   = $stmt->fetch(PDO::FETCH_ASSOC);
+        $total = (int)($row['total'] ?? 0);
+        if ($total === 0) {
+            return 0.0;
+        }
+
+        return round((int)$row['passed'] / $total, 4);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validate(string $quiz): string
+    {
+        $quiz = trim($quiz);
+        if ($quiz === '') {
+            throw new \InvalidArgumentException('Quiz must not be empty.');
+        }
+
+        return $quiz;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-292.md
+++ b/docs/field-trials/2026-05-field-trial-292.md
@@ -1,0 +1,41 @@
+# Field Trial 292 — QuizAttempt
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft292-quiz-attempt`
+**Baseline**: post FT291 merge
+
+## Goal
+
+Add `Nene\Kit\QuizAttempt` — record and score quiz / assessment attempts per user, with best-score, has-passed, history, and per-quiz pass rate. Distinct from `SurveyResponse` (FT215, un-scored answers) and `VotePoll` (FT239, voting).
+
+## What was built
+
+### `Nene\Kit\QuizAttempt` (`class/kit/QuizAttempt.php`)
+
+| Method | Description |
+| --- | --- |
+| `record(quiz, userId, score, maxScore, passMark): int` | Append an attempt; pass = `score >= passMark`. |
+| `bestScore(quiz, userId): ?int` | Highest score (null if none). |
+| `hasPassed(quiz, userId)` | Any passing attempt? |
+| `attemptCount / attempts (quiz, userId)` | Count / history (newest first). |
+| `passRate(quiz): float` | Passed attempts / total (0.0 when none). |
+
+Key design points:
+
+- **Append-only attempts**; pass/fail computed and stored at record time (`score >= passMark`, boundary inclusive).
+- Validation: `0 <= score <= maxScore`, `maxScore > 0`, `0 <= passMark <= maxScore`.
+- `passRate` is attempt-based (passed/total), rounded to 4 dp.
+
+### Tests (`tests/Unit/Kit/QuizAttemptTest.php`)
+
+13 unit tests (20 assertions): record/count, pass-mark boundary (at/below), hasPassed if any passed, bestScore, null/zero when none, attempts newest-first, passRate 0.5, passRate 0 when none, quiz/user separation, validation (score>max, zero max, passMark>max, empty quiz).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/QuizAttemptTest.php
+++ b/tests/Unit/Kit/QuizAttemptTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\QuizAttempt;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for QuizAttempt.
+ */
+final class QuizAttemptTest extends TestCase
+{
+    private PDO $db;
+    private QuizAttempt $q;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE quiz_attempts (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                quiz       VARCHAR(150) NOT NULL,
+                user_id    BIGINT       NOT NULL,
+                score      INTEGER      NOT NULL,
+                max_score  INTEGER      NOT NULL,
+                passed     INTEGER      NOT NULL DEFAULT 0,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->q = new QuizAttempt($this->db);
+    }
+
+    public function testRecordAndAttemptCount(): void
+    {
+        $this->q->record('php', 1, 7, 10, 6);
+        $this->q->record('php', 1, 5, 10, 6);
+        $this->assertSame(2, $this->q->attemptCount('php', 1));
+    }
+
+    public function testPassMarkBoundary(): void
+    {
+        $this->q->record('php', 1, 6, 10, 6); // exactly at pass mark → passed
+        $this->assertTrue($this->q->hasPassed('php', 1));
+        $this->q->record('php', 2, 5, 10, 6); // below → failed
+        $this->assertFalse($this->q->hasPassed('php', 2));
+    }
+
+    public function testHasPassedTrueIfAnyAttemptPassed(): void
+    {
+        $this->q->record('php', 1, 5, 10, 6); // fail
+        $this->q->record('php', 1, 8, 10, 6); // pass
+        $this->assertTrue($this->q->hasPassed('php', 1));
+    }
+
+    public function testBestScore(): void
+    {
+        $this->q->record('php', 1, 5, 10, 6);
+        $this->q->record('php', 1, 9, 10, 6);
+        $this->q->record('php', 1, 7, 10, 6);
+        $this->assertSame(9, $this->q->bestScore('php', 1));
+    }
+
+    public function testBestScoreNullWhenNoAttempts(): void
+    {
+        $this->assertNull($this->q->bestScore('php', 1));
+        $this->assertFalse($this->q->hasPassed('php', 1));
+        $this->assertSame(0, $this->q->attemptCount('php', 1));
+    }
+
+    public function testAttemptsNewestFirst(): void
+    {
+        $this->q->record('php', 1, 5, 10, 6);
+        $this->q->record('php', 1, 8, 10, 6);
+        $attempts = $this->q->attempts('php', 1);
+        $this->assertCount(2, $attempts);
+        $this->assertSame(8, $attempts[0]['score']);   // newest first
+        $this->assertTrue($attempts[0]['passed']);
+        $this->assertFalse($attempts[1]['passed']);
+    }
+
+    public function testPassRate(): void
+    {
+        $this->q->record('php', 1, 8, 10, 6); // pass
+        $this->q->record('php', 2, 7, 10, 6); // pass
+        $this->q->record('php', 3, 4, 10, 6); // fail
+        $this->q->record('php', 4, 3, 10, 6); // fail
+        $this->assertSame(0.5, $this->q->passRate('php'));
+    }
+
+    public function testPassRateZeroWhenNoAttempts(): void
+    {
+        $this->assertSame(0.0, $this->q->passRate('php'));
+    }
+
+    public function testQuizzesAndUsersAreSeparate(): void
+    {
+        $this->q->record('php', 1, 8, 10, 6);
+        $this->assertSame(0, $this->q->attemptCount('sql', 1));
+        $this->assertSame(0, $this->q->attemptCount('php', 2));
+    }
+
+    public function testRecordRejectsScoreAboveMax(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->q->record('php', 1, 11, 10, 6);
+    }
+
+    public function testRecordRejectsZeroMax(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->q->record('php', 1, 0, 0, 0);
+    }
+
+    public function testRecordRejectsPassMarkAboveMax(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->q->record('php', 1, 5, 10, 11);
+    }
+
+    public function testRecordRejectsEmptyQuiz(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->q->record('  ', 1, 5, 10, 6);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT292** — `Nene\Kit\QuizAttempt`: record and score quiz/assessment attempts per user. Distinct from `SurveyResponse` (FT215, un-scored) and `VotePoll` (FT239).

| Method | Description |
| --- | --- |
| `record(quiz, userId, score, maxScore, passMark): int` | Append; pass = `score >= passMark`. |
| `bestScore / hasPassed / attemptCount / attempts` | Read. |
| `passRate(quiz): float` | Passed/total attempts. |

- Append-only; pass computed at record time (inclusive); score/max/passMark range-validated.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 20 assertions (count, pass-mark boundary, hasPassed-any, bestScore, none→null, newest-first, passRate 0.5/0, separation, validation×4)
- [x] `composer precommit` green (format → Phan → 4918 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)