### PR TITLE
feat(kit): Kudos — peer recognition / shout-outs between users (FT309)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -239,6 +239,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `Endorsement` | peer skill endorsements between users. |
 | `EventRsvp` | event attendance management with accept/decline/maybe responses. |
 | `FeatureRequest` | user-submitted feature requests with voting and status tracking. |
+| `Kudos` | peer recognition / shout-outs between users. |
 | `Label` | colored label definitions with entity assignment. |
 | `Leaderboard` | Score-based leaderboard with best-score retention, ranking, and personal rank lookup. |
 | `Petition` | signature campaign toward a goal. |

--- a/class/kit/Kudos.php
+++ b/class/kit/Kudos.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * Kudos — peer recognition / shout-outs between users.
+ *
+ * Lets users give one another public "kudos" (a thank-you / shout-out) with an
+ * optional message and category (e.g. 'teamwork', 'innovation'), and reports
+ * received/given counts and leaderboards. Distinct from `Endorsement` (FT285,
+ * skill endorsements) and `Reaction` (FT, emoji on content): this is
+ * free-form peer recognition between people. Self-kudos is disallowed.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $k = new Kudos($pdo);
+ *
+ * $k->give(fromUser: 1, toUser: 2, message: 'Saved the release!', category: 'teamwork');
+ *
+ * $k->receivedCount(2);          // 1
+ * $k->givenCount(1);             // 1
+ * $k->received(2);               // [['from_user'=>1,'message'=>...,'category'=>'teamwork'], ...]
+ * $k->topRecipients(10);         // [['to_user'=>2,'count'=>1], ...]
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE kudos (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     from_user  BIGINT       NOT NULL,
+ *     to_user    BIGINT       NOT NULL,
+ *     message    VARCHAR(255) NOT NULL DEFAULT '',
+ *     category   VARCHAR(50)  NOT NULL DEFAULT '',
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class Kudos
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Give kudos to another user.
+     *
+     * @param  int    $fromUser Giver user id.
+     * @param  int    $toUser   Recipient user id (must differ from giver).
+     * @param  string $message  Optional message.
+     * @param  string $category Optional category tag.
+     * @return int              New kudos id.
+     * @throws \InvalidArgumentException on self-kudos.
+     */
+    public function give(int $fromUser, int $toUser, string $message = '', string $category = ''): int
+    {
+        if ($fromUser === $toUser) {
+            throw new \InvalidArgumentException('A user cannot give kudos to themselves.');
+        }
+
+        $stmt = $this->db()->prepare('INSERT INTO kudos (from_user, to_user, message, category) VALUES (?, ?, ?, ?)');
+        $stmt->execute([$fromUser, $toUser, $message, trim($category)]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Number of kudos a user has received.
+     */
+    public function receivedCount(int $toUser): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM kudos WHERE to_user = ?');
+        $stmt->execute([$toUser]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Number of kudos a user has given.
+     */
+    public function givenCount(int $fromUser): int
+    {
+        $stmt = $this->db()->prepare('SELECT COUNT(*) FROM kudos WHERE from_user = ?');
+        $stmt->execute([$fromUser]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Kudos a user has received, newest first.
+     *
+     * @param  int      $toUser Recipient user id.
+     * @param  int|null $limit  Optional cap.
+     * @return array<int,array{from_user:int,message:string,category:string}>
+     */
+    public function received(int $toUser, ?int $limit = null): array
+    {
+        $sql = 'SELECT from_user, message, category FROM kudos WHERE to_user = ? ORDER BY id DESC';
+        if ($limit !== null) {
+            $sql .= ' LIMIT ' . max(0, $limit);
+        }
+        $stmt = $this->db()->prepare($sql);
+        $stmt->execute([$toUser]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = [
+                'from_user' => (int)$row['from_user'],
+                'message'   => (string)$row['message'],
+                'category'  => (string)$row['category'],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Per-category counts of kudos a user received, busiest first.
+     *
+     * @return array<string,int> category → count (blank category as '')
+     */
+    public function countByCategory(int $toUser): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT category, COUNT(*) AS c FROM kudos WHERE to_user = ? GROUP BY category ORDER BY c DESC, category ASC'
+        );
+        $stmt->execute([$toUser]);
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[(string)$row['category']] = (int)$row['c'];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Top recipients by kudos count, most first.
+     *
+     * @param  int $limit Maximum rows (>= 1).
+     * @return array<int,array{to_user:int,count:int}>
+     */
+    public function topRecipients(int $limit = 10): array
+    {
+        $limit = max(1, $limit);
+        $stmt  = $this->db()->prepare(
+            'SELECT to_user, COUNT(*) AS c FROM kudos GROUP BY to_user ORDER BY c DESC, to_user ASC LIMIT ?'
+        );
+        $stmt->bindValue(1, $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        $out = [];
+        /** @var array<string,mixed> $row */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $out[] = ['to_user' => (int)$row['to_user'], 'count' => (int)$row['c']];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Remove a kudos by id. No-op if absent.
+     */
+    public function remove(int $id): void
+    {
+        $stmt = $this->db()->prepare('DELETE FROM kudos WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-309.md
+++ b/docs/field-trials/2026-05-field-trial-309.md
@@ -1,0 +1,40 @@
+# Field Trial 309 — Kudos
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft309-kudos`
+**Baseline**: post FT308 merge
+
+## Goal
+
+Add `Nene\Kit\Kudos` — peer recognition / shout-outs between users, with optional message + category, received/given counts, and a recipient leaderboard. Distinct from `Endorsement` (FT285, skill endorsements) and `Reaction` (emoji on content).
+
+## What was built
+
+### `Nene\Kit\Kudos` (`class/kit/Kudos.php`)
+
+| Method | Description |
+| --- | --- |
+| `give(fromUser, toUser, message='', category=''): int` | Give kudos (no self-kudos). |
+| `receivedCount / givenCount` | Counts. |
+| `received(toUser, limit=null)` | Recent received (newest first). |
+| `countByCategory(toUser) / topRecipients(limit=10)` | Breakdown / leaderboard. |
+| `remove(id)` | Delete. |
+
+Key design points:
+
+- **Self-kudos disallowed** (from == to throws); append-only; category trimmed.
+- `topRecipients` groups by recipient ordered by count desc.
+
+### Tests (`tests/Unit/Kit/KudosTest.php`)
+
+9 unit tests (16 assertions): give + counts, received newest-first, received limit, countByCategory, topRecipients ranking, remove (+ missing no-op), category trimmed, self-kudos rejected.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 9 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/KudosTest.php
+++ b/tests/Unit/Kit/KudosTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\Kudos;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Kudos.
+ */
+final class KudosTest extends TestCase
+{
+    private PDO $db;
+    private Kudos $k;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE kudos (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                from_user  BIGINT       NOT NULL,
+                to_user    BIGINT       NOT NULL,
+                message    VARCHAR(255) NOT NULL DEFAULT \'\',
+                category   VARCHAR(50)  NOT NULL DEFAULT \'\',
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->k = new Kudos($this->db);
+    }
+
+    public function testGiveAndCounts(): void
+    {
+        $this->k->give(1, 2, 'great work', 'teamwork');
+        $this->k->give(3, 2);
+        $this->assertSame(2, $this->k->receivedCount(2));
+        $this->assertSame(1, $this->k->givenCount(1));
+        $this->assertSame(0, $this->k->givenCount(2));
+    }
+
+    public function testReceivedNewestFirst(): void
+    {
+        $this->k->give(1, 2, 'first');
+        $this->k->give(3, 2, 'second');
+        $r = $this->k->received(2);
+        $this->assertCount(2, $r);
+        $this->assertSame('second', $r[0]['message']);
+        $this->assertSame(3, $r[0]['from_user']);
+    }
+
+    public function testReceivedLimit(): void
+    {
+        $this->k->give(1, 2);
+        $this->k->give(1, 2);
+        $this->k->give(1, 2);
+        $this->assertCount(2, $this->k->received(2, 2));
+    }
+
+    public function testCountByCategory(): void
+    {
+        $this->k->give(1, 2, '', 'teamwork');
+        $this->k->give(3, 2, '', 'teamwork');
+        $this->k->give(4, 2, '', 'innovation');
+        $counts = $this->k->countByCategory(2);
+        $this->assertSame(2, $counts['teamwork']);
+        $this->assertSame(1, $counts['innovation']);
+    }
+
+    public function testTopRecipients(): void
+    {
+        $this->k->give(1, 2);
+        $this->k->give(3, 2);
+        $this->k->give(4, 5);
+        $top = $this->k->topRecipients();
+        $this->assertSame(2, $top[0]['to_user']);
+        $this->assertSame(2, $top[0]['count']);
+        $this->assertSame(5, $top[1]['to_user']);
+    }
+
+    public function testRemove(): void
+    {
+        $id = $this->k->give(1, 2);
+        $this->k->remove($id);
+        $this->assertSame(0, $this->k->receivedCount(2));
+    }
+
+    public function testRemoveMissingIsNoop(): void
+    {
+        $this->k->remove(999);
+        $this->assertSame(0, $this->k->receivedCount(2));
+    }
+
+    public function testCategoryTrimmed(): void
+    {
+        $this->k->give(1, 2, '', '  teamwork  ');
+        $this->assertSame(1, $this->k->countByCategory(2)['teamwork']);
+    }
+
+    public function testSelfKudosRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->k->give(2, 2, 'self five');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT309** — `Nene\Kit\Kudos`: peer recognition / shout-outs with message + category, counts, and a recipient leaderboard. Distinct from `Endorsement` (FT285, skills) and `Reaction`.

| Method | Description |
| --- | --- |
| `give(fromUser, toUser, message='', category=''): int` | No self-kudos. |
| `receivedCount / givenCount / received` | Counts / recent. |
| `countByCategory / topRecipients / remove` | Breakdown / leaderboard. |

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 9 tests / 16 assertions (give+counts, newest-first, limit, by-category, topRecipients, remove, trimmed category, self-kudos rejected)
- [x] `composer precommit` green (format → Phan → 5120 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)