### PR TITLE
feat(kit): PurchaseLimit — per-user per-SKU purchase caps (FT295)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -183,6 +183,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `PriceList` | product price catalog with multiple price tiers per SKU. |
 | `ProductBundle` | product bundle definitions with included items. |
 | `ProductReview` | entity reviews with ratings and helpfulness voting. |
+| `PurchaseLimit` | per-user purchase caps per SKU over a rolling window. |
 | `Quota` | plan-based resource quota management. |
 | `RecurringPayment` | Recurring payment schedule management. |
 | `ShippingZone` | region → shipping-zone rate lookup with free-shipping threshold. |

--- a/class/kit/PurchaseLimit.php
+++ b/class/kit/PurchaseLimit.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * PurchaseLimit — per-user purchase caps per SKU over a rolling window.
+ *
+ * Enforces "max N of this item per user per P days" rules (limited drops,
+ * fair-allocation sales, regulated goods). A policy table holds the cap per
+ * SKU; a records table logs purchases; `canPurchase()` checks the rolling
+ * window. Distinct from `Quota` (FT166, plan resource quotas) and
+ * `StorageQuota`: this is per-user, per-SKU purchase frequency.
+ *
+ * Integer quantities; `asOf` makes the rolling window deterministic in tests.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $pl = new PurchaseLimit($pdo);
+ *
+ * $pl->setLimit('sku-1', maxQty: 2, periodDays: 30);  // 2 per 30 days
+ *
+ * $pl->canPurchase('sku-1', userId: 7, qty: 2);  // true
+ * $pl->record('sku-1', 7, 2);                    // they buy 2
+ * $pl->remaining('sku-1', 7);                    // 0
+ * $pl->canPurchase('sku-1', 7, 1);               // false (cap reached)
+ *
+ * $pl->canPurchase('unlimited-sku', 7, 99);      // true (no policy = unlimited)
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE purchase_limit_policies (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     sku         VARCHAR(150) NOT NULL,
+ *     max_qty     INTEGER      NOT NULL,
+ *     period_days INTEGER      NOT NULL,
+ *     UNIQUE (sku)
+ * );
+ * CREATE TABLE purchase_limit_records (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     sku          VARCHAR(150) NOT NULL,
+ *     user_id      BIGINT       NOT NULL,
+ *     qty          INTEGER      NOT NULL,
+ *     purchased_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class PurchaseLimit
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── policy ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Set (or replace) the purchase cap for a SKU. Idempotent per SKU.
+     *
+     * @param  string $sku        Product identifier.
+     * @param  int    $maxQty     Max units per user per window (>= 1).
+     * @param  int    $periodDays Rolling window length in days (>= 1).
+     * @throws \InvalidArgumentException on empty SKU or non-positive bounds.
+     */
+    public function setLimit(string $sku, int $maxQty, int $periodDays): void
+    {
+        $sku = $this->validate($sku, 'SKU');
+        if ($maxQty < 1 || $periodDays < 1) {
+            throw new \InvalidArgumentException('Max quantity and period must be at least 1.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'purchase_limit_policies',
+            data:         ['sku' => $sku, 'max_qty' => $maxQty, 'period_days' => $periodDays],
+            conflictCols: ['sku'],
+            updateCols:   ['max_qty', 'period_days'],
+        );
+    }
+
+    /**
+     * Remove a SKU's cap (makes it unlimited). No-op if absent.
+     */
+    public function removeLimit(string $sku): void
+    {
+        $sku  = $this->validate($sku, 'SKU');
+        $stmt = $this->db()->prepare('DELETE FROM purchase_limit_policies WHERE sku = ?');
+        $stmt->execute([$sku]);
+    }
+
+    // ── purchases ─────────────────────────────────────────────────────────────
+
+    /**
+     * Record a purchase (always logged, even for un-capped SKUs).
+     *
+     * @param  string      $sku    Product identifier.
+     * @param  int         $userId Buyer user id.
+     * @param  int         $qty    Quantity purchased (>= 1).
+     * @param  string|null $asOf   Purchase time; defaults to now.
+     * @throws \InvalidArgumentException on empty SKU or qty < 1.
+     */
+    public function record(string $sku, int $userId, int $qty, ?string $asOf = null): void
+    {
+        $sku = $this->validate($sku, 'SKU');
+        if ($qty < 1) {
+            throw new \InvalidArgumentException('Quantity must be at least 1.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO purchase_limit_records (sku, user_id, qty, purchased_at) VALUES (?, ?, ?, ?)'
+        );
+        $stmt->execute([$sku, $userId, $qty, $this->ts($asOf)]);
+    }
+
+    /**
+     * Quantity a user has purchased of a SKU within the current rolling window.
+     *
+     * @param string      $sku    Product identifier.
+     * @param int         $userId Buyer user id.
+     * @param string|null $asOf   Reference time; defaults to now.
+     */
+    public function purchasedInPeriod(string $sku, int $userId, ?string $asOf = null): int
+    {
+        $sku    = $this->validate($sku, 'SKU');
+        $policy = $this->policy($sku);
+        // With no policy there is no window; count is meaningful only relative to
+        // a window, so use the policy window if present, else all-time.
+        if ($policy !== null) {
+            $cutoff = $this->windowCutoff($policy['period_days'], $asOf);
+            $stmt   = $this->db()->prepare(
+                'SELECT COALESCE(SUM(qty), 0) FROM purchase_limit_records WHERE sku = ? AND user_id = ? AND purchased_at >= ?'
+            );
+            $stmt->execute([$sku, $userId, $cutoff]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT COALESCE(SUM(qty), 0) FROM purchase_limit_records WHERE sku = ? AND user_id = ?'
+            );
+            $stmt->execute([$sku, $userId]);
+        }
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Remaining units a user may purchase, or null if the SKU is un-capped.
+     *
+     * @return int|null Never negative.
+     */
+    public function remaining(string $sku, int $userId, ?string $asOf = null): ?int
+    {
+        $sku    = $this->validate($sku, 'SKU');
+        $policy = $this->policy($sku);
+        if ($policy === null) {
+            return null;
+        }
+
+        return max(0, $policy['max_qty'] - $this->purchasedInPeriod($sku, $userId, $asOf));
+    }
+
+    /**
+     * Whether a user may purchase $qty more of a SKU now. Un-capped SKUs always allow.
+     *
+     * @throws \InvalidArgumentException on qty < 1.
+     */
+    public function canPurchase(string $sku, int $userId, int $qty, ?string $asOf = null): bool
+    {
+        if ($qty < 1) {
+            throw new \InvalidArgumentException('Quantity must be at least 1.');
+        }
+        $remaining = $this->remaining($sku, $userId, $asOf);
+
+        return $remaining === null || $qty <= $remaining;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array{max_qty:int,period_days:int}|null
+     */
+    private function policy(string $sku): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT max_qty, period_days FROM purchase_limit_policies WHERE sku = ?');
+        $stmt->execute([$sku]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : ['max_qty' => (int)$row['max_qty'], 'period_days' => (int)$row['period_days']];
+    }
+
+    private function windowCutoff(int $periodDays, ?string $asOf): string
+    {
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid reference time.');
+        }
+
+        return date('Y-m-d H:i:s', $epoch - $periodDays * 86400);
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function ts(?string $asOf): string
+    {
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid timestamp.');
+        }
+
+        return date('Y-m-d H:i:s', $epoch);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-295.md
+++ b/docs/field-trials/2026-05-field-trial-295.md
@@ -1,0 +1,43 @@
+# Field Trial 295 — PurchaseLimit
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft295-purchase-limit`
+**Baseline**: post FT294 merge
+
+## Goal
+
+Add `Nene\Kit\PurchaseLimit` — per-user purchase caps per SKU over a rolling window ("max N per user per P days": limited drops, fair allocation, regulated goods). Distinct from `Quota` (FT166, plan resource quotas) and `StorageQuota`.
+
+## What was built
+
+### `Nene\Kit\PurchaseLimit` (`class/kit/PurchaseLimit.php`)
+
+Two tables: a per-SKU policy (max + window) and a purchase-records log.
+
+| Method | Description |
+| --- | --- |
+| `setLimit(sku, maxQty, periodDays) / removeLimit(sku)` | Configure / clear cap. |
+| `record(sku, userId, qty, asOf=null)` | Log a purchase. |
+| `purchasedInPeriod(sku, userId, asOf=null)` | Qty bought in the rolling window. |
+| `remaining(sku, userId, asOf=null): ?int` | Units left (null = un-capped). |
+| `canPurchase(sku, userId, qty, asOf=null): bool` | Cap check (un-capped → true). |
+
+Key design points:
+
+- **Rolling window**: counts records with `purchased_at >= asOf - periodDays` (boundary inclusive); old purchases age out.
+- **Un-capped = unlimited**: no policy → `remaining` null, `canPurchase` true; records are still logged.
+- Integer quantities; `asOf` makes the window deterministic in tests.
+
+### Tests (`tests/Unit/Kit/PurchaseLimitTest.php`)
+
+12 unit tests (21 assertions): un-capped always allows, remaining/cap, canPurchase up-to-cap, rolling window expiry, window boundary inclusive, user/SKU separation, removeLimit → unlimited, idempotent setLimit, validation (zero limit, zero record qty, zero canPurchase qty).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/PurchaseLimitTest.php
+++ b/tests/Unit/Kit/PurchaseLimitTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\PurchaseLimit;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PurchaseLimit.
+ */
+final class PurchaseLimitTest extends TestCase
+{
+    private PDO $db;
+    private PurchaseLimit $pl;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE purchase_limit_policies (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                sku         VARCHAR(150) NOT NULL,
+                max_qty     INTEGER      NOT NULL,
+                period_days INTEGER      NOT NULL,
+                UNIQUE (sku)
+            )
+        ');
+        $this->db->exec('
+            CREATE TABLE purchase_limit_records (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                sku          VARCHAR(150) NOT NULL,
+                user_id      BIGINT       NOT NULL,
+                qty          INTEGER      NOT NULL,
+                purchased_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->pl = new PurchaseLimit($this->db);
+    }
+
+    public function testUncappedSkuAlwaysAllows(): void
+    {
+        $this->assertTrue($this->pl->canPurchase('free', 7, 999));
+        $this->assertNull($this->pl->remaining('free', 7));
+    }
+
+    public function testRemainingAndCap(): void
+    {
+        $this->pl->setLimit('sku', 2, 30);
+        $this->assertSame(2, $this->pl->remaining('sku', 7));
+        $this->pl->record('sku', 7, 2, '2026-06-01 00:00:00');
+        $this->assertSame(0, $this->pl->remaining('sku', 7, '2026-06-02 00:00:00'));
+        $this->assertFalse($this->pl->canPurchase('sku', 7, 1, '2026-06-02 00:00:00'));
+    }
+
+    public function testCanPurchaseUpToCap(): void
+    {
+        $this->pl->setLimit('sku', 3, 30);
+        $this->pl->record('sku', 7, 1, '2026-06-01 00:00:00');
+        $this->assertTrue($this->pl->canPurchase('sku', 7, 2, '2026-06-02 00:00:00'));  // 1+2 = 3 ok
+        $this->assertFalse($this->pl->canPurchase('sku', 7, 3, '2026-06-02 00:00:00')); // 1+3 = 4 over
+    }
+
+    public function testRollingWindowExpiresOldPurchases(): void
+    {
+        $this->pl->setLimit('sku', 2, 30);
+        $this->pl->record('sku', 7, 2, '2026-05-01 00:00:00'); // old
+        // 40 days later → outside the 30-day window
+        $this->assertSame(2, $this->pl->remaining('sku', 7, '2026-06-10 00:00:00'));
+        $this->assertTrue($this->pl->canPurchase('sku', 7, 2, '2026-06-10 00:00:00'));
+    }
+
+    public function testWindowBoundaryInclusive(): void
+    {
+        $this->pl->setLimit('sku', 2, 30);
+        $this->pl->record('sku', 7, 2, '2026-05-01 00:00:00');
+        // exactly 30 days later → cutoff is 2026-05-01 00:00:00; purchase at cutoff counts (>=)
+        $this->assertSame(0, $this->pl->remaining('sku', 7, '2026-05-31 00:00:00'));
+    }
+
+    public function testUsersAreSeparate(): void
+    {
+        $this->pl->setLimit('sku', 2, 30);
+        $this->pl->record('sku', 7, 2, '2026-06-01 00:00:00');
+        $this->assertSame(0, $this->pl->remaining('sku', 7, '2026-06-02 00:00:00'));
+        $this->assertSame(2, $this->pl->remaining('sku', 8, '2026-06-02 00:00:00'));
+    }
+
+    public function testSkusAreSeparate(): void
+    {
+        $this->pl->setLimit('a', 1, 30);
+        $this->pl->setLimit('b', 5, 30);
+        $this->pl->record('a', 7, 1, '2026-06-01 00:00:00');
+        $this->assertFalse($this->pl->canPurchase('a', 7, 1, '2026-06-02 00:00:00'));
+        $this->assertTrue($this->pl->canPurchase('b', 7, 5, '2026-06-02 00:00:00'));
+    }
+
+    public function testRemoveLimitMakesUnlimited(): void
+    {
+        $this->pl->setLimit('sku', 1, 30);
+        $this->pl->record('sku', 7, 1, '2026-06-01 00:00:00');
+        $this->pl->removeLimit('sku');
+        $this->assertTrue($this->pl->canPurchase('sku', 7, 100, '2026-06-02 00:00:00'));
+        $this->assertNull($this->pl->remaining('sku', 7));
+    }
+
+    public function testSetLimitIsIdempotent(): void
+    {
+        $this->pl->setLimit('sku', 2, 30);
+        $this->pl->setLimit('sku', 5, 7);
+        $this->assertSame(5, $this->pl->remaining('sku', 7));
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM purchase_limit_policies')->fetchColumn());
+    }
+
+    public function testSetLimitRejectsZero(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pl->setLimit('sku', 0, 30);
+    }
+
+    public function testRecordRejectsZeroQty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pl->record('sku', 7, 0);
+    }
+
+    public function testCanPurchaseRejectsZeroQty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pl->canPurchase('sku', 7, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT295** — `Nene\Kit\PurchaseLimit`: per-user purchase caps per SKU over a rolling window ("max N per user per P days"). Distinct from `Quota` (FT166) / `StorageQuota`.

| Method | Description |
| --- | --- |
| `setLimit(sku, maxQty, periodDays) / removeLimit` | Configure / clear. |
| `record(sku, userId, qty, asOf=null)` | Log a purchase. |
| `purchasedInPeriod / remaining(?int) / canPurchase(bool)` | Window checks. |

- Rolling window inclusive (`purchased_at >= asOf - periodDays`); un-capped SKU → `remaining` null, `canPurchase` true.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 21 assertions (un-capped, cap, up-to-cap, window expiry, boundary inclusive, user/SKU separation, removeLimit, idempotent, validation×3)
- [x] `composer precommit` green (format → Phan → 4955 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)