### PR TITLE
feat(kit): LeaveRequest — employee time-off requests with approval (FT307)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -307,6 +307,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `DocumentLock` | optimistic editing lock for collaborative document editing. |
 | `DocumentSignature` | e-signature request workflow with multi-signatory support. |
 | `JobQueue` | simple DB-backed background job queue. |
+| `LeaveRequest` | employee time-off requests with an approval workflow. |
 | `OptimisticLock` | — |
 | `QueueTicket` | take-a-number service queue with now-serving tracking. |
 | `ReportSchedule` | recurring report definitions with a next-run clock. |

--- a/class/kit/LeaveRequest.php
+++ b/class/kit/LeaveRequest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * LeaveRequest — employee time-off requests with an approval workflow.
+ *
+ * Tracks paid-leave / vacation / sick requests per employee: submit a request
+ * for a date range and day count, then approve or reject it. Reports a
+ * running total of approved days (overall or by leave type). The day count is
+ * supplied by the caller (use `BusinessCalendar` (FT266) to compute working
+ * days). Distinct from `Approval` (FT, a generic single-approver workflow):
+ * this carries leave-specific fields and day accounting.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $lr = new LeaveRequest($pdo);
+ *
+ * $id = $lr->request('emp-7', 'vacation', '2026-07-01', '2026-07-05', days: 5);
+ *
+ * $lr->approve($id);
+ * $lr->status($id);                  // 'approved'
+ * $lr->approvedDays('emp-7');        // 5
+ * $lr->pending();                    // approver inbox (all pending)
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE leave_requests (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     employee   VARCHAR(190) NOT NULL,
+ *     type       VARCHAR(50)  NOT NULL,
+ *     start_date CHAR(10)     NOT NULL,
+ *     end_date   CHAR(10)     NOT NULL,
+ *     days       INTEGER      NOT NULL,
+ *     status     VARCHAR(10)  NOT NULL DEFAULT 'pending',
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class LeaveRequest
+{
+    public const string STATUS_PENDING  = 'pending';
+    public const string STATUS_APPROVED = 'approved';
+    public const string STATUS_REJECTED = 'rejected';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Submit a pending leave request.
+     *
+     * @param  string $employee  Employee identifier.
+     * @param  string $type      Leave type (e.g. 'vacation', 'sick').
+     * @param  string $startDate Start date 'Y-m-d'.
+     * @param  string $endDate   End date 'Y-m-d' (>= start).
+     * @param  int    $days      Number of leave days (>= 1).
+     * @return int               New request id.
+     * @throws \InvalidArgumentException on empty fields, days < 1, or end < start.
+     */
+    public function request(string $employee, string $type, string $startDate, string $endDate, int $days): int
+    {
+        $employee = $this->validate($employee, 'Employee');
+        $type     = $this->validate($type, 'Type');
+        $start    = $this->date($startDate);
+        $end      = $this->date($endDate);
+        if ($end < $start) {
+            throw new \InvalidArgumentException('End date must not be before start date.');
+        }
+        if ($days < 1) {
+            throw new \InvalidArgumentException('Days must be at least 1.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO leave_requests (employee, type, start_date, end_date, days, status)
+             VALUES (?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([$employee, $type, $start, $end, $days, self::STATUS_PENDING]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Approve a pending request. Returns true if it was pending.
+     */
+    public function approve(int $id): bool
+    {
+        return $this->transition($id, self::STATUS_APPROVED);
+    }
+
+    /**
+     * Reject a pending request. Returns true if it was pending.
+     */
+    public function reject(int $id): bool
+    {
+        return $this->transition($id, self::STATUS_REJECTED);
+    }
+
+    /**
+     * Status of a request, or null if unknown.
+     */
+    public function status(int $id): ?string
+    {
+        $stmt = $this->db()->prepare('SELECT status FROM leave_requests WHERE id = ?');
+        $stmt->execute([$id]);
+        $s = $stmt->fetchColumn();
+
+        return $s === false ? null : (string)$s;
+    }
+
+    /**
+     * Total approved leave days for an employee, optionally by type.
+     */
+    public function approvedDays(string $employee, ?string $type = null): int
+    {
+        $employee = $this->validate($employee, 'Employee');
+
+        if ($type === null) {
+            $stmt = $this->db()->prepare(
+                'SELECT COALESCE(SUM(days), 0) FROM leave_requests WHERE employee = ? AND status = ?'
+            );
+            $stmt->execute([$employee, self::STATUS_APPROVED]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT COALESCE(SUM(days), 0) FROM leave_requests WHERE employee = ? AND status = ? AND type = ?'
+            );
+            $stmt->execute([$employee, self::STATUS_APPROVED, $type]);
+        }
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * An employee's requests (optionally by status), newest first.
+     *
+     * @return array<int,array{id:int,type:string,start_date:string,end_date:string,days:int,status:string}>
+     */
+    public function requestsFor(string $employee, ?string $status = null): array
+    {
+        $employee = $this->validate($employee, 'Employee');
+
+        if ($status === null) {
+            $stmt = $this->db()->prepare(
+                'SELECT id, type, start_date, end_date, days, status FROM leave_requests WHERE employee = ? ORDER BY id DESC'
+            );
+            $stmt->execute([$employee]);
+        } else {
+            $stmt = $this->db()->prepare(
+                'SELECT id, type, start_date, end_date, days, status FROM leave_requests WHERE employee = ? AND status = ? ORDER BY id DESC'
+            );
+            $stmt->execute([$employee, $status]);
+        }
+
+        return $this->hydrateRows($stmt->fetchAll(PDO::FETCH_ASSOC));
+    }
+
+    /**
+     * All pending requests (approver inbox), oldest first.
+     *
+     * @return array<int,array{id:int,employee:string,type:string,start_date:string,end_date:string,days:int}>
+     */
+    public function pending(): array
+    {
+        $stmt = $this->db()->query(
+            "SELECT id, employee, type, start_date, end_date, days FROM leave_requests WHERE status = 'pending' ORDER BY id ASC"
+        );
+        $rows = $stmt === false ? [] : $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $out = [];
+        /** @var array<string,mixed> $r */
+        foreach ($rows as $r) {
+            $out[] = [
+                'id'         => (int)$r['id'],
+                'employee'   => (string)$r['employee'],
+                'type'       => (string)$r['type'],
+                'start_date' => (string)$r['start_date'],
+                'end_date'   => (string)$r['end_date'],
+                'days'       => (int)$r['days'],
+            ];
+        }
+
+        return $out;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function transition(int $id, string $to): bool
+    {
+        $stmt = $this->db()->prepare(
+            'UPDATE leave_requests SET status = ? WHERE id = ? AND status = ?'
+        );
+        $stmt->execute([$to, $id, self::STATUS_PENDING]);
+
+        return $stmt->rowCount() === 1;
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>> $rows
+     * @return array<int,array{id:int,type:string,start_date:string,end_date:string,days:int,status:string}>
+     */
+    private function hydrateRows(array $rows): array
+    {
+        $out = [];
+        foreach ($rows as $r) {
+            $out[] = [
+                'id'         => (int)$r['id'],
+                'type'       => (string)$r['type'],
+                'start_date' => (string)$r['start_date'],
+                'end_date'   => (string)$r['end_date'],
+                'days'       => (int)$r['days'],
+                'status'     => (string)$r['status'],
+            ];
+        }
+
+        return $out;
+    }
+
+    private function date(string $value): string
+    {
+        $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if ($parsed === false || $parsed->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException("Invalid date (expected Y-m-d): {$value}");
+        }
+
+        return $value;
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-307.md
+++ b/docs/field-trials/2026-05-field-trial-307.md
@@ -1,0 +1,41 @@
+# Field Trial 307 — LeaveRequest
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft307-leave-request`
+**Baseline**: post FT306 merge — **batch 5 (final 10) begins**
+
+## Goal
+
+Add `Nene\Kit\LeaveRequest` — employee time-off requests with an approve/reject workflow and approved-day accounting. Distinct from `Approval` (FT, generic single-approver): carries leave-specific fields and day totals.
+
+## What was built
+
+### `Nene\Kit\LeaveRequest` (`class/kit/LeaveRequest.php`)
+
+| Method | Description |
+| --- | --- |
+| `request(employee, type, start, end, days): int` | Submit (pending). |
+| `approve(id) / reject(id): bool` | Pending → approved/rejected (guarded). |
+| `status(id) / requestsFor(employee, status=null)` | Read. |
+| `approvedDays(employee, type=null)` | Sum approved days. |
+| `pending()` | Approver inbox. |
+
+Key design points:
+
+- **Status guard** in the WHERE clause: approve/reject only act on pending rows (no double-decision); returns whether a row changed.
+- Day count supplied by caller (pair with `BusinessCalendar` FT266); dates validated (`Y-m-d`, end >= start).
+- `approvedDays` sums only approved rows, optionally by type.
+
+### Tests (`tests/Unit/Kit/LeaveRequestTest.php`)
+
+12 unit tests (24 assertions): pending on submit, approve + approvedDays, reject (not counted), no double-decision, approvedDays by type, requestsFor by status, pending inbox, unknown null, validation (end<start, zero days, bad date, empty employee).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/LeaveRequestTest.php
+++ b/tests/Unit/Kit/LeaveRequestTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\LeaveRequest;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for LeaveRequest.
+ */
+final class LeaveRequestTest extends TestCase
+{
+    private PDO $db;
+    private LeaveRequest $lr;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE leave_requests (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                employee   VARCHAR(190) NOT NULL,
+                type       VARCHAR(50)  NOT NULL,
+                start_date CHAR(10)     NOT NULL,
+                end_date   CHAR(10)     NOT NULL,
+                days       INTEGER      NOT NULL,
+                status     VARCHAR(10)  NOT NULL DEFAULT \'pending\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->lr = new LeaveRequest($this->db);
+    }
+
+    public function testRequestStartsPending(): void
+    {
+        $id = $this->lr->request('emp', 'vacation', '2026-07-01', '2026-07-05', 5);
+        $this->assertSame('pending', $this->lr->status($id));
+    }
+
+    public function testApprove(): void
+    {
+        $id = $this->lr->request('emp', 'vacation', '2026-07-01', '2026-07-05', 5);
+        $this->assertTrue($this->lr->approve($id));
+        $this->assertSame('approved', $this->lr->status($id));
+        $this->assertSame(5, $this->lr->approvedDays('emp'));
+    }
+
+    public function testReject(): void
+    {
+        $id = $this->lr->request('emp', 'vacation', '2026-07-01', '2026-07-05', 5);
+        $this->assertTrue($this->lr->reject($id));
+        $this->assertSame('rejected', $this->lr->status($id));
+        $this->assertSame(0, $this->lr->approvedDays('emp')); // rejected not counted
+    }
+
+    public function testCannotApproveTwice(): void
+    {
+        $id = $this->lr->request('emp', 'vacation', '2026-07-01', '2026-07-05', 5);
+        $this->assertTrue($this->lr->approve($id));
+        $this->assertFalse($this->lr->approve($id));  // already approved
+        $this->assertFalse($this->lr->reject($id));   // can't reject approved
+    }
+
+    public function testApprovedDaysByType(): void
+    {
+        $a = $this->lr->request('emp', 'vacation', '2026-07-01', '2026-07-03', 3);
+        $b = $this->lr->request('emp', 'sick', '2026-08-01', '2026-08-02', 2);
+        $this->lr->approve($a);
+        $this->lr->approve($b);
+        $this->assertSame(5, $this->lr->approvedDays('emp'));
+        $this->assertSame(3, $this->lr->approvedDays('emp', 'vacation'));
+        $this->assertSame(2, $this->lr->approvedDays('emp', 'sick'));
+    }
+
+    public function testRequestsForByStatus(): void
+    {
+        $a = $this->lr->request('emp', 'vacation', '2026-07-01', '2026-07-03', 3);
+        $this->lr->request('emp', 'sick', '2026-08-01', '2026-08-02', 2);
+        $this->lr->approve($a);
+        $this->assertCount(2, $this->lr->requestsFor('emp'));
+        $this->assertCount(1, $this->lr->requestsFor('emp', LeaveRequest::STATUS_APPROVED));
+        $this->assertCount(1, $this->lr->requestsFor('emp', LeaveRequest::STATUS_PENDING));
+    }
+
+    public function testPendingInbox(): void
+    {
+        $a = $this->lr->request('e1', 'vacation', '2026-07-01', '2026-07-03', 3);
+        $this->lr->request('e2', 'sick', '2026-08-01', '2026-08-02', 2);
+        $this->lr->approve($a);
+        $pending = $this->lr->pending();
+        $this->assertCount(1, $pending);
+        $this->assertSame('e2', $pending[0]['employee']);
+    }
+
+    public function testStatusUnknownIsNull(): void
+    {
+        $this->assertNull($this->lr->status(999));
+        $this->assertFalse($this->lr->approve(999));
+    }
+
+    public function testRequestRejectsEndBeforeStart(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->lr->request('emp', 'vacation', '2026-07-05', '2026-07-01', 3);
+    }
+
+    public function testRequestRejectsZeroDays(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->lr->request('emp', 'vacation', '2026-07-01', '2026-07-05', 0);
+    }
+
+    public function testRequestRejectsBadDate(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->lr->request('emp', 'vacation', '2026-07-32', '2026-07-05', 3);
+    }
+
+    public function testRequestRejectsEmptyEmployee(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->lr->request('  ', 'vacation', '2026-07-01', '2026-07-05', 3);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT307** (batch 5 begins) — `Nene\Kit\LeaveRequest`: employee time-off requests with an approve/reject workflow and approved-day accounting. Distinct from generic `Approval`.

| Method | Description |
| --- | --- |
| `request(employee, type, start, end, days): int` | Submit (pending). |
| `approve / reject (id): bool` | Pending → decided (guarded). |
| `status / requestsFor / approvedDays / pending` | Read / sums / inbox. |

- Status-guarded transitions; date-validated; day count caller-supplied.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 24 assertions (pending, approve+days, reject not counted, no double-decision, by-type, by-status, inbox, unknown null, validation×4)
- [x] `composer precommit` green (format → Phan → 5099 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)