### PR TITLE
feat(kit): Pseudonymizer — stable real→pseudonym token mapping for PII (FT301)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -48,6 +48,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `IpAllowlist` | per-resource IP allowlist with CIDR range support. |
 | `IpBlocklist` | global IP address blocklist with optional expiry. |
 | `IpReputation` | running reputation score per IP address. |
+| `Pseudonymizer` | stable real-value → pseudonym token mapping for PII. |
 | `RedactionRule` | configurable PII/secret masking rules for text. |
 | `ResourceLock` | advisory lock on any entity to prevent concurrent edits. |
 | `TrustScore` | append-only fraud/trust score per user. |

--- a/class/kit/Pseudonymizer.php
+++ b/class/kit/Pseudonymizer.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * Pseudonymizer — stable real-value → pseudonym token mapping for PII.
+ *
+ * Maps a sensitive value (user id, email, account number) to a stable random
+ * pseudonym token within a namespace, so logs, exports, and analytics can use
+ * the token instead of the real value while still correlating across records.
+ * Authorized callers can `reverse()` a token back to the real value, and
+ * `forget()` supports GDPR erasure. Distinct from `RedactionRule` (FT279, which
+ * masks text irreversibly) and `ChecksumRegistry` (FT287, integrity hashes).
+ *
+ * The same `(namespace, value)` always yields the same token; different
+ * namespaces keep their mappings independent (e.g. per export job).
+ *
+ * ## Usage
+ *
+ * ```php
+ * $pz = new Pseudonymizer($pdo);
+ *
+ * $t1 = $pz->pseudonymize('analytics', 'user-42'); // 'a1b2…'
+ * $t2 = $pz->pseudonymize('analytics', 'user-42'); // same token ($t1 === $t2)
+ *
+ * $pz->reverse('analytics', $t1);  // 'user-42'  (authorized re-identification)
+ * $pz->has('analytics', 'user-42'); // true
+ * $pz->forget('analytics', 'user-42'); // GDPR erasure
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE pseudonyms (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     namespace  VARCHAR(100) NOT NULL,
+ *     real_value VARCHAR(255) NOT NULL,
+ *     token      VARCHAR(64)  NOT NULL,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (namespace, real_value),
+ *     UNIQUE (namespace, token)
+ * );
+ * ```
+ */
+final class Pseudonymizer
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Return the stable pseudonym token for a value, creating one if needed.
+     *
+     * @param  string $namespace Mapping namespace.
+     * @param  string $value     Sensitive value to pseudonymise.
+     * @return string            The stable token (same value → same token).
+     * @throws \InvalidArgumentException on empty namespace or value.
+     */
+    public function pseudonymize(string $namespace, string $value): string
+    {
+        $namespace = $this->validate($namespace, 'Namespace');
+        $value     = $this->validate($value, 'Value');
+
+        $existing = $this->tokenFor($namespace, $value);
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        // Insert a fresh token; ON CONFLICT DO NOTHING means the first writer
+        // wins under concurrency, so we re-read to return the persisted token.
+        $token = bin2hex(random_bytes(16));
+        DbUpsert::run(
+            $this->db(),
+            table:        'pseudonyms',
+            data:         ['namespace' => $namespace, 'real_value' => $value, 'token' => $token],
+            conflictCols: ['namespace', 'real_value'],
+        );
+
+        return $this->tokenFor($namespace, $value) ?? $token;
+    }
+
+    /**
+     * Resolve a token back to its real value, or null if unknown.
+     */
+    public function reverse(string $namespace, string $token): ?string
+    {
+        $namespace = $this->validate($namespace, 'Namespace');
+        $stmt      = $this->db()->prepare('SELECT real_value FROM pseudonyms WHERE namespace = ? AND token = ?');
+        $stmt->execute([$namespace, $token]);
+        $v = $stmt->fetchColumn();
+
+        return $v === false ? null : (string)$v;
+    }
+
+    /**
+     * Whether a value already has a pseudonym in a namespace.
+     */
+    public function has(string $namespace, string $value): bool
+    {
+        $namespace = $this->validate($namespace, 'Namespace');
+        $value     = $this->validate($value, 'Value');
+
+        return $this->tokenFor($namespace, $value) !== null;
+    }
+
+    /**
+     * Erase a value's mapping (GDPR). No-op if absent.
+     */
+    public function forget(string $namespace, string $value): void
+    {
+        $namespace = $this->validate($namespace, 'Namespace');
+        $value     = $this->validate($value, 'Value');
+        $stmt      = $this->db()->prepare('DELETE FROM pseudonyms WHERE namespace = ? AND real_value = ?');
+        $stmt->execute([$namespace, $value]);
+    }
+
+    /**
+     * Number of mappings in a namespace.
+     */
+    public function count(string $namespace): int
+    {
+        $namespace = $this->validate($namespace, 'Namespace');
+        $stmt      = $this->db()->prepare('SELECT COUNT(*) FROM pseudonyms WHERE namespace = ?');
+        $stmt->execute([$namespace]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function tokenFor(string $namespace, string $value): ?string
+    {
+        $stmt = $this->db()->prepare('SELECT token FROM pseudonyms WHERE namespace = ? AND real_value = ?');
+        $stmt->execute([$namespace, $value]);
+        $t = $stmt->fetchColumn();
+
+        return $t === false ? null : (string)$t;
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-301.md
+++ b/docs/field-trials/2026-05-field-trial-301.md
@@ -1,0 +1,41 @@
+# Field Trial 301 — Pseudonymizer
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft301-pseudonymizer`
+**Baseline**: post FT300 merge
+
+## Goal
+
+Add `Nene\Kit\Pseudonymizer` — stable real-value → pseudonym token mapping for PII, so logs/exports/analytics can use tokens while still correlating records and authorized callers can re-identify. Distinct from `RedactionRule` (FT279, irreversible text masking) and `ChecksumRegistry` (FT287, integrity hashes).
+
+## What was built
+
+### `Nene\Kit\Pseudonymizer` (`class/kit/Pseudonymizer.php`)
+
+| Method | Description |
+| --- | --- |
+| `pseudonymize(namespace, value): string` | Stable token (creates one if new). |
+| `reverse(namespace, token): ?string` | Re-identify (authorized). |
+| `has(namespace, value) / count(namespace)` | Membership / size. |
+| `forget(namespace, value)` | GDPR erasure. |
+
+Key design points:
+
+- **Stable + namespaced**: same `(namespace, value)` → same token; namespaces are independent (per export job / context).
+- **Concurrency-safe creation**: insert with `ON CONFLICT (namespace, real_value) DO NOTHING` then re-read, so the first writer's token wins.
+- **Reversible** within a namespace (unlike redaction); `forget()` erases, after which a fresh token is minted.
+- Random 128-bit token (`bin2hex(random_bytes(16))`).
+
+### Tests (`tests/Unit/Kit/PseudonymizerTest.php`)
+
+11 unit tests (19 assertions): stable token (no duplication), distinct values → distinct tokens, reverse + unknown null, namespace independence (same value, scoped reverse), has, forget, forget-then-re-pseudonymize → new token, count per namespace, missing forget no-op, validation (empty namespace/value).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 11 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/PseudonymizerTest.php
+++ b/tests/Unit/Kit/PseudonymizerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\Pseudonymizer;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Pseudonymizer.
+ */
+final class PseudonymizerTest extends TestCase
+{
+    private PDO $db;
+    private Pseudonymizer $pz;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE pseudonyms (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                namespace  VARCHAR(100) NOT NULL,
+                real_value VARCHAR(255) NOT NULL,
+                token      VARCHAR(64)  NOT NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (namespace, real_value),
+                UNIQUE (namespace, token)
+            )
+        ');
+        $this->pz = new Pseudonymizer($this->db);
+    }
+
+    public function testStableTokenForSameValue(): void
+    {
+        $a = $this->pz->pseudonymize('analytics', 'user-42');
+        $b = $this->pz->pseudonymize('analytics', 'user-42');
+        $this->assertSame($a, $b);
+        $this->assertNotSame('', $a);
+        $this->assertSame(1, $this->pz->count('analytics')); // not duplicated
+    }
+
+    public function testDifferentValuesGetDifferentTokens(): void
+    {
+        $a = $this->pz->pseudonymize('analytics', 'user-1');
+        $b = $this->pz->pseudonymize('analytics', 'user-2');
+        $this->assertNotSame($a, $b);
+    }
+
+    public function testReverse(): void
+    {
+        $t = $this->pz->pseudonymize('analytics', 'user-42');
+        $this->assertSame('user-42', $this->pz->reverse('analytics', $t));
+        $this->assertNull($this->pz->reverse('analytics', 'unknown-token'));
+    }
+
+    public function testNamespacesAreIndependent(): void
+    {
+        $a = $this->pz->pseudonymize('exportA', 'user-42');
+        $b = $this->pz->pseudonymize('exportB', 'user-42');
+        // same real value, different namespace → independent tokens
+        $this->assertNotSame($a, $b);
+        // reverse only resolves within the namespace
+        $this->assertSame('user-42', $this->pz->reverse('exportA', $a));
+        $this->assertNull($this->pz->reverse('exportB', $a));
+    }
+
+    public function testHas(): void
+    {
+        $this->pz->pseudonymize('ns', 'x');
+        $this->assertTrue($this->pz->has('ns', 'x'));
+        $this->assertFalse($this->pz->has('ns', 'y'));
+    }
+
+    public function testForget(): void
+    {
+        $t = $this->pz->pseudonymize('ns', 'x');
+        $this->pz->forget('ns', 'x');
+        $this->assertFalse($this->pz->has('ns', 'x'));
+        $this->assertNull($this->pz->reverse('ns', $t));
+    }
+
+    public function testForgetThenRePseudonymizeGetsNewToken(): void
+    {
+        $first = $this->pz->pseudonymize('ns', 'x');
+        $this->pz->forget('ns', 'x');
+        $second = $this->pz->pseudonymize('ns', 'x');
+        $this->assertNotSame($first, $second); // erasure means a fresh token
+    }
+
+    public function testCount(): void
+    {
+        $this->pz->pseudonymize('ns', 'a');
+        $this->pz->pseudonymize('ns', 'b');
+        $this->pz->pseudonymize('other', 'c');
+        $this->assertSame(2, $this->pz->count('ns'));
+        $this->assertSame(1, $this->pz->count('other'));
+    }
+
+    public function testForgetMissingIsNoop(): void
+    {
+        $this->pz->forget('ns', 'ghost');
+        $this->assertSame(0, $this->pz->count('ns'));
+    }
+
+    public function testPseudonymizeRejectsEmptyNamespace(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pz->pseudonymize('  ', 'x');
+    }
+
+    public function testPseudonymizeRejectsEmptyValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pz->pseudonymize('ns', '  ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT301** — `Nene\Kit\Pseudonymizer`: stable real-value → pseudonym token mapping per namespace for PII in logs/exports/analytics, with authorized re-identification and GDPR erasure. Distinct from `RedactionRule` (FT279, irreversible) and `ChecksumRegistry` (FT287).

| Method | Description |
| --- | --- |
| `pseudonymize(namespace, value): string` | Stable token (creates if new). |
| `reverse(namespace, token): ?string` | Re-identify. |
| `has / count / forget` | Membership / size / GDPR erasure. |

- Stable + namespaced; concurrency-safe creation (`ON CONFLICT DO NOTHING` + re-read); reversible; `forget` mints a fresh token next time.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 11 tests / 19 assertions (stable no-dup, distinct values, reverse, namespace independence, has, forget + re-pseudonymize new token, count, no-op, validation)
- [x] `composer precommit` green (format → Phan → 5027 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)