### PR TITLE
feat(kit): StockTransfer — multi-location stock ledger with moves (FT297)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -304,6 +304,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `RetrySchedule` | exponential-backoff retry tracking for arbitrary operations. |
 | `RoundRobinAssigner` | fair rotating assignment across a named pool. |
 | `ScheduledTask` | cron-style task schedule registry with last-run tracking. |
+| `StockTransfer` | multi-location stock ledger with location-to-location moves. |
 | `TokenBucket` | DB-backed token bucket algorithm for flexible rate limiting. |
 
 ---

--- a/class/kit/StockTransfer.php
+++ b/class/kit/StockTransfer.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * StockTransfer — multi-location stock ledger with location-to-location moves.
+ *
+ * Tracks SKU quantities across named locations (warehouses, stores) as an
+ * append-only delta ledger: `receive()` brings stock into a location, and
+ * `transfer()` atomically moves it between locations (guarded against
+ * overdraw). Distinct from `InventoryStock` (FT201), which is a single-pool
+ * reserve/release/commit model — this is about *where* stock physically sits
+ * and moving it around.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $st = new StockTransfer($pdo);
+ *
+ * $st->receive('sku-1', 'warehouse', 100);
+ * $st->transfer('sku-1', 'warehouse', 'store-a', 30);
+ *
+ * $st->balance('sku-1', 'warehouse'); // 70
+ * $st->balance('sku-1', 'store-a');   // 30
+ * $st->totalStock('sku-1');           // 100
+ * $st->locations('sku-1');            // [['location'=>'store-a','balance'=>30], ...]
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE stock_ledger (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     sku        VARCHAR(150) NOT NULL,
+ *     location   VARCHAR(150) NOT NULL,
+ *     delta      INTEGER      NOT NULL,
+ *     note       VARCHAR(190) NOT NULL DEFAULT '',
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class StockTransfer
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Bring stock into a location (inbound, no source).
+     *
+     * @param  string $sku      Product identifier.
+     * @param  string $location Destination location.
+     * @param  int    $qty      Quantity received (> 0).
+     * @throws \InvalidArgumentException on empty names or qty < 1.
+     */
+    public function receive(string $sku, string $location, int $qty): void
+    {
+        $sku      = $this->validate($sku, 'SKU');
+        $location = $this->validate($location, 'Location');
+        $this->requirePositive($qty);
+
+        $this->append($sku, $location, $qty, 'receive');
+    }
+
+    /**
+     * Move stock between two locations atomically. Guards against overdrawing
+     * the source.
+     *
+     * @param  string $sku  Product identifier.
+     * @param  string $from Source location.
+     * @param  string $to   Destination location.
+     * @param  int    $qty  Quantity to move (> 0).
+     * @throws \InvalidArgumentException on bad input, same from/to, or insufficient stock.
+     */
+    public function transfer(string $sku, string $from, string $to, int $qty): void
+    {
+        $sku  = $this->validate($sku, 'SKU');
+        $from = $this->validate($from, 'From location');
+        $to   = $this->validate($to, 'To location');
+        $this->requirePositive($qty);
+        if ($from === $to) {
+            throw new \InvalidArgumentException('Source and destination must differ.');
+        }
+
+        $db             = $this->db();
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+        try {
+            if ($this->balance($sku, $from) < $qty) {
+                throw new \InvalidArgumentException("Insufficient stock at {$from} for {$sku}.");
+            }
+            $this->append($sku, $from, -$qty, "transfer-out:{$to}");
+            $this->append($sku, $to, $qty, "transfer-in:{$from}");
+            if ($ownTransaction) {
+                $db->commit();
+            }
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Current balance of a SKU at a location.
+     */
+    public function balance(string $sku, string $location): int
+    {
+        $sku      = $this->validate($sku, 'SKU');
+        $location = $this->validate($location, 'Location');
+        $stmt     = $this->db()->prepare('SELECT COALESCE(SUM(delta), 0) FROM stock_ledger WHERE sku = ? AND location = ?');
+        $stmt->execute([$sku, $location]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Total stock of a SKU across all locations.
+     */
+    public function totalStock(string $sku): int
+    {
+        $sku  = $this->validate($sku, 'SKU');
+        $stmt = $this->db()->prepare('SELECT COALESCE(SUM(delta), 0) FROM stock_ledger WHERE sku = ?');
+        $stmt->execute([$sku]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Locations holding a non-zero balance of a SKU, by location name.
+     *
+     * @return array<int,array{location:string,balance:int}>
+     */
+    public function locations(string $sku): array
+    {
+        $sku  = $this->validate($sku, 'SKU');
+        $stmt = $this->db()->prepare(
+            'SELECT location, SUM(delta) AS bal FROM stock_ledger WHERE sku = ?
+             GROUP BY location HAVING SUM(delta) <> 0 ORDER BY location ASC'
+        );
+        $stmt->execute([$sku]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['location' => (string)$row['location'], 'balance' => (int)$row['bal']];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Movement history for a SKU (optionally a single location), newest first.
+     *
+     * @return array<int,array{location:string,delta:int,note:string,created_at:string}>
+     */
+    public function history(string $sku, ?string $location = null): array
+    {
+        $sku = $this->validate($sku, 'SKU');
+
+        if ($location === null) {
+            $stmt = $this->db()->prepare('SELECT location, delta, note, created_at FROM stock_ledger WHERE sku = ? ORDER BY id DESC');
+            $stmt->execute([$sku]);
+        } else {
+            $location = $this->validate($location, 'Location');
+            $stmt     = $this->db()->prepare('SELECT location, delta, note, created_at FROM stock_ledger WHERE sku = ? AND location = ? ORDER BY id DESC');
+            $stmt->execute([$sku, $location]);
+        }
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = [
+                'location'   => (string)$row['location'],
+                'delta'      => (int)$row['delta'],
+                'note'       => (string)$row['note'],
+                'created_at' => (string)$row['created_at'],
+            ];
+        }
+
+        return $out;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function append(string $sku, string $location, int $delta, string $note): void
+    {
+        $stmt = $this->db()->prepare('INSERT INTO stock_ledger (sku, location, delta, note) VALUES (?, ?, ?, ?)');
+        $stmt->execute([$sku, $location, $delta, $note]);
+    }
+
+    private function requirePositive(int $qty): void
+    {
+        if ($qty < 1) {
+            throw new \InvalidArgumentException('Quantity must be at least 1.');
+        }
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-297.md
+++ b/docs/field-trials/2026-05-field-trial-297.md
@@ -1,0 +1,43 @@
+# Field Trial 297 — StockTransfer
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft297-stock-transfer`
+**Baseline**: post FT296 merge
+
+## Goal
+
+Add `Nene\Kit\StockTransfer` — multi-location stock ledger that tracks SKU quantities across named locations and moves them between locations atomically. Distinct from `InventoryStock` (FT201, single-pool reserve/release/commit): this is about *where* stock sits.
+
+## What was built
+
+### `Nene\Kit\StockTransfer` (`class/kit/StockTransfer.php`)
+
+Append-only delta ledger; balances are derived sums.
+
+| Method | Description |
+| --- | --- |
+| `receive(sku, location, qty)` | Inbound stock (+delta). |
+| `transfer(sku, from, to, qty)` | Atomic move; guards against overdrawing source. |
+| `balance(sku, location) / totalStock(sku)` | Derived sums. |
+| `locations(sku)` | Non-zero balances per location. |
+| `history(sku, location=null)` | Movement log. |
+
+Key design points:
+
+- **Transfer = two ledger rows in a transaction** (−from, +to), guarded by `balance(from) >= qty`; an overdraw throws and applies nothing (rollback).
+- **Total conserved** across moves (a transfer is delta-neutral); `locations()` hides drained (zero) locations.
+- Distinct from InventoryStock's reservation model.
+
+### Tests (`tests/Unit/Kit/StockTransferTest.php`)
+
+11 unit tests (18 assertions): receive/balance, transfer moves, total conserved across chained moves, overdraw guard, **overdraw is all-or-nothing (no partial apply)**, locations excludes zero, history rows, SKU separation, same-location rejected, validation (zero qty, empty location).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 11 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/StockTransferTest.php
+++ b/tests/Unit/Kit/StockTransferTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\StockTransfer;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for StockTransfer.
+ */
+final class StockTransferTest extends TestCase
+{
+    private PDO $db;
+    private StockTransfer $st;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE stock_ledger (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                sku        VARCHAR(150) NOT NULL,
+                location   VARCHAR(150) NOT NULL,
+                delta      INTEGER      NOT NULL,
+                note       VARCHAR(190) NOT NULL DEFAULT \'\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->st = new StockTransfer($this->db);
+    }
+
+    public function testReceiveAndBalance(): void
+    {
+        $this->st->receive('sku', 'wh', 100);
+        $this->assertSame(100, $this->st->balance('sku', 'wh'));
+        $this->assertSame(0, $this->st->balance('sku', 'store'));
+    }
+
+    public function testTransferMovesStock(): void
+    {
+        $this->st->receive('sku', 'wh', 100);
+        $this->st->transfer('sku', 'wh', 'store', 30);
+        $this->assertSame(70, $this->st->balance('sku', 'wh'));
+        $this->assertSame(30, $this->st->balance('sku', 'store'));
+    }
+
+    public function testTotalStockConserved(): void
+    {
+        $this->st->receive('sku', 'wh', 100);
+        $this->st->transfer('sku', 'wh', 'store', 40);
+        $this->st->transfer('sku', 'store', 'kiosk', 10);
+        $this->assertSame(100, $this->st->totalStock('sku')); // moves don't change total
+    }
+
+    public function testTransferGuardsAgainstOverdraw(): void
+    {
+        $this->st->receive('sku', 'wh', 20);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->st->transfer('sku', 'wh', 'store', 21);
+    }
+
+    public function testOverdrawDoesNotPartiallyApply(): void
+    {
+        $this->st->receive('sku', 'wh', 20);
+        try {
+            $this->st->transfer('sku', 'wh', 'store', 21);
+        } catch (\InvalidArgumentException) {
+            // expected
+        }
+        $this->assertSame(20, $this->st->balance('sku', 'wh'));  // unchanged
+        $this->assertSame(0, $this->st->balance('sku', 'store')); // nothing added
+    }
+
+    public function testLocationsExcludesZeroBalances(): void
+    {
+        $this->st->receive('sku', 'wh', 50);
+        $this->st->transfer('sku', 'wh', 'store', 50); // wh now 0
+        $locs = $this->st->locations('sku');
+        $this->assertCount(1, $locs); // only 'store' has non-zero
+        $this->assertSame('store', $locs[0]['location']);
+        $this->assertSame(50, $locs[0]['balance']);
+    }
+
+    public function testHistoryRecordsMoves(): void
+    {
+        $this->st->receive('sku', 'wh', 100);
+        $this->st->transfer('sku', 'wh', 'store', 30);
+        $this->assertCount(3, $this->st->history('sku'));       // receive + 2 transfer rows
+        $this->assertCount(2, $this->st->history('sku', 'wh')); // receive + transfer-out
+    }
+
+    public function testSkusAreSeparate(): void
+    {
+        $this->st->receive('a', 'wh', 10);
+        $this->st->receive('b', 'wh', 5);
+        $this->assertSame(10, $this->st->balance('a', 'wh'));
+        $this->assertSame(5, $this->st->balance('b', 'wh'));
+    }
+
+    public function testTransferRejectsSameLocation(): void
+    {
+        $this->st->receive('sku', 'wh', 10);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->st->transfer('sku', 'wh', 'wh', 5);
+    }
+
+    public function testReceiveRejectsZeroQty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->st->receive('sku', 'wh', 0);
+    }
+
+    public function testReceiveRejectsEmptyLocation(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->st->receive('sku', '  ', 10);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT297** — `Nene\Kit\StockTransfer`: multi-location stock ledger tracking SKU quantities across locations and moving them atomically. Distinct from `InventoryStock` (FT201, single-pool reserve/commit).

| Method | Description |
| --- | --- |
| `receive(sku, location, qty)` | Inbound (+delta). |
| `transfer(sku, from, to, qty)` | Atomic move; overdraw-guarded. |
| `balance / totalStock / locations / history` | Derived sums / log. |

- Transfer = two ledger rows in a transaction; overdraw throws and applies nothing; total conserved across moves.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 11 tests / 18 assertions (receive/balance, move, total conserved, overdraw guard + all-or-nothing, locations excl zero, history, separation, same-location reject, validation)
- [x] `composer precommit` green (format → Phan → 4978 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)