### PR TITLE
feat(kit): ShiftRoster — staff shift scheduling with coverage tracking (FT313)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -319,6 +319,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `RetrySchedule` | exponential-backoff retry tracking for arbitrary operations. |
 | `RoundRobinAssigner` | fair rotating assignment across a named pool. |
 | `ScheduledTask` | cron-style task schedule registry with last-run tracking. |
+| `ShiftRoster` | staff shift scheduling with coverage tracking. |
 | `StockTransfer` | multi-location stock ledger with location-to-location moves. |
 | `TokenBucket` | DB-backed token bucket algorithm for flexible rate limiting. |
 

--- a/class/kit/ShiftRoster.php
+++ b/class/kit/ShiftRoster.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * ShiftRoster — staff shift scheduling with coverage tracking.
+ *
+ * Models named shifts on a given day (e.g. 2026-06-01 "morning") each with a
+ * required headcount, and assigns workers to them. Prevents double-assigning
+ * the same worker to one shift, reports coverage (assigned vs. required), and
+ * lists a worker's shifts. Distinct from `TimeSlot` (appointment booking by a
+ * customer against availability) and `AccessSchedule` (time-window access
+ * control): this is the staffing roster.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $r = new ShiftRoster($pdo);
+ *
+ * $r->defineShift('2026-06-01', 'morning', required: 2);
+ * $r->assign('2026-06-01', 'morning', 'alice'); // true
+ * $r->assign('2026-06-01', 'morning', 'bob');   // true
+ *
+ * $r->isCovered('2026-06-01', 'morning');       // true (2 >= 2)
+ * $r->coverage('2026-06-01', 'morning');        // ['required'=>2,'assigned'=>2,'short'=>0]
+ * $r->assignees('2026-06-01', 'morning');       // ['alice','bob']
+ * $r->shiftsFor('alice', '2026-06-01');         // ['morning']
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE roster_shifts (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     shift_date CHAR(10)     NOT NULL,
+ *     name       VARCHAR(100) NOT NULL,
+ *     required   INTEGER      NOT NULL DEFAULT 1,
+ *     UNIQUE (shift_date, name)
+ * );
+ * CREATE TABLE roster_assignments (
+ *     id       INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     shift_id BIGINT       NOT NULL,
+ *     worker   VARCHAR(190) NOT NULL,
+ *     UNIQUE (shift_id, worker)
+ * );
+ * ```
+ */
+final class ShiftRoster
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Define (or update the required headcount of) a shift. Idempotent on
+     * (date, name).
+     *
+     * @param  string $date     Shift day 'Y-m-d'.
+     * @param  string $name     Shift name (e.g. 'morning').
+     * @param  int    $required Headcount required (>= 1).
+     * @return int              The shift id.
+     * @throws \InvalidArgumentException on empty fields or non-positive headcount.
+     */
+    public function defineShift(string $date, string $name, int $required = 1): int
+    {
+        $date = $this->nonEmpty($date, 'Date');
+        $name = $this->nonEmpty($name, 'Name');
+        if ($required < 1) {
+            throw new \InvalidArgumentException('Required headcount must be at least 1.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table: 'roster_shifts',
+            data: ['shift_date' => $date, 'name' => $name, 'required' => $required],
+            conflictCols: ['shift_date', 'name'],
+            updateCols: ['required'],
+        );
+
+        $id = $this->shiftId($date, $name);
+        if ($id === null) {
+            throw new \RuntimeException('Failed to persist shift.');
+        }
+
+        return $id;
+    }
+
+    /**
+     * Assign a worker to a defined shift. Idempotent.
+     *
+     * @return bool True if newly assigned; false if already on this shift.
+     * @throws \InvalidArgumentException if the shift is not defined or worker empty.
+     */
+    public function assign(string $date, string $name, string $worker): bool
+    {
+        $worker = $this->nonEmpty($worker, 'Worker');
+        $shift  = $this->requireShiftId($date, $name);
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO roster_assignments (shift_id, worker) VALUES (?, ?)
+             ON CONFLICT (shift_id, worker) DO NOTHING'
+        );
+        $stmt->execute([$shift, $worker]);
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Remove a worker from a shift.
+     *
+     * @return bool True if a row was removed.
+     * @throws \InvalidArgumentException if the shift is not defined.
+     */
+    public function unassign(string $date, string $name, string $worker): bool
+    {
+        $worker = $this->nonEmpty($worker, 'Worker');
+        $shift  = $this->requireShiftId($date, $name);
+
+        $stmt = $this->db()->prepare('DELETE FROM roster_assignments WHERE shift_id = ? AND worker = ?');
+        $stmt->execute([$shift, $worker]);
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Workers assigned to a shift, in assignment order.
+     *
+     * @return array<int,string>
+     */
+    public function assignees(string $date, string $name): array
+    {
+        $shift = $this->shiftId($this->nonEmpty($date, 'Date'), $this->nonEmpty($name, 'Name'));
+        if ($shift === null) {
+            return [];
+        }
+        $stmt = $this->db()->prepare('SELECT worker FROM roster_assignments WHERE shift_id = ? ORDER BY id ASC');
+        $stmt->execute([$shift]);
+
+        return array_map(static fn ($w): string => (string)$w, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    /**
+     * Whether a shift has at least its required headcount assigned. False if
+     * the shift is undefined.
+     */
+    public function isCovered(string $date, string $name): bool
+    {
+        $c = $this->coverage($date, $name);
+
+        return $c !== null && $c['short'] === 0;
+    }
+
+    /**
+     * Coverage for a shift, or null if it is undefined.
+     *
+     * @return array{required:int,assigned:int,short:int}|null
+     */
+    public function coverage(string $date, string $name): ?array
+    {
+        $date = $this->nonEmpty($date, 'Date');
+        $name = $this->nonEmpty($name, 'Name');
+
+        $stmt = $this->db()->prepare('SELECT id, required FROM roster_shifts WHERE shift_date = ? AND name = ?');
+        $stmt->execute([$date, $name]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+
+        $required = (int)$row['required'];
+        $cnt      = $this->db()->prepare('SELECT COUNT(*) FROM roster_assignments WHERE shift_id = ?');
+        $cnt->execute([(int)$row['id']]);
+        $assigned = (int)$cnt->fetchColumn();
+        $short    = $required - $assigned;
+
+        return [
+            'required' => $required,
+            'assigned' => $assigned,
+            'short'    => $short > 0 ? $short : 0,
+        ];
+    }
+
+    /**
+     * Named shifts a worker is assigned to on a given day, in shift-name order.
+     *
+     * @return array<int,string>
+     */
+    public function shiftsFor(string $worker, string $date): array
+    {
+        $worker = $this->nonEmpty($worker, 'Worker');
+        $date   = $this->nonEmpty($date, 'Date');
+
+        $stmt = $this->db()->prepare(
+            'SELECT s.name FROM roster_shifts s
+             JOIN roster_assignments a ON a.shift_id = s.id
+             WHERE s.shift_date = ? AND a.worker = ?
+             ORDER BY s.name ASC'
+        );
+        $stmt->execute([$date, $worker]);
+
+        return array_map(static fn ($n): string => (string)$n, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function requireShiftId(string $date, string $name): int
+    {
+        $id = $this->shiftId($this->nonEmpty($date, 'Date'), $this->nonEmpty($name, 'Name'));
+        if ($id === null) {
+            throw new \InvalidArgumentException("Shift not defined: {$date} {$name}");
+        }
+
+        return $id;
+    }
+
+    private function shiftId(string $date, string $name): ?int
+    {
+        $stmt = $this->db()->prepare('SELECT id FROM roster_shifts WHERE shift_date = ? AND name = ?');
+        $stmt->execute([$date, $name]);
+        $id = $stmt->fetchColumn();
+
+        return $id === false ? null : (int)$id;
+    }
+
+    private function nonEmpty(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-313.md
+++ b/docs/field-trials/2026-05-field-trial-313.md
@@ -1,0 +1,40 @@
+# Field Trial 313 — ShiftRoster
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft313-shiftroster`
+**Baseline**: post FT312 merge
+
+## Goal
+
+Add `Nene\Kit\ShiftRoster` — staff shift scheduling: define named shifts on a day (e.g. 2026-06-01 "morning") with a required headcount, assign workers, and track coverage (assigned vs. required). Distinct from `TimeSlot` (customer appointment booking) and `AccessSchedule` (time-window access control).
+
+## What was built
+
+### `Nene\Kit\ShiftRoster` (`class/kit/ShiftRoster.php`)
+
+Two tables: `roster_shifts` (date + name + required) and `roster_assignments`.
+
+| Method | Description |
+| --- | --- |
+| `defineShift(date, name, required=1): int` | Idempotent on (date, name); updates headcount. |
+| `assign(date, name, worker): bool` | Assign to a defined shift (idempotent). |
+| `unassign(date, name, worker): bool` | Remove. |
+| `assignees(date, name): array` | Workers, in assignment order. |
+| `isCovered / coverage` | Coverage (required/assigned/short). |
+| `shiftsFor(worker, date): array` | A worker's shifts that day. |
+
+Key design points:
+
+- **`defineShift` uses `DbUpsert::run`** (cross-driver) for the (date, name) unique key, then reads back the id so it works on both INSERT and update.
+- **`assign` uses `ON CONFLICT DO NOTHING`** for idempotent assignment; returns whether a row was newly added (`rowCount`).
+- **Undefined-shift reads are safe** (coverage→null, isCovered→false, assignees→[]); only writes (`assign`/`unassign`) require a defined shift.
+
+## Findings
+
+### F-1 — DbUpsert lives in `Nene\Xion`, not `Nene\Kit`
+
+The scaffold imports only `Nene\Xion\PdoConnection`. Referencing `DbUpsert` without an import resolved to `Nene\Kit\DbUpsert` (undeclared) — caught immediately by Phan (`PhanUndeclaredClassMethod`) and the failing tests. Added `use Nene\Xion\DbUpsert;`. A reminder that `Nene\Kit` helpers reaching for a core utility must import it from `Nene\Xion`.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/ShiftRosterTest.php
+++ b/tests/Unit/Kit/ShiftRosterTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\ShiftRoster;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ShiftRoster.
+ */
+final class ShiftRosterTest extends TestCase
+{
+    private PDO $db;
+    private ShiftRoster $r;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE roster_shifts (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                shift_date CHAR(10)     NOT NULL,
+                name       VARCHAR(100) NOT NULL,
+                required   INTEGER      NOT NULL DEFAULT 1,
+                UNIQUE (shift_date, name)
+            )
+        ');
+        $this->db->exec('
+            CREATE TABLE roster_assignments (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                shift_id BIGINT       NOT NULL,
+                worker   VARCHAR(190) NOT NULL,
+                UNIQUE (shift_id, worker)
+            )
+        ');
+        $this->r = new ShiftRoster($this->db);
+    }
+
+    public function testAssignAndCoverage(): void
+    {
+        $this->r->defineShift('2026-06-01', 'morning', 2);
+        $this->assertFalse($this->r->isCovered('2026-06-01', 'morning'));
+        $this->assertTrue($this->r->assign('2026-06-01', 'morning', 'alice'));
+        $this->assertTrue($this->r->assign('2026-06-01', 'morning', 'bob'));
+        $this->assertTrue($this->r->isCovered('2026-06-01', 'morning')); // 2 >= 2
+        $this->assertSame(
+            ['required' => 2, 'assigned' => 2, 'short' => 0],
+            $this->r->coverage('2026-06-01', 'morning')
+        );
+    }
+
+    public function testUnderstaffedShortfall(): void
+    {
+        $this->r->defineShift('2026-06-01', 'night', 3);
+        $this->r->assign('2026-06-01', 'night', 'alice');
+        $this->assertSame(
+            ['required' => 3, 'assigned' => 1, 'short' => 2],
+            $this->r->coverage('2026-06-01', 'night')
+        );
+        $this->assertFalse($this->r->isCovered('2026-06-01', 'night'));
+    }
+
+    public function testAssignIsIdempotent(): void
+    {
+        $this->r->defineShift('2026-06-01', 'morning', 2);
+        $this->assertTrue($this->r->assign('2026-06-01', 'morning', 'alice'));
+        $this->assertFalse($this->r->assign('2026-06-01', 'morning', 'alice')); // already on
+        $this->assertSame(['alice'], $this->r->assignees('2026-06-01', 'morning'));
+    }
+
+    public function testUnassign(): void
+    {
+        $this->r->defineShift('2026-06-01', 'morning', 2);
+        $this->r->assign('2026-06-01', 'morning', 'alice');
+        $this->assertTrue($this->r->unassign('2026-06-01', 'morning', 'alice'));
+        $this->assertFalse($this->r->unassign('2026-06-01', 'morning', 'alice')); // already gone
+        $this->assertSame([], $this->r->assignees('2026-06-01', 'morning'));
+    }
+
+    public function testDefineShiftUpdatesRequired(): void
+    {
+        $id1 = $this->r->defineShift('2026-06-01', 'morning', 2);
+        $id2 = $this->r->defineShift('2026-06-01', 'morning', 5); // update headcount
+        $this->assertSame($id1, $id2); // same shift
+        $this->assertSame(5, $this->r->coverage('2026-06-01', 'morning')['required']);
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM roster_shifts')->fetchColumn());
+    }
+
+    public function testShiftsForWorker(): void
+    {
+        $this->r->defineShift('2026-06-01', 'morning', 2);
+        $this->r->defineShift('2026-06-01', 'evening', 2);
+        $this->r->defineShift('2026-06-02', 'morning', 2);
+        $this->r->assign('2026-06-01', 'morning', 'alice');
+        $this->r->assign('2026-06-01', 'evening', 'alice');
+        $this->r->assign('2026-06-02', 'morning', 'alice'); // different day
+        $this->assertSame(['evening', 'morning'], $this->r->shiftsFor('alice', '2026-06-01'));
+    }
+
+    public function testAssigneesOrderAndSeparation(): void
+    {
+        $this->r->defineShift('2026-06-01', 'morning', 3);
+        $this->r->assign('2026-06-01', 'morning', 'carol');
+        $this->r->assign('2026-06-01', 'morning', 'alice');
+        $this->assertSame(['carol', 'alice'], $this->r->assignees('2026-06-01', 'morning')); // insertion order
+    }
+
+    public function testUndefinedShiftReads(): void
+    {
+        $this->assertNull($this->r->coverage('2026-06-01', 'ghost'));
+        $this->assertFalse($this->r->isCovered('2026-06-01', 'ghost'));
+        $this->assertSame([], $this->r->assignees('2026-06-01', 'ghost'));
+    }
+
+    public function testAssignUndefinedShiftThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->assign('2026-06-01', 'ghost', 'alice');
+    }
+
+    public function testDefineShiftRejectsZeroRequired(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->defineShift('2026-06-01', 'morning', 0);
+    }
+
+    public function testAssignRejectsEmptyWorker(): void
+    {
+        $this->r->defineShift('2026-06-01', 'morning', 2);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->r->assign('2026-06-01', 'morning', '  ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT313** — `Nene\Kit\ShiftRoster`: staff shift scheduling with coverage tracking. Distinct from `TimeSlot` (customer booking) and `AccessSchedule`.

| Method | Description |
| --- | --- |
| `defineShift(date, name, required=1): int` | Idempotent; updates headcount. |
| `assign / unassign(date, name, worker): bool` | Idempotent assignment. |
| `assignees / isCovered / coverage / shiftsFor` | Reads. |

- `defineShift` via `DbUpsert::run` (cross-driver); `assign` via `ON CONFLICT DO NOTHING`.
- Undefined-shift reads return safe empties; writes require a defined shift.

## F-N findings
- **F-1** — `DbUpsert` lives in `Nene\Xion`; the scaffold omitted the import (resolved to undeclared `Nene\Kit\DbUpsert`). Caught by Phan + tests; added `use Nene\Xion\DbUpsert;`.

## Test plan
- [x] 11 tests / 24 assertions (coverage math, shortfall, idempotent assign/unassign, headcount update keeps one row, shiftsFor day-scoped, order/separation, safe undefined reads, validation)
- [x] `composer precommit` green (format → Phan → 5168 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)