### PR TITLE
feat(kit): PledgeDrive — crowdfunding drive with monetary pledges (FT312)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -184,6 +184,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `OrderLine` | e-commerce order header with line items. |
 | `PaymentRecord` | simple payment/transaction ledger. |
 | `Payout` | accrue amounts owed to payees and settle them in payout runs. |
+| `PledgeDrive` | crowdfunding / fundraising drive with monetary pledges. |
 | `PointBalance` | user loyalty/reward points with append-only ledger. |
 | `PointLedger` | Append-only point / loyalty system with negative-balance prevention. |
 | `PriceAlert` | notify users when an item's price drops to their target. |

--- a/class/kit/PledgeDrive.php
+++ b/class/kit/PledgeDrive.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * PledgeDrive — crowdfunding / fundraising drive with monetary pledges.
+ *
+ * A drive has a funding goal (integer cents) and optional deadline; supporters
+ * pledge amounts toward it. Tracks total raised, progress toward goal, distinct
+ * backer count, and whether the goal has been reached. Distinct from `Petition`
+ * (signature count toward a goal — no money) and `CreditLedger`/`Payout`
+ * (accounting primitives): this is the campaign-and-pledges aggregate.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $pd = new PledgeDrive($pdo);
+ *
+ * $id = $pd->createDrive('New roof', 500000, deadline: '2026-07-01'); // goal 5000.00
+ * $pd->pledge($id, 'alice', 200000); // 2000.00
+ * $pd->pledge($id, 'bob',   350000); // 3500.00
+ *
+ * $pd->raised($id);       // 550000
+ * $pd->goalReached($id);  // true
+ * $pd->progress($id);     // 1.0 (capped at 1.0)
+ * $pd->backerCount($id);  // 2
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE pledge_drives (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     name       VARCHAR(190) NOT NULL,
+ *     goal_cents INTEGER      NOT NULL,
+ *     deadline   CHAR(10)     NULL,
+ *     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * CREATE TABLE pledge_drive_pledges (
+ *     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     drive_id     BIGINT       NOT NULL,
+ *     backer       VARCHAR(190) NOT NULL,
+ *     amount_cents INTEGER      NOT NULL,
+ *     created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+ * );
+ * ```
+ */
+final class PledgeDrive
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Create a drive with a funding goal (integer cents) and optional deadline.
+     *
+     * @param  string      $name     Drive name.
+     * @param  int         $goalCents Funding goal in cents (> 0).
+     * @param  string|null $deadline  Optional 'Y-m-d' deadline.
+     * @return int                    New drive id.
+     * @throws \InvalidArgumentException on empty name or non-positive goal.
+     */
+    public function createDrive(string $name, int $goalCents, ?string $deadline = null): int
+    {
+        $name = trim($name);
+        if ($name === '') {
+            throw new \InvalidArgumentException('Name must not be empty.');
+        }
+        if ($goalCents <= 0) {
+            throw new \InvalidArgumentException('Goal must be positive.');
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO pledge_drives (name, goal_cents, deadline) VALUES (?, ?, ?)'
+        );
+        $stmt->execute([$name, $goalCents, $deadline]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Record a pledge toward a drive.
+     *
+     * @param  int    $driveId     Drive id (must exist).
+     * @param  string $backer      Backer identifier.
+     * @param  int    $amountCents Pledge amount in cents (> 0).
+     * @return int                 New pledge id.
+     * @throws \InvalidArgumentException on unknown drive, empty backer, or non-positive amount.
+     */
+    public function pledge(int $driveId, string $backer, int $amountCents): int
+    {
+        $backer = trim($backer);
+        if ($backer === '') {
+            throw new \InvalidArgumentException('Backer must not be empty.');
+        }
+        if ($amountCents <= 0) {
+            throw new \InvalidArgumentException('Pledge amount must be positive.');
+        }
+        if (!$this->driveExists($driveId)) {
+            throw new \InvalidArgumentException("Unknown drive: {$driveId}");
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO pledge_drive_pledges (drive_id, backer, amount_cents) VALUES (?, ?, ?)'
+        );
+        $stmt->execute([$driveId, $backer, $amountCents]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Total amount raised for a drive (cents).
+     */
+    public function raised(int $driveId): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COALESCE(SUM(amount_cents), 0) FROM pledge_drive_pledges WHERE drive_id = ?'
+        );
+        $stmt->execute([$driveId]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Progress toward the goal as a ratio in [0.0, 1.0] (capped). Returns 0.0
+     * for an unknown drive.
+     */
+    public function progress(int $driveId): float
+    {
+        $goal = $this->goal($driveId);
+        if ($goal === null) {
+            return 0.0;
+        }
+        $ratio = $this->raised($driveId) / $goal;
+
+        return $ratio > 1.0 ? 1.0 : $ratio;
+    }
+
+    /**
+     * Whether the goal has been reached (raised >= goal). False for unknown drive.
+     */
+    public function goalReached(int $driveId): bool
+    {
+        $goal = $this->goal($driveId);
+
+        return $goal !== null && $this->raised($driveId) >= $goal;
+    }
+
+    /**
+     * Amount still needed to reach the goal (cents); 0 once reached. Returns 0
+     * for an unknown drive.
+     */
+    public function remaining(int $driveId): int
+    {
+        $goal = $this->goal($driveId);
+        if ($goal === null) {
+            return 0;
+        }
+        $left = $goal - $this->raised($driveId);
+
+        return $left > 0 ? $left : 0;
+    }
+
+    /**
+     * Number of distinct backers for a drive.
+     */
+    public function backerCount(int $driveId): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(DISTINCT backer) FROM pledge_drive_pledges WHERE drive_id = ?'
+        );
+        $stmt->execute([$driveId]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * Top backers by total pledged (descending), with their summed amount.
+     *
+     * @return array<int,array{backer:string,total:int}>
+     */
+    public function topBackers(int $driveId, int $limit = 10): array
+    {
+        if ($limit < 1) {
+            throw new \InvalidArgumentException('Limit must be at least 1.');
+        }
+        $stmt = $this->db()->prepare(
+            'SELECT backer, SUM(amount_cents) AS total FROM pledge_drive_pledges
+             WHERE drive_id = ? GROUP BY backer ORDER BY total DESC, backer ASC LIMIT ?'
+        );
+        $stmt->bindValue(1, $driveId, PDO::PARAM_INT);
+        $stmt->bindValue(2, $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        $out = [];
+        /** @var array<string,mixed> $r */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+            $out[] = ['backer' => (string)$r['backer'], 'total' => (int)$r['total']];
+        }
+
+        return $out;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function goal(int $driveId): ?int
+    {
+        $stmt = $this->db()->prepare('SELECT goal_cents FROM pledge_drives WHERE id = ?');
+        $stmt->execute([$driveId]);
+        $g = $stmt->fetchColumn();
+
+        return $g === false ? null : (int)$g;
+    }
+
+    private function driveExists(int $driveId): bool
+    {
+        return $this->goal($driveId) !== null;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-312.md
+++ b/docs/field-trials/2026-05-field-trial-312.md
@@ -1,0 +1,46 @@
+# Field Trial 312 — PledgeDrive
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft312-pledgedrive`
+**Baseline**: post FT311 merge
+
+## Goal
+
+Add `Nene\Kit\PledgeDrive` — a crowdfunding / fundraising drive: a campaign with a monetary goal (integer cents) and optional deadline, plus pledges toward it. Report total raised, progress toward goal, distinct backers, top backers, and whether the goal is reached. Distinct from `Petition` (signature count toward a goal — no money) and `Payout`/`CreditLedger` (accounting primitives).
+
+## What was built
+
+### `Nene\Kit\PledgeDrive` (`class/kit/PledgeDrive.php`)
+
+Two tables: `pledge_drives` (goal + deadline) and `pledge_drive_pledges`.
+
+| Method | Description |
+| --- | --- |
+| `createDrive(name, goalCents, deadline=null): int` | Create a drive (goal > 0). |
+| `pledge(driveId, backer, amountCents): int` | Record a pledge (drive must exist; amount > 0). |
+| `raised(driveId): int` | Total pledged (cents). |
+| `progress(driveId): float` | raised/goal, capped at 1.0. |
+| `goalReached(driveId): bool` | raised >= goal. |
+| `remaining(driveId): int` | Cents still needed (0 once reached). |
+| `backerCount(driveId): int` | Distinct backers. |
+| `topBackers(driveId, limit=10): array` | Backers by summed pledge, descending. |
+
+Key design points:
+
+- **Integer cents** throughout; goal and pledge amounts must be positive.
+- **Unknown-drive reads are safe**: `raised`/`progress`/`goalReached`/`remaining` return zero-ish values rather than throwing; only `pledge()` rejects an unknown drive (writes must be valid).
+- `topBackers` groups by backer with a deterministic `total DESC, backer ASC` tiebreak.
+
+### Tests (`tests/Unit/Kit/PledgeDriveTest.php`)
+
+13 tests (27 assertions): raised + goalReached, exact-goal boundary, progress cap at 1.0, remaining, distinct backer count, topBackers sum/order/limit, drive separation, safe unknown-drive reads, and four validation guards.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 13 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/PledgeDriveTest.php
+++ b/tests/Unit/Kit/PledgeDriveTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\PledgeDrive;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for PledgeDrive.
+ */
+final class PledgeDriveTest extends TestCase
+{
+    private PDO $db;
+    private PledgeDrive $pd;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE pledge_drives (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                name       VARCHAR(190) NOT NULL,
+                goal_cents INTEGER      NOT NULL,
+                deadline   CHAR(10)     NULL,
+                created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->db->exec('
+            CREATE TABLE pledge_drive_pledges (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                drive_id     BIGINT       NOT NULL,
+                backer       VARCHAR(190) NOT NULL,
+                amount_cents INTEGER      NOT NULL,
+                created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->pd = new PledgeDrive($this->db);
+    }
+
+    public function testRaisedAndGoalReached(): void
+    {
+        $id = $this->pd->createDrive('Roof', 500000);
+        $this->assertSame(0, $this->pd->raised($id));
+        $this->assertFalse($this->pd->goalReached($id));
+        $this->pd->pledge($id, 'alice', 200000);
+        $this->pd->pledge($id, 'bob', 350000);
+        $this->assertSame(550000, $this->pd->raised($id));
+        $this->assertTrue($this->pd->goalReached($id));
+    }
+
+    public function testGoalReachedExactlyAtGoal(): void
+    {
+        $id = $this->pd->createDrive('Roof', 1000);
+        $this->pd->pledge($id, 'alice', 1000); // exactly the goal
+        $this->assertTrue($this->pd->goalReached($id));
+        $this->assertSame(0, $this->pd->remaining($id));
+    }
+
+    public function testProgressCapsAtOne(): void
+    {
+        $id = $this->pd->createDrive('Roof', 1000);
+        $this->pd->pledge($id, 'alice', 250);
+        $this->assertSame(0.25, $this->pd->progress($id));
+        $this->pd->pledge($id, 'bob', 5000); // overshoot
+        $this->assertSame(1.0, $this->pd->progress($id)); // capped
+    }
+
+    public function testRemaining(): void
+    {
+        $id = $this->pd->createDrive('Roof', 1000);
+        $this->pd->pledge($id, 'alice', 300);
+        $this->assertSame(700, $this->pd->remaining($id));
+    }
+
+    public function testBackerCountIsDistinct(): void
+    {
+        $id = $this->pd->createDrive('Roof', 1000);
+        $this->pd->pledge($id, 'alice', 100);
+        $this->pd->pledge($id, 'alice', 100); // same backer twice
+        $this->pd->pledge($id, 'bob', 100);
+        $this->assertSame(2, $this->pd->backerCount($id));
+        $this->assertSame(300, $this->pd->raised($id));
+    }
+
+    public function testTopBackersSumsAndOrders(): void
+    {
+        $id = $this->pd->createDrive('Roof', 10000);
+        $this->pd->pledge($id, 'alice', 100);
+        $this->pd->pledge($id, 'alice', 400); // alice total 500
+        $this->pd->pledge($id, 'bob', 900);
+        $top = $this->pd->topBackers($id, 5);
+        $this->assertSame('bob', $top[0]['backer']);
+        $this->assertSame(900, $top[0]['total']);
+        $this->assertSame('alice', $top[1]['backer']);
+        $this->assertSame(500, $top[1]['total']);
+    }
+
+    public function testTopBackersRespectsLimit(): void
+    {
+        $id = $this->pd->createDrive('Roof', 10000);
+        $this->pd->pledge($id, 'a', 100);
+        $this->pd->pledge($id, 'b', 200);
+        $this->pd->pledge($id, 'c', 300);
+        $this->assertCount(2, $this->pd->topBackers($id, 2));
+    }
+
+    public function testDrivesAreSeparate(): void
+    {
+        $a = $this->pd->createDrive('A', 1000);
+        $b = $this->pd->createDrive('B', 1000);
+        $this->pd->pledge($a, 'x', 1000);
+        $this->assertTrue($this->pd->goalReached($a));
+        $this->assertFalse($this->pd->goalReached($b));
+        $this->assertSame(0, $this->pd->raised($b));
+    }
+
+    public function testUnknownDriveReadsAreSafe(): void
+    {
+        $this->assertSame(0, $this->pd->raised(999));
+        $this->assertSame(0.0, $this->pd->progress(999));
+        $this->assertFalse($this->pd->goalReached(999));
+        $this->assertSame(0, $this->pd->remaining(999));
+    }
+
+    public function testPledgeUnknownDriveThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pd->pledge(999, 'alice', 100);
+    }
+
+    public function testCreateDriveRejectsNonPositiveGoal(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pd->createDrive('Roof', 0);
+    }
+
+    public function testPledgeRejectsNonPositiveAmount(): void
+    {
+        $id = $this->pd->createDrive('Roof', 1000);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pd->pledge($id, 'alice', 0);
+    }
+
+    public function testPledgeRejectsEmptyBacker(): void
+    {
+        $id = $this->pd->createDrive('Roof', 1000);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->pd->pledge($id, '  ', 100);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT312** — `Nene\Kit\PledgeDrive`: a fundraising campaign with a monetary goal and pledges. Distinct from `Petition` (signatures, no money).

| Method | Description |
| --- | --- |
| `createDrive(name, goalCents, deadline=null): int` | Goal > 0. |
| `pledge(driveId, backer, amountCents): int` | Drive must exist; amount > 0. |
| `raised / progress (cap 1.0) / goalReached / remaining` | Aggregate reads. |
| `backerCount / topBackers` | Backer analytics. |

- Integer cents throughout; unknown-drive reads return safe zeros (only `pledge()` rejects unknown drive).

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 13 tests / 27 assertions (raised/goalReached, exact-goal boundary, progress cap, remaining, distinct backers, topBackers sum/order/limit, separation, safe unknown reads, validation)
- [x] `composer precommit` green (format → Phan → 5157 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)