### PR TITLE
feat(kit): BulkDiscount — quantity-tiered percentage discounts per SKU (FT298)

### DIFF
--- a/class/kit/BulkDiscount.php
+++ b/class/kit/BulkDiscount.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * BulkDiscount — quantity-tiered percentage discounts per SKU.
+ *
+ * Defines "buy N or more, get X% off" tiers per product and computes the
+ * discounted total for a given quantity (integer cents, no floats). The
+ * applicable tier is the highest `min_qty` that does not exceed the purchased
+ * quantity. Distinct from `CouponCode` (code-based discounts) and `PriceList`
+ * (per-customer-type price tiers): this is volume pricing.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $bd = new BulkDiscount($pdo);
+ *
+ * $bd->addTier('sku-1', minQty: 10, percentOff: 5);
+ * $bd->addTier('sku-1', minQty: 50, percentOff: 12);
+ *
+ * $bd->discountFor('sku-1', 8);   // 0  (below first tier)
+ * $bd->discountFor('sku-1', 20);  // 5
+ * $bd->discountFor('sku-1', 100); // 12
+ *
+ * $bd->priceFor('sku-1', 20, 1000); // 20 × $10 = $200, −5% = 19000 cents
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE bulk_discount_tiers (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     sku         VARCHAR(150) NOT NULL,
+ *     min_qty     INTEGER      NOT NULL,
+ *     percent_off INTEGER      NOT NULL,
+ *     UNIQUE (sku, min_qty)
+ * );
+ * ```
+ */
+final class BulkDiscount
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add or update a discount tier. Idempotent per (sku, minQty).
+     *
+     * @param  string $sku        Product identifier.
+     * @param  int    $minQty     Minimum quantity for the tier (>= 1).
+     * @param  int    $percentOff Discount percentage (0–100).
+     * @throws \InvalidArgumentException on empty SKU, minQty < 1, or bad percentage.
+     */
+    public function addTier(string $sku, int $minQty, int $percentOff): void
+    {
+        $sku = $this->validate($sku);
+        if ($minQty < 1) {
+            throw new \InvalidArgumentException('Minimum quantity must be at least 1.');
+        }
+        if ($percentOff < 0 || $percentOff > 100) {
+            throw new \InvalidArgumentException('Percentage must be between 0 and 100.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'bulk_discount_tiers',
+            data:         ['sku' => $sku, 'min_qty' => $minQty, 'percent_off' => $percentOff],
+            conflictCols: ['sku', 'min_qty'],
+            updateCols:   ['percent_off'],
+        );
+    }
+
+    /**
+     * Discount percentage applicable to a quantity (highest qualifying tier).
+     *
+     * @param  string $sku Product identifier.
+     * @param  int    $qty Purchase quantity.
+     * @return int         Percentage off (0 if no tier qualifies).
+     */
+    public function discountFor(string $sku, int $qty): int
+    {
+        $sku  = $this->validate($sku);
+        $stmt = $this->db()->prepare(
+            'SELECT percent_off FROM bulk_discount_tiers WHERE sku = ? AND min_qty <= ?
+             ORDER BY min_qty DESC LIMIT 1'
+        );
+        $stmt->execute([$sku, $qty]);
+        $pct = $stmt->fetchColumn();
+
+        return $pct === false ? 0 : (int)$pct;
+    }
+
+    /**
+     * Discounted total for `qty × unitCents`, applying the qualifying tier.
+     * Rounds the discount amount half-up to whole cents.
+     *
+     * @param  string $sku       Product identifier.
+     * @param  int    $qty       Quantity (>= 0).
+     * @param  int    $unitCents Unit price in cents (>= 0).
+     * @return int               Total in cents after discount.
+     * @throws \InvalidArgumentException on negative qty/price.
+     */
+    public function priceFor(string $sku, int $qty, int $unitCents): int
+    {
+        if ($qty < 0 || $unitCents < 0) {
+            throw new \InvalidArgumentException('Quantity and unit price must not be negative.');
+        }
+
+        $gross    = $qty * $unitCents;
+        $pct      = $this->discountFor($sku, $qty);
+        $discount = intdiv($gross * $pct + 50, 100); // half-up
+
+        return $gross - $discount;
+    }
+
+    /**
+     * All tiers for a SKU, ascending by minimum quantity.
+     *
+     * @return array<int,array{min_qty:int,percent_off:int}>
+     */
+    public function tiers(string $sku): array
+    {
+        $sku  = $this->validate($sku);
+        $stmt = $this->db()->prepare('SELECT min_qty, percent_off FROM bulk_discount_tiers WHERE sku = ? ORDER BY min_qty ASC');
+        $stmt->execute([$sku]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['min_qty' => (int)$row['min_qty'], 'percent_off' => (int)$row['percent_off']];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Remove a single tier. No-op if absent.
+     */
+    public function removeTier(string $sku, int $minQty): void
+    {
+        $sku  = $this->validate($sku);
+        $stmt = $this->db()->prepare('DELETE FROM bulk_discount_tiers WHERE sku = ? AND min_qty = ?');
+        $stmt->execute([$sku, $minQty]);
+    }
+
+    /**
+     * Remove all tiers for a SKU. Returns the number removed.
+     */
+    public function clear(string $sku): int
+    {
+        $sku  = $this->validate($sku);
+        $stmt = $this->db()->prepare('DELETE FROM bulk_discount_tiers WHERE sku = ?');
+        $stmt->execute([$sku]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validate(string $sku): string
+    {
+        $sku = trim($sku);
+        if ($sku === '') {
+            throw new \InvalidArgumentException('SKU must not be empty.');
+        }
+
+        return $sku;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -167,6 +167,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 |-------|-------------|
 | `BillingUsage` | metered usage tracking for billing. |
 | `BudgetTracker` | period-based budget allocation and spend tracking. |
+| `BulkDiscount` | quantity-tiered percentage discounts per SKU. |
 | `CouponCode` | Coupon / promo code management with usage limits and per-user redemption tracking. |
 | `CreditLedger` | append-only double-entry credit/debit ledger per user. |
 | `CreditNote` | financial credit notes / refund adjustments. |

--- a/docs/field-trials/2026-05-field-trial-298.md
+++ b/docs/field-trials/2026-05-field-trial-298.md
@@ -1,0 +1,40 @@
+# Field Trial 298 — BulkDiscount
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft298-bulk-discount`
+**Baseline**: post FT297 merge
+
+## Goal
+
+Add `Nene\Kit\BulkDiscount` — quantity-tiered percentage discounts per SKU ("buy N+ get X% off"), with integer-cent total computation. Distinct from `CouponCode` (code-based) and `PriceList` (per-customer-type tiers): this is volume pricing.
+
+## What was built
+
+### `Nene\Kit\BulkDiscount` (`class/kit/BulkDiscount.php`)
+
+| Method | Description |
+| --- | --- |
+| `addTier(sku, minQty, percentOff)` | Upsert a tier (percent 0–100). |
+| `discountFor(sku, qty): int` | Highest qualifying tier's percentage (0 if none). |
+| `priceFor(sku, qty, unitCents): int` | Discounted total, half-up rounded. |
+| `tiers(sku) / removeTier / clear` | List / remove. |
+
+Key design points:
+
+- **Highest qualifying tier**: `min_qty <= qty ORDER BY min_qty DESC LIMIT 1` (boundary inclusive).
+- **Integer-cent** total: `gross − round(gross·pct/100)` via `intdiv(gross·pct + 50, 100)` (half-up); no floats.
+- Tiers upserted per `(sku, min_qty)`.
+
+### Tests (`tests/Unit/Kit/BulkDiscountTest.php`)
+
+13 unit tests (22 assertions): tier selection (below/at/between/highest), no-tiers 0, priceFor applies discount, no-discount below tier, **half-up rounding (333→330, 350→346 at 1%)**, zero-qty, idempotent tier update, ascending tiers, removeTier, clear, SKU separation, validation (bad percentage, zero minQty).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/BulkDiscountTest.php
+++ b/tests/Unit/Kit/BulkDiscountTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\BulkDiscount;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for BulkDiscount.
+ */
+final class BulkDiscountTest extends TestCase
+{
+    private PDO $db;
+    private BulkDiscount $bd;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE bulk_discount_tiers (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                sku         VARCHAR(150) NOT NULL,
+                min_qty     INTEGER      NOT NULL,
+                percent_off INTEGER      NOT NULL,
+                UNIQUE (sku, min_qty)
+            )
+        ');
+        $this->bd = new BulkDiscount($this->db);
+    }
+
+    public function testDiscountForPicksHighestQualifyingTier(): void
+    {
+        $this->bd->addTier('sku', 10, 5);
+        $this->bd->addTier('sku', 50, 12);
+        $this->assertSame(0, $this->bd->discountFor('sku', 8));    // below first tier
+        $this->assertSame(5, $this->bd->discountFor('sku', 10));   // exactly at tier
+        $this->assertSame(5, $this->bd->discountFor('sku', 20));
+        $this->assertSame(12, $this->bd->discountFor('sku', 50));
+        $this->assertSame(12, $this->bd->discountFor('sku', 100));
+    }
+
+    public function testDiscountForNoTiersIsZero(): void
+    {
+        $this->assertSame(0, $this->bd->discountFor('sku', 100));
+    }
+
+    public function testPriceForAppliesDiscount(): void
+    {
+        $this->bd->addTier('sku', 10, 5);
+        // 20 × 1000 = 20000; 5% off = 1000; total 19000
+        $this->assertSame(19000, $this->bd->priceFor('sku', 20, 1000));
+    }
+
+    public function testPriceForNoDiscountBelowTier(): void
+    {
+        $this->bd->addTier('sku', 10, 5);
+        $this->assertSame(8000, $this->bd->priceFor('sku', 8, 1000)); // 8×1000, no tier
+    }
+
+    public function testPriceForRoundsHalfUp(): void
+    {
+        $this->bd->addTier('sku', 1, 1);
+        // 1 × 333 = 333; 1% = 3.33 → 3 (half-up: 333*1+50=383 /100 = 3)
+        $this->assertSame(330, $this->bd->priceFor('sku', 1, 333));
+        // 1 × 350 = 350; 1% = 3.5 → 4 (half-up)
+        $this->assertSame(346, $this->bd->priceFor('sku', 1, 350));
+    }
+
+    public function testPriceForZeroQty(): void
+    {
+        $this->bd->addTier('sku', 1, 50);
+        $this->assertSame(0, $this->bd->priceFor('sku', 0, 1000));
+    }
+
+    public function testAddTierIsIdempotent(): void
+    {
+        $this->bd->addTier('sku', 10, 5);
+        $this->bd->addTier('sku', 10, 8); // update same tier
+        $this->assertSame(8, $this->bd->discountFor('sku', 10));
+        $this->assertCount(1, $this->bd->tiers('sku'));
+    }
+
+    public function testTiersAscending(): void
+    {
+        $this->bd->addTier('sku', 50, 12);
+        $this->bd->addTier('sku', 10, 5);
+        $tiers = $this->bd->tiers('sku');
+        $this->assertSame(10, $tiers[0]['min_qty']);
+        $this->assertSame(50, $tiers[1]['min_qty']);
+    }
+
+    public function testRemoveTier(): void
+    {
+        $this->bd->addTier('sku', 10, 5);
+        $this->bd->addTier('sku', 50, 12);
+        $this->bd->removeTier('sku', 10);
+        $this->assertSame(0, $this->bd->discountFor('sku', 20)); // 10-tier gone
+        $this->assertSame(12, $this->bd->discountFor('sku', 50));
+    }
+
+    public function testClear(): void
+    {
+        $this->bd->addTier('sku', 10, 5);
+        $this->bd->addTier('sku', 50, 12);
+        $this->assertSame(2, $this->bd->clear('sku'));
+        $this->assertSame([], $this->bd->tiers('sku'));
+    }
+
+    public function testSkusAreSeparate(): void
+    {
+        $this->bd->addTier('a', 10, 5);
+        $this->assertSame(0, $this->bd->discountFor('b', 100));
+    }
+
+    public function testAddTierRejectsBadPercentage(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->bd->addTier('sku', 10, 101);
+    }
+
+    public function testAddTierRejectsZeroMinQty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->bd->addTier('sku', 0, 5);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT298** — `Nene\Kit\BulkDiscount`: "buy N+ get X% off" volume-pricing tiers per SKU with integer-cent totals. Distinct from `CouponCode` (codes) / `PriceList` (customer tiers).

| Method | Description |
| --- | --- |
| `addTier(sku, minQty, percentOff)` | Upsert tier (0–100). |
| `discountFor(sku, qty): int` | Highest qualifying tier %. |
| `priceFor(sku, qty, unitCents): int` | Discounted total (half-up). |
| `tiers / removeTier / clear` | List / remove. |

- Highest qualifying tier (`min_qty <= qty`, inclusive); integer-cent half-up rounding.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 22 assertions (tier selection, no-tier 0, priceFor, half-up 333→330/350→346, zero-qty, idempotent, ascending, removeTier, clear, separation, validation)
- [x] `composer precommit` green (format → Phan → 4991 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)