### PR TITLE
feat(kit): SpaceOccupancy — live headcount for a capacity-limited space (FT314)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -320,6 +320,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `RoundRobinAssigner` | fair rotating assignment across a named pool. |
 | `ScheduledTask` | cron-style task schedule registry with last-run tracking. |
 | `ShiftRoster` | staff shift scheduling with coverage tracking. |
+| `SpaceOccupancy` | live headcount for a capacity-limited physical space. |
 | `StockTransfer` | multi-location stock ledger with location-to-location moves. |
 | `TokenBucket` | DB-backed token bucket algorithm for flexible rate limiting. |
 

--- a/class/kit/SpaceOccupancy.php
+++ b/class/kit/SpaceOccupancy.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\DbUpsert;
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * SpaceOccupancy — live headcount for a capacity-limited physical space.
+ *
+ * Tracks the current (anonymous) occupancy of a named space against a hard
+ * capacity: `enter()` admits people only while room remains, `leave()` releases
+ * them, and a high-water `peak` is recorded. Distinct from `PresenceChannel`
+ * (which tracks *which identities* are present, with no capacity ceiling) and
+ * `EventTicket` (pre-sold tickets with check-in): this is a real-time counter
+ * for rooms, parking lots, gyms, or venues.
+ *
+ * The counter mutations are single guarded `UPDATE` statements, so admission is
+ * atomic and never overshoots capacity even under concurrency.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $o = new SpaceOccupancy($pdo);
+ *
+ * $o->defineSpace('gym', capacity: 50);
+ * $o->enter('gym');        // true  — 1/50
+ * $o->enter('gym', 49);    // true  — 50/50
+ * $o->enter('gym');        // false — full
+ * $o->isFull('gym');       // true
+ * $o->leave('gym', 2);     // true  — 48/50
+ * $o->available('gym');    // 2
+ * $o->peak('gym');         // 50
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE space_occupancy (
+ *     id       INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     space    VARCHAR(150) NOT NULL,
+ *     capacity INTEGER      NOT NULL,
+ *     current  INTEGER      NOT NULL DEFAULT 0,
+ *     peak     INTEGER      NOT NULL DEFAULT 0,
+ *     UNIQUE (space)
+ * );
+ * ```
+ */
+final class SpaceOccupancy
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Define a space (or update its capacity). Idempotent on the space name;
+     * the live count and peak are preserved across capacity changes.
+     *
+     * @param  string $space    Space name.
+     * @param  int    $capacity Maximum occupancy (>= 1).
+     * @return int              The space id.
+     * @throws \InvalidArgumentException on empty name or non-positive capacity.
+     */
+    public function defineSpace(string $space, int $capacity): int
+    {
+        $space = $this->nonEmpty($space, 'Space');
+        if ($capacity < 1) {
+            throw new \InvalidArgumentException('Capacity must be at least 1.');
+        }
+
+        DbUpsert::run(
+            $this->db(),
+            table: 'space_occupancy',
+            data: ['space' => $space, 'capacity' => $capacity],
+            conflictCols: ['space'],
+            updateCols: ['capacity'],
+        );
+
+        $id = $this->spaceId($space);
+        if ($id === null) {
+            throw new \RuntimeException('Failed to persist space.');
+        }
+
+        return $id;
+    }
+
+    /**
+     * Admit `count` occupants if (and only if) they all fit. Atomic.
+     *
+     * @return bool True if admitted; false if it would exceed capacity.
+     * @throws \InvalidArgumentException on unknown space or non-positive count.
+     */
+    public function enter(string $space, int $count = 1): bool
+    {
+        $space = $this->nonEmpty($space, 'Space');
+        $this->requirePositive($count);
+        $this->requireSpace($space);
+
+        $stmt = $this->db()->prepare(
+            'UPDATE space_occupancy
+                SET current = current + :n,
+                    peak    = CASE WHEN current + :n > peak THEN current + :n ELSE peak END
+              WHERE space = :s AND current + :n <= capacity'
+        );
+        $stmt->bindValue(':n', $count, PDO::PARAM_INT);
+        $stmt->bindValue(':s', $space, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Release `count` occupants (never below zero).
+     *
+     * @return bool True if the space exists; false otherwise.
+     * @throws \InvalidArgumentException on non-positive count.
+     */
+    public function leave(string $space, int $count = 1): bool
+    {
+        $space = $this->nonEmpty($space, 'Space');
+        $this->requirePositive($count);
+        if ($this->spaceId($space) === null) {
+            return false;
+        }
+
+        $stmt = $this->db()->prepare(
+            'UPDATE space_occupancy
+                SET current = CASE WHEN current >= :n THEN current - :n ELSE 0 END
+              WHERE space = :s'
+        );
+        $stmt->bindValue(':n', $count, PDO::PARAM_INT);
+        $stmt->bindValue(':s', $space, PDO::PARAM_STR);
+        $stmt->execute();
+
+        return true;
+    }
+
+    /**
+     * Reset the live count to zero (peak is retained).
+     */
+    public function reset(string $space): bool
+    {
+        $space = $this->nonEmpty($space, 'Space');
+        if ($this->spaceId($space) === null) {
+            return false;
+        }
+        $this->db()->prepare('UPDATE space_occupancy SET current = 0 WHERE space = ?')->execute([$space]);
+
+        return true;
+    }
+
+    /**
+     * Current occupancy (0 for an unknown space).
+     */
+    public function current(string $space): int
+    {
+        return $this->column($space, 'current') ?? 0;
+    }
+
+    /**
+     * Remaining capacity (0 for an unknown space or when full).
+     */
+    public function available(string $space): int
+    {
+        $row = $this->row($space);
+        if ($row === null) {
+            return 0;
+        }
+        $left = $row['capacity'] - $row['current'];
+
+        return $left > 0 ? $left : 0;
+    }
+
+    /**
+     * Whether the space is at (or over) capacity. False for an unknown space.
+     */
+    public function isFull(string $space): bool
+    {
+        $row = $this->row($space);
+
+        return $row !== null && $row['current'] >= $row['capacity'];
+    }
+
+    /**
+     * Highest occupancy ever recorded (0 for an unknown space).
+     */
+    public function peak(string $space): int
+    {
+        return $this->column($space, 'peak') ?? 0;
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array{capacity:int,current:int}|null
+     */
+    private function row(string $space): ?array
+    {
+        $stmt = $this->db()->prepare('SELECT capacity, current FROM space_occupancy WHERE space = ?');
+        $stmt->execute([$this->nonEmpty($space, 'Space')]);
+        $r = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($r === false) {
+            return null;
+        }
+
+        return ['capacity' => (int)$r['capacity'], 'current' => (int)$r['current']];
+    }
+
+    private function column(string $space, string $col): ?int
+    {
+        // $col is a fixed internal literal ('current' | 'peak'), never user input.
+        $stmt = $this->db()->prepare("SELECT {$col} FROM space_occupancy WHERE space = ?");
+        $stmt->execute([$this->nonEmpty($space, 'Space')]);
+        $v = $stmt->fetchColumn();
+
+        return $v === false ? null : (int)$v;
+    }
+
+    private function spaceId(string $space): ?int
+    {
+        $stmt = $this->db()->prepare('SELECT id FROM space_occupancy WHERE space = ?');
+        $stmt->execute([$space]);
+        $id = $stmt->fetchColumn();
+
+        return $id === false ? null : (int)$id;
+    }
+
+    private function requireSpace(string $space): void
+    {
+        if ($this->spaceId($space) === null) {
+            throw new \InvalidArgumentException("Unknown space: {$space}");
+        }
+    }
+
+    private function requirePositive(int $count): void
+    {
+        if ($count < 1) {
+            throw new \InvalidArgumentException('Count must be at least 1.');
+        }
+    }
+
+    private function nonEmpty(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-314.md
+++ b/docs/field-trials/2026-05-field-trial-314.md
@@ -1,0 +1,45 @@
+# Field Trial 314 — SpaceOccupancy
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft314-spaceoccupancy`
+**Baseline**: post FT313 merge
+
+## Goal
+
+Add `Nene\Kit\SpaceOccupancy` — a live, capacity-limited headcount for a physical space (room, gym, parking lot, venue): admit occupants only while room remains, release them, and record a high-water peak.
+
+## Pivot — concept-duplicate avoided (the FT281 discipline)
+
+This slot was originally scoped as **PunchCard** (clock in/out). The pre-work concept scan (`grep -i class/kit/INDEX.md`) surfaced `TimeEntry` — *"work time tracking with start/stop/duration"* — which already covers clock-in/clock-out and total worked time, including active timers and manual entries. PunchCard would have been a near-duplicate (cf. the FT281 TermsAcceptance ≈ TermConsent lesson). Pivoted to **SpaceOccupancy**, which has no existing analogue: `PresenceChannel` tracks *which identities* are in a channel (no capacity ceiling), `EventTicket` is pre-sold tickets with check-in. SpaceOccupancy is an anonymous, capacity-enforced live counter.
+
+## What was built
+
+### `Nene\Kit\SpaceOccupancy` (`class/kit/SpaceOccupancy.php`)
+
+| Method | Description |
+| --- | --- |
+| `defineSpace(space, capacity): int` | Idempotent; updates capacity, preserves count/peak. |
+| `enter(space, count=1): bool` | All-or-nothing admission; false if it would overflow. |
+| `leave(space, count=1): bool` | Release (floored at 0). |
+| `reset(space): bool` | Zero the live count (peak retained). |
+| `current / available / isFull / peak` | Reads. |
+
+Key design points:
+
+- **Atomic, overshoot-proof admission**: `enter()` is a single guarded `UPDATE … WHERE current + :n <= capacity`, with `peak` advanced via an inline `CASE` in the same statement — no read-modify-write race, capacity can never be exceeded even under concurrency.
+- **All-or-nothing**: a multi-person `enter` that would partially fit is rejected entirely.
+- **Unknown-space reads are safe** (zeros / false); only `enter()` rejects an unknown space.
+
+### Tests (`tests/Unit/Kit/SpaceOccupancyTest.php`)
+
+12 tests (36 assertions): fill to capacity, partial-overflow rejection + exact fill, leave/available, leave floors at zero, peak high-water across enter/leave/enter, reset keeps peak, capacity update keeps count + one row, space separation, safe unknown reads, and three validation guards.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 12 tests pass; CS Fixer and Phan clean. (`DbUpsert` imported from `Nene\Xion` per the FT313 finding.)
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/SpaceOccupancyTest.php
+++ b/tests/Unit/Kit/SpaceOccupancyTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\SpaceOccupancy;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for SpaceOccupancy.
+ */
+final class SpaceOccupancyTest extends TestCase
+{
+    private PDO $db;
+    private SpaceOccupancy $o;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE space_occupancy (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                space    VARCHAR(150) NOT NULL,
+                capacity INTEGER      NOT NULL,
+                current  INTEGER      NOT NULL DEFAULT 0,
+                peak     INTEGER      NOT NULL DEFAULT 0,
+                UNIQUE (space)
+            )
+        ');
+        $this->o = new SpaceOccupancy($this->db);
+    }
+
+    public function testEnterUntilFull(): void
+    {
+        $this->o->defineSpace('gym', 50);
+        $this->assertTrue($this->o->enter('gym'));      // 1
+        $this->assertTrue($this->o->enter('gym', 49));  // 50
+        $this->assertSame(50, $this->o->current('gym'));
+        $this->assertTrue($this->o->isFull('gym'));
+        $this->assertFalse($this->o->enter('gym'));     // would overflow
+        $this->assertSame(50, $this->o->current('gym')); // unchanged
+    }
+
+    public function testEnterRejectsPartialOverflow(): void
+    {
+        $this->o->defineSpace('room', 10);
+        $this->o->enter('room', 8);
+        $this->assertFalse($this->o->enter('room', 3)); // 8+3 > 10, all-or-nothing
+        $this->assertSame(8, $this->o->current('room'));
+        $this->assertTrue($this->o->enter('room', 2));  // exactly fills
+        $this->assertSame(10, $this->o->current('room'));
+    }
+
+    public function testLeaveAndAvailable(): void
+    {
+        $this->o->defineSpace('gym', 50);
+        $this->o->enter('gym', 30);
+        $this->assertTrue($this->o->leave('gym', 10));
+        $this->assertSame(20, $this->o->current('gym'));
+        $this->assertSame(30, $this->o->available('gym'));
+        $this->assertFalse($this->o->isFull('gym'));
+    }
+
+    public function testLeaveNeverGoesNegative(): void
+    {
+        $this->o->defineSpace('gym', 50);
+        $this->o->enter('gym', 3);
+        $this->o->leave('gym', 10); // floor at 0
+        $this->assertSame(0, $this->o->current('gym'));
+    }
+
+    public function testPeakIsHighWaterMark(): void
+    {
+        $this->o->defineSpace('gym', 50);
+        $this->o->enter('gym', 40);
+        $this->o->leave('gym', 35);
+        $this->o->enter('gym', 5);
+        $this->assertSame(10, $this->o->current('gym'));
+        $this->assertSame(40, $this->o->peak('gym')); // peak retained
+    }
+
+    public function testResetClearsCountButKeepsPeak(): void
+    {
+        $this->o->defineSpace('gym', 50);
+        $this->o->enter('gym', 30);
+        $this->assertTrue($this->o->reset('gym'));
+        $this->assertSame(0, $this->o->current('gym'));
+        $this->assertSame(30, $this->o->peak('gym'));
+    }
+
+    public function testDefineSpaceUpdatesCapacityKeepsCount(): void
+    {
+        $id1 = $this->o->defineSpace('gym', 50);
+        $this->o->enter('gym', 20);
+        $id2 = $this->o->defineSpace('gym', 30); // shrink capacity
+        $this->assertSame($id1, $id2);
+        $this->assertSame(20, $this->o->current('gym')); // count preserved
+        $this->assertSame(10, $this->o->available('gym'));
+        $this->assertSame(1, (int)$this->db->query('SELECT COUNT(*) FROM space_occupancy')->fetchColumn());
+    }
+
+    public function testSpacesAreSeparate(): void
+    {
+        $this->o->defineSpace('a', 10);
+        $this->o->defineSpace('b', 10);
+        $this->o->enter('a', 10);
+        $this->assertTrue($this->o->isFull('a'));
+        $this->assertFalse($this->o->isFull('b'));
+        $this->assertSame(0, $this->o->current('b'));
+    }
+
+    public function testUnknownSpaceReadsAreSafe(): void
+    {
+        $this->assertSame(0, $this->o->current('ghost'));
+        $this->assertSame(0, $this->o->available('ghost'));
+        $this->assertSame(0, $this->o->peak('ghost'));
+        $this->assertFalse($this->o->isFull('ghost'));
+        $this->assertFalse($this->o->leave('ghost'));
+        $this->assertFalse($this->o->reset('ghost'));
+    }
+
+    public function testEnterUnknownSpaceThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->o->enter('ghost');
+    }
+
+    public function testDefineSpaceRejectsZeroCapacity(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->o->defineSpace('gym', 0);
+    }
+
+    public function testEnterRejectsZeroCount(): void
+    {
+        $this->o->defineSpace('gym', 50);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->o->enter('gym', 0);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT314** — `Nene\Kit\SpaceOccupancy`: a real-time, capacity-enforced occupancy counter for rooms / parking lots / venues.

> **Pivot:** originally scoped as PunchCard, but the concept scan found `TimeEntry` already covers clock-in/out work-time tracking — a near-duplicate (FT281 discipline). Pivoted to SpaceOccupancy, which has no analogue (`PresenceChannel` tracks identities without a capacity ceiling).

| Method | Description |
| --- | --- |
| `defineSpace(space, capacity): int` | Idempotent; preserves count/peak. |
| `enter(space, count=1): bool` | All-or-nothing admission; false on overflow. |
| `leave(space, count=1): bool` | Release (floored at 0). |
| `reset / current / available / isFull / peak` | Reads + reset. |

- **Atomic admission**: single guarded `UPDATE … WHERE current + :n <= capacity`, peak advanced inline via `CASE` — never overshoots under concurrency.

## F-N findings
- **F-1** — none (clean trial).

## Test plan
- [x] 12 tests / 36 assertions (fill, partial-overflow rejection, leave/available, floor-at-zero, peak high-water, reset keeps peak, capacity update keeps count, separation, safe unknown reads, validation)
- [x] `composer precommit` green (format → Phan → 5180 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)