### PR TITLE
feat(kit): Petition — signature campaign toward a goal (FT299)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -234,6 +234,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `FeatureRequest` | user-submitted feature requests with voting and status tracking. |
 | `Label` | colored label definitions with entity assignment. |
 | `Leaderboard` | Score-based leaderboard with best-score retention, ranking, and personal rank lookup. |
+| `Petition` | signature campaign toward a goal. |
 | `QuizAttempt` | record and score quiz / assessment attempts per user. |
 | `Raffle` | ticket-based prize draw with weighted winner selection. |
 | `Reaction` | emoji / symbol reactions on any entity. |

--- a/class/kit/Petition.php
+++ b/class/kit/Petition.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * Petition — signature campaign toward a goal.
+ *
+ * Models a named petition with a signature goal: people `sign()` it (once
+ * each, optionally with a comment), and the campaign tracks progress toward
+ * the goal and can be `close()`d. Distinct from `DocumentSignature` (FT248, an
+ * e-signature *approval* workflow over a specific document) and `VotePoll`
+ * (FT239, multi-option voting): this is one-sided public support collection.
+ *
+ * Two tables: a petition definition (goal, closed flag) and its signatures
+ * (unique per signer).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $p = new Petition($pdo);
+ *
+ * $p->create('save-the-park', goal: 1000);
+ * $p->sign('save-the-park', 'alice', 'Please keep it green!');
+ * $p->sign('save-the-park', 'bob');
+ *
+ * $p->signatureCount('save-the-park'); // 2
+ * $p->hasSigned('save-the-park', 'alice'); // true
+ * $p->progress('save-the-park');       // ['count'=>2,'goal'=>1000,'reached'=>false,'pct'=>0.2]
+ * $p->close('save-the-park');          // no more signatures accepted
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE petitions (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     name       VARCHAR(150) NOT NULL,
+ *     goal       INTEGER      NOT NULL,
+ *     closed     INTEGER      NOT NULL DEFAULT 0,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (name)
+ * );
+ * CREATE TABLE petition_signatures (
+ *     id        INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     petition  VARCHAR(150) NOT NULL,
+ *     signer    VARCHAR(190) NOT NULL,
+ *     comment   TEXT         NOT NULL DEFAULT '',
+ *     signed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (petition, signer)
+ * );
+ * ```
+ */
+final class Petition
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── petition lifecycle ──────────────────────────────────────────────────────
+
+    /**
+     * Create (or update) a petition with a signature goal. Re-creating updates
+     * the goal and re-opens it.
+     *
+     * @param  string $name Petition name.
+     * @param  int    $goal Target signature count (>= 1).
+     * @throws \InvalidArgumentException on empty name or goal < 1.
+     */
+    public function create(string $name, int $goal): void
+    {
+        $name = $this->validate($name, 'Name');
+        if ($goal < 1) {
+            throw new \InvalidArgumentException('Goal must be at least 1.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'petitions',
+            data:         ['name' => $name, 'goal' => $goal, 'closed' => 0],
+            conflictCols: ['name'],
+            updateCols:   ['goal', 'closed'],
+        );
+    }
+
+    /**
+     * Close a petition (no more signatures). No-op if absent.
+     */
+    public function close(string $name): void
+    {
+        $name = $this->validate($name, 'Name');
+        $stmt = $this->db()->prepare('UPDATE petitions SET closed = 1 WHERE name = ?');
+        $stmt->execute([$name]);
+    }
+
+    /**
+     * Whether a petition is closed (false if unknown).
+     */
+    public function isClosed(string $name): bool
+    {
+        $row = $this->petition($this->validate($name, 'Name'));
+
+        return $row !== null && (int)$row['closed'] === 1;
+    }
+
+    // ── signing ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Sign a petition (once per signer).
+     *
+     * @param  string $name    Petition name (must exist and be open).
+     * @param  string $signer  Signer identifier.
+     * @param  string $comment Optional comment.
+     * @return bool            True if newly signed; false if already signed.
+     * @throws \InvalidArgumentException if the petition is unknown or closed.
+     */
+    public function sign(string $name, string $signer, string $comment = ''): bool
+    {
+        $name   = $this->validate($name, 'Name');
+        $signer = $this->validate($signer, 'Signer');
+        $row    = $this->petition($name);
+        if ($row === null) {
+            throw new \InvalidArgumentException("Petition does not exist: {$name}");
+        }
+        if ((int)$row['closed'] === 1) {
+            throw new \InvalidArgumentException("Petition is closed: {$name}");
+        }
+        if ($this->hasSigned($name, $signer)) {
+            return false;
+        }
+
+        $stmt = $this->db()->prepare('INSERT INTO petition_signatures (petition, signer, comment) VALUES (?, ?, ?)');
+        $stmt->execute([$name, $signer, $comment]);
+
+        return true;
+    }
+
+    /**
+     * Whether a signer has signed a petition.
+     */
+    public function hasSigned(string $name, string $signer): bool
+    {
+        $name   = $this->validate($name, 'Name');
+        $signer = $this->validate($signer, 'Signer');
+        $stmt   = $this->db()->prepare('SELECT 1 FROM petition_signatures WHERE petition = ? AND signer = ? LIMIT 1');
+        $stmt->execute([$name, $signer]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Current signature count.
+     */
+    public function signatureCount(string $name): int
+    {
+        $name = $this->validate($name, 'Name');
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM petition_signatures WHERE petition = ?');
+        $stmt->execute([$name]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Whether the signature goal has been reached.
+     */
+    public function goalReached(string $name): bool
+    {
+        $row = $this->petition($this->validate($name, 'Name'));
+        if ($row === null) {
+            return false;
+        }
+
+        return $this->signatureCount($name) >= (int)$row['goal'];
+    }
+
+    /**
+     * Progress summary, or null if the petition is unknown.
+     *
+     * @return array{count:int,goal:int,reached:bool,pct:float}|null
+     */
+    public function progress(string $name): ?array
+    {
+        $name = $this->validate($name, 'Name');
+        $row  = $this->petition($name);
+        if ($row === null) {
+            return null;
+        }
+
+        $goal  = (int)$row['goal'];
+        $count = $this->signatureCount($name);
+
+        return [
+            'count'   => $count,
+            'goal'    => $goal,
+            'reached' => $count >= $goal,
+            'pct'     => round(min(1.0, $count / $goal), 4),
+        ];
+    }
+
+    /**
+     * Recent signatures (signer + comment), newest first.
+     *
+     * @param  string   $name  Petition name.
+     * @param  int|null $limit Optional cap.
+     * @return array<int,array{signer:string,comment:string}>
+     */
+    public function signatures(string $name, ?int $limit = null): array
+    {
+        $name = $this->validate($name, 'Name');
+        $sql  = 'SELECT signer, comment FROM petition_signatures WHERE petition = ? ORDER BY id DESC';
+        if ($limit !== null) {
+            $sql .= ' LIMIT ' . max(0, $limit);
+        }
+        $stmt = $this->db()->prepare($sql);
+        $stmt->execute([$name]);
+
+        $out = [];
+        /** @var array<string,mixed> $r */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+            $out[] = ['signer' => (string)$r['signer'], 'comment' => (string)$r['comment']];
+        }
+
+        return $out;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function petition(string $name): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT goal, closed FROM petitions WHERE name = ?');
+        $stmt->execute([$name]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-299.md
+++ b/docs/field-trials/2026-05-field-trial-299.md
@@ -1,0 +1,43 @@
+# Field Trial 299 — Petition
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft299-petition`
+**Baseline**: post FT298 merge
+
+## Goal
+
+Add `Nene\Kit\Petition` — a signature campaign toward a goal: people sign once each, progress tracks toward a target, and the petition can be closed. Distinct from `DocumentSignature` (FT248, e-signature approval workflow) and `VotePoll` (FT239, multi-option voting).
+
+## What was built
+
+### `Nene\Kit\Petition` (`class/kit/Petition.php`)
+
+Two tables: petition definition (goal, closed) + signatures (unique per signer).
+
+| Method | Description |
+| --- | --- |
+| `create(name, goal) / close(name) / isClosed(name)` | Lifecycle. |
+| `sign(name, signer, comment=''): bool` | Sign once (guards unknown/closed). |
+| `hasSigned / signatureCount / goalReached` | Membership / counts. |
+| `progress(name): ?array` | `{count, goal, reached, pct}`. |
+| `signatures(name, limit=null)` | Recent signatures. |
+
+Key design points:
+
+- **One signature per `(petition, signer)`**; re-sign returns false (no double-count); `sign` throws for unknown or closed petitions.
+- **`progress.pct` capped at 1.0**; `goalReached` is `count >= goal` (inclusive).
+- Re-`create` re-opens with a new goal.
+
+### Tests (`tests/Unit/Kit/PetitionTest.php`)
+
+13 unit tests (29 assertions): create/sign/count, idempotent per signer, hasSigned, goalReached at count==goal, progress, pct caps at 1.0, unknown→null, close stops signing, re-create reopens, signatures newest-first, petition separation, sign-unknown throws, zero-goal rejected.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/PetitionTest.php
+++ b/tests/Unit/Kit/PetitionTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\Petition;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Petition.
+ */
+final class PetitionTest extends TestCase
+{
+    private PDO $db;
+    private Petition $p;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE petitions (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                name       VARCHAR(150) NOT NULL,
+                goal       INTEGER      NOT NULL,
+                closed     INTEGER      NOT NULL DEFAULT 0,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (name)
+            )
+        ');
+        $this->db->exec('
+            CREATE TABLE petition_signatures (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                petition  VARCHAR(150) NOT NULL,
+                signer    VARCHAR(190) NOT NULL,
+                comment   TEXT         NOT NULL DEFAULT \'\',
+                signed_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (petition, signer)
+            )
+        ');
+        $this->p = new Petition($this->db);
+    }
+
+    public function testCreateSignAndCount(): void
+    {
+        $this->p->create('park', 1000);
+        $this->assertTrue($this->p->sign('park', 'alice', 'keep it green'));
+        $this->assertTrue($this->p->sign('park', 'bob'));
+        $this->assertSame(2, $this->p->signatureCount('park'));
+    }
+
+    public function testSignIsIdempotentPerSigner(): void
+    {
+        $this->p->create('park', 1000);
+        $this->assertTrue($this->p->sign('park', 'alice'));
+        $this->assertFalse($this->p->sign('park', 'alice')); // already signed
+        $this->assertSame(1, $this->p->signatureCount('park'));
+    }
+
+    public function testHasSigned(): void
+    {
+        $this->p->create('park', 1000);
+        $this->p->sign('park', 'alice');
+        $this->assertTrue($this->p->hasSigned('park', 'alice'));
+        $this->assertFalse($this->p->hasSigned('park', 'bob'));
+    }
+
+    public function testGoalReached(): void
+    {
+        $this->p->create('park', 2);
+        $this->p->sign('park', 'a');
+        $this->assertFalse($this->p->goalReached('park'));
+        $this->p->sign('park', 'b');
+        $this->assertTrue($this->p->goalReached('park')); // count == goal
+    }
+
+    public function testProgress(): void
+    {
+        $this->p->create('park', 4);
+        $this->p->sign('park', 'a');
+        $prog = $this->p->progress('park');
+        $this->assertSame(1, $prog['count']);
+        $this->assertSame(4, $prog['goal']);
+        $this->assertFalse($prog['reached']);
+        $this->assertSame(0.25, $prog['pct']);
+    }
+
+    public function testProgressPctCapsAtOne(): void
+    {
+        $this->p->create('park', 1);
+        $this->p->sign('park', 'a');
+        $this->p->sign('park', 'b'); // exceeds goal
+        $this->assertSame(1.0, $this->p->progress('park')['pct']);
+        $this->assertTrue($this->p->progress('park')['reached']);
+    }
+
+    public function testProgressUnknownIsNull(): void
+    {
+        $this->assertNull($this->p->progress('nope'));
+        $this->assertFalse($this->p->goalReached('nope'));
+    }
+
+    public function testCloseStopsSigning(): void
+    {
+        $this->p->create('park', 1000);
+        $this->p->sign('park', 'a');
+        $this->p->close('park');
+        $this->assertTrue($this->p->isClosed('park'));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->p->sign('park', 'b');
+    }
+
+    public function testRecreateReopens(): void
+    {
+        $this->p->create('park', 1000);
+        $this->p->close('park');
+        $this->p->create('park', 500); // re-create reopens + new goal
+        $this->assertFalse($this->p->isClosed('park'));
+        $this->assertTrue($this->p->sign('park', 'a'));
+        $this->assertSame(500, $this->p->progress('park')['goal']);
+    }
+
+    public function testSignatures(): void
+    {
+        $this->p->create('park', 1000);
+        $this->p->sign('park', 'a', 'first');
+        $this->p->sign('park', 'b', 'second');
+        $sigs = $this->p->signatures('park');
+        $this->assertSame('b', $sigs[0]['signer']); // newest first
+        $this->assertSame('second', $sigs[0]['comment']);
+    }
+
+    public function testPetitionsAreSeparate(): void
+    {
+        $this->p->create('a', 10);
+        $this->p->create('b', 10);
+        $this->p->sign('a', 'x');
+        $this->assertSame(1, $this->p->signatureCount('a'));
+        $this->assertSame(0, $this->p->signatureCount('b'));
+    }
+
+    public function testSignUnknownPetitionThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->p->sign('ghost', 'a');
+    }
+
+    public function testCreateRejectsZeroGoal(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->p->create('park', 0);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT299** — `Nene\Kit\Petition`: a signature campaign toward a goal (sign once each, track progress, close). Distinct from `DocumentSignature` (FT248, e-sign approval) and `VotePoll` (FT239).

| Method | Description |
| --- | --- |
| `create / close / isClosed` | Lifecycle. |
| `sign(name, signer, comment=''): bool` | Sign once (guards unknown/closed). |
| `hasSigned / signatureCount / goalReached` | Membership / counts. |
| `progress(name): ?array` | `{count, goal, reached, pct≤1.0}`. |
| `signatures(name, limit=null)` | Recent signatures. |

- One per (petition, signer); re-create reopens; `goalReached` inclusive.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 29 assertions (idempotent sign, goalReached, progress + pct cap, close stops signing, re-create reopens, signatures order, separation, unknown throw, zero-goal)
- [x] `composer precommit` green (format → Phan → 5004 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)