### PR TITLE
feat(kit): ReportSchedule — recurring report definitions with next-run clock (FT293)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -297,6 +297,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `DocumentSignature` | e-signature request workflow with multi-signatory support. |
 | `JobQueue` | simple DB-backed background job queue. |
 | `OptimisticLock` | — |
+| `ReportSchedule` | recurring report definitions with a next-run clock. |
 | `RetrySchedule` | exponential-backoff retry tracking for arbitrary operations. |
 | `RoundRobinAssigner` | fair rotating assignment across a named pool. |
 | `ScheduledTask` | cron-style task schedule registry with last-run tracking. |

--- a/class/kit/ReportSchedule.php
+++ b/class/kit/ReportSchedule.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * ReportSchedule — recurring report definitions with a next-run clock.
+ *
+ * Stores named scheduled reports — their recipients, output format, and
+ * fixed-interval cadence — and tracks when each is next due. A report cron
+ * calls {@see ReportSchedule::due()} to find reports to generate, then
+ * {@see ReportSchedule::markGenerated()} to advance the next-run time by the
+ * interval (cadence-preserving, no drift). Distinct from `ScheduledTask`
+ * (FT174, a generic last-run registry): this carries report-specific config
+ * (recipients, format) and an interval-advancing next-run.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $rs = new ReportSchedule($pdo);
+ *
+ * $rs->schedule('weekly-sales', intervalDays: 7, recipients: ['ops@x.com'], format: 'pdf', firstRun: '2026-06-01 06:00:00');
+ *
+ * foreach ($rs->due('2026-06-01 07:00:00') as $r) {
+ *     // generate $r['name'] for $r['recipients'] in $r['format'] …
+ *     $rs->markGenerated($r['name']); // next_run += 7 days
+ * }
+ *
+ * $rs->pause('weekly-sales');   // stop without deleting
+ * $rs->resume('weekly-sales');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE report_schedules (
+ *     id            INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     name          VARCHAR(150) NOT NULL,
+ *     recipients    TEXT         NOT NULL DEFAULT '[]',
+ *     format        VARCHAR(20)  NOT NULL DEFAULT 'csv',
+ *     interval_days INTEGER      NOT NULL,
+ *     next_run      DATETIME     NOT NULL,
+ *     active        INTEGER      NOT NULL DEFAULT 1,
+ *     created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (name)
+ * );
+ * ```
+ */
+final class ReportSchedule
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create or replace a scheduled report. Idempotent per name; re-scheduling
+     * resets cadence and re-activates.
+     *
+     * @param  string             $name        Report name.
+     * @param  int                $intervalDays Cadence in days (>= 1).
+     * @param  array<int,string>  $recipients  Recipient list.
+     * @param  string             $format      Output format (e.g. 'csv', 'pdf').
+     * @param  string|null        $firstRun    First run time; defaults to now.
+     * @throws \InvalidArgumentException on empty name, interval < 1, or bad time.
+     */
+    public function schedule(string $name, int $intervalDays, array $recipients = [], string $format = 'csv', ?string $firstRun = null): void
+    {
+        $name = $this->validate($name);
+        if ($intervalDays < 1) {
+            throw new \InvalidArgumentException('Interval must be at least 1 day.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'report_schedules',
+            data:         [
+                'name'          => $name,
+                'recipients'    => json_encode(array_values($recipients), JSON_THROW_ON_ERROR),
+                'format'        => trim($format),
+                'interval_days' => $intervalDays,
+                'next_run'      => $this->ts($firstRun),
+                'active'        => 1,
+            ],
+            conflictCols: ['name'],
+            updateCols:   ['recipients', 'format', 'interval_days', 'next_run', 'active'],
+        );
+    }
+
+    /**
+     * Active reports due to run (next_run on or before the reference time),
+     * soonest first.
+     *
+     * @param  string|null $asOf Reference time; defaults to now.
+     * @return array<int,array{name:string,recipients:array<int,string>,format:string,next_run:string}>
+     */
+    public function due(?string $asOf = null): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT name, recipients, format, next_run FROM report_schedules
+             WHERE active = 1 AND next_run <= ? ORDER BY next_run ASC'
+        );
+        $stmt->execute([$this->ts($asOf)]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = [
+                'name'       => (string)$row['name'],
+                'recipients' => $this->decodeRecipients((string)$row['recipients']),
+                'format'     => (string)$row['format'],
+                'next_run'   => (string)$row['next_run'],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Advance a report's next-run time by its interval (cadence-preserving).
+     *
+     * @param  string $name Report name (must be scheduled).
+     * @throws \InvalidArgumentException if the report is not scheduled.
+     */
+    public function markGenerated(string $name): void
+    {
+        $name = $this->validate($name);
+        $row  = $this->fetch($name);
+        if ($row === null) {
+            throw new \InvalidArgumentException("Report is not scheduled: {$name}");
+        }
+
+        $next = (new \DateTimeImmutable((string)$row['next_run']))
+            ->add(new \DateInterval('P' . (int)$row['interval_days'] . 'D'))
+            ->format('Y-m-d H:i:s');
+
+        $stmt = $this->db()->prepare('UPDATE report_schedules SET next_run = ? WHERE name = ?');
+        $stmt->execute([$next, $name]);
+    }
+
+    /**
+     * Return a report's full definition, or null.
+     *
+     * @return array{name:string,recipients:array<int,string>,format:string,interval_days:int,next_run:string,active:bool}|null
+     */
+    public function get(string $name): ?array
+    {
+        $row = $this->fetch($this->validate($name));
+        if ($row === null) {
+            return null;
+        }
+
+        return [
+            'name'          => (string)$row['name'],
+            'recipients'    => $this->decodeRecipients((string)$row['recipients']),
+            'format'        => (string)$row['format'],
+            'interval_days' => (int)$row['interval_days'],
+            'next_run'      => (string)$row['next_run'],
+            'active'        => (bool)$row['active'],
+        ];
+    }
+
+    /**
+     * Pause a report (excluded from due()). No-op if absent.
+     */
+    public function pause(string $name): void
+    {
+        $this->setActive($name, false);
+    }
+
+    /**
+     * Resume a paused report. No-op if absent.
+     */
+    public function resume(string $name): void
+    {
+        $this->setActive($name, true);
+    }
+
+    /**
+     * Delete a scheduled report. No-op if absent.
+     */
+    public function remove(string $name): void
+    {
+        $name = $this->validate($name);
+        $stmt = $this->db()->prepare('DELETE FROM report_schedules WHERE name = ?');
+        $stmt->execute([$name]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function setActive(string $name, bool $active): void
+    {
+        $name = $this->validate($name);
+        $stmt = $this->db()->prepare('UPDATE report_schedules SET active = ? WHERE name = ?');
+        $stmt->execute([$active ? 1 : 0, $name]);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function fetch(string $name): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT name, recipients, format, interval_days, next_run, active FROM report_schedules WHERE name = ?'
+        );
+        $stmt->execute([$name]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function decodeRecipients(string $json): array
+    {
+        /** @var mixed $decoded */
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return array_map(static fn ($r): string => (string)$r, array_values($decoded));
+    }
+
+    private function validate(string $name): string
+    {
+        $name = trim($name);
+        if ($name === '') {
+            throw new \InvalidArgumentException('Name must not be empty.');
+        }
+
+        return $name;
+    }
+
+    private function ts(?string $value): string
+    {
+        $epoch = strtotime($value ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid time.');
+        }
+
+        return date('Y-m-d H:i:s', $epoch);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-293.md
+++ b/docs/field-trials/2026-05-field-trial-293.md
@@ -1,0 +1,39 @@
+# Field Trial 293 — ReportSchedule
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft293-report-schedule`
+**Baseline**: post FT292 merge
+
+## Goal
+
+Add `Nene\Kit\ReportSchedule` — recurring report definitions (recipients, format, fixed-interval cadence) with a next-run clock for a report-generation cron. Distinct from `ScheduledTask` (FT174, generic last-run registry): this carries report config and an interval-advancing next-run.
+
+## What was built
+
+### `Nene\Kit\ReportSchedule` (`class/kit/ReportSchedule.php`)
+
+| Method | Description |
+| --- | --- |
+| `schedule(name, intervalDays, recipients=[], format='csv', firstRun=null)` | Upsert; resets cadence + re-activates. |
+| `due(asOf=null)` | Active reports with next_run ≤ now, soonest first. |
+| `markGenerated(name)` | Advance next_run by interval (cadence-preserving). |
+| `get(name) / pause / resume / remove` | Read / toggle / delete. |
+
+Key design points:
+
+- **Cadence-preserving advance**: `markGenerated` adds the interval to the *previous* next_run (not "now"), so a fixed schedule never drifts.
+- `due` is `active = 1 AND next_run <= asOf`; pause excludes without deleting; recipients stored as JSON.
+
+### Tests (`tests/Unit/Kit/ReportScheduleTest.php`)
+
+13 unit tests (25 assertions): schedule/get, due boundary (before/at/after), markGenerated +interval, cadence-preserving over two runs, due soonest-first, pause excludes, resume, idempotent re-schedule re-activates, remove, unknown get null, markGenerated-unknown throws, validation (zero interval, empty name).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/ReportScheduleTest.php
+++ b/tests/Unit/Kit/ReportScheduleTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\ReportSchedule;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ReportSchedule.
+ */
+final class ReportScheduleTest extends TestCase
+{
+    private PDO $db;
+    private ReportSchedule $rs;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE report_schedules (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                name          VARCHAR(150) NOT NULL,
+                recipients    TEXT         NOT NULL DEFAULT \'[]\',
+                format        VARCHAR(20)  NOT NULL DEFAULT \'csv\',
+                interval_days INTEGER      NOT NULL,
+                next_run      DATETIME     NOT NULL,
+                active        INTEGER      NOT NULL DEFAULT 1,
+                created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (name)
+            )
+        ');
+        $this->rs = new ReportSchedule($this->db);
+    }
+
+    public function testScheduleAndGet(): void
+    {
+        $this->rs->schedule('weekly', 7, ['a@x.com', 'b@x.com'], 'pdf', '2026-06-01 06:00:00');
+        $g = $this->rs->get('weekly');
+        $this->assertNotNull($g);
+        $this->assertSame(7, $g['interval_days']);
+        $this->assertSame('pdf', $g['format']);
+        $this->assertSame(['a@x.com', 'b@x.com'], $g['recipients']);
+        $this->assertSame('2026-06-01 06:00:00', $g['next_run']);
+        $this->assertTrue($g['active']);
+    }
+
+    public function testDueRespectsNextRun(): void
+    {
+        $this->rs->schedule('weekly', 7, [], 'csv', '2026-06-01 06:00:00');
+        $this->assertSame([], $this->rs->due('2026-06-01 05:00:00'));  // before
+        $this->assertCount(1, $this->rs->due('2026-06-01 06:00:00'));  // exactly at next_run
+        $this->assertCount(1, $this->rs->due('2026-06-02 00:00:00'));  // after
+    }
+
+    public function testMarkGeneratedAdvancesByInterval(): void
+    {
+        $this->rs->schedule('weekly', 7, [], 'csv', '2026-06-01 06:00:00');
+        $this->rs->markGenerated('weekly');
+        $this->assertSame('2026-06-08 06:00:00', $this->rs->get('weekly')['next_run']);
+        // No longer due at a time before the new next_run.
+        $this->assertSame([], $this->rs->due('2026-06-02 00:00:00'));
+    }
+
+    public function testMarkGeneratedIsCadencePreserving(): void
+    {
+        // Advancing from next_run (not from "now") keeps a fixed cadence.
+        $this->rs->schedule('daily', 1, [], 'csv', '2026-06-01 00:00:00');
+        $this->rs->markGenerated('daily');
+        $this->rs->markGenerated('daily');
+        $this->assertSame('2026-06-03 00:00:00', $this->rs->get('daily')['next_run']);
+    }
+
+    public function testDueSoonestFirst(): void
+    {
+        $this->rs->schedule('a', 7, [], 'csv', '2026-06-05 00:00:00');
+        $this->rs->schedule('b', 7, [], 'csv', '2026-06-01 00:00:00');
+        $due = $this->rs->due('2026-06-10 00:00:00');
+        $this->assertSame('b', $due[0]['name']);
+        $this->assertSame('a', $due[1]['name']);
+    }
+
+    public function testPauseExcludesFromDue(): void
+    {
+        $this->rs->schedule('weekly', 7, [], 'csv', '2026-06-01 06:00:00');
+        $this->rs->pause('weekly');
+        $this->assertSame([], $this->rs->due('2026-07-01 00:00:00'));
+        $this->assertFalse($this->rs->get('weekly')['active']);
+    }
+
+    public function testResume(): void
+    {
+        $this->rs->schedule('weekly', 7, [], 'csv', '2026-06-01 06:00:00');
+        $this->rs->pause('weekly');
+        $this->rs->resume('weekly');
+        $this->assertCount(1, $this->rs->due('2026-07-01 00:00:00'));
+    }
+
+    public function testScheduleIsIdempotentAndReactivates(): void
+    {
+        $this->rs->schedule('weekly', 7, [], 'csv', '2026-06-01 06:00:00');
+        $this->rs->pause('weekly');
+        $this->rs->schedule('weekly', 30, ['x@y.com'], 'xlsx', '2026-07-01 06:00:00');
+        $g = $this->rs->get('weekly');
+        $this->assertSame(30, $g['interval_days']);
+        $this->assertTrue($g['active']); // re-scheduling re-activates
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM report_schedules')->fetchColumn());
+    }
+
+    public function testRemove(): void
+    {
+        $this->rs->schedule('weekly', 7, [], 'csv', '2026-06-01 06:00:00');
+        $this->rs->remove('weekly');
+        $this->assertNull($this->rs->get('weekly'));
+    }
+
+    public function testGetUnknownIsNull(): void
+    {
+        $this->assertNull($this->rs->get('nope'));
+    }
+
+    public function testMarkGeneratedUnknownThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rs->markGenerated('nope');
+    }
+
+    public function testScheduleRejectsZeroInterval(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rs->schedule('weekly', 0);
+    }
+
+    public function testScheduleRejectsEmptyName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->rs->schedule('  ', 7);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT293** — `Nene\Kit\ReportSchedule`: recurring report definitions (recipients, format, interval) with a next-run clock for a report-generation cron. Distinct from `ScheduledTask` (FT174, generic last-run registry).

| Method | Description |
| --- | --- |
| `schedule(name, intervalDays, recipients=[], format='csv', firstRun=null)` | Upsert; resets cadence + re-activates. |
| `due(asOf=null)` | Active, next_run ≤ now, soonest first. |
| `markGenerated(name)` | Advance next_run by interval (cadence-preserving). |
| `get / pause / resume / remove` | Read / toggle / delete. |

- `markGenerated` advances from the previous next_run (not "now") → fixed cadence, no drift.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 25 assertions (due boundary, +interval, cadence-preserving ×2, soonest-first, pause/resume, idempotent re-activate, remove, unknown null/throw, validation)
- [x] `composer precommit` green (format → Phan → 4931 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)