### PR TITLE
feat(kit): SeatMap — named-seat reservation for a fixed venue layout (FT315)

### DIFF
--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -319,6 +319,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `RetrySchedule` | exponential-backoff retry tracking for arbitrary operations. |
 | `RoundRobinAssigner` | fair rotating assignment across a named pool. |
 | `ScheduledTask` | cron-style task schedule registry with last-run tracking. |
+| `SeatMap` | named-seat reservation for a fixed venue layout. |
 | `ShiftRoster` | staff shift scheduling with coverage tracking. |
 | `SpaceOccupancy` | live headcount for a capacity-limited physical space. |
 | `StockTransfer` | multi-location stock ledger with location-to-location moves. |

--- a/class/kit/SeatMap.php
+++ b/class/kit/SeatMap.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * SeatMap — named-seat reservation for a fixed venue layout.
+ *
+ * Models a venue as a fixed set of named seats (e.g. "A1".."A10") and lets a
+ * holder reserve a *specific* seat, release it, and query who holds what.
+ * Reservation is a single guarded UPDATE, so two holders can never claim the
+ * same seat. Distinct from `EventTicket` (a capacity *count* with check-in, no
+ * seat identity), `ResourceReservation` (time-bounded, one shared resource),
+ * and `TimeSlot` (appointment booking): this is assigned seating.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $m = new SeatMap($pdo);
+ *
+ * $m->addRow('hall', 'A', 10);            // seats A1..A10
+ * $m->reserve('hall', 'A1', 'alice');     // true
+ * $m->reserve('hall', 'A1', 'bob');       // false — taken
+ * $m->holderOf('hall', 'A1');             // 'alice'
+ * $m->availableSeats('hall');             // ['A2','A3',...]
+ * $m->release('hall', 'A1');              // true
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE seat_map (
+ *     id     INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     venue  VARCHAR(150) NOT NULL,
+ *     seat   VARCHAR(50)  NOT NULL,
+ *     holder VARCHAR(190) NULL,
+ *     UNIQUE (venue, seat)
+ * );
+ * ```
+ */
+final class SeatMap
+{
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Add a single seat to a venue. Idempotent (existing seat is left as-is,
+     * holder preserved).
+     *
+     * @throws \InvalidArgumentException on empty venue/seat.
+     */
+    public function addSeat(string $venue, string $seat): void
+    {
+        $venue = $this->nonEmpty($venue, 'Venue');
+        $seat  = $this->nonEmpty($seat, 'Seat');
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO seat_map (venue, seat) VALUES (?, ?) ON CONFLICT (venue, seat) DO NOTHING'
+        );
+        $stmt->execute([$venue, $seat]);
+    }
+
+    /**
+     * Add a numbered row of seats: `$row . 1` .. `$row . $count`.
+     *
+     * @throws \InvalidArgumentException on empty row or non-positive count.
+     */
+    public function addRow(string $venue, string $row, int $count): void
+    {
+        $row = $this->nonEmpty($row, 'Row');
+        if ($count < 1) {
+            throw new \InvalidArgumentException('Count must be at least 1.');
+        }
+        for ($i = 1; $i <= $count; $i++) {
+            $this->addSeat($venue, $row . $i);
+        }
+    }
+
+    /**
+     * Reserve a specific seat for a holder, if it is currently free.
+     *
+     * @return bool True if reserved; false if already taken.
+     * @throws \InvalidArgumentException if the seat does not exist, or empty holder.
+     */
+    public function reserve(string $venue, string $seat, string $holder): bool
+    {
+        $venue  = $this->nonEmpty($venue, 'Venue');
+        $seat   = $this->nonEmpty($seat, 'Seat');
+        $holder = $this->nonEmpty($holder, 'Holder');
+        if (!$this->seatExists($venue, $seat)) {
+            throw new \InvalidArgumentException("No such seat: {$venue} {$seat}");
+        }
+
+        $stmt = $this->db()->prepare(
+            'UPDATE seat_map SET holder = ? WHERE venue = ? AND seat = ? AND holder IS NULL'
+        );
+        $stmt->execute([$holder, $venue, $seat]);
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Release a seat back to the pool.
+     *
+     * @return bool True if it was reserved (now freed); false if already free
+     *              or the seat does not exist.
+     */
+    public function release(string $venue, string $seat): bool
+    {
+        $venue = $this->nonEmpty($venue, 'Venue');
+        $seat  = $this->nonEmpty($seat, 'Seat');
+
+        $stmt = $this->db()->prepare(
+            'UPDATE seat_map SET holder = NULL WHERE venue = ? AND seat = ? AND holder IS NOT NULL'
+        );
+        $stmt->execute([$venue, $seat]);
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * The holder of a seat, or null if free / nonexistent.
+     */
+    public function holderOf(string $venue, string $seat): ?string
+    {
+        $stmt = $this->db()->prepare('SELECT holder FROM seat_map WHERE venue = ? AND seat = ?');
+        $stmt->execute([$this->nonEmpty($venue, 'Venue'), $this->nonEmpty($seat, 'Seat')]);
+        $h = $stmt->fetchColumn();
+
+        return $h === false || $h === null ? null : (string)$h;
+    }
+
+    /**
+     * Whether a seat exists and is currently unreserved.
+     */
+    public function isAvailable(string $venue, string $seat): bool
+    {
+        $stmt = $this->db()->prepare('SELECT holder FROM seat_map WHERE venue = ? AND seat = ?');
+        $stmt->execute([$this->nonEmpty($venue, 'Venue'), $this->nonEmpty($seat, 'Seat')]);
+        $r = $stmt->fetch(PDO::FETCH_NUM);
+
+        return $r !== false && $r[0] === null;
+    }
+
+    /**
+     * Free seats in a venue, in seat order.
+     *
+     * @return array<int,string>
+     */
+    public function availableSeats(string $venue): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT seat FROM seat_map WHERE venue = ? AND holder IS NULL ORDER BY seat ASC'
+        );
+        $stmt->execute([$this->nonEmpty($venue, 'Venue')]);
+
+        return array_map(static fn ($s): string => (string)$s, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    /**
+     * Reserved seats in a venue with their holders, in seat order.
+     *
+     * @return array<int,array{seat:string,holder:string}>
+     */
+    public function reservedSeats(string $venue): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT seat, holder FROM seat_map WHERE venue = ? AND holder IS NOT NULL ORDER BY seat ASC'
+        );
+        $stmt->execute([$this->nonEmpty($venue, 'Venue')]);
+
+        $out = [];
+        /** @var array<string,mixed> $r */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+            $out[] = ['seat' => (string)$r['seat'], 'holder' => (string)$r['holder']];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Seats held by a given holder in a venue, in seat order.
+     *
+     * @return array<int,string>
+     */
+    public function seatsOf(string $venue, string $holder): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT seat FROM seat_map WHERE venue = ? AND holder = ? ORDER BY seat ASC'
+        );
+        $stmt->execute([$this->nonEmpty($venue, 'Venue'), $this->nonEmpty($holder, 'Holder')]);
+
+        return array_map(static fn ($s): string => (string)$s, $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    private function seatExists(string $venue, string $seat): bool
+    {
+        $stmt = $this->db()->prepare('SELECT 1 FROM seat_map WHERE venue = ? AND seat = ? LIMIT 1');
+        $stmt->execute([$venue, $seat]);
+
+        return $stmt->fetchColumn() !== false;
+    }
+
+    private function nonEmpty(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/docs/field-trials/2026-05-field-trial-315.md
+++ b/docs/field-trials/2026-05-field-trial-315.md
@@ -1,0 +1,37 @@
+# Field Trial 315 — SeatMap
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft315-seatmap`
+**Baseline**: post FT314 merge
+
+## Goal
+
+Add `Nene\Kit\SeatMap` — named-seat reservation for a fixed venue layout: define seats (e.g. "A1".."A10"), reserve a *specific* seat for a holder, release it, and query who holds what. Distinct from `EventTicket` (a capacity count with check-in, no seat identity), `ResourceReservation` (time-bounded, single shared resource), and `TimeSlot` (appointment booking).
+
+## What was built
+
+### `Nene\Kit\SeatMap` (`class/kit/SeatMap.php`)
+
+| Method | Description |
+| --- | --- |
+| `addSeat(venue, seat)` / `addRow(venue, row, count)` | Define seats (idempotent; `addRow` makes `row.1`..`row.count`). |
+| `reserve(venue, seat, holder): bool` | Claim a free seat; false if taken. |
+| `release(venue, seat): bool` | Free it; false if already free. |
+| `holderOf / isAvailable` | Per-seat reads. |
+| `availableSeats / reservedSeats / seatsOf` | Venue/holder listings. |
+
+Key design points:
+
+- **Race-free claim**: `reserve()` is a single guarded `UPDATE … WHERE … AND holder IS NULL` (`rowCount() > 0` = won the seat); two holders can never claim the same seat.
+- **Idempotent seat definition** via `ON CONFLICT DO NOTHING`, so re-adding a seat never wipes its holder.
+- **Reserve targets a real seat**: reserving a nonexistent seat throws; reads of unknown seats are safe.
+
+## Findings
+
+### F-1 — Seat names sort lexically
+
+`availableSeats`/`seatsOf` order by the seat column, so "A10" sorts before "A2" lexically. For human-natural ordering with >9 seats per row, zero-pad seat numbers ("A01"). Documented; the helper deliberately stays storage-order-agnostic rather than embedding a numeric parser. Tests use a 5-seat row where lexical and numeric order coincide.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised.

