### PR TITLE
feat(kit): Annotation — per-user text highlights/notes over ranges (FT305)

### DIFF
--- a/class/kit/Annotation.php
+++ b/class/kit/Annotation.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * Annotation — per-user text highlights and notes over content ranges.
+ *
+ * Stores highlighted character ranges within a document, each with the
+ * highlighted quote and an optional note (Kindle/Hypothes.is-style
+ * annotations). Distinct from `EntityComment` (FT214, flat comments on an
+ * entity) and `CommentThread` (FT69): this anchors to a character `[start,
+ * end)` range inside a document's text.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $an = new Annotation($pdo);
+ *
+ * $id = $an->add(userId: 1, document: 'doc-9', start: 100, end: 140,
+ *                quote: 'the quick brown fox', note: 'great line');
+ *
+ * $an->forDocument('doc-9');     // all annotations, ordered by start offset
+ * $an->forUser(1, 'doc-9');      // just user 1's
+ * $an->updateNote($id, 'edited note');
+ * $an->remove($id);
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE annotations (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     user_id      BIGINT       NOT NULL,
+ *     document     VARCHAR(190) NOT NULL,
+ *     start_offset INTEGER      NOT NULL,
+ *     end_offset   INTEGER      NOT NULL,
+ *     quote        TEXT         NOT NULL DEFAULT '',
+ *     note         TEXT         NOT NULL DEFAULT '',
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class Annotation
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add an annotation over a character range `[start, end)`.
+     *
+     * @param  int    $userId   Annotator user id.
+     * @param  string $document Document identifier.
+     * @param  int    $start    Start offset (>= 0).
+     * @param  int    $end      End offset (> start).
+     * @param  string $quote    The highlighted text.
+     * @param  string $note     Optional note.
+     * @return int              New annotation id.
+     * @throws \InvalidArgumentException on empty document or invalid range.
+     */
+    public function add(int $userId, string $document, int $start, int $end, string $quote = '', string $note = ''): int
+    {
+        $document = $this->validate($document);
+        if ($start < 0) {
+            throw new \InvalidArgumentException('Start offset must not be negative.');
+        }
+        if ($end <= $start) {
+            throw new \InvalidArgumentException('End offset must be greater than start.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO annotations (user_id, document, start_offset, end_offset, quote, note)
+             VALUES (?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([$userId, $document, $start, $end, $quote, $note]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Fetch a single annotation by id.
+     *
+     * @return array{id:int,user_id:int,document:string,start:int,end:int,quote:string,note:string}|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, user_id, document, start_offset, end_offset, quote, note FROM annotations WHERE id = ?'
+        );
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $this->hydrate($row);
+    }
+
+    /**
+     * All annotations on a document (any user), ordered by start then id.
+     *
+     * @return array<int,array{id:int,user_id:int,document:string,start:int,end:int,quote:string,note:string}>
+     */
+    public function forDocument(string $document): array
+    {
+        return $this->query('document = ?', [$this->validate($document)]);
+    }
+
+    /**
+     * A single user's annotations on a document, ordered by start then id.
+     *
+     * @return array<int,array{id:int,user_id:int,document:string,start:int,end:int,quote:string,note:string}>
+     */
+    public function forUser(int $userId, string $document): array
+    {
+        return $this->query('document = ? AND user_id = ?', [$this->validate($document), $userId]);
+    }
+
+    /**
+     * Number of annotations on a document.
+     */
+    public function countFor(string $document): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM annotations WHERE document = ?');
+        $stmt->execute([$this->validate($document)]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Update an annotation's note. Returns true if a row was changed.
+     */
+    public function updateNote(int $id, string $note): bool
+    {
+        $stmt = $this->db()->prepare('UPDATE annotations SET note = ? WHERE id = ?');
+        $stmt->execute([$note, $id]);
+
+        return $stmt->rowCount() === 1;
+    }
+
+    /**
+     * Delete an annotation. No-op if absent.
+     */
+    public function remove(int $id): void
+    {
+        $stmt = $this->db()->prepare('DELETE FROM annotations WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @param  array<int,mixed> $params
+     * @return array<int,array{id:int,user_id:int,document:string,start:int,end:int,quote:string,note:string}>
+     */
+    private function query(string $where, array $params): array
+    {
+        $stmt = $this->db()->prepare(
+            "SELECT id, user_id, document, start_offset, end_offset, quote, note FROM annotations
+             WHERE {$where} ORDER BY start_offset ASC, id ASC"
+        );
+        $stmt->execute($params);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = $this->hydrate($row);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<string,mixed> $row
+     * @return array{id:int,user_id:int,document:string,start:int,end:int,quote:string,note:string}
+     */
+    private function hydrate(array $row): array
+    {
+        return [
+            'id'       => (int)$row['id'],
+            'user_id'  => (int)$row['user_id'],
+            'document' => (string)$row['document'],
+            'start'    => (int)$row['start_offset'],
+            'end'      => (int)$row['end_offset'],
+            'quote'    => (string)$row['quote'],
+            'note'     => (string)$row['note'],
+        ];
+    }
+
+    private function validate(string $document): string
+    {
+        $document = trim($document);
+        if ($document === '') {
+            throw new \InvalidArgumentException('Document must not be empty.');
+        }
+
+        return $document;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -60,6 +60,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 
 | Class | Description |
 |-------|-------------|
+| `Annotation` | per-user text highlights and notes over content ranges. |
 | `Announcement` | site-wide announcements with scheduling and per-user dismissal. |
 | `Checklist` | ordered checklist items attached to any entity. |
 | `CommentThread` | threaded comments attached to any entity. |

--- a/docs/field-trials/2026-05-field-trial-305.md
+++ b/docs/field-trials/2026-05-field-trial-305.md
@@ -1,0 +1,39 @@
+# Field Trial 305 — Annotation
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft305-annotation`
+**Baseline**: post FT304 merge
+
+## Goal
+
+Add `Nene\Kit\Annotation` — per-user text highlights and notes anchored to a character range within a document (Kindle / Hypothes.is-style). Distinct from `EntityComment` (FT214, flat entity comments) and `CommentThread` (FT69): this anchors to a `[start, end)` text range.
+
+## What was built
+
+### `Nene\Kit\Annotation` (`class/kit/Annotation.php`)
+
+| Method | Description |
+| --- | --- |
+| `add(userId, document, start, end, quote='', note=''): int` | Highlight a range. |
+| `get(id) / forDocument(document) / forUser(userId, document)` | Read (ordered by start). |
+| `countFor(document) / updateNote(id, note) / remove(id)` | Count / edit / delete. |
+
+Key design points:
+
+- **Half-open `[start, end)` range** with `end > start` and `start >= 0` validated; stores the highlighted `quote` + optional `note`.
+- `forDocument`/`forUser` ordered by start offset then id (stable reading order).
+- `updateNote` returns whether a row changed.
+
+### Tests (`tests/Unit/Kit/AnnotationTest.php`)
+
+13 unit tests (23 assertions): add/get, missing null, forDocument ordered-by-start, forUser scoping, countFor, updateNote (+ missing false), remove (+ missing no-op), document separation, zero-start allowed, validation (end<=start, negative start, empty document).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/AnnotationTest.php
+++ b/tests/Unit/Kit/AnnotationTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\Annotation;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Annotation.
+ */
+final class AnnotationTest extends TestCase
+{
+    private PDO $db;
+    private Annotation $an;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE annotations (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id      BIGINT       NOT NULL,
+                document     VARCHAR(190) NOT NULL,
+                start_offset INTEGER      NOT NULL,
+                end_offset   INTEGER      NOT NULL,
+                quote        TEXT         NOT NULL DEFAULT \'\',
+                note         TEXT         NOT NULL DEFAULT \'\',
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->an = new Annotation($this->db);
+    }
+
+    public function testAddAndGet(): void
+    {
+        $id = $this->an->add(1, 'doc', 100, 140, 'quick brown fox', 'nice');
+        $a  = $this->an->get($id);
+        $this->assertNotNull($a);
+        $this->assertSame(1, $a['user_id']);
+        $this->assertSame(100, $a['start']);
+        $this->assertSame(140, $a['end']);
+        $this->assertSame('quick brown fox', $a['quote']);
+        $this->assertSame('nice', $a['note']);
+    }
+
+    public function testGetMissingIsNull(): void
+    {
+        $this->assertNull($this->an->get(999));
+    }
+
+    public function testForDocumentOrderedByStart(): void
+    {
+        $this->an->add(1, 'doc', 200, 210);
+        $this->an->add(2, 'doc', 50, 60);
+        $this->an->add(1, 'doc', 100, 110);
+        $starts = array_map(static fn (array $a): int => $a['start'], $this->an->forDocument('doc'));
+        $this->assertSame([50, 100, 200], $starts);
+    }
+
+    public function testForUser(): void
+    {
+        $this->an->add(1, 'doc', 10, 20);
+        $this->an->add(2, 'doc', 30, 40);
+        $this->an->add(1, 'doc', 50, 60);
+        $this->assertCount(2, $this->an->forUser(1, 'doc'));
+        $this->assertCount(1, $this->an->forUser(2, 'doc'));
+    }
+
+    public function testCountFor(): void
+    {
+        $this->an->add(1, 'doc', 10, 20);
+        $this->an->add(2, 'doc', 30, 40);
+        $this->assertSame(2, $this->an->countFor('doc'));
+        $this->assertSame(0, $this->an->countFor('other'));
+    }
+
+    public function testUpdateNote(): void
+    {
+        $id = $this->an->add(1, 'doc', 10, 20, 'q', 'old');
+        $this->assertTrue($this->an->updateNote($id, 'new'));
+        $this->assertSame('new', $this->an->get($id)['note']);
+        $this->assertFalse($this->an->updateNote(999, 'x')); // missing
+    }
+
+    public function testRemove(): void
+    {
+        $id = $this->an->add(1, 'doc', 10, 20);
+        $this->an->remove($id);
+        $this->assertNull($this->an->get($id));
+        $this->assertSame(0, $this->an->countFor('doc'));
+    }
+
+    public function testRemoveMissingIsNoop(): void
+    {
+        $this->an->remove(999);
+        $this->assertSame(0, $this->an->countFor('doc'));
+    }
+
+    public function testDocumentsAreSeparate(): void
+    {
+        $this->an->add(1, 'a', 10, 20);
+        $this->an->add(1, 'b', 10, 20);
+        $this->assertCount(1, $this->an->forDocument('a'));
+    }
+
+    public function testAddAllowsZeroStart(): void
+    {
+        $id = $this->an->add(1, 'doc', 0, 5);
+        $this->assertSame(0, $this->an->get($id)['start']);
+    }
+
+    public function testAddRejectsEndNotAfterStart(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->an->add(1, 'doc', 50, 50);
+    }
+
+    public function testAddRejectsNegativeStart(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->an->add(1, 'doc', -1, 10);
+    }
+
+    public function testAddRejectsEmptyDocument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->an->add(1, '  ', 0, 10);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT305** — `Nene\Kit\Annotation`: per-user text highlights/notes anchored to a `[start, end)` character range in a document. Distinct from `EntityComment` (FT214) / `CommentThread` (FT69).

| Method | Description |
| --- | --- |
| `add(userId, document, start, end, quote='', note=''): int` | Highlight a range. |
| `get / forDocument / forUser` | Read (ordered by start). |
| `countFor / updateNote / remove` | Count / edit / delete. |

- Half-open range, `end > start`, `start >= 0`; ordered by start then id.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 23 assertions (add/get, ordered-by-start, forUser scoping, count, updateNote, remove, separation, zero-start, validation×3)
- [x] `composer precommit` green (format → Phan → 5073 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)