### PR TITLE
feat(kit): ExpenseClaim — reimbursement claims with line items + approval (FT308)

### DIFF
--- a/class/kit/ExpenseClaim.php
+++ b/class/kit/ExpenseClaim.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * ExpenseClaim — expense reimbursement claims with line items and approval.
+ *
+ * A claimant opens a draft claim, adds integer-cent line items, submits it,
+ * and an approver approves/rejects; approved claims can be marked paid.
+ * Distinct from `Payout` (FT291, outbound marketplace settlements),
+ * `BudgetTracker` (FT, allocation/spend), and `CreditNote` (FT, refunds):
+ * this is employee expense reimbursement.
+ *
+ * Lifecycle: `draft → submitted → approved | rejected`; `approved → paid`.
+ * Line items can only be added while the claim is a draft.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $ec = new ExpenseClaim($pdo);
+ *
+ * $id = $ec->create('emp-7');
+ * $ec->addItem($id, 'Taxi', 2400);
+ * $ec->addItem($id, 'Lunch', 1800);
+ * $ec->total($id);        // 4200
+ * $ec->submit($id);       // draft → submitted
+ * $ec->approve($id);      // submitted → approved
+ * $ec->markPaid($id);     // approved → paid
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE expense_claims (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     claimant   VARCHAR(190) NOT NULL,
+ *     status     VARCHAR(10)  NOT NULL DEFAULT 'draft',
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE TABLE expense_claim_items (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     claim_id     BIGINT       NOT NULL,
+ *     description  VARCHAR(255) NOT NULL DEFAULT '',
+ *     amount_cents INTEGER      NOT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class ExpenseClaim
+{
+    public const string STATUS_DRAFT     = 'draft';
+    public const string STATUS_SUBMITTED = 'submitted';
+    public const string STATUS_APPROVED  = 'approved';
+    public const string STATUS_REJECTED  = 'rejected';
+    public const string STATUS_PAID      = 'paid';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Open a new draft claim.
+     *
+     * @throws \InvalidArgumentException on empty claimant.
+     */
+    public function create(string $claimant): int
+    {
+        $claimant = $this->validate($claimant, 'Claimant');
+        $stmt     = $this->db()->prepare('INSERT INTO expense_claims (claimant, status) VALUES (?, ?)');
+        $stmt->execute([$claimant, self::STATUS_DRAFT]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Add a line item to a draft claim.
+     *
+     * @param  int    $claimId     Claim id (must be a draft).
+     * @param  string $description Line description.
+     * @param  int    $amountCents Line amount in cents (> 0).
+     * @throws \InvalidArgumentException on non-positive amount or non-draft claim.
+     */
+    public function addItem(int $claimId, string $description, int $amountCents): void
+    {
+        if ($amountCents <= 0) {
+            throw new \InvalidArgumentException('Amount must be positive.');
+        }
+        if ($this->status($claimId) !== self::STATUS_DRAFT) {
+            throw new \InvalidArgumentException('Items can only be added to a draft claim.');
+        }
+
+        $stmt = $this->db()->prepare('INSERT INTO expense_claim_items (claim_id, description, amount_cents) VALUES (?, ?, ?)');
+        $stmt->execute([$claimId, $description, $amountCents]);
+    }
+
+    /**
+     * Total of a claim's line items in cents.
+     */
+    public function total(int $claimId): int
+    {
+        $stmt = $this->db()->prepare('SELECT COALESCE(SUM(amount_cents), 0) FROM expense_claim_items WHERE claim_id = ?');
+        $stmt->execute([$claimId]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Line items of a claim, in insertion order.
+     *
+     * @return array<int,array{description:string,amount_cents:int}>
+     */
+    public function items(int $claimId): array
+    {
+        $stmt = $this->db()->prepare('SELECT description, amount_cents FROM expense_claim_items WHERE claim_id = ? ORDER BY id ASC');
+        $stmt->execute([$claimId]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['description' => (string)$row['description'], 'amount_cents' => (int)$row['amount_cents']];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Submit a draft claim (requires at least one line item).
+     *
+     * @return bool True on success; false if not a draft.
+     * @throws \InvalidArgumentException if the claim has no items.
+     */
+    public function submit(int $claimId): bool
+    {
+        if ($this->status($claimId) !== self::STATUS_DRAFT) {
+            return false;
+        }
+        if ($this->total($claimId) === 0 && $this->items($claimId) === []) {
+            throw new \InvalidArgumentException('Cannot submit a claim with no items.');
+        }
+
+        return $this->transition($claimId, self::STATUS_DRAFT, self::STATUS_SUBMITTED);
+    }
+
+    /**
+     * Approve a submitted claim. Returns true if it was submitted.
+     */
+    public function approve(int $claimId): bool
+    {
+        return $this->transition($claimId, self::STATUS_SUBMITTED, self::STATUS_APPROVED);
+    }
+
+    /**
+     * Reject a submitted claim. Returns true if it was submitted.
+     */
+    public function reject(int $claimId): bool
+    {
+        return $this->transition($claimId, self::STATUS_SUBMITTED, self::STATUS_REJECTED);
+    }
+
+    /**
+     * Mark an approved claim paid. Returns true if it was approved.
+     */
+    public function markPaid(int $claimId): bool
+    {
+        return $this->transition($claimId, self::STATUS_APPROVED, self::STATUS_PAID);
+    }
+
+    /**
+     * Status of a claim, or null if unknown.
+     */
+    public function status(int $claimId): ?string
+    {
+        $stmt = $this->db()->prepare('SELECT status FROM expense_claims WHERE id = ?');
+        $stmt->execute([$claimId]);
+        $s = $stmt->fetchColumn();
+
+        return $s === false ? null : (string)$s;
+    }
+
+    /**
+     * A claimant's claims (optionally by status) with totals, newest first.
+     *
+     * @return array<int,array{id:int,status:string,total:int}>
+     */
+    public function claimsFor(string $claimant, ?string $status = null): array
+    {
+        $claimant = $this->validate($claimant, 'Claimant');
+
+        if ($status === null) {
+            $stmt = $this->db()->prepare('SELECT id, status FROM expense_claims WHERE claimant = ? ORDER BY id DESC');
+            $stmt->execute([$claimant]);
+        } else {
+            $stmt = $this->db()->prepare('SELECT id, status FROM expense_claims WHERE claimant = ? AND status = ? ORDER BY id DESC');
+            $stmt->execute([$claimant, $status]);
+        }
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $id    = (int)$row['id'];
+            $out[] = ['id' => $id, 'status' => (string)$row['status'], 'total' => $this->total($id)];
+        }
+
+        return $out;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function transition(int $claimId, string $from, string $to): bool
+    {
+        $stmt = $this->db()->prepare('UPDATE expense_claims SET status = ? WHERE id = ? AND status = ?');
+        $stmt->execute([$to, $claimId, $from]);
+
+        return $stmt->rowCount() === 1;
+    }
+
+    private function validate(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -176,6 +176,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `CreditNote` | financial credit notes / refund adjustments. |
 | `ExchangeRate` | effective-dated currency conversion rate table. |
 | `EventTicket` | event ticketing with capacity management and check-in tracking. |
+| `ExpenseClaim` | expense reimbursement claims with line items and approval. |
 | `GiftCard` | prepaid gift card balance with partial redemption support. |
 | `GiftRegistry` | wish-list of desired items that others can claim. |
 | `InventoryStock` | product/SKU stock tracking with atomic reserve/release/commit. |

--- a/docs/field-trials/2026-05-field-trial-308.md
+++ b/docs/field-trials/2026-05-field-trial-308.md
@@ -1,0 +1,42 @@
+# Field Trial 308 — ExpenseClaim
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft308-expense-claim`
+**Baseline**: post FT307 merge
+
+## Goal
+
+Add `Nene\Kit\ExpenseClaim` — employee expense reimbursement claims with integer-cent line items and an approval lifecycle. Distinct from `Payout` (FT291), `BudgetTracker`, and `CreditNote`.
+
+## What was built
+
+### `Nene\Kit\ExpenseClaim` (`class/kit/ExpenseClaim.php`)
+
+Two tables: claims + line items. Lifecycle `draft → submitted → approved | rejected`; `approved → paid`.
+
+| Method | Description |
+| --- | --- |
+| `create(claimant): int` | Open a draft. |
+| `addItem(claimId, description, amountCents)` | Add a line (draft only). |
+| `total(claimId) / items(claimId)` | Sum / lines. |
+| `submit / approve / reject / markPaid (claimId): bool` | Guarded transitions. |
+| `status / claimsFor(claimant, status=null)` | Read (with totals). |
+
+Key design points:
+
+- **Status-guarded transitions** (`UPDATE … WHERE status = <from>`); items only addable while draft; submit requires ≥1 item.
+- **Integer-cent** totals computed from line items (no stored/denormalised total → no drift).
+
+### Tests (`tests/Unit/Kit/ExpenseClaimTest.php`)
+
+12 unit tests (26 assertions): create/add/total, full lifecycle (submit→approve→paid), reject, no-add-after-submit, empty-submit throws, transition guards (approve-before-submit, paid-before-approve), no double-approve, claimsFor with totals + by-status, claimant separation, unknown null, validation (non-positive amount, empty claimant).
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 12 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/ExpenseClaimTest.php
+++ b/tests/Unit/Kit/ExpenseClaimTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\ExpenseClaim;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ExpenseClaim.
+ */
+final class ExpenseClaimTest extends TestCase
+{
+    private PDO $db;
+    private ExpenseClaim $ec;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE expense_claims (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                claimant   VARCHAR(190) NOT NULL,
+                status     VARCHAR(10)  NOT NULL DEFAULT \'draft\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->db->exec('
+            CREATE TABLE expense_claim_items (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                claim_id     BIGINT       NOT NULL,
+                description  VARCHAR(255) NOT NULL DEFAULT \'\',
+                amount_cents INTEGER      NOT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->ec = new ExpenseClaim($this->db);
+    }
+
+    public function testCreateDraftAndAddItems(): void
+    {
+        $id = $this->ec->create('emp');
+        $this->assertSame('draft', $this->ec->status($id));
+        $this->ec->addItem($id, 'Taxi', 2400);
+        $this->ec->addItem($id, 'Lunch', 1800);
+        $this->assertSame(4200, $this->ec->total($id));
+        $this->assertCount(2, $this->ec->items($id));
+    }
+
+    public function testFullLifecycle(): void
+    {
+        $id = $this->ec->create('emp');
+        $this->ec->addItem($id, 'Taxi', 2400);
+        $this->assertTrue($this->ec->submit($id));
+        $this->assertSame('submitted', $this->ec->status($id));
+        $this->assertTrue($this->ec->approve($id));
+        $this->assertSame('approved', $this->ec->status($id));
+        $this->assertTrue($this->ec->markPaid($id));
+        $this->assertSame('paid', $this->ec->status($id));
+    }
+
+    public function testReject(): void
+    {
+        $id = $this->ec->create('emp');
+        $this->ec->addItem($id, 'x', 100);
+        $this->ec->submit($id);
+        $this->assertTrue($this->ec->reject($id));
+        $this->assertSame('rejected', $this->ec->status($id));
+    }
+
+    public function testCannotAddItemAfterSubmit(): void
+    {
+        $id = $this->ec->create('emp');
+        $this->ec->addItem($id, 'x', 100);
+        $this->ec->submit($id);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ec->addItem($id, 'late', 50);
+    }
+
+    public function testSubmitEmptyClaimThrows(): void
+    {
+        $id = $this->ec->create('emp');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ec->submit($id);
+    }
+
+    public function testTransitionsGuardStatus(): void
+    {
+        $id = $this->ec->create('emp');
+        $this->ec->addItem($id, 'x', 100);
+        $this->assertFalse($this->ec->approve($id)); // still draft, not submitted
+        $this->assertFalse($this->ec->markPaid($id));
+        $this->ec->submit($id);
+        $this->assertFalse($this->ec->markPaid($id)); // submitted, not approved
+    }
+
+    public function testCannotApproveTwice(): void
+    {
+        $id = $this->ec->create('emp');
+        $this->ec->addItem($id, 'x', 100);
+        $this->ec->submit($id);
+        $this->ec->approve($id);
+        $this->assertFalse($this->ec->approve($id));
+        $this->assertFalse($this->ec->reject($id)); // already approved
+    }
+
+    public function testClaimsForWithTotals(): void
+    {
+        $a = $this->ec->create('emp');
+        $this->ec->addItem($a, 'x', 1000);
+        $b = $this->ec->create('emp');
+        $this->ec->addItem($b, 'y', 500);
+        $this->ec->submit($a);
+        $claims = $this->ec->claimsFor('emp');
+        $this->assertCount(2, $claims);
+        $this->assertCount(1, $this->ec->claimsFor('emp', ExpenseClaim::STATUS_SUBMITTED));
+        // newest first → b (draft, 500)
+        $this->assertSame(500, $claims[0]['total']);
+    }
+
+    public function testClaimantsAreSeparate(): void
+    {
+        $this->ec->create('e1');
+        $this->ec->create('e2');
+        $this->assertCount(1, $this->ec->claimsFor('e1'));
+    }
+
+    public function testStatusUnknownIsNull(): void
+    {
+        $this->assertNull($this->ec->status(999));
+        $this->assertFalse($this->ec->submit(999));
+    }
+
+    public function testAddItemRejectsNonPositive(): void
+    {
+        $id = $this->ec->create('emp');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ec->addItem($id, 'x', 0);
+    }
+
+    public function testCreateRejectsEmptyClaimant(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->ec->create('  ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT308** — `Nene\Kit\ExpenseClaim`: employee expense reimbursement claims with integer-cent line items and an approval lifecycle. Distinct from `Payout` (FT291) / `BudgetTracker` / `CreditNote`.

| Method | Description |
| --- | --- |
| `create / addItem (draft only) / total / items` | Build. |
| `submit / approve / reject / markPaid` | Guarded transitions. |
| `status / claimsFor(claimant, status=null)` | Read (with totals). |

- `draft → submitted → approved|rejected; approved → paid`; items addable only while draft; submit needs ≥1 item; totals computed from lines.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 26 assertions (lifecycle, reject, no-add-after-submit, empty-submit throw, transition guards, no double-approve, claimsFor totals/status, separation, validation)
- [x] `composer precommit` green (format → Phan → 5111 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)