### PR TITLE
feat(kit): Dispute — transaction dispute/chargeback workflow (FT311)

### DIFF
--- a/class/kit/Dispute.php
+++ b/class/kit/Dispute.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * Dispute — transaction dispute / chargeback workflow.
+ *
+ * Tracks a payment dispute through its lifecycle: open → under_review →
+ * won|lost. Evidence can be attached while the case is unresolved, and the
+ * total amount currently at risk (open + under_review) can be summed for
+ * reporting. Distinct from `ContentReport`/`ContentFlag` (moderation queues)
+ * and generic ticketing: this is money-bearing, with a guarded state machine
+ * and a final win/loss outcome.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $d = new Dispute($pdo);
+ *
+ * $id = $d->open('txn_8842', 'item not received', 1500); // open, 1500 cents
+ * $d->review($id);                                        // → under_review
+ * $d->addEvidence($id, 'tracking shows delivered');
+ * $d->resolve($id, won: true);                            // → won
+ *
+ * $d->status($id);          // 'won'
+ * $d->byStatus('open');     // [ ...rows... ]
+ * $d->amountAtRisk();       // sum of open + under_review amounts (cents)
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE disputes (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     reference    VARCHAR(190) NOT NULL,
+ *     reason       VARCHAR(255) NOT NULL DEFAULT '',
+ *     amount_cents INTEGER      NOT NULL DEFAULT 0,
+ *     status       VARCHAR(20)  NOT NULL DEFAULT 'open',
+ *     evidence     TEXT         NOT NULL DEFAULT '',
+ *     opened_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     resolved_at  DATETIME     NULL
+ * );
+ * ```
+ */
+final class Dispute
+{
+    private const OPEN   = 'open';
+    private const REVIEW = 'under_review';
+    private const WON    = 'won';
+    private const LOST   = 'lost';
+
+    /** Statuses where the case is not yet resolved (money still at risk). */
+    private const UNRESOLVED = [self::OPEN, self::REVIEW];
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Open a new dispute against a transaction reference.
+     *
+     * @param  string $reference   Transaction / order identifier.
+     * @param  string $reason      Free-text reason.
+     * @param  int    $amountCents Disputed amount in integer cents (>= 0).
+     * @return int                 New dispute id.
+     * @throws \InvalidArgumentException on empty reference or negative amount.
+     */
+    public function open(string $reference, string $reason, int $amountCents): int
+    {
+        $reference = trim($reference);
+        if ($reference === '') {
+            throw new \InvalidArgumentException('Reference must not be empty.');
+        }
+        if ($amountCents < 0) {
+            throw new \InvalidArgumentException('Amount must not be negative.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO disputes (reference, reason, amount_cents, status) VALUES (?, ?, ?, ?)'
+        );
+        $stmt->execute([$reference, trim($reason), $amountCents, self::OPEN]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Move an open dispute into review. Returns false if the dispute is not
+     * currently open (missing or already past open).
+     */
+    public function review(int $id): bool
+    {
+        return $this->transition($id, self::REVIEW, [self::OPEN], false);
+    }
+
+    /**
+     * Append a line of evidence. Allowed only while the case is unresolved.
+     *
+     * @throws \InvalidArgumentException on empty text.
+     * @return bool True if appended; false if the dispute is missing or resolved.
+     */
+    public function addEvidence(int $id, string $text): bool
+    {
+        $text = trim($text);
+        if ($text === '') {
+            throw new \InvalidArgumentException('Evidence must not be empty.');
+        }
+
+        $db             = $this->db();
+        $ownTransaction = !$db->inTransaction();
+        if ($ownTransaction) {
+            $db->beginTransaction();
+        }
+        try {
+            $row = $this->lockRow($id);
+            if ($row === null || !in_array($row['status'], self::UNRESOLVED, true)) {
+                if ($ownTransaction) {
+                    $db->commit();
+                }
+
+                return false;
+            }
+
+            $existing = $row['evidence'];
+            $merged   = $existing === '' ? $text : $existing . "\n" . $text;
+            $db->prepare('UPDATE disputes SET evidence = ? WHERE id = ?')->execute([$merged, $id]);
+
+            if ($ownTransaction) {
+                $db->commit();
+            }
+
+            return true;
+        } catch (\Throwable $e) {
+            if ($ownTransaction && $db->inTransaction()) {
+                $db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Resolve the dispute as won or lost. Allowed from open or under_review.
+     *
+     * @param  int  $id  Dispute id.
+     * @param  bool $won True → won, false → lost.
+     * @return bool      True if resolved; false if missing or already resolved.
+     */
+    public function resolve(int $id, bool $won): bool
+    {
+        return $this->transition($id, $won ? self::WON : self::LOST, self::UNRESOLVED, true);
+    }
+
+    /**
+     * Current status, or null if the dispute does not exist.
+     */
+    public function status(int $id): ?string
+    {
+        $row = $this->get($id);
+
+        return $row === null ? null : $row['status'];
+    }
+
+    /**
+     * Full dispute row, or null.
+     *
+     * @return array{id:int,reference:string,reason:string,amount_cents:int,status:string,evidence:string,resolved_at:?string}|null
+     */
+    public function get(int $id): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, reference, reason, amount_cents, status, evidence, resolved_at FROM disputes WHERE id = ?'
+        );
+        $stmt->execute([$id]);
+        $r = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($r === false) {
+            return null;
+        }
+
+        return [
+            'id'           => (int)$r['id'],
+            'reference'    => (string)$r['reference'],
+            'reason'       => (string)$r['reason'],
+            'amount_cents' => (int)$r['amount_cents'],
+            'status'       => (string)$r['status'],
+            'evidence'     => (string)$r['evidence'],
+            'resolved_at'  => $r['resolved_at'] === null ? null : (string)$r['resolved_at'],
+        ];
+    }
+
+    /**
+     * Disputes with the given status, newest first.
+     *
+     * @return array<int,array{id:int,reference:string,reason:string,amount_cents:int,status:string}>
+     */
+    public function byStatus(string $status): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT id, reference, reason, amount_cents, status FROM disputes WHERE status = ? ORDER BY id DESC'
+        );
+        $stmt->execute([$status]);
+
+        $out = [];
+        /** @var array<string,mixed> $r */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+            $out[] = [
+                'id'           => (int)$r['id'],
+                'reference'    => (string)$r['reference'],
+                'reason'       => (string)$r['reason'],
+                'amount_cents' => (int)$r['amount_cents'],
+                'status'       => (string)$r['status'],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Total amount (cents) currently at risk: sum of open + under_review.
+     */
+    public function amountAtRisk(): int
+    {
+        $place = implode(', ', array_fill(0, count(self::UNRESOLVED), '?'));
+        $stmt  = $this->db()->prepare(
+            "SELECT COALESCE(SUM(amount_cents), 0) FROM disputes WHERE status IN ({$place})"
+        );
+        $stmt->execute(self::UNRESOLVED);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * Guarded status transition.
+     *
+     * @param array<int,string> $from         Allowed source statuses.
+     * @param bool              $stampResolve Whether to set resolved_at = now.
+     */
+    private function transition(int $id, string $to, array $from, bool $stampResolve): bool
+    {
+        $place = implode(', ', array_fill(0, count($from), '?'));
+        $sql   = $stampResolve
+            ? "UPDATE disputes SET status = ?, resolved_at = CURRENT_TIMESTAMP WHERE id = ? AND status IN ({$place})"
+            : "UPDATE disputes SET status = ? WHERE id = ? AND status IN ({$place})";
+
+        $stmt = $this->db()->prepare($sql);
+        $stmt->execute([$to, $id, ...$from]);
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Read the row for an in-transaction update.
+     *
+     * @return array{status:string,evidence:string}|null
+     */
+    private function lockRow(int $id): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT status, evidence FROM disputes WHERE id = ?');
+        $stmt->execute([$id]);
+        $r = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($r === false) {
+            return null;
+        }
+
+        return ['status' => (string)$r['status'], 'evidence' => (string)$r['evidence']];
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -174,6 +174,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `CouponCode` | Coupon / promo code management with usage limits and per-user redemption tracking. |
 | `CreditLedger` | append-only double-entry credit/debit ledger per user. |
 | `CreditNote` | financial credit notes / refund adjustments. |
+| `Dispute` | transaction dispute / chargeback workflow. |
 | `ExchangeRate` | effective-dated currency conversion rate table. |
 | `EventTicket` | event ticketing with capacity management and check-in tracking. |
 | `ExpenseClaim` | expense reimbursement claims with line items and approval. |
@@ -339,5 +340,4 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 ---
 
 *Generated from PHPDoc descriptions. Run `composer kit:index` to refresh after adding classes.*
-
 

--- a/docs/field-trials/2026-05-field-trial-311.md
+++ b/docs/field-trials/2026-05-field-trial-311.md
@@ -1,0 +1,42 @@
+# Field Trial 311 — Dispute
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft311-dispute`
+**Baseline**: post FT310 merge
+
+## Goal
+
+Add `Nene\Kit\Dispute` — a transaction dispute / chargeback workflow: open a money-bearing case, move it through review, attach evidence, and resolve it won/lost, with a running total of the amount still at risk. Distinct from `ContentReport`/`ContentFlag` (moderation queues): this is financial, with a guarded state machine.
+
+## What was built
+
+### `Nene\Kit\Dispute` (`class/kit/Dispute.php`)
+
+| Method | Description |
+| --- | --- |
+| `open(reference, reason, amountCents): int` | Open a dispute (status `open`). |
+| `review(id): bool` | `open` → `under_review` (guarded). |
+| `addEvidence(id, text): bool` | Append a line; only while unresolved (transactional read-modify-write). |
+| `resolve(id, won): bool` | `open`/`under_review` → `won`/`lost`; stamps `resolved_at`. |
+| `status / get / byStatus` | Read. |
+| `amountAtRisk(): int` | Sum of `open` + `under_review` amounts (cents). |
+
+Key design points:
+
+- **Guarded transitions**: each state change is `UPDATE … WHERE id = ? AND status IN (…)`, returning `rowCount() > 0`, so illegal/double transitions are no-ops returning false.
+- **Evidence append** is wrapped in a transaction (reused if already in one) to avoid lost updates.
+- **Integer cents** throughout; negative amounts rejected at `open`.
+
+### Tests (`tests/Unit/Kit/DisputeTest.php`)
+
+13 tests (30 assertions): open defaults, full lifecycle, direct resolve-from-open, review-only-from-open, no double resolve, evidence append + newline join, no evidence after resolve, amount-at-risk math across statuses, byStatus filtering, missing-id nulls, and three validation guards.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/DisputeTest.php
+++ b/tests/Unit/Kit/DisputeTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\Dispute;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Dispute.
+ */
+final class DisputeTest extends TestCase
+{
+    private PDO $db;
+    private Dispute $d;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE disputes (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                reference    VARCHAR(190) NOT NULL,
+                reason       VARCHAR(255) NOT NULL DEFAULT \'\',
+                amount_cents INTEGER      NOT NULL DEFAULT 0,
+                status       VARCHAR(20)  NOT NULL DEFAULT \'open\',
+                evidence     TEXT         NOT NULL DEFAULT \'\',
+                opened_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                resolved_at  DATETIME     NULL
+            )
+        ');
+        $this->d = new Dispute($this->db);
+    }
+
+    public function testOpenStartsOpen(): void
+    {
+        $id = $this->d->open('txn_1', 'not received', 1500);
+        $this->assertSame('open', $this->d->status($id));
+        $row = $this->d->get($id);
+        $this->assertSame(1500, $row['amount_cents']);
+        $this->assertSame('txn_1', $row['reference']);
+        $this->assertNull($row['resolved_at']);
+    }
+
+    public function testFullLifecycle(): void
+    {
+        $id = $this->d->open('txn_1', 'not received', 1500);
+        $this->assertTrue($this->d->review($id));
+        $this->assertSame('under_review', $this->d->status($id));
+        $this->assertTrue($this->d->resolve($id, won: true));
+        $this->assertSame('won', $this->d->status($id));
+        $this->assertNotNull($this->d->get($id)['resolved_at']);
+    }
+
+    public function testResolveLost(): void
+    {
+        $id = $this->d->open('txn_1', 'x', 200);
+        $this->assertTrue($this->d->resolve($id, won: false)); // direct from open
+        $this->assertSame('lost', $this->d->status($id));
+    }
+
+    public function testReviewOnlyFromOpen(): void
+    {
+        $id = $this->d->open('txn_1', 'x', 200);
+        $this->d->resolve($id, won: true);
+        $this->assertFalse($this->d->review($id)); // already resolved
+    }
+
+    public function testCannotResolveTwice(): void
+    {
+        $id = $this->d->open('txn_1', 'x', 200);
+        $this->assertTrue($this->d->resolve($id, won: true));
+        $this->assertFalse($this->d->resolve($id, won: false)); // already won
+        $this->assertSame('won', $this->d->status($id));
+    }
+
+    public function testAddEvidenceAppends(): void
+    {
+        $id = $this->d->open('txn_1', 'x', 200);
+        $this->assertTrue($this->d->addEvidence($id, 'first'));
+        $this->assertTrue($this->d->addEvidence($id, 'second'));
+        $this->assertSame("first\nsecond", $this->d->get($id)['evidence']);
+    }
+
+    public function testCannotAddEvidenceWhenResolved(): void
+    {
+        $id = $this->d->open('txn_1', 'x', 200);
+        $this->d->resolve($id, won: true);
+        $this->assertFalse($this->d->addEvidence($id, 'late'));
+        $this->assertSame('', $this->d->get($id)['evidence']);
+    }
+
+    public function testAmountAtRisk(): void
+    {
+        $a = $this->d->open('t1', 'x', 1000); // open
+        $this->d->open('t2', 'x', 500);       // open
+        $c = $this->d->open('t3', 'x', 700);
+        $this->d->review($c);                 // under_review — still at risk
+        $w = $this->d->open('t4', 'x', 9999);
+        $this->d->resolve($w, won: true);     // resolved — not at risk
+        $this->assertSame(2200, $this->d->amountAtRisk()); // 1000 + 500 + 700
+        $this->d->resolve($a, won: false);
+        $this->assertSame(1200, $this->d->amountAtRisk()); // 500 + 700
+    }
+
+    public function testByStatus(): void
+    {
+        $this->d->open('t1', 'x', 100);
+        $b = $this->d->open('t2', 'x', 100);
+        $this->d->review($b);
+        $this->assertCount(1, $this->d->byStatus('open'));
+        $this->assertCount(1, $this->d->byStatus('under_review'));
+        $this->assertCount(0, $this->d->byStatus('won'));
+    }
+
+    public function testStatusOfMissingIsNull(): void
+    {
+        $this->assertNull($this->d->status(999));
+        $this->assertNull($this->d->get(999));
+    }
+
+    public function testOpenRejectsEmptyReference(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->d->open('  ', 'x', 100);
+    }
+
+    public function testOpenRejectsNegativeAmount(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->d->open('t1', 'x', -1);
+    }
+
+    public function testAddEvidenceRejectsEmpty(): void
+    {
+        $id = $this->d->open('t1', 'x', 100);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->d->addEvidence($id, '   ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT311** — `Nene\Kit\Dispute`: a payment dispute / chargeback workflow with a guarded state machine and money tracking.

| Method | Description |
| --- | --- |
| `open(reference, reason, amountCents): int` | Open (status `open`). |
| `review(id): bool` | `open` → `under_review`. |
| `addEvidence(id, text): bool` | Append while unresolved (transactional). |
| `resolve(id, won): bool` | → `won`/`lost`; stamps `resolved_at`. |
| `status / get / byStatus / amountAtRisk` | Read. |

- Guarded transitions (`UPDATE … WHERE status IN (…)`) → illegal/double transitions are no-op false.
- Integer cents; `amountAtRisk()` sums open + under_review.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 30 assertions (lifecycle, transition guards, evidence append/lockout, amount-at-risk math, validation)
- [x] `composer precommit` green (format → Phan → 5144 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)