### PR TITLE
feat(kit): ServiceStatus — public status-page component states (FT300)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -217,6 +217,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `IntegrationLog` | outbound/inbound API call log with request and response data. |
 | `KpiTracker` | KPI / OKR metric tracking with target vs. actual comparison. |
 | `PageView` | page and resource view analytics tracking. |
+| `ServiceStatus` | public status-page component states with an overall roll-up. |
 | `SlaTracker` | SLA/SLO breach detection for timed work items. |
 | `UtmCampaign` | UTM marketing-attribution touch capture. |
 

--- a/class/kit/ServiceStatus.php
+++ b/class/kit/ServiceStatus.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * ServiceStatus — public status-page component states with an overall roll-up.
+ *
+ * Holds the current operational state of each named component (API, web,
+ * database, …) for a public status page, and rolls them up to a single
+ * overall status (the worst component). Distinct from `HealthCheck` (FT225,
+ * internal probe log), `Heartbeat` (FT273, liveness), and `IncidentLog`
+ * (incident tracking): this is the operator-set, user-facing status board.
+ *
+ * Severity order (low → high): operational, maintenance, degraded,
+ * partial_outage, major_outage. `overall()` returns the highest present (or
+ * `operational` when nothing is registered).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ss = new ServiceStatus($pdo);
+ *
+ * $ss->setStatus('api', ServiceStatus::DEGRADED, 'Elevated latency');
+ * $ss->setStatus('web', ServiceStatus::OPERATIONAL);
+ *
+ * $ss->statusOf('api');   // 'degraded'
+ * $ss->overall();         // 'degraded' (worst component)
+ * $ss->isOperational();   // false
+ * $ss->components();       // [['component'=>'api','status'=>'degraded','message'=>...], ...]
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE service_status (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     component  VARCHAR(150) NOT NULL,
+ *     status     VARCHAR(20)  NOT NULL,
+ *     message    VARCHAR(255) NOT NULL DEFAULT '',
+ *     updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (component)
+ * );
+ * ```
+ */
+final class ServiceStatus
+{
+    public const string OPERATIONAL     = 'operational';
+    public const string MAINTENANCE     = 'maintenance';
+    public const string DEGRADED        = 'degraded';
+    public const string PARTIAL_OUTAGE  = 'partial_outage';
+    public const string MAJOR_OUTAGE    = 'major_outage';
+
+    /** Severity ranking (low → high). */
+    private const array SEVERITY = [
+        self::OPERATIONAL    => 0,
+        self::MAINTENANCE    => 1,
+        self::DEGRADED       => 2,
+        self::PARTIAL_OUTAGE => 3,
+        self::MAJOR_OUTAGE   => 4,
+    ];
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Set a component's current status. Idempotent per component.
+     *
+     * @param  string $component Component name.
+     * @param  string $status    One of the status constants.
+     * @param  string $message   Optional human message.
+     * @throws \InvalidArgumentException on empty component or unknown status.
+     */
+    public function setStatus(string $component, string $status, string $message = ''): void
+    {
+        $component = $this->validate($component);
+        if (!isset(self::SEVERITY[$status])) {
+            throw new \InvalidArgumentException("Unknown status: {$status}");
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'service_status',
+            data:         ['component' => $component, 'status' => $status, 'message' => $message],
+            conflictCols: ['component'],
+            updateCols:   ['status', 'message'],
+            updateExprs:  ['updated_at' => 'CURRENT_TIMESTAMP'],
+        );
+    }
+
+    /**
+     * Current status of a component, or null if not registered.
+     */
+    public function statusOf(string $component): ?string
+    {
+        $component = $this->validate($component);
+        $stmt      = $this->db()->prepare('SELECT status FROM service_status WHERE component = ?');
+        $stmt->execute([$component]);
+        $s = $stmt->fetchColumn();
+
+        return $s === false ? null : (string)$s;
+    }
+
+    /**
+     * All components and their statuses, by component name.
+     *
+     * @return array<int,array{component:string,status:string,message:string}>
+     */
+    public function components(): array
+    {
+        $stmt = $this->db()->query('SELECT component, status, message FROM service_status ORDER BY component ASC');
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($rows as $row) {
+            $out[] = [
+                'component' => (string)$row['component'],
+                'status'    => (string)$row['status'],
+                'message'   => (string)$row['message'],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Overall status: the worst (highest-severity) component, or `operational`
+     * when no components are registered.
+     */
+    public function overall(): string
+    {
+        $stmt = $this->db()->query('SELECT status FROM service_status');
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        $worst    = self::OPERATIONAL;
+        $worstSev = 0;
+        foreach ($rows as $status) {
+            $sev = self::SEVERITY[(string)$status] ?? 0;
+            if ($sev > $worstSev) {
+                $worstSev = $sev;
+                $worst    = (string)$status;
+            }
+        }
+
+        return $worst;
+    }
+
+    /**
+     * Whether everything is operational (overall == operational).
+     */
+    public function isOperational(): bool
+    {
+        return $this->overall() === self::OPERATIONAL;
+    }
+
+    /**
+     * Remove a component. No-op if absent.
+     */
+    public function remove(string $component): void
+    {
+        $component = $this->validate($component);
+        $stmt      = $this->db()->prepare('DELETE FROM service_status WHERE component = ?');
+        $stmt->execute([$component]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function validate(string $component): string
+    {
+        $component = trim($component);
+        if ($component === '') {
+            throw new \InvalidArgumentException('Component must not be empty.');
+        }
+
+        return $component;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-300.md
+++ b/docs/field-trials/2026-05-field-trial-300.md
@@ -1,0 +1,40 @@
+# Field Trial 300 — ServiceStatus
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft300-service-status`
+**Baseline**: post FT299 merge
+
+## Goal
+
+Add `Nene\Kit\ServiceStatus` — public status-page component states with an overall roll-up (the worst component). Distinct from `HealthCheck` (FT225, internal probe log), `Heartbeat` (FT273, liveness), and `IncidentLog` (incident tracking): this is the operator-set, user-facing status board.
+
+## What was built
+
+### `Nene\Kit\ServiceStatus` (`class/kit/ServiceStatus.php`)
+
+| Method | Description |
+| --- | --- |
+| `setStatus(component, status, message='')` | Upsert a component's state. |
+| `statusOf(component): ?string` | Current state. |
+| `components()` | All components + statuses. |
+| `overall(): string` | Worst component (operational when empty). |
+| `isOperational() / remove(component)` | Roll-up check / delete. |
+
+Key design points:
+
+- **Severity roll-up**: operational < maintenance < degraded < partial_outage < major_outage; `overall()` returns the highest present, defaulting to `operational` when nothing is registered.
+- Status values validated against the constant set; cross-driver upsert per component.
+
+### Tests (`tests/Unit/Kit/ServiceStatusTest.php`)
+
+12 unit tests (19 assertions): set/statusOf, empty → operational, all-operational, overall returns worst, severity ordering (partial_outage > maintenance), maintenance > operational, components ordered, idempotent set, remove → operational, missing no-op, validation (unknown status, empty component).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 12 tests pass; CS Fixer and Phan clean. (FT300 milestone — 300 field trials.)
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/ServiceStatusTest.php
+++ b/tests/Unit/Kit/ServiceStatusTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\ServiceStatus;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ServiceStatus.
+ */
+final class ServiceStatusTest extends TestCase
+{
+    private PDO $db;
+    private ServiceStatus $ss;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE service_status (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                component  VARCHAR(150) NOT NULL,
+                status     VARCHAR(20)  NOT NULL,
+                message    VARCHAR(255) NOT NULL DEFAULT \'\',
+                updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (component)
+            )
+        ');
+        $this->ss = new ServiceStatus($this->db);
+    }
+
+    public function testSetAndStatusOf(): void
+    {
+        $this->ss->setStatus('api', ServiceStatus::DEGRADED, 'slow');
+        $this->assertSame('degraded', $this->ss->statusOf('api'));
+        $this->assertNull($this->ss->statusOf('web'));
+    }
+
+    public function testOverallEmptyIsOperational(): void
+    {
+        $this->assertSame(ServiceStatus::OPERATIONAL, $this->ss->overall());
+        $this->assertTrue($this->ss->isOperational());
+    }
+
+    public function testOverallAllOperational(): void
+    {
+        $this->ss->setStatus('api', ServiceStatus::OPERATIONAL);
+        $this->ss->setStatus('web', ServiceStatus::OPERATIONAL);
+        $this->assertTrue($this->ss->isOperational());
+    }
+
+    public function testOverallReturnsWorst(): void
+    {
+        $this->ss->setStatus('api', ServiceStatus::DEGRADED);
+        $this->ss->setStatus('web', ServiceStatus::OPERATIONAL);
+        $this->ss->setStatus('db', ServiceStatus::MAJOR_OUTAGE);
+        $this->assertSame(ServiceStatus::MAJOR_OUTAGE, $this->ss->overall());
+        $this->assertFalse($this->ss->isOperational());
+    }
+
+    public function testSeverityOrdering(): void
+    {
+        $this->ss->setStatus('a', ServiceStatus::MAINTENANCE);
+        $this->ss->setStatus('b', ServiceStatus::PARTIAL_OUTAGE);
+        // partial_outage outranks maintenance
+        $this->assertSame(ServiceStatus::PARTIAL_OUTAGE, $this->ss->overall());
+    }
+
+    public function testMaintenanceOutranksOperational(): void
+    {
+        $this->ss->setStatus('a', ServiceStatus::OPERATIONAL);
+        $this->ss->setStatus('b', ServiceStatus::MAINTENANCE);
+        $this->assertSame(ServiceStatus::MAINTENANCE, $this->ss->overall());
+        $this->assertFalse($this->ss->isOperational());
+    }
+
+    public function testComponentsListed(): void
+    {
+        $this->ss->setStatus('web', ServiceStatus::OPERATIONAL, 'ok');
+        $this->ss->setStatus('api', ServiceStatus::DEGRADED, 'slow');
+        $comps = $this->ss->components();
+        $this->assertSame('api', $comps[0]['component']); // ordered by name
+        $this->assertSame('slow', $comps[0]['message']);
+    }
+
+    public function testSetStatusIsIdempotent(): void
+    {
+        $this->ss->setStatus('api', ServiceStatus::DEGRADED);
+        $this->ss->setStatus('api', ServiceStatus::OPERATIONAL);
+        $this->assertSame('operational', $this->ss->statusOf('api'));
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM service_status')->fetchColumn());
+    }
+
+    public function testRemove(): void
+    {
+        $this->ss->setStatus('api', ServiceStatus::MAJOR_OUTAGE);
+        $this->ss->remove('api');
+        $this->assertNull($this->ss->statusOf('api'));
+        $this->assertTrue($this->ss->isOperational()); // back to empty/operational
+    }
+
+    public function testRemoveMissingIsNoop(): void
+    {
+        $this->ss->remove('ghost');
+        $this->assertSame([], $this->ss->components());
+    }
+
+    public function testSetStatusRejectsUnknownStatus(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ss->setStatus('api', 'exploded');
+    }
+
+    public function testSetStatusRejectsEmptyComponent(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ss->setStatus('  ', ServiceStatus::OPERATIONAL);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT300** 🎉 — `Nene\Kit\ServiceStatus`: operator-set per-component status for a public status page, with an overall severity roll-up. Distinct from `HealthCheck` (FT225) / `Heartbeat` (FT273) / `IncidentLog`.

| Method | Description |
| --- | --- |
| `setStatus(component, status, message='')` | Upsert state. |
| `statusOf / components / overall / isOperational / remove` | Read / roll-up / delete. |

- Severity: operational < maintenance < degraded < partial_outage < major_outage; `overall()` = worst (operational when empty).

## F-N findings
- **F-1** — none (clean trial). 300th field trial.

## Test plan
- [x] 12 tests / 19 assertions (worst roll-up, severity ordering, empty→operational, idempotent, remove, validation)
- [x] `composer precommit` green (format → Phan → 5016 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)