### PR TITLE
feat(kit): QueueTicket — take-a-number service queue (FT304)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -306,6 +306,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `DocumentSignature` | e-signature request workflow with multi-signatory support. |
 | `JobQueue` | simple DB-backed background job queue. |
 | `OptimisticLock` | — |
+| `QueueTicket` | take-a-number service queue with now-serving tracking. |
 | `ReportSchedule` | recurring report definitions with a next-run clock. |
 | `RetrySchedule` | exponential-backoff retry tracking for arbitrary operations. |
 | `RoundRobinAssigner` | fair rotating assignment across a named pool. |

--- a/class/kit/QueueTicket.php
+++ b/class/kit/QueueTicket.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * QueueTicket — take-a-number service queue with now-serving tracking.
+ *
+ * Models a physical/virtual "take a number" line per queue: customers `issue()`
+ * a ticket, staff `callNext()` to advance the now-serving number, and a
+ * waiting customer can see their `position()`. Distinct from `JobQueue` (FT73,
+ * background work) and `TimeSlot` (FT203, booked appointments): this is an
+ * ordered, human-facing service line.
+ *
+ * Ticket lifecycle: `waiting` → `serving` → `done`; a ticket may also be
+ * `skipped`. Numbers increase per queue.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $q = new QueueTicket($pdo);
+ *
+ * $n1 = $q->issue('deli', 'Alice'); // 1
+ * $n2 = $q->issue('deli', 'Bob');   // 2
+ *
+ * $q->waiting('deli');       // 2
+ * $q->position('deli', $n2); // 2 (one ahead)
+ * $q->callNext('deli');      // 1 — Alice now serving
+ * $q->nowServing('deli');    // 1
+ * $q->position('deli', $n2); // 1 (next up)
+ * $q->callNext('deli');      // 2 — Alice done, Bob serving
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE queue_tickets (
+ *     id        INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     queue     VARCHAR(100) NOT NULL,
+ *     number    INTEGER      NOT NULL,
+ *     label     VARCHAR(190) NOT NULL DEFAULT '',
+ *     status    VARCHAR(10)  NOT NULL DEFAULT 'waiting',
+ *     issued_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (queue, number)
+ * );
+ * ```
+ */
+final class QueueTicket
+{
+    public const string WAITING = 'waiting';
+    public const string SERVING = 'serving';
+    public const string DONE    = 'done';
+    public const string SKIPPED = 'skipped';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Issue the next ticket number for a queue.
+     *
+     * @param  string $queue Queue name.
+     * @param  string $label Optional label (customer name, etc.).
+     * @return int           The assigned ticket number.
+     * @throws \InvalidArgumentException on empty queue.
+     */
+    public function issue(string $queue, string $label = ''): int
+    {
+        $queue          = $this->validate($queue);
+        $db             = $this->db();
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+        try {
+            $next = $this->maxNumber($queue) + 1;
+            $stmt = $db->prepare('INSERT INTO queue_tickets (queue, number, label, status) VALUES (?, ?, ?, ?)');
+            $stmt->execute([$queue, $next, $label, self::WAITING]);
+            if ($ownTransaction) {
+                $db->commit();
+            }
+
+            return $next;
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Complete the current serving ticket and start serving the next waiting
+     * ticket (lowest number).
+     *
+     * @param  string $queue Queue name.
+     * @return int|null      The newly-serving number, or null if none waiting.
+     */
+    public function callNext(string $queue): ?int
+    {
+        $queue          = $this->validate($queue);
+        $db             = $this->db();
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+        try {
+            // Finish whoever is currently serving.
+            $db->prepare('UPDATE queue_tickets SET status = ? WHERE queue = ? AND status = ?')
+               ->execute([self::DONE, $queue, self::SERVING]);
+
+            $sel = $db->prepare('SELECT number FROM queue_tickets WHERE queue = ? AND status = ? ORDER BY number ASC LIMIT 1');
+            $sel->execute([$queue, self::WAITING]);
+            $number = $sel->fetchColumn();
+
+            if ($number === false) {
+                if ($ownTransaction) {
+                    $db->commit();
+                }
+
+                return null;
+            }
+
+            $db->prepare('UPDATE queue_tickets SET status = ? WHERE queue = ? AND number = ?')
+               ->execute([self::SERVING, $queue, (int)$number]);
+
+            if ($ownTransaction) {
+                $db->commit();
+            }
+
+            return (int)$number;
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * The currently-serving number for a queue, or null.
+     */
+    public function nowServing(string $queue): ?int
+    {
+        $queue = $this->validate($queue);
+        $stmt  = $this->db()->prepare('SELECT number FROM queue_tickets WHERE queue = ? AND status = ? LIMIT 1');
+        $stmt->execute([$queue, self::SERVING]);
+        $n = $stmt->fetchColumn();
+
+        return $n === false ? null : (int)$n;
+    }
+
+    /**
+     * 1-based position of a waiting ticket (1 = next up), or null if it is not
+     * waiting (already served, skipped, or unknown).
+     */
+    public function position(string $queue, int $number): ?int
+    {
+        $queue = $this->validate($queue);
+
+        $own = $this->db()->prepare('SELECT 1 FROM queue_tickets WHERE queue = ? AND number = ? AND status = ?');
+        $own->execute([$queue, $number, self::WAITING]);
+        if ($own->fetchColumn() === false) {
+            return null;
+        }
+
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM queue_tickets WHERE queue = ? AND status = ? AND number < ?'
+        );
+        $stmt->execute([$queue, self::WAITING, $number]);
+
+        return (int)$stmt->fetchColumn() + 1;
+    }
+
+    /**
+     * Number of waiting tickets in a queue.
+     */
+    public function waiting(string $queue): int
+    {
+        $queue = $this->validate($queue);
+        $stmt  = $this->db()->prepare('SELECT COUNT(*) FROM queue_tickets WHERE queue = ? AND status = ?');
+        $stmt->execute([$queue, self::WAITING]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Mark a ticket done. No-op if absent.
+     */
+    public function complete(string $queue, int $number): void
+    {
+        $this->setStatus($queue, $number, self::DONE);
+    }
+
+    /**
+     * Skip a ticket (e.g. no-show). No-op if absent.
+     */
+    public function skip(string $queue, int $number): void
+    {
+        $this->setStatus($queue, $number, self::SKIPPED);
+    }
+
+    /**
+     * Remove all tickets for a queue (numbering restarts). Returns rows removed.
+     */
+    public function reset(string $queue): int
+    {
+        $queue = $this->validate($queue);
+        $stmt  = $this->db()->prepare('DELETE FROM queue_tickets WHERE queue = ?');
+        $stmt->execute([$queue]);
+
+        return $stmt->rowCount();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function setStatus(string $queue, int $number, string $status): void
+    {
+        $queue = $this->validate($queue);
+        $stmt  = $this->db()->prepare('UPDATE queue_tickets SET status = ? WHERE queue = ? AND number = ?');
+        $stmt->execute([$status, $queue, $number]);
+    }
+
+    private function maxNumber(string $queue): int
+    {
+        $stmt = $this->db()->prepare('SELECT COALESCE(MAX(number), 0) FROM queue_tickets WHERE queue = ?');
+        $stmt->execute([$queue]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function validate(string $queue): string
+    {
+        $queue = trim($queue);
+        if ($queue === '') {
+            throw new \InvalidArgumentException('Queue must not be empty.');
+        }
+
+        return $queue;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-304.md
+++ b/docs/field-trials/2026-05-field-trial-304.md
@@ -1,0 +1,42 @@
+# Field Trial 304 — QueueTicket
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft304-queue-ticket`
+**Baseline**: post FT303 merge
+
+## Goal
+
+Add `Nene\Kit\QueueTicket` — a "take a number" service queue: issue tickets, advance the now-serving number, and show a waiting customer their position. Distinct from `JobQueue` (FT73, background work) and `TimeSlot` (FT203, booked appointments): a human-facing ordered service line.
+
+## What was built
+
+### `Nene\Kit\QueueTicket` (`class/kit/QueueTicket.php`)
+
+Lifecycle: `waiting → serving → done` (or `skipped`); numbers increase per queue.
+
+| Method | Description |
+| --- | --- |
+| `issue(queue, label='') : int` | Assign next number (atomic). |
+| `callNext(queue): ?int` | Finish current serving, serve lowest waiting. |
+| `nowServing(queue) / position(queue, number) / waiting(queue)` | Read. |
+| `complete / skip (queue, number) / reset(queue)` | Mutate. |
+
+Key design points:
+
+- **Atomic issue + callNext** in transactions; `callNext` completes the current serving ticket then promotes the lowest waiting number.
+- **`position` is 1-based** (1 = next up) and only for waiting tickets; skipped tickets are excluded from `callNext` and `position`.
+- `reset` restarts numbering.
+
+### Tests (`tests/Unit/Kit/QueueTicketTest.php`)
+
+11 unit tests (27 assertions): incrementing numbers, waiting count, callNext advances (done→serving), empty→null, position (1-based + after-call), unknown null, complete, skip excludes from line, queue separation, reset restarts numbering, empty-queue validation.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 11 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/QueueTicketTest.php
+++ b/tests/Unit/Kit/QueueTicketTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\QueueTicket;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for QueueTicket.
+ */
+final class QueueTicketTest extends TestCase
+{
+    private PDO $db;
+    private QueueTicket $q;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE queue_tickets (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                queue     VARCHAR(100) NOT NULL,
+                number    INTEGER      NOT NULL,
+                label     VARCHAR(190) NOT NULL DEFAULT \'\',
+                status    VARCHAR(10)  NOT NULL DEFAULT \'waiting\',
+                issued_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (queue, number)
+            )
+        ');
+        $this->q = new QueueTicket($this->db);
+    }
+
+    public function testIssueIncrementsNumbers(): void
+    {
+        $this->assertSame(1, $this->q->issue('deli', 'Alice'));
+        $this->assertSame(2, $this->q->issue('deli', 'Bob'));
+        $this->assertSame(3, $this->q->issue('deli'));
+    }
+
+    public function testWaitingCount(): void
+    {
+        $this->q->issue('deli');
+        $this->q->issue('deli');
+        $this->assertSame(2, $this->q->waiting('deli'));
+    }
+
+    public function testCallNextAdvances(): void
+    {
+        $this->q->issue('deli'); // 1
+        $this->q->issue('deli'); // 2
+        $this->assertSame(1, $this->q->callNext('deli'));
+        $this->assertSame(1, $this->q->nowServing('deli'));
+        $this->assertSame(1, $this->q->waiting('deli')); // ticket 2 still waiting
+        $this->assertSame(2, $this->q->callNext('deli')); // 1 done, 2 serving
+        $this->assertSame(2, $this->q->nowServing('deli'));
+        $this->assertSame(0, $this->q->waiting('deli'));
+    }
+
+    public function testCallNextEmptyReturnsNull(): void
+    {
+        $this->assertNull($this->q->callNext('deli'));
+        $this->assertNull($this->q->nowServing('deli'));
+    }
+
+    public function testPosition(): void
+    {
+        $a = $this->q->issue('deli');
+        $b = $this->q->issue('deli');
+        $c = $this->q->issue('deli');
+        $this->assertSame(1, $this->q->position('deli', $a));
+        $this->assertSame(2, $this->q->position('deli', $b));
+        $this->assertSame(3, $this->q->position('deli', $c));
+        $this->q->callNext('deli'); // a now serving
+        $this->assertNull($this->q->position('deli', $a)); // no longer waiting
+        $this->assertSame(1, $this->q->position('deli', $b)); // next up
+    }
+
+    public function testPositionUnknownIsNull(): void
+    {
+        $this->assertNull($this->q->position('deli', 99));
+    }
+
+    public function testComplete(): void
+    {
+        $n = $this->q->issue('deli');
+        $this->q->complete('deli', $n);
+        $this->assertSame(0, $this->q->waiting('deli'));
+        $this->assertNull($this->q->position('deli', $n));
+    }
+
+    public function testSkipRemovesFromWaiting(): void
+    {
+        $a = $this->q->issue('deli');
+        $b = $this->q->issue('deli');
+        $this->q->skip('deli', $a);
+        $this->assertSame(1, $this->q->waiting('deli'));
+        $this->assertSame(1, $this->q->position('deli', $b)); // b now first
+        $this->assertSame($b, $this->q->callNext('deli'));    // skipped a is not served
+    }
+
+    public function testQueuesAreSeparate(): void
+    {
+        $this->q->issue('a');
+        $this->assertSame(1, $this->q->issue('b')); // independent numbering
+    }
+
+    public function testResetRestartsNumbering(): void
+    {
+        $this->q->issue('deli');
+        $this->q->issue('deli');
+        $this->assertSame(2, $this->q->reset('deli'));
+        $this->assertSame(1, $this->q->issue('deli')); // numbering restarts
+    }
+
+    public function testIssueRejectsEmptyQueue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->q->issue('  ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT304** — `Nene\Kit\QueueTicket`: a "take a number" service line. Distinct from `JobQueue` (FT73) / `TimeSlot` (FT203).

| Method | Description |
| --- | --- |
| `issue(queue, label='') : int` | Next number (atomic). |
| `callNext(queue): ?int` | Finish current, serve lowest waiting. |
| `nowServing / position(1-based) / waiting` | Read. |
| `complete / skip / reset` | Mutate. |

- Lifecycle waiting→serving→done (or skipped); `position` 1-based, waiting-only; skipped excluded from callNext.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 11 tests / 27 assertions (incrementing, callNext advance, empty null, position 1-based + post-call, skip excludes, separation, reset restarts, validation)
- [x] `composer precommit` green (format → Phan → 5060 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)