### PR TITLE
feat(kit): DailyReward — once-per-day claimable reward with streak (FT302)

### DIFF
--- a/class/kit/DailyReward.php
+++ b/class/kit/DailyReward.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * DailyReward — once-per-day claimable reward with a consecutive-day streak.
+ *
+ * Lets a user claim a reward at most once per calendar day (daily login bonus,
+ * spin-the-wheel, etc.) and tracks the streak of consecutive claim days.
+ * Distinct from `DailyStreak` (FT255, which counts activity days) and
+ * `PointBalance` (FT213, a points ledger): this records the *claim grant*
+ * itself with one-per-day enforcement.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $dr = new DailyReward($pdo);
+ *
+ * $dr->claim(42, reward: 10, asOf: '2026-06-01'); // true — granted
+ * $dr->claim(42, reward: 10, asOf: '2026-06-01'); // false — already claimed today
+ * $dr->claim(42, reward: 20, asOf: '2026-06-02'); // true
+ *
+ * $dr->claimedToday(42, '2026-06-02'); // true
+ * $dr->canClaim(42, '2026-06-03');     // true
+ * $dr->claimStreak(42, '2026-06-02');  // 2 (Jun 1 + 2 consecutive)
+ * $dr->totalClaimed(42);               // 30
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE daily_reward_claims (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id    BIGINT   NOT NULL,
+ *     claim_date CHAR(10) NOT NULL,
+ *     reward     INTEGER  NOT NULL DEFAULT 0,
+ *     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (user_id, claim_date)
+ * );
+ * ```
+ */
+final class DailyReward
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Claim the day's reward. At most once per calendar day per user.
+     *
+     * @param  int         $userId User id.
+     * @param  int         $reward Reward amount granted (>= 0).
+     * @param  string|null $asOf   Reference date 'Y-m-d' (or parseable); defaults to today.
+     * @return bool                True if newly claimed; false if already claimed today.
+     * @throws \InvalidArgumentException on negative reward or bad date.
+     */
+    public function claim(int $userId, int $reward, ?string $asOf = null): bool
+    {
+        if ($reward < 0) {
+            throw new \InvalidArgumentException('Reward must not be negative.');
+        }
+        $day = $this->day($asOf);
+        if ($this->claimedOn($userId, $day)) {
+            return false;
+        }
+
+        $stmt = $this->db()->prepare('INSERT INTO daily_reward_claims (user_id, claim_date, reward) VALUES (?, ?, ?)');
+        $stmt->execute([$userId, $day, $reward]);
+
+        return true;
+    }
+
+    /**
+     * Whether the user has claimed today's reward.
+     */
+    public function claimedToday(int $userId, ?string $asOf = null): bool
+    {
+        return $this->claimedOn($userId, $this->day($asOf));
+    }
+
+    /**
+     * Whether the user can claim now (has not claimed today).
+     */
+    public function canClaim(int $userId, ?string $asOf = null): bool
+    {
+        return !$this->claimedToday($userId, $asOf);
+    }
+
+    /**
+     * The user's most recent claim date, or null.
+     */
+    public function lastClaim(int $userId): ?string
+    {
+        $stmt = $this->db()->prepare('SELECT MAX(claim_date) FROM daily_reward_claims WHERE user_id = ?');
+        $stmt->execute([$userId]);
+        $d = $stmt->fetchColumn();
+
+        return $d === null || $d === false ? null : (string)$d;
+    }
+
+    /**
+     * Total reward amount the user has claimed.
+     */
+    public function totalClaimed(int $userId): int
+    {
+        $stmt = $this->db()->prepare('SELECT COALESCE(SUM(reward), 0) FROM daily_reward_claims WHERE user_id = ?');
+        $stmt->execute([$userId]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Length of the current consecutive-day claim streak ending at the
+     * reference day (or the day before, if today is unclaimed).
+     *
+     * @param int         $userId User id.
+     * @param string|null $asOf   Reference date; defaults to today.
+     */
+    public function claimStreak(int $userId, ?string $asOf = null): int
+    {
+        $cursor = new \DateTimeImmutable($this->day($asOf));
+        // If today is not claimed, the streak (if any) ends yesterday.
+        if (!$this->claimedOn($userId, $cursor->format('Y-m-d'))) {
+            $cursor = $cursor->sub(new \DateInterval('P1D'));
+        }
+
+        $streak = 0;
+        while ($this->claimedOn($userId, $cursor->format('Y-m-d'))) {
+            $streak++;
+            $cursor = $cursor->sub(new \DateInterval('P1D'));
+        }
+
+        return $streak;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function claimedOn(int $userId, string $day): bool
+    {
+        $stmt = $this->db()->prepare('SELECT 1 FROM daily_reward_claims WHERE user_id = ? AND claim_date = ? LIMIT 1');
+        $stmt->execute([$userId, $day]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    private function day(?string $asOf): string
+    {
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid date.');
+        }
+
+        return date('Y-m-d', $epoch);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -93,6 +93,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `Bookmark` | Generic per-user bookmark / saved-item manager. |
 | `BookmarkCollection` | user-curated collections of bookmarked entities. |
 | `ConsentLog` | immutable record of user consent grants and withdrawals. |
+| `DailyReward` | once-per-day claimable reward with a consecutive-day streak. |
 | `DailyStreak` | Track per-user daily activity streaks. |
 | `EntityAlias` | multiple identifier aliases for an entity. |
 | `FeatureTour` | per-user state for one-time UI tours / coachmarks. |

--- a/docs/field-trials/2026-05-field-trial-302.md
+++ b/docs/field-trials/2026-05-field-trial-302.md
@@ -1,0 +1,40 @@
+# Field Trial 302 — DailyReward
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft302-daily-reward`
+**Baseline**: post FT301 merge
+
+## Goal
+
+Add `Nene\Kit\DailyReward` — once-per-day claimable reward (daily login bonus) with a consecutive-day claim streak. Distinct from `DailyStreak` (FT255, counts activity days) and `PointBalance` (FT213, ledger): this records the claim grant with one-per-day enforcement.
+
+## What was built
+
+### `Nene\Kit\DailyReward` (`class/kit/DailyReward.php`)
+
+| Method | Description |
+| --- | --- |
+| `claim(userId, reward, asOf=null): bool` | Claim today (true if newly claimed). |
+| `claimedToday / canClaim (userId, asOf=null)` | Today's state. |
+| `lastClaim(userId) / totalClaimed(userId)` | Last date / sum. |
+| `claimStreak(userId, asOf=null): int` | Consecutive claim days. |
+
+Key design points:
+
+- **One per calendar day** via `UNIQUE (user_id, claim_date)`; a second claim the same day returns false.
+- **Streak counts through yesterday** when today is unclaimed (so a not-yet-claimed today doesn't zero the streak), and breaks on a gap.
+- `asOf` ('Y-m-d') makes day logic deterministic.
+
+### Tests (`tests/Unit/Kit/DailyRewardTest.php`)
+
+11 unit tests (18 assertions): claim once-per-day, claimedToday/canClaim, totalClaimed sum, lastClaim, streak consecutive, streak breaks on gap, **streak counts through yesterday when today unclaimed**, streak 0 when gap before yesterday, user separation, negative-reward rejected, zero reward allowed.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 11 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/DailyRewardTest.php
+++ b/tests/Unit/Kit/DailyRewardTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\DailyReward;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for DailyReward.
+ */
+final class DailyRewardTest extends TestCase
+{
+    private PDO $db;
+    private DailyReward $dr;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE daily_reward_claims (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id    BIGINT   NOT NULL,
+                claim_date CHAR(10) NOT NULL,
+                reward     INTEGER  NOT NULL DEFAULT 0,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (user_id, claim_date)
+            )
+        ');
+        $this->dr = new DailyReward($this->db);
+    }
+
+    public function testClaimOncePerDay(): void
+    {
+        $this->assertTrue($this->dr->claim(42, 10, '2026-06-01'));
+        $this->assertFalse($this->dr->claim(42, 10, '2026-06-01')); // already claimed
+        $this->assertTrue($this->dr->claim(42, 20, '2026-06-02'));
+    }
+
+    public function testClaimedTodayAndCanClaim(): void
+    {
+        $this->dr->claim(42, 10, '2026-06-01');
+        $this->assertTrue($this->dr->claimedToday(42, '2026-06-01'));
+        $this->assertFalse($this->dr->canClaim(42, '2026-06-01'));
+        $this->assertTrue($this->dr->canClaim(42, '2026-06-02'));
+    }
+
+    public function testTotalClaimed(): void
+    {
+        $this->dr->claim(42, 10, '2026-06-01');
+        $this->dr->claim(42, 20, '2026-06-02');
+        $this->dr->claim(42, 5, '2026-06-03');
+        $this->assertSame(35, $this->dr->totalClaimed(42));
+    }
+
+    public function testLastClaim(): void
+    {
+        $this->dr->claim(42, 10, '2026-06-01');
+        $this->dr->claim(42, 10, '2026-06-05');
+        $this->assertSame('2026-06-05', $this->dr->lastClaim(42));
+        $this->assertNull($this->dr->lastClaim(99));
+    }
+
+    public function testStreakConsecutiveDays(): void
+    {
+        $this->dr->claim(42, 1, '2026-06-01');
+        $this->dr->claim(42, 1, '2026-06-02');
+        $this->dr->claim(42, 1, '2026-06-03');
+        $this->assertSame(3, $this->dr->claimStreak(42, '2026-06-03'));
+    }
+
+    public function testStreakBreaksOnGap(): void
+    {
+        $this->dr->claim(42, 1, '2026-06-01');
+        $this->dr->claim(42, 1, '2026-06-02');
+        // gap on the 3rd
+        $this->dr->claim(42, 1, '2026-06-04');
+        $this->dr->claim(42, 1, '2026-06-05');
+        $this->assertSame(2, $this->dr->claimStreak(42, '2026-06-05')); // only 4th+5th
+    }
+
+    public function testStreakCountsThroughYesterdayWhenTodayUnclaimed(): void
+    {
+        $this->dr->claim(42, 1, '2026-06-01');
+        $this->dr->claim(42, 1, '2026-06-02');
+        // today (06-03) not yet claimed → streak still counts up to yesterday
+        $this->assertSame(2, $this->dr->claimStreak(42, '2026-06-03'));
+    }
+
+    public function testStreakZeroWhenGapBeforeYesterday(): void
+    {
+        $this->dr->claim(42, 1, '2026-06-01');
+        // today 06-03, yesterday 06-02 unclaimed → streak 0
+        $this->assertSame(0, $this->dr->claimStreak(42, '2026-06-03'));
+    }
+
+    public function testUsersAreSeparate(): void
+    {
+        $this->dr->claim(1, 10, '2026-06-01');
+        $this->assertTrue($this->dr->canClaim(2, '2026-06-01'));
+        $this->assertSame(0, $this->dr->totalClaimed(2));
+    }
+
+    public function testClaimRejectsNegativeReward(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->dr->claim(42, -1, '2026-06-01');
+    }
+
+    public function testZeroRewardIsAllowed(): void
+    {
+        $this->assertTrue($this->dr->claim(42, 0, '2026-06-01'));
+        $this->assertSame(0, $this->dr->totalClaimed(42));
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT302** — `Nene\Kit\DailyReward`: once-per-day claimable reward (login bonus) with a consecutive-day streak. Distinct from `DailyStreak` (FT255, activity days) and `PointBalance` (FT213, ledger).

| Method | Description |
| --- | --- |
| `claim(userId, reward, asOf=null): bool` | Once per day (true if new). |
| `claimedToday / canClaim` | Today's state. |
| `lastClaim / totalClaimed / claimStreak` | Date / sum / consecutive days. |

- `UNIQUE (user, date)`; streak counts through yesterday when today unclaimed, breaks on gap.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 11 tests / 18 assertions (once-per-day, claimedToday, total, lastClaim, streak consecutive/gap/through-yesterday/zero, separation, neg reward, zero allowed)
- [x] `composer precommit` green (format → Phan → 5038 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)