### PR TITLE
feat(kit): GiftRegistry — claimable gift registry (FT306)

### DIFF
--- a/class/kit/GiftRegistry.php
+++ b/class/kit/GiftRegistry.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * GiftRegistry — wish-list of desired items that others can claim.
+ *
+ * Models a wedding/baby-style gift registry: the owner lists items with a
+ * desired quantity, and gift-givers `claim()` quantities so the same gift
+ * isn't bought twice. Distinct from `Wishlist` (FT81), a private saved-item
+ * list with no third-party claiming: the novel mechanic here is the
+ * claimed-vs-desired accounting that prevents over-gifting.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $gr = new GiftRegistry($pdo);
+ *
+ * $gr->addItem('wedding-alice', 'toaster', desiredQty: 1);
+ * $gr->addItem('wedding-alice', 'wine-glass', desiredQty: 6);
+ *
+ * $gr->claim('wedding-alice', 'wine-glass', 4); // true (4/6)
+ * $gr->remaining('wedding-alice', 'wine-glass'); // 2
+ * $gr->claim('wedding-alice', 'wine-glass', 3);  // false — would exceed
+ * $gr->isFulfilled('wedding-alice', 'toaster');  // false (0/1)
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE gift_registry_items (
+ *     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     registry    VARCHAR(150) NOT NULL,
+ *     item        VARCHAR(190) NOT NULL,
+ *     desired_qty INTEGER      NOT NULL DEFAULT 1,
+ *     claimed_qty INTEGER      NOT NULL DEFAULT 0,
+ *     created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     UNIQUE (registry, item)
+ * );
+ * ```
+ */
+final class GiftRegistry
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add an item to a registry (or update its desired quantity). Idempotent;
+     * the claimed quantity is preserved.
+     *
+     * @param  string $registry   Registry identifier.
+     * @param  string $item       Item identifier.
+     * @param  int    $desiredQty Desired quantity (>= 1).
+     * @throws \InvalidArgumentException on empty names or desiredQty < 1.
+     */
+    public function addItem(string $registry, string $item, int $desiredQty = 1): void
+    {
+        $registry = $this->validate($registry, 'Registry');
+        $item     = $this->validate($item, 'Item');
+        if ($desiredQty < 1) {
+            throw new \InvalidArgumentException('Desired quantity must be at least 1.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table:        'gift_registry_items',
+            data:         ['registry' => $registry, 'item' => $item, 'desired_qty' => $desiredQty],
+            conflictCols: ['registry', 'item'],
+            updateCols:   ['desired_qty'],
+        );
+    }
+
+    /**
+     * Claim a quantity of an item. Fails (returns false) if the item is unknown
+     * or the claim would exceed the desired quantity.
+     *
+     * @param  string $registry Registry identifier.
+     * @param  string $item     Item identifier.
+     * @param  int    $qty      Quantity to claim (>= 1).
+     * @return bool             True if claimed; false if unavailable.
+     * @throws \InvalidArgumentException on empty names or qty < 1.
+     */
+    public function claim(string $registry, string $item, int $qty = 1): bool
+    {
+        $registry = $this->validate($registry, 'Registry');
+        $item     = $this->validate($item, 'Item');
+        if ($qty < 1) {
+            throw new \InvalidArgumentException('Quantity must be at least 1.');
+        }
+
+        $db             = $this->db();
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+        try {
+            $row = $this->row($registry, $item);
+            if ($row === null || (int)$row['claimed_qty'] + $qty > (int)$row['desired_qty']) {
+                if ($ownTransaction) {
+                    $db->commit();
+                }
+
+                return false;
+            }
+
+            $stmt = $db->prepare('UPDATE gift_registry_items SET claimed_qty = claimed_qty + ? WHERE registry = ? AND item = ?');
+            $stmt->execute([$qty, $registry, $item]);
+
+            if ($ownTransaction) {
+                $db->commit();
+            }
+
+            return true;
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Release a previously-claimed quantity (claim cancelled). Clamps at 0.
+     */
+    public function unclaim(string $registry, string $item, int $qty = 1): void
+    {
+        $registry = $this->validate($registry, 'Registry');
+        $item     = $this->validate($item, 'Item');
+        if ($qty < 1) {
+            throw new \InvalidArgumentException('Quantity must be at least 1.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'UPDATE gift_registry_items SET claimed_qty = MAX(0, claimed_qty - ?) WHERE registry = ? AND item = ?'
+        );
+        $stmt->execute([$qty, $registry, $item]);
+    }
+
+    /**
+     * Quantity claimed for an item (0 if unknown).
+     */
+    public function claimedQty(string $registry, string $item): int
+    {
+        $row = $this->row($this->validate($registry, 'Registry'), $this->validate($item, 'Item'));
+
+        return $row === null ? 0 : (int)$row['claimed_qty'];
+    }
+
+    /**
+     * Remaining unclaimed quantity for an item (0 if unknown).
+     */
+    public function remaining(string $registry, string $item): int
+    {
+        $row = $this->row($this->validate($registry, 'Registry'), $this->validate($item, 'Item'));
+
+        return $row === null ? 0 : max(0, (int)$row['desired_qty'] - (int)$row['claimed_qty']);
+    }
+
+    /**
+     * Whether an item is fully claimed (claimed >= desired). False if unknown.
+     */
+    public function isFulfilled(string $registry, string $item): bool
+    {
+        $row = $this->row($this->validate($registry, 'Registry'), $this->validate($item, 'Item'));
+
+        return $row !== null && (int)$row['claimed_qty'] >= (int)$row['desired_qty'];
+    }
+
+    /**
+     * All items in a registry with their claim accounting, by item name.
+     *
+     * @return array<int,array{item:string,desired:int,claimed:int,remaining:int}>
+     */
+    public function items(string $registry): array
+    {
+        $registry = $this->validate($registry, 'Registry');
+        $stmt     = $this->db()->prepare(
+            'SELECT item, desired_qty, claimed_qty FROM gift_registry_items WHERE registry = ? ORDER BY item ASC'
+        );
+        $stmt->execute([$registry]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $desired = (int)$row['desired_qty'];
+            $claimed = (int)$row['claimed_qty'];
+            $out[]   = [
+                'item'      => (string)$row['item'],
+                'desired'   => $desired,
+                'claimed'   => $claimed,
+                'remaining' => max(0, $desired - $claimed),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Remove an item from a registry. No-op if absent.
+     */
+    public function removeItem(string $registry, string $item): void
+    {
+        $registry = $this->validate($registry, 'Registry');
+        $item     = $this->validate($item, 'Item');
+        $stmt     = $this->db()->prepare('DELETE FROM gift_registry_items WHERE registry = ? AND item = ?');
+        $stmt->execute([$registry, $item]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function row(string $registry, string $item): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT desired_qty, claimed_qty FROM gift_registry_items WHERE registry = ? AND item = ?');
+        $stmt->execute([$registry, $item]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -177,6 +177,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `ExchangeRate` | effective-dated currency conversion rate table. |
 | `EventTicket` | event ticketing with capacity management and check-in tracking. |
 | `GiftCard` | prepaid gift card balance with partial redemption support. |
+| `GiftRegistry` | wish-list of desired items that others can claim. |
 | `InventoryStock` | product/SKU stock tracking with atomic reserve/release/commit. |
 | `OrderLine` | e-commerce order header with line items. |
 | `PaymentRecord` | simple payment/transaction ledger. |

--- a/docs/field-trials/2026-05-field-trial-306.md
+++ b/docs/field-trials/2026-05-field-trial-306.md
@@ -1,0 +1,41 @@
+# Field Trial 306 — GiftRegistry
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft306-gift-registry`
+**Baseline**: post FT305 merge
+
+## Goal
+
+Add `Nene\Kit\GiftRegistry` — a wedding/baby-style gift registry where the owner lists desired items and gift-givers claim quantities so the same gift isn't bought twice. Distinct from `Wishlist` (FT81, private saved items, no claiming): the novel mechanic is claimed-vs-desired accounting.
+
+## What was built
+
+### `Nene\Kit\GiftRegistry` (`class/kit/GiftRegistry.php`)
+
+| Method | Description |
+| --- | --- |
+| `addItem(registry, item, desiredQty=1)` | List/requantify (preserves claims). |
+| `claim(registry, item, qty=1): bool` | Claim if within desired (atomic). |
+| `unclaim(registry, item, qty=1)` | Release (clamps at 0). |
+| `claimedQty / remaining / isFulfilled` | Accounting. |
+| `items(registry) / removeItem(...)` | List / delete. |
+
+Key design points:
+
+- **Claimed-vs-desired guard**: `claim` succeeds only if `claimed + qty <= desired` (atomic read-modify-write in a transaction), preventing over-gifting; unknown item → false.
+- **Requantify preserves claims**: `addItem` updates desired_qty but keeps claimed_qty.
+- `unclaim` clamps at 0; `isFulfilled` = claimed >= desired.
+
+### Tests (`tests/Unit/Kit/GiftRegistryTest.php`)
+
+14 unit tests (28 assertions): add/remaining, claim reduces remaining, claim up-to-desired, exceeding fails (unchanged), unknown item fails, unclaim releases + clamps at 0, isFulfilled, items accounting, requantify preserves claims, removeItem, registry separation, validation (zero desired, zero claim qty).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 14 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/GiftRegistryTest.php
+++ b/tests/Unit/Kit/GiftRegistryTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\GiftRegistry;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for GiftRegistry.
+ */
+final class GiftRegistryTest extends TestCase
+{
+    private PDO $db;
+    private GiftRegistry $gr;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE gift_registry_items (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                registry    VARCHAR(150) NOT NULL,
+                item        VARCHAR(190) NOT NULL,
+                desired_qty INTEGER      NOT NULL DEFAULT 1,
+                claimed_qty INTEGER      NOT NULL DEFAULT 0,
+                created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (registry, item)
+            )
+        ');
+        $this->gr = new GiftRegistry($this->db);
+    }
+
+    public function testAddItemAndRemaining(): void
+    {
+        $this->gr->addItem('reg', 'glass', 6);
+        $this->assertSame(6, $this->gr->remaining('reg', 'glass'));
+        $this->assertSame(0, $this->gr->claimedQty('reg', 'glass'));
+    }
+
+    public function testClaimReducesRemaining(): void
+    {
+        $this->gr->addItem('reg', 'glass', 6);
+        $this->assertTrue($this->gr->claim('reg', 'glass', 4));
+        $this->assertSame(4, $this->gr->claimedQty('reg', 'glass'));
+        $this->assertSame(2, $this->gr->remaining('reg', 'glass'));
+    }
+
+    public function testClaimUpToDesired(): void
+    {
+        $this->gr->addItem('reg', 'glass', 6);
+        $this->gr->claim('reg', 'glass', 4);
+        $this->assertTrue($this->gr->claim('reg', 'glass', 2));  // 4+2 = 6 ok
+        $this->assertTrue($this->gr->isFulfilled('reg', 'glass'));
+    }
+
+    public function testClaimExceedingFails(): void
+    {
+        $this->gr->addItem('reg', 'glass', 6);
+        $this->gr->claim('reg', 'glass', 4);
+        $this->assertFalse($this->gr->claim('reg', 'glass', 3)); // 4+3 > 6
+        $this->assertSame(4, $this->gr->claimedQty('reg', 'glass')); // unchanged
+    }
+
+    public function testClaimUnknownItemFails(): void
+    {
+        $this->assertFalse($this->gr->claim('reg', 'ghost', 1));
+    }
+
+    public function testUnclaimReleases(): void
+    {
+        $this->gr->addItem('reg', 'glass', 6);
+        $this->gr->claim('reg', 'glass', 4);
+        $this->gr->unclaim('reg', 'glass', 2);
+        $this->assertSame(2, $this->gr->claimedQty('reg', 'glass'));
+        $this->assertTrue($this->gr->claim('reg', 'glass', 4)); // room again
+    }
+
+    public function testUnclaimClampsAtZero(): void
+    {
+        $this->gr->addItem('reg', 'glass', 6);
+        $this->gr->claim('reg', 'glass', 1);
+        $this->gr->unclaim('reg', 'glass', 5); // more than claimed
+        $this->assertSame(0, $this->gr->claimedQty('reg', 'glass'));
+    }
+
+    public function testIsFulfilled(): void
+    {
+        $this->gr->addItem('reg', 'toaster', 1);
+        $this->assertFalse($this->gr->isFulfilled('reg', 'toaster'));
+        $this->gr->claim('reg', 'toaster', 1);
+        $this->assertTrue($this->gr->isFulfilled('reg', 'toaster'));
+    }
+
+    public function testItemsAccounting(): void
+    {
+        $this->gr->addItem('reg', 'glass', 6);
+        $this->gr->addItem('reg', 'toaster', 1);
+        $this->gr->claim('reg', 'glass', 4);
+        $items = $this->gr->items('reg');
+        $this->assertSame('glass', $items[0]['item']);
+        $this->assertSame(6, $items[0]['desired']);
+        $this->assertSame(4, $items[0]['claimed']);
+        $this->assertSame(2, $items[0]['remaining']);
+    }
+
+    public function testAddItemPreservesClaimedOnRequantify(): void
+    {
+        $this->gr->addItem('reg', 'glass', 6);
+        $this->gr->claim('reg', 'glass', 4);
+        $this->gr->addItem('reg', 'glass', 10); // bump desired
+        $this->assertSame(4, $this->gr->claimedQty('reg', 'glass')); // claims kept
+        $this->assertSame(6, $this->gr->remaining('reg', 'glass'));
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM gift_registry_items')->fetchColumn());
+    }
+
+    public function testRemoveItem(): void
+    {
+        $this->gr->addItem('reg', 'glass', 6);
+        $this->gr->removeItem('reg', 'glass');
+        $this->assertSame(0, $this->gr->remaining('reg', 'glass'));
+        $this->assertSame([], $this->gr->items('reg'));
+    }
+
+    public function testRegistriesAreSeparate(): void
+    {
+        $this->gr->addItem('a', 'glass', 6);
+        $this->gr->addItem('b', 'glass', 6);
+        $this->gr->claim('a', 'glass', 6);
+        $this->assertTrue($this->gr->isFulfilled('a', 'glass'));
+        $this->assertFalse($this->gr->isFulfilled('b', 'glass'));
+    }
+
+    public function testAddItemRejectsZeroDesired(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->gr->addItem('reg', 'glass', 0);
+    }
+
+    public function testClaimRejectsZeroQty(): void
+    {
+        $this->gr->addItem('reg', 'glass', 6);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->gr->claim('reg', 'glass', 0);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT306** — `Nene\Kit\GiftRegistry`: a wedding/baby-style registry where givers claim quantities so the same gift isn't bought twice. Distinct from `Wishlist` (FT81, private, no claiming).

| Method | Description |
| --- | --- |
| `addItem(registry, item, desiredQty=1)` | List (preserves claims on requantify). |
| `claim(registry, item, qty=1): bool` | Guarded (`claimed+qty <= desired`, atomic). |
| `unclaim / claimedQty / remaining / isFulfilled / items / removeItem` | Manage. |

- Claimed-vs-desired accounting prevents over-gifting; unclaim clamps at 0.

## F-N findings
- **F-1** — none (clean trial). Completes batch 4 (FT297–306).

## Test plan
- [x] 14 tests / 28 assertions (claim up-to/exceeding, unknown, unclaim+clamp, isFulfilled, items accounting, requantify preserves claims, separation, validation)
- [x] `composer precommit` green (format → Phan → 5087 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)