### PR TITLE
feat(kit): Achievement — progress-tracked auto-unlocking achievements (FT303)

### DIFF
--- a/class/kit/Achievement.php
+++ b/class/kit/Achievement.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * Achievement — progress-tracked, auto-unlocking achievements per user.
+ *
+ * Defines achievements with a numeric target ("read 10 articles") and tracks
+ * each user's progress, automatically unlocking when progress reaches the
+ * target. Distinct from `ProfileBadge` (FT257), which awards a badge in one
+ * shot: this models *progress toward* an unlock.
+ *
+ * Two tables: achievement definitions and per-user progress.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $a = new Achievement($pdo);
+ *
+ * $a->define('bookworm', 'Bookworm', target: 10);
+ *
+ * $a->advance(42, 'bookworm', 7);   // false (7/10)
+ * $a->advance(42, 'bookworm', 3);   // true  — just hit 10/10 → unlocked
+ * $a->advance(42, 'bookworm');      // false (already unlocked)
+ *
+ * $a->progress(42, 'bookworm');     // 10
+ * $a->isUnlocked(42, 'bookworm');   // true
+ * $a->unlockedFor(42);              // ['bookworm']
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE achievement_defs (
+ *     id     INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     code   VARCHAR(100) NOT NULL,
+ *     name   VARCHAR(190) NOT NULL DEFAULT '',
+ *     target INTEGER      NOT NULL,
+ *     UNIQUE (code)
+ * );
+ * CREATE TABLE achievement_progress (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id     BIGINT       NOT NULL,
+ *     code        VARCHAR(100) NOT NULL,
+ *     progress    INTEGER      NOT NULL DEFAULT 0,
+ *     unlocked    INTEGER      NOT NULL DEFAULT 0,
+ *     unlocked_at DATETIME     NULL,
+ *     UNIQUE (user_id, code)
+ * );
+ * ```
+ */
+final class Achievement
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── definitions ─────────────────────────────────────────────────────────────
+
+    /**
+     * Define (or update) an achievement. Idempotent per code.
+     *
+     * @param  string $code   Achievement code.
+     * @param  string $name   Display name.
+     * @param  int    $target Progress required to unlock (>= 1).
+     * @throws \InvalidArgumentException on empty code or target < 1.
+     */
+    public function define(string $code, string $name, int $target): void
+    {
+        $code = $this->validate($code, 'Code');
+        if ($target < 1) {
+            throw new \InvalidArgumentException('Target must be at least 1.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'achievement_defs',
+            data:         ['code' => $code, 'name' => trim($name), 'target' => $target],
+            conflictCols: ['code'],
+            updateCols:   ['name', 'target'],
+        );
+    }
+
+    // ── progress ────────────────────────────────────────────────────────────────
+
+    /**
+     * Add progress for a user; unlock when the target is reached.
+     *
+     * @param  string      $code Achievement code (must be defined).
+     * @param  int         $by   Progress to add (>= 1).
+     * @param  string|null $asOf Unlock time; defaults to now.
+     * @return bool              True only on the call that crosses into unlocked.
+     * @throws \InvalidArgumentException if undefined or $by < 1.
+     */
+    public function advance(int $userId, string $code, int $by = 1, ?string $asOf = null): bool
+    {
+        $code = $this->validate($code, 'Code');
+        if ($by < 1) {
+            throw new \InvalidArgumentException('Increment must be at least 1.');
+        }
+        $target = $this->target($code);
+        if ($target === null) {
+            throw new \InvalidArgumentException("Achievement is not defined: {$code}");
+        }
+
+        $db             = $this->db();
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+        try {
+            $row         = $this->progressRow($userId, $code);
+            $wasUnlocked = $row !== null && (int)$row['unlocked'] === 1;
+            $current     = $row === null ? 0 : (int)$row['progress'];
+            $new         = min($target, $current + $by);
+            $nowUnlocked = $new >= $target;
+
+            DbUpsert::run(
+                $db,
+                table:        'achievement_progress',
+                data:         [
+                    'user_id'     => $userId,
+                    'code'        => $code,
+                    'progress'    => $new,
+                    'unlocked'    => $nowUnlocked ? 1 : 0,
+                    'unlocked_at' => $nowUnlocked && !$wasUnlocked ? $this->ts($asOf) : ($row['unlocked_at'] ?? null),
+                ],
+                conflictCols: ['user_id', 'code'],
+                updateCols:   ['progress', 'unlocked', 'unlocked_at'],
+            );
+
+            if ($ownTransaction) {
+                $db->commit();
+            }
+
+            return $nowUnlocked && !$wasUnlocked;
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * A user's current progress on an achievement (0 if none).
+     */
+    public function progress(int $userId, string $code): int
+    {
+        $row = $this->progressRow($userId, $this->validate($code, 'Code'));
+
+        return $row === null ? 0 : (int)$row['progress'];
+    }
+
+    /**
+     * Whether a user has unlocked an achievement.
+     */
+    public function isUnlocked(int $userId, string $code): bool
+    {
+        $row = $this->progressRow($userId, $this->validate($code, 'Code'));
+
+        return $row !== null && (int)$row['unlocked'] === 1;
+    }
+
+    /**
+     * Progress as a fraction of the target (0.0–1.0), 0.0 if undefined.
+     */
+    public function progressPct(int $userId, string $code): float
+    {
+        $code   = $this->validate($code, 'Code');
+        $target = $this->target($code);
+        if ($target === null) {
+            return 0.0;
+        }
+
+        return round(min(1.0, $this->progress($userId, $code) / $target), 4);
+    }
+
+    /**
+     * Codes a user has unlocked, ascending.
+     *
+     * @return array<int,string>
+     */
+    public function unlockedFor(int $userId): array
+    {
+        $stmt = $this->db()->prepare('SELECT code FROM achievement_progress WHERE user_id = ? AND unlocked = 1 ORDER BY code ASC');
+        $stmt->execute([$userId]);
+
+        return array_map(static fn ($c): string => (string)$c, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function target(string $code): ?int
+    {
+        $stmt = $this->db()->prepare('SELECT target FROM achievement_defs WHERE code = ?');
+        $stmt->execute([$code]);
+        $t = $stmt->fetchColumn();
+
+        return $t === false ? null : (int)$t;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function progressRow(int $userId, string $code): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT progress, unlocked, unlocked_at FROM achievement_progress WHERE user_id = ? AND code = ?');
+        $stmt->execute([$userId, $code]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function ts(?string $asOf): string
+    {
+        $epoch = strtotime($asOf ?? 'now');
+        if ($epoch === false) {
+            throw new \InvalidArgumentException('Invalid timestamp.');
+        }
+
+        return date('Y-m-d H:i:s', $epoch);
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -230,6 +230,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | Class | Description |
 |-------|-------------|
 | `AbTest` | A/B test variant assignment and conversion tracking. |
+| `Achievement` | progress-tracked, auto-unlocking achievements per user. |
 | `Approval` | single-approver workflow (request → approve / reject). |
 | `ChangeRequest` | formal RFC / change-management approval workflow. |
 | `Endorsement` | peer skill endorsements between users. |

--- a/docs/field-trials/2026-05-field-trial-303.md
+++ b/docs/field-trials/2026-05-field-trial-303.md
@@ -1,0 +1,42 @@
+# Field Trial 303 — Achievement
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft303-achievement`
+**Baseline**: post FT302 merge
+
+## Goal
+
+Add `Nene\Kit\Achievement` — progress-tracked, auto-unlocking achievements per user ("read 10 articles"). Distinct from `ProfileBadge` (FT257, one-shot badge award): this models *progress toward* an unlock.
+
+## What was built
+
+### `Nene\Kit\Achievement` (`class/kit/Achievement.php`)
+
+Two tables: definitions (code, target) + per-user progress.
+
+| Method | Description |
+| --- | --- |
+| `define(code, name, target)` | Define an achievement (target ≥ 1). |
+| `advance(userId, code, by=1, asOf=null): bool` | Add progress; true only on the unlocking call. |
+| `progress / isUnlocked / progressPct` | Per-user state. |
+| `unlockedFor(userId)` | Codes unlocked. |
+
+Key design points:
+
+- **Auto-unlock at target**; `advance` returns true *only* on the call that crosses into unlocked (idempotent thereafter) — a clean hook for "achievement unlocked!" notifications.
+- **Progress capped at target**; atomic read-modify-write in a transaction.
+- `progressPct` capped at 1.0; re-`define` changes the target.
+
+### Tests (`tests/Unit/Kit/AchievementTest.php`)
+
+11 unit tests (21 assertions): unlock at target, true-only-on-unlocking-call, progress caps at target, progressPct, unlockedFor, unknown progress 0, user separation, idempotent define (raises target), advance-undefined throws, zero-increment rejected, zero-target rejected.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 11 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/AchievementTest.php
+++ b/tests/Unit/Kit/AchievementTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\Achievement;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Achievement.
+ */
+final class AchievementTest extends TestCase
+{
+    private PDO $db;
+    private Achievement $a;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE achievement_defs (
+                id     INTEGER PRIMARY KEY AUTOINCREMENT,
+                code   VARCHAR(100) NOT NULL,
+                name   VARCHAR(190) NOT NULL DEFAULT \'\',
+                target INTEGER      NOT NULL,
+                UNIQUE (code)
+            )
+        ');
+        $this->db->exec('
+            CREATE TABLE achievement_progress (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     BIGINT       NOT NULL,
+                code        VARCHAR(100) NOT NULL,
+                progress    INTEGER      NOT NULL DEFAULT 0,
+                unlocked    INTEGER      NOT NULL DEFAULT 0,
+                unlocked_at DATETIME     NULL,
+                UNIQUE (user_id, code)
+            )
+        ');
+        $this->a = new Achievement($this->db);
+    }
+
+    public function testAdvanceUnlocksAtTarget(): void
+    {
+        $this->a->define('bw', 'Bookworm', 10);
+        $this->assertFalse($this->a->advance(42, 'bw', 7));  // 7/10
+        $this->assertTrue($this->a->advance(42, 'bw', 3));   // hits 10 → unlocked
+        $this->assertTrue($this->a->isUnlocked(42, 'bw'));
+        $this->assertSame(10, $this->a->progress(42, 'bw'));
+    }
+
+    public function testAdvanceReturnsTrueOnlyOnUnlockingCall(): void
+    {
+        $this->a->define('bw', 'Bookworm', 5);
+        $this->assertFalse($this->a->advance(42, 'bw', 4));
+        $this->assertTrue($this->a->advance(42, 'bw', 1));  // crosses
+        $this->assertFalse($this->a->advance(42, 'bw', 1)); // already unlocked
+    }
+
+    public function testProgressCapsAtTarget(): void
+    {
+        $this->a->define('bw', 'Bookworm', 5);
+        $this->a->advance(42, 'bw', 100); // overshoot
+        $this->assertSame(5, $this->a->progress(42, 'bw')); // capped
+    }
+
+    public function testProgressPct(): void
+    {
+        $this->a->define('bw', 'Bookworm', 4);
+        $this->a->advance(42, 'bw', 1);
+        $this->assertSame(0.25, $this->a->progressPct(42, 'bw'));
+        $this->a->advance(42, 'bw', 3);
+        $this->assertSame(1.0, $this->a->progressPct(42, 'bw'));
+    }
+
+    public function testUnlockedFor(): void
+    {
+        $this->a->define('a', 'A', 1);
+        $this->a->define('b', 'B', 5);
+        $this->a->advance(42, 'a', 1); // unlock a
+        $this->a->advance(42, 'b', 2); // partial b
+        $this->assertSame(['a'], $this->a->unlockedFor(42));
+    }
+
+    public function testProgressUnknownIsZero(): void
+    {
+        $this->a->define('bw', 'Bookworm', 5);
+        $this->assertSame(0, $this->a->progress(42, 'bw'));
+        $this->assertFalse($this->a->isUnlocked(42, 'bw'));
+    }
+
+    public function testUsersAreSeparate(): void
+    {
+        $this->a->define('bw', 'Bookworm', 2);
+        $this->a->advance(1, 'bw', 2); // user 1 unlocks
+        $this->assertTrue($this->a->isUnlocked(1, 'bw'));
+        $this->assertFalse($this->a->isUnlocked(2, 'bw'));
+        $this->assertSame(0, $this->a->progress(2, 'bw'));
+    }
+
+    public function testDefineIsIdempotent(): void
+    {
+        $this->a->define('bw', 'Bookworm', 10);
+        $this->a->define('bw', 'Book Worm', 20);
+        $this->a->advance(42, 'bw', 10);
+        $this->assertFalse($this->a->isUnlocked(42, 'bw')); // target is now 20
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM achievement_defs')->fetchColumn());
+    }
+
+    public function testAdvanceUndefinedThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->a->advance(42, 'ghost', 1);
+    }
+
+    public function testAdvanceRejectsZeroIncrement(): void
+    {
+        $this->a->define('bw', 'Bookworm', 5);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->a->advance(42, 'bw', 0);
+    }
+
+    public function testDefineRejectsZeroTarget(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->a->define('bw', 'Bookworm', 0);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT303** — `Nene\Kit\Achievement`: progress-tracked, auto-unlocking achievements per user ("read 10 articles"). Distinct from `ProfileBadge` (FT257, one-shot award).

| Method | Description |
| --- | --- |
| `define(code, name, target)` | Define (target ≥ 1). |
| `advance(userId, code, by=1, asOf=null): bool` | Progress; true only on unlocking call. |
| `progress / isUnlocked / progressPct / unlockedFor` | State. |

- Auto-unlock at target; `advance` true only on the crossing call (idempotent after); progress capped; atomic.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 11 tests / 21 assertions (unlock at target, true-only-on-cross, cap, pct, unlockedFor, unknown 0, separation, idempotent define, undefined throw, zero increment/target)
- [x] `composer precommit` green (format → Phan → 5049 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)