### PR TITLE
feat(kit): Raffle — ticket-based prize draw with weighted winners (FT294)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -232,6 +232,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `Label` | colored label definitions with entity assignment. |
 | `Leaderboard` | Score-based leaderboard with best-score retention, ranking, and personal rank lookup. |
 | `QuizAttempt` | record and score quiz / assessment attempts per user. |
+| `Raffle` | ticket-based prize draw with weighted winner selection. |
 | `Reaction` | emoji / symbol reactions on any entity. |
 | `ReactionCounter` | emoji/type reactions on any entity with per-user state. |
 | `Referral` | referral code generation, attribution, and conversion tracking. |

--- a/class/kit/Raffle.php
+++ b/class/kit/Raffle.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * Raffle — ticket-based prize draw with weighted winner selection.
+ *
+ * Collects entries (tickets) per participant for a named raffle, then draws a
+ * number of distinct winners with probability proportional to ticket count.
+ * Distinct from `WeightedPicker` (FT277, a stateless weighted pick over a
+ * configured pool): this accumulates real participant entries and draws
+ * *distinct* winners from them.
+ *
+ * `draw()` is random; pass a `$seed` for a deterministic, reproducible draw
+ * (audited draws, tests).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $r = new Raffle($pdo);
+ *
+ * $r->enter('summer', 'alice', tickets: 3);
+ * $r->enter('summer', 'bob');
+ * $r->enter('summer', 'carol', tickets: 2);
+ *
+ * $r->entryCount('summer');        // 6 tickets
+ * $r->ticketsFor('summer', 'alice'); // 3
+ * $winners = $r->draw('summer', 2); // 2 distinct participants, ticket-weighted
+ * $r->draw('summer', 1, seed: 42);  // deterministic
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE raffle_entries (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     raffle      VARCHAR(150) NOT NULL,
+ *     participant VARCHAR(190) NOT NULL,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class Raffle
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add tickets for a participant in a raffle. More tickets = higher chance.
+     *
+     * @param  string $raffle      Raffle name.
+     * @param  string $participant Participant identifier.
+     * @param  int    $tickets     Number of tickets to add (>= 1).
+     * @throws \InvalidArgumentException on empty names or tickets < 1.
+     */
+    public function enter(string $raffle, string $participant, int $tickets = 1): void
+    {
+        $raffle      = $this->validate($raffle, 'Raffle');
+        $participant = $this->validate($participant, 'Participant');
+        if ($tickets < 1) {
+            throw new \InvalidArgumentException('Tickets must be at least 1.');
+        }
+
+        $db             = $this->db();
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+        try {
+            $stmt = $db->prepare('INSERT INTO raffle_entries (raffle, participant) VALUES (?, ?)');
+            for ($i = 0; $i < $tickets; $i++) {
+                $stmt->execute([$raffle, $participant]);
+            }
+            if ($ownTransaction) {
+                $db->commit();
+            }
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Total tickets entered in a raffle.
+     */
+    public function entryCount(string $raffle): int
+    {
+        $raffle = $this->validate($raffle, 'Raffle');
+        $stmt   = $this->db()->prepare('SELECT COUNT(*) FROM raffle_entries WHERE raffle = ?');
+        $stmt->execute([$raffle]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Tickets held by a participant in a raffle.
+     */
+    public function ticketsFor(string $raffle, string $participant): int
+    {
+        $raffle      = $this->validate($raffle, 'Raffle');
+        $participant = $this->validate($participant, 'Participant');
+        $stmt        = $this->db()->prepare('SELECT COUNT(*) FROM raffle_entries WHERE raffle = ? AND participant = ?');
+        $stmt->execute([$raffle, $participant]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Whether a participant has any tickets in a raffle.
+     */
+    public function hasEntered(string $raffle, string $participant): bool
+    {
+        return $this->ticketsFor($raffle, $participant) > 0;
+    }
+
+    /**
+     * Distinct participants in a raffle, ascending.
+     *
+     * @return array<int,string>
+     */
+    public function participants(string $raffle): array
+    {
+        $raffle = $this->validate($raffle, 'Raffle');
+        $stmt   = $this->db()->prepare('SELECT DISTINCT participant FROM raffle_entries WHERE raffle = ? ORDER BY participant ASC');
+        $stmt->execute([$raffle]);
+
+        return array_map(static fn ($p): string => (string)$p, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    /**
+     * Draw distinct winners, weighted by ticket count.
+     *
+     * @param  string   $raffle Raffle name.
+     * @param  int      $count  Number of distinct winners to draw (>= 1).
+     * @param  int|null $seed   Seed for a deterministic draw, or null for random.
+     * @return array<int,string> Winning participants (up to the number available).
+     * @throws \InvalidArgumentException on empty raffle or count < 1.
+     */
+    public function draw(string $raffle, int $count = 1, ?int $seed = null): array
+    {
+        $raffle = $this->validate($raffle, 'Raffle');
+        if ($count < 1) {
+            throw new \InvalidArgumentException('Count must be at least 1.');
+        }
+
+        $stmt = $this->db()->prepare('SELECT participant FROM raffle_entries WHERE raffle = ? ORDER BY id ASC');
+        $stmt->execute([$raffle]);
+        /** @var array<int,string> $tickets */
+        $tickets = array_map(static fn ($p): string => (string)$p, $stmt->fetchAll(PDO::FETCH_COLUMN));
+        if ($tickets === []) {
+            return [];
+        }
+
+        if ($seed !== null) {
+            mt_srand($seed);
+        }
+        // Fisher–Yates shuffle of the ticket list, then take distinct
+        // participants in shuffled order — more tickets ⇒ likelier to appear first.
+        for ($i = count($tickets) - 1; $i > 0; $i--) {
+            $j = mt_rand(0, $i);
+            [$tickets[$i], $tickets[$j]] = [$tickets[$j], $tickets[$i]];
+        }
+        if ($seed !== null) {
+            mt_srand();
+        }
+
+        $winners = [];
+        foreach ($tickets as $p) {
+            if (!in_array($p, $winners, true)) {
+                $winners[] = $p;
+                if (count($winners) === $count) {
+                    break;
+                }
+            }
+        }
+
+        return $winners;
+    }
+
+    /**
+     * Remove all entries for a raffle. Returns the number of tickets removed.
+     */
+    public function clear(string $raffle): int
+    {
+        $raffle = $this->validate($raffle, 'Raffle');
+        $stmt   = $this->db()->prepare('DELETE FROM raffle_entries WHERE raffle = ?');
+        $stmt->execute([$raffle]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-294.md
+++ b/docs/field-trials/2026-05-field-trial-294.md
@@ -1,0 +1,40 @@
+# Field Trial 294 — Raffle
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft294-raffle`
+**Baseline**: post FT293 merge
+
+## Goal
+
+Add `Nene\Kit\Raffle` — ticket-based prize draw: collect entries per participant, then draw distinct winners weighted by ticket count. Distinct from `WeightedPicker` (FT277, stateless weighted pick over a configured pool): this accumulates real participant entries.
+
+## What was built
+
+### `Nene\Kit\Raffle` (`class/kit/Raffle.php`)
+
+| Method | Description |
+| --- | --- |
+| `enter(raffle, participant, tickets=1)` | Add tickets (each a row; more tickets = higher chance). |
+| `entryCount / ticketsFor / hasEntered / participants` | Counts / membership. |
+| `draw(raffle, count=1, seed=null): array` | Distinct winners, ticket-weighted; seedable. |
+| `clear(raffle): int` | Remove all entries. |
+
+Key design points:
+
+- **Ticket-weighted distinct draw**: Fisher–Yates shuffle of the ticket list, then take distinct participants in shuffle order (more tickets ⇒ likelier early ⇒ weighted), clamped to available participants.
+- **Seedable** (`mt_srand($seed)`) for reproducible/audited draws; restores the RNG afterward.
+- Entries added inside a transaction.
+
+### Tests (`tests/Unit/Kit/RaffleTest.php`)
+
+12 unit tests (20 assertions), property-based for the random parts: enter/counts, hasEntered/participants, draw returns an entrant, **distinct winners (no dupes)**, count clamps to participants, empty raffle → empty, **seeded draw deterministic**, raffle separation, clear, validation (zero tickets, empty participant, zero count).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/RaffleTest.php
+++ b/tests/Unit/Kit/RaffleTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\Raffle;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Raffle.
+ *
+ * Winner identity from a shuffle isn't hard-coded; tests assert *properties*
+ * (winner is an entrant, distinct, count) plus seeded determinism.
+ */
+final class RaffleTest extends TestCase
+{
+    private PDO $db;
+    private Raffle $r;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE raffle_entries (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                raffle      VARCHAR(150) NOT NULL,
+                participant VARCHAR(190) NOT NULL,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->r = new Raffle($this->db);
+    }
+
+    public function testEnterAndCounts(): void
+    {
+        $this->r->enter('summer', 'alice', 3);
+        $this->r->enter('summer', 'bob');
+        $this->assertSame(4, $this->r->entryCount('summer'));
+        $this->assertSame(3, $this->r->ticketsFor('summer', 'alice'));
+        $this->assertSame(1, $this->r->ticketsFor('summer', 'bob'));
+    }
+
+    public function testHasEnteredAndParticipants(): void
+    {
+        $this->r->enter('summer', 'alice', 2);
+        $this->r->enter('summer', 'carol');
+        $this->assertTrue($this->r->hasEntered('summer', 'alice'));
+        $this->assertFalse($this->r->hasEntered('summer', 'dave'));
+        $this->assertSame(['alice', 'carol'], $this->r->participants('summer'));
+    }
+
+    public function testDrawReturnsAnEntrant(): void
+    {
+        $this->r->enter('summer', 'alice', 3);
+        $this->r->enter('summer', 'bob', 2);
+        $winners = $this->r->draw('summer', 1);
+        $this->assertCount(1, $winners);
+        $this->assertContains($winners[0], ['alice', 'bob']);
+    }
+
+    public function testDrawDistinctWinners(): void
+    {
+        $this->r->enter('summer', 'a', 5);
+        $this->r->enter('summer', 'b', 5);
+        $this->r->enter('summer', 'c', 5);
+        $winners = $this->r->draw('summer', 3);
+        $this->assertCount(3, $winners);
+        $this->assertSame($winners, array_values(array_unique($winners))); // no dupes
+    }
+
+    public function testDrawCountClampsToParticipants(): void
+    {
+        $this->r->enter('summer', 'a', 10);
+        $this->r->enter('summer', 'b', 10);
+        $winners = $this->r->draw('summer', 5); // only 2 distinct participants
+        $this->assertCount(2, $winners);
+    }
+
+    public function testDrawEmptyRaffleReturnsEmpty(): void
+    {
+        $this->assertSame([], $this->r->draw('ghost', 1));
+    }
+
+    public function testSeededDrawIsDeterministic(): void
+    {
+        $this->r->enter('summer', 'a', 3);
+        $this->r->enter('summer', 'b', 3);
+        $this->r->enter('summer', 'c', 3);
+        $first  = $this->r->draw('summer', 2, seed: 12345);
+        $second = $this->r->draw('summer', 2, seed: 12345);
+        $this->assertSame($first, $second);
+    }
+
+    public function testRafflesAreSeparate(): void
+    {
+        $this->r->enter('a', 'alice');
+        $this->r->enter('b', 'bob');
+        $this->assertSame(1, $this->r->entryCount('a'));
+        $this->assertSame(['bob'], $this->r->participants('b'));
+    }
+
+    public function testClear(): void
+    {
+        $this->r->enter('summer', 'a', 3);
+        $removed = $this->r->clear('summer');
+        $this->assertSame(3, $removed);
+        $this->assertSame(0, $this->r->entryCount('summer'));
+    }
+
+    public function testEnterRejectsZeroTickets(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->enter('summer', 'a', 0);
+    }
+
+    public function testEnterRejectsEmptyParticipant(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->enter('summer', '  ');
+    }
+
+    public function testDrawRejectsZeroCount(): void
+    {
+        $this->r->enter('summer', 'a');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->draw('summer', 0);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT294** — `Nene\Kit\Raffle`: collect per-participant ticket entries, then draw distinct winners weighted by ticket count. Distinct from `WeightedPicker` (FT277, stateless pick over a configured pool).

| Method | Description |
| --- | --- |
| `enter(raffle, participant, tickets=1)` | Add tickets. |
| `entryCount / ticketsFor / hasEntered / participants` | Counts. |
| `draw(raffle, count=1, seed=null): array` | Distinct weighted winners; seedable. |
| `clear(raffle): int` | Remove entries. |

- Fisher–Yates shuffle of tickets → distinct participants in order (ticket-weighted), clamped; seed for reproducible draws.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 20 assertions, property-based (entrant, distinct no-dupe, clamp, empty, **seeded determinism**, separation, clear, validation)
- [x] `composer precommit` green (format → Phan → 4943 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)