--- a/tests/Unit/Kit/SeatMapTest.php
+++ b/tests/Unit/Kit/SeatMapTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\SeatMap;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for SeatMap.
+ */
+final class SeatMapTest extends TestCase
+{
+    private PDO $db;
+    private SeatMap $m;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE seat_map (
+                id     INTEGER PRIMARY KEY AUTOINCREMENT,
+                venue  VARCHAR(150) NOT NULL,
+                seat   VARCHAR(50)  NOT NULL,
+                holder VARCHAR(190) NULL,
+                UNIQUE (venue, seat)
+            )
+        ');
+        $this->m = new SeatMap($this->db);
+        $this->m->addRow('hall', 'A', 5); // A1..A5
+    }
+
+    public function testReserveAndHolder(): void
+    {
+        $this->assertTrue($this->m->reserve('hall', 'A1', 'alice'));
+        $this->assertSame('alice', $this->m->holderOf('hall', 'A1'));
+        $this->assertFalse($this->m->isAvailable('hall', 'A1'));
+    }
+
+    public function testCannotDoubleReserve(): void
+    {
+        $this->assertTrue($this->m->reserve('hall', 'A1', 'alice'));
+        $this->assertFalse($this->m->reserve('hall', 'A1', 'bob')); // taken
+        $this->assertSame('alice', $this->m->holderOf('hall', 'A1')); // unchanged
+    }
+
+    public function testRelease(): void
+    {
+        $this->m->reserve('hall', 'A1', 'alice');
+        $this->assertTrue($this->m->release('hall', 'A1'));
+        $this->assertNull($this->m->holderOf('hall', 'A1'));
+        $this->assertTrue($this->m->isAvailable('hall', 'A1'));
+        $this->assertFalse($this->m->release('hall', 'A1')); // already free
+        $this->assertTrue($this->m->reserve('hall', 'A1', 'bob')); // re-reservable
+    }
+
+    public function testAvailableSeats(): void
+    {
+        $this->m->reserve('hall', 'A2', 'alice');
+        $this->m->reserve('hall', 'A4', 'bob');
+        $this->assertSame(['A1', 'A3', 'A5'], $this->m->availableSeats('hall'));
+    }
+
+    public function testReservedSeats(): void
+    {
+        $this->m->reserve('hall', 'A3', 'alice');
+        $this->m->reserve('hall', 'A1', 'bob');
+        $reserved = $this->m->reservedSeats('hall');
+        $this->assertSame('A1', $reserved[0]['seat']);
+        $this->assertSame('bob', $reserved[0]['holder']);
+        $this->assertSame('A3', $reserved[1]['seat']);
+    }
+
+    public function testSeatsOfHolder(): void
+    {
+        $this->m->reserve('hall', 'A1', 'alice');
+        $this->m->reserve('hall', 'A3', 'alice');
+        $this->m->reserve('hall', 'A2', 'bob');
+        $this->assertSame(['A1', 'A3'], $this->m->seatsOf('hall', 'alice'));
+    }
+
+    public function testAddSeatIsIdempotentAndKeepsHolder(): void
+    {
+        $this->m->reserve('hall', 'A1', 'alice');
+        $this->m->addSeat('hall', 'A1'); // re-add must not wipe holder
+        $this->assertSame('alice', $this->m->holderOf('hall', 'A1'));
+        $this->assertSame(5, (int)$this->db->query('SELECT COUNT(*) FROM seat_map')->fetchColumn());
+    }
+
+    public function testVenuesAreSeparate(): void
+    {
+        $this->m->addRow('annex', 'A', 3);
+        $this->m->reserve('hall', 'A1', 'alice');
+        $this->assertTrue($this->m->isAvailable('annex', 'A1')); // different venue
+        $this->assertCount(3, $this->m->availableSeats('annex'));
+    }
+
+    public function testReserveNonexistentSeatThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->m->reserve('hall', 'Z9', 'alice');
+    }
+
+    public function testHolderOfUnknownIsNull(): void
+    {
+        $this->assertNull($this->m->holderOf('hall', 'Z9'));
+        $this->assertFalse($this->m->isAvailable('hall', 'Z9')); // nonexistent != available
+    }
+
+    public function testAddRowRejectsZeroCount(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->m->addRow('hall', 'B', 0);
+    }
+
+    public function testReserveRejectsEmptyHolder(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->m->reserve('hall', 'A1', '  ');
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT315** — `Nene\Kit\SeatMap`: assigned seating over a fixed venue layout. Distinct from `EventTicket` (capacity count), `ResourceReservation` (time-bounded), `TimeSlot` (appointments).

| Method | Description |
| --- | --- |
| `addSeat / addRow` | Define seats (idempotent). |
| `reserve(venue, seat, holder): bool` | Claim a free seat; false if taken. |
| `release(venue, seat): bool` | Free it. |
| `holderOf / isAvailable / availableSeats / reservedSeats / seatsOf` | Reads. |

- Race-free claim: single guarded `UPDATE … WHERE … AND holder IS NULL`.
- Idempotent seat definition never wipes a holder; reserving a nonexistent seat throws.

## F-N findings
- **F-1** — seat names sort lexically ("A10" before "A2"); zero-pad for >9-seat rows. Documented; helper stays storage-order-agnostic.

## Test plan
- [x] 12 tests / 25 assertions (reserve/holder, double-reserve guard, release+re-reserve, available/reserved listings, seatsOf, idempotent addSeat keeps holder, venue separation, nonexistent-seat throw, safe unknown reads, validation)
- [x] `composer precommit` green (format → Phan → 5192 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)