### PR TITLE
feat(kit): PriceAlert — notify when an item's price drops to target (FT296)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -179,6 +179,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `Payout` | accrue amounts owed to payees and settle them in payout runs. |
 | `PointBalance` | user loyalty/reward points with append-only ledger. |
 | `PointLedger` | Append-only point / loyalty system with negative-balance prevention. |
+| `PriceAlert` | notify users when an item's price drops to their target. |
 | `PriceHistory` | append-only price change log for products or any priced entity. |
 | `PriceList` | product price catalog with multiple price tiers per SKU. |
 | `ProductBundle` | product bundle definitions with included items. |

--- a/class/kit/PriceAlert.php
+++ b/class/kit/PriceAlert.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * PriceAlert — notify users when an item's price drops to their target.
+ *
+ * Users watch an item with a target price (integer cents); a price-feed job
+ * calls {@see PriceAlert::check()} with the current price, which fires (and
+ * marks triggered) every watcher whose target is at or above it. Distinct from
+ * `StockAlert` (FT232, back-in-stock) and `AlertRule` (metric thresholds):
+ * this is consumer price-drop watching.
+ *
+ * One alert per `(user_id, item)`; re-watching updates the target and re-arms.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $pa = new PriceAlert($pdo);
+ *
+ * $pa->watch(userId: 1, item: 'sku-9', targetCents: 5000); // alert at/below $50
+ * $pa->watch(2, 'sku-9', 4500);
+ *
+ * // Price feed reports $48.00:
+ * $fired = $pa->check('sku-9', 4800); // [1] — user 1 (target 5000 >= 4800); user 2 (4500) not yet
+ * // each fired alert is marked triggered and won't re-fire until re-watched
+ *
+ * $pa->pending('sku-9');   // still-watching user ids
+ * $pa->unwatch(1, 'sku-9');
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE price_alerts (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id      BIGINT       NOT NULL,
+ *     item         VARCHAR(190) NOT NULL,
+ *     target_cents INTEGER      NOT NULL,
+ *     triggered    INTEGER      NOT NULL DEFAULT 0,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     triggered_at DATETIME     NULL,
+ *     UNIQUE (user_id, item)
+ * );
+ * ```
+ */
+final class PriceAlert
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Watch an item for a target price (re-arms if already watched).
+     *
+     * @param  int    $userId      Watcher user id.
+     * @param  string $item        Item identifier.
+     * @param  int    $targetCents Trigger at/below this price, in cents (> 0).
+     * @throws \InvalidArgumentException on empty item or non-positive target.
+     */
+    public function watch(int $userId, string $item, int $targetCents): void
+    {
+        $item = $this->validate($item);
+        if ($targetCents <= 0) {
+            throw new \InvalidArgumentException('Target must be positive.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'price_alerts',
+            data:         ['user_id' => $userId, 'item' => $item, 'target_cents' => $targetCents, 'triggered' => 0, 'triggered_at' => null],
+            conflictCols: ['user_id', 'item'],
+            updateCols:   ['target_cents', 'triggered', 'triggered_at'],
+        );
+    }
+
+    /**
+     * Fire all armed alerts for an item whose target is at/above the current
+     * price; mark them triggered. Returns the user ids that fired.
+     *
+     * @param  string      $item         Item identifier.
+     * @param  int         $currentCents Current price in cents.
+     * @param  string|null $asOf         Trigger time; defaults to now.
+     * @return array<int,int> Watcher user ids that fired (ascending).
+     */
+    public function check(string $item, int $currentCents, ?string $asOf = null): array
+    {
+        $item = $this->validate($item);
+
+        $sel = $this->db()->prepare(
+            'SELECT user_id FROM price_alerts WHERE item = ? AND triggered = 0 AND target_cents >= ? ORDER BY user_id ASC'
+        );
+        $sel->execute([$item, $currentCents]);
+        $fired = array_map(static fn ($u): int => (int)$u, $sel->fetchAll(PDO::FETCH_COLUMN));
+        if ($fired === []) {
+            return [];
+        }
+
+        $upd = $this->db()->prepare(
+            'UPDATE price_alerts SET triggered = 1, triggered_at = ? WHERE item = ? AND triggered = 0 AND target_cents >= ?'
+        );
+        $upd->execute([$this->ts($asOf), $item, $currentCents]);
+
+        return $fired;
+    }
+
+    /**
+     * Whether a user is actively watching an item (armed, not yet triggered).
+     */
+    public function isWatching(int $userId, string $item): bool
+    {
+        $item = $this->validate($item);
+        $stmt = $this->db()->prepare(
+            'SELECT 1 FROM price_alerts WHERE user_id = ? AND item = ? AND triggered = 0 LIMIT 1'
+        );
+        $stmt->execute([$userId, $item]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * A user's target price for an item, or null if not watching.
+     */
+    public function targetFor(int $userId, string $item): ?int
+    {
+        $item = $this->validate($item);
+        $stmt = $this->db()->prepare('SELECT target_cents FROM price_alerts WHERE user_id = ? AND item = ?');
+        $stmt->execute([$userId, $item]);
+        $t = $stmt->fetchColumn();
+
+        return $t === false ? null : (int)$t;
+    }
+
+    /**
+     * User ids still armed (not triggered) for an item, ascending.
+     *
+     * @return array<int,int>
+     */
+    public function pending(string $item): array
+    {
+        $item = $this->validate($item);
+        $stmt = $this->db()->prepare(
+            'SELECT user_id FROM price_alerts WHERE item = ? AND triggered = 0 ORDER BY user_id ASC'
+        );
+        $stmt->execute([$item]);
+
+        return array_map(static fn ($u): int => (int)$u, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    /**
+     * Stop watching. No-op if absent.
+     */
+    public function unwatch(int $userId, string $item): void
+    {
+        $item = $this->validate($item);
+        $stmt = $this->db()->prepare('DELETE FROM price_alerts WHERE user_id = ? AND item = ?');
+        $stmt->execute([$userId, $item]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validate(string $item): string
+    {
+        $item = trim($item);
+        if ($item === '') {
+            throw new \InvalidArgumentException('Item must not be empty.');
+        }
+
+        return $item;
+    }
+
+    private function ts(?string $asOf): string
+    {
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid timestamp.');
+        }
+
+        return date('Y-m-d H:i:s', $epoch);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-296.md
+++ b/docs/field-trials/2026-05-field-trial-296.md
@@ -1,0 +1,40 @@
+# Field Trial 296 — PriceAlert
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft296-price-alert`
+**Baseline**: post FT295 merge
+
+## Goal
+
+Add `Nene\Kit\PriceAlert` — users watch an item for a target price; a price feed fires every watcher whose target is at/above the current price. Distinct from `StockAlert` (FT232, back-in-stock) and `AlertRule` (metric thresholds).
+
+## What was built
+
+### `Nene\Kit\PriceAlert` (`class/kit/PriceAlert.php`)
+
+| Method | Description |
+| --- | --- |
+| `watch(userId, item, targetCents)` | Arm an alert (re-watch re-arms with new target). |
+| `check(item, currentCents, asOf=null): array` | Fire + mark watchers with `target >= current`; returns fired user ids. |
+| `isWatching / targetFor / pending` | Read armed state. |
+| `unwatch(userId, item)` | Stop watching. |
+
+Key design points:
+
+- **Drop-to-target semantics**: `check` fires watchers where `target_cents >= currentCents` (boundary inclusive), marks them triggered so they don't re-fire until re-watched.
+- One alert per `(user_id, item)` (cross-driver upsert); re-watch resets `triggered`.
+- Integer cents; `asOf` for deterministic trigger time.
+
+### Tests (`tests/Unit/Kit/PriceAlertTest.php`)
+
+12 unit tests (19 assertions): watch/target, check fires at/below target, boundary inclusive, no-refire after trigger, re-watch re-arms, multiple watchers fire, pending excludes triggered, item separation, unwatch, no-match empty, validation (non-positive target, empty item).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/PriceAlertTest.php
+++ b/tests/Unit/Kit/PriceAlertTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\PriceAlert;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PriceAlert.
+ */
+final class PriceAlertTest extends TestCase
+{
+    private PDO $db;
+    private PriceAlert $pa;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE price_alerts (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id      BIGINT       NOT NULL,
+                item         VARCHAR(190) NOT NULL,
+                target_cents INTEGER      NOT NULL,
+                triggered    INTEGER      NOT NULL DEFAULT 0,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                triggered_at DATETIME     NULL,
+                UNIQUE (user_id, item)
+            )
+        ');
+        $this->pa = new PriceAlert($this->db);
+    }
+
+    public function testWatchAndTarget(): void
+    {
+        $this->pa->watch(1, 'sku', 5000);
+        $this->assertTrue($this->pa->isWatching(1, 'sku'));
+        $this->assertSame(5000, $this->pa->targetFor(1, 'sku'));
+    }
+
+    public function testCheckFiresAtOrBelowTarget(): void
+    {
+        $this->pa->watch(1, 'sku', 5000); // alert at/below 5000
+        $this->pa->watch(2, 'sku', 4500);
+        // current 4800 → user 1 (5000>=4800) fires; user 2 (4500) does not
+        $fired = $this->pa->check('sku', 4800);
+        $this->assertSame([1], $fired);
+        $this->assertFalse($this->pa->isWatching(1, 'sku')); // now triggered
+        $this->assertTrue($this->pa->isWatching(2, 'sku'));
+    }
+
+    public function testCheckBoundaryInclusive(): void
+    {
+        $this->pa->watch(1, 'sku', 5000);
+        $fired = $this->pa->check('sku', 5000); // exactly at target → fires
+        $this->assertSame([1], $fired);
+    }
+
+    public function testTriggeredAlertDoesNotRefire(): void
+    {
+        $this->pa->watch(1, 'sku', 5000);
+        $this->pa->check('sku', 4000);          // fires
+        $this->assertSame([], $this->pa->check('sku', 3000)); // already triggered
+    }
+
+    public function testReWatchReArms(): void
+    {
+        $this->pa->watch(1, 'sku', 5000);
+        $this->pa->check('sku', 4000); // triggered
+        $this->pa->watch(1, 'sku', 3000); // re-arm with new target
+        $this->assertTrue($this->pa->isWatching(1, 'sku'));
+        $this->assertSame(3000, $this->pa->targetFor(1, 'sku'));
+        $this->assertSame([1], $this->pa->check('sku', 2500));
+    }
+
+    public function testCheckFiresMultipleWatchers(): void
+    {
+        $this->pa->watch(1, 'sku', 5000);
+        $this->pa->watch(2, 'sku', 4900);
+        $this->pa->watch(3, 'sku', 3000);
+        $fired = $this->pa->check('sku', 4800); // users 1,2 fire (>=4800); user 3 (3000) no
+        $this->assertSame([1, 2], $fired);
+    }
+
+    public function testPending(): void
+    {
+        $this->pa->watch(1, 'sku', 5000);
+        $this->pa->watch(2, 'sku', 3000);
+        $this->pa->check('sku', 4800); // user 1 fires
+        $this->assertSame([2], $this->pa->pending('sku'));
+    }
+
+    public function testItemsAreSeparate(): void
+    {
+        $this->pa->watch(1, 'a', 5000);
+        $this->pa->watch(1, 'b', 5000);
+        $this->pa->check('a', 1000);
+        $this->assertFalse($this->pa->isWatching(1, 'a'));
+        $this->assertTrue($this->pa->isWatching(1, 'b'));
+    }
+
+    public function testUnwatch(): void
+    {
+        $this->pa->watch(1, 'sku', 5000);
+        $this->pa->unwatch(1, 'sku');
+        $this->assertFalse($this->pa->isWatching(1, 'sku'));
+        $this->assertNull($this->pa->targetFor(1, 'sku'));
+    }
+
+    public function testCheckNoMatchesReturnsEmpty(): void
+    {
+        $this->pa->watch(1, 'sku', 3000);
+        $this->assertSame([], $this->pa->check('sku', 4000)); // price above target
+    }
+
+    public function testWatchRejectsNonPositiveTarget(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pa->watch(1, 'sku', 0);
+    }
+
+    public function testWatchRejectsEmptyItem(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pa->watch(1, '  ', 5000);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT296** — `Nene\Kit\PriceAlert`: users watch an item for a target price; a price feed fires every watcher whose target is at/above the current price. Distinct from `StockAlert` (FT232) and `AlertRule`.

| Method | Description |
| --- | --- |
| `watch(userId, item, targetCents)` | Arm (re-watch re-arms). |
| `check(item, currentCents, asOf=null): array` | Fire + mark `target >= current`; returns user ids. |
| `isWatching / targetFor / pending / unwatch` | Read / stop. |

- Drop-to-target inclusive; triggered alerts don't re-fire until re-watched; one per (user, item).

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 19 assertions (fire at/below, boundary inclusive, no-refire, re-arm, multi-watcher, pending excl triggered, separation, unwatch, no-match, validation)
- [x] `composer precommit` green (format → Phan → 4967 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)