### PR TITLE
feat(kit): Escalation — tiered escalation ladder for a work item (FT316)

### DIFF
--- a/class/kit/Escalation.php
+++ b/class/kit/Escalation.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Kit;
+
+use Nene\Xion\PdoConnection;
+use PDO;
+
+/**
+ * Escalation — tiered escalation ladder for a work item.
+ *
+ * Drives a reference (ticket, incident, alert) up an ordered ladder of levels
+ * (L1 → L2 → … → Lmax) and resolves it. Each step is a single guarded UPDATE,
+ * so a level never exceeds the ceiling and a resolved case cannot be escalated.
+ * Distinct from `IncidentLog` (records incidents with severity/lifecycle) and
+ * `SlaTracker` (deadline-breach detection): this is the who-handles-it-next
+ * tier-progression state machine.
+ *
+ * ## Usage
+ *
+ * ```php
+ * $e = new Escalation($pdo);
+ *
+ * $e->open('ticket-99', maxLevel: 3); // starts at L1
+ * $e->escalate('ticket-99');          // true  → L2
+ * $e->escalate('ticket-99');          // true  → L3
+ * $e->escalate('ticket-99');          // false — already at ceiling
+ * $e->atMaxLevel('ticket-99');        // true
+ * $e->resolve('ticket-99');           // true
+ * $e->escalate('ticket-99');          // false — resolved
+ * ```
+ *
+ * ## Schema (SQLite / MySQL compatible)
+ *
+ * ```sql
+ * CREATE TABLE escalation_cases (
+ *     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     reference  VARCHAR(190) NOT NULL,
+ *     level      INTEGER      NOT NULL DEFAULT 1,
+ *     max_level  INTEGER      NOT NULL,
+ *     status     VARCHAR(20)  NOT NULL DEFAULT 'open',
+ *     opened_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at DATETIME     NULL,
+ *     UNIQUE (reference)
+ * );
+ * ```
+ */
+final class Escalation
+{
+    private const OPEN     = 'open';
+    private const RESOLVED = 'resolved';
+
+    public function __construct(private readonly ?PDO $db = null)
+    {
+    }
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Open an escalation case at level 1.
+     *
+     * @param  string $reference Work-item reference.
+     * @param  int    $maxLevel  Highest level the ladder reaches (>= 1).
+     * @return int               New case id.
+     * @throws \InvalidArgumentException on empty reference, max < 1, or an
+     *                                   existing case for the reference.
+     */
+    public function open(string $reference, int $maxLevel = 3): int
+    {
+        $reference = $this->nonEmpty($reference, 'Reference');
+        if ($maxLevel < 1) {
+            throw new \InvalidArgumentException('Max level must be at least 1.');
+        }
+        if ($this->caseId($reference) !== null) {
+            throw new \InvalidArgumentException("Case already exists: {$reference}");
+        }
+
+        $stmt = $this->db()->prepare(
+            'INSERT INTO escalation_cases (reference, level, max_level, status) VALUES (?, 1, ?, ?)'
+        );
+        $stmt->execute([$reference, $maxLevel, self::OPEN]);
+
+        return (int)$this->db()->lastInsertId();
+    }
+
+    /**
+     * Escalate one level, if open and below the ceiling.
+     *
+     * @return bool True if the level advanced; false if at the ceiling,
+     *              resolved, or unknown.
+     */
+    public function escalate(string $reference): bool
+    {
+        $reference = $this->nonEmpty($reference, 'Reference');
+
+        $stmt = $this->db()->prepare(
+            'UPDATE escalation_cases
+                SET level = level + 1, updated_at = CURRENT_TIMESTAMP
+              WHERE reference = ? AND status = ? AND level < max_level'
+        );
+        $stmt->execute([$reference, self::OPEN]);
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Resolve an open case.
+     *
+     * @return bool True if it was open (now resolved); false if already
+     *              resolved or unknown.
+     */
+    public function resolve(string $reference): bool
+    {
+        $reference = $this->nonEmpty($reference, 'Reference');
+
+        $stmt = $this->db()->prepare(
+            'UPDATE escalation_cases
+                SET status = ?, updated_at = CURRENT_TIMESTAMP
+              WHERE reference = ? AND status = ?'
+        );
+        $stmt->execute([self::RESOLVED, $reference, self::OPEN]);
+
+        return $stmt->rowCount() > 0;
+    }
+
+    /**
+     * Current level, or null if the case does not exist.
+     */
+    public function level(string $reference): ?int
+    {
+        $row = $this->row($reference);
+
+        return $row === null ? null : $row['level'];
+    }
+
+    /**
+     * Whether a case is resolved. False if it does not exist.
+     */
+    public function isResolved(string $reference): bool
+    {
+        $row = $this->row($reference);
+
+        return $row !== null && $row['status'] === self::RESOLVED;
+    }
+
+    /**
+     * Whether an open case sits at its ceiling. False if resolved or unknown.
+     */
+    public function atMaxLevel(string $reference): bool
+    {
+        $row = $this->row($reference);
+
+        return $row !== null && $row['status'] === self::OPEN && $row['level'] >= $row['max_level'];
+    }
+
+    /**
+     * Open cases, most-escalated first (level DESC, then reference).
+     *
+     * @return array<int,array{reference:string,level:int,max_level:int}>
+     */
+    public function activeCases(): array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT reference, level, max_level FROM escalation_cases
+              WHERE status = ? ORDER BY level DESC, reference ASC'
+        );
+        $stmt->execute([self::OPEN]);
+
+        $out = [];
+        /** @var array<string,mixed> $r */
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+            $out[] = [
+                'reference' => (string)$r['reference'],
+                'level'     => (int)$r['level'],
+                'max_level' => (int)$r['max_level'],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Number of open cases currently at a given level.
+     */
+    public function countAtLevel(int $level): int
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT COUNT(*) FROM escalation_cases WHERE status = ? AND level = ?'
+        );
+        $stmt->execute([self::OPEN, $level]);
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── private ───────────────────────────────────────────────────────────────
+
+    /**
+     * @return array{level:int,max_level:int,status:string}|null
+     */
+    private function row(string $reference): ?array
+    {
+        $stmt = $this->db()->prepare(
+            'SELECT level, max_level, status FROM escalation_cases WHERE reference = ?'
+        );
+        $stmt->execute([$this->nonEmpty($reference, 'Reference')]);
+        $r = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($r === false) {
+            return null;
+        }
+
+        return [
+            'level'     => (int)$r['level'],
+            'max_level' => (int)$r['max_level'],
+            'status'    => (string)$r['status'],
+        ];
+    }
+
+    private function caseId(string $reference): ?int
+    {
+        $stmt = $this->db()->prepare('SELECT id FROM escalation_cases WHERE reference = ?');
+        $stmt->execute([$reference]);
+        $id = $stmt->fetchColumn();
+
+        return $id === false ? null : (int)$id;
+    }
+
+    private function nonEmpty(string $value, string $label): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new \InvalidArgumentException("{$label} must not be empty.");
+        }
+
+        return $value;
+    }
+
+    private function db(): PDO
+    {
+        return $this->db ?? PdoConnection::getInstance();
+    }
+}

--- a/class/kit/INDEX.md
+++ b/class/kit/INDEX.md
@@ -218,6 +218,7 @@ Quick reference for all opt-in helper classes in `class/kit/` (`Nene\Kit`). Grou
 | `CounterMetric` | named metric counters with daily/hourly bucket aggregation. |
 | `CronLog` | scheduled task execution log. |
 | `DownloadCounter` | Download counter — track file/asset download events. |
+| `Escalation` | tiered escalation ladder for a work item. |
 | `EventLog` | append-only domain event log for event sourcing–lite patterns. |
 | `FunnelStep` | conversion-funnel step completion tracking. |
 | `IncidentLog` | IT/service incident tracking with severity and lifecycle. |

--- a/docs/field-trials/2026-05-field-trial-316.md
+++ b/docs/field-trials/2026-05-field-trial-316.md
@@ -1,0 +1,42 @@
+# Field Trial 316 — Escalation
+
+**Date**: 2026-05-29
+**Branch**: `feat/ft316-escalation`
+**Baseline**: post FT315 merge
+
+## Goal
+
+Add `Nene\Kit\Escalation` — a tiered escalation ladder for a work item (ticket, incident, alert): drive a reference up ordered levels (L1 → L2 → … → Lmax) and resolve it. Distinct from `IncidentLog` (records incidents with severity/lifecycle) and `SlaTracker` (deadline-breach detection): this is the who-handles-it-next tier-progression state machine.
+
+## What was built
+
+### `Nene\Kit\Escalation` (`class/kit/Escalation.php`)
+
+| Method | Description |
+| --- | --- |
+| `open(reference, maxLevel=3): int` | Open a case at L1. |
+| `escalate(reference): bool` | +1 level if open and below ceiling. |
+| `resolve(reference): bool` | Close an open case. |
+| `level / isResolved / atMaxLevel` | Per-case reads. |
+| `activeCases(): array` | Open cases, most-escalated first. |
+| `countAtLevel(level): int` | Open cases at a level. |
+
+Key design points:
+
+- **Guarded ladder**: `escalate()` is one `UPDATE … SET level = level + 1 WHERE status = 'open' AND level < max_level`, so it never exceeds the ceiling and is a no-op on a resolved/unknown case (`rowCount() > 0` reports whether it advanced).
+- **`resolve()`** likewise guards on `status = 'open'`, so double-resolve returns false.
+- **Unknown-reference reads are safe** (null / false); `open()` rejects a duplicate reference (UNIQUE).
+
+### Tests (`tests/Unit/Kit/EscalationTest.php`)
+
+11 tests (34 assertions): open at L1, full ladder to ceiling + cap, resolve stops escalation, no double-resolve, single-level ladder immediately at max, activeCases ordering + exclusion of resolved, countAtLevel across escalate/resolve, safe unknown reads, duplicate-open throw, and two validation guards.
+
+## Findings
+
+### F-1 — No finding (clean trial)
+
+Clean `Nene\Kit` helper. 11 tests pass; CS Fixer and Phan clean.
+
+## Decision
+
+Merge as-is. No follow-up Issues raised. **This closes the FT307–FT316 batch-5 wave (50 trials in the Nene\Kit run).**

--- a/tests/Unit/Kit/EscalationTest.php
+++ b/tests/Unit/Kit/EscalationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nene\Tests\Unit\Kit;
+
+use Nene\Kit\Escalation;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Escalation.
+ */
+final class EscalationTest extends TestCase
+{
+    private PDO $db;
+    private Escalation $e;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('
+            CREATE TABLE escalation_cases (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                reference  VARCHAR(190) NOT NULL,
+                level      INTEGER      NOT NULL DEFAULT 1,
+                max_level  INTEGER      NOT NULL,
+                status     VARCHAR(20)  NOT NULL DEFAULT \'open\',
+                opened_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME     NULL,
+                UNIQUE (reference)
+            )
+        ');
+        $this->e = new Escalation($this->db);
+    }
+
+    public function testOpenStartsAtLevelOne(): void
+    {
+        $this->e->open('t1', 3);
+        $this->assertSame(1, $this->e->level('t1'));
+        $this->assertFalse($this->e->isResolved('t1'));
+        $this->assertFalse($this->e->atMaxLevel('t1'));
+    }
+
+    public function testEscalateLadderToCeiling(): void
+    {
+        $this->e->open('t1', 3);
+        $this->assertTrue($this->e->escalate('t1'));  // L2
+        $this->assertSame(2, $this->e->level('t1'));
+        $this->assertTrue($this->e->escalate('t1'));  // L3
+        $this->assertSame(3, $this->e->level('t1'));
+        $this->assertTrue($this->e->atMaxLevel('t1'));
+        $this->assertFalse($this->e->escalate('t1')); // at ceiling
+        $this->assertSame(3, $this->e->level('t1'));  // unchanged
+    }
+
+    public function testResolveStopsEscalation(): void
+    {
+        $this->e->open('t1', 3);
+        $this->e->escalate('t1'); // L2
+        $this->assertTrue($this->e->resolve('t1'));
+        $this->assertTrue($this->e->isResolved('t1'));
+        $this->assertFalse($this->e->escalate('t1')); // resolved → no-op
+        $this->assertSame(2, $this->e->level('t1'));
+        $this->assertFalse($this->e->atMaxLevel('t1')); // resolved, not "at max"
+    }
+
+    public function testCannotResolveTwice(): void
+    {
+        $this->e->open('t1', 3);
+        $this->assertTrue($this->e->resolve('t1'));
+        $this->assertFalse($this->e->resolve('t1')); // already resolved
+    }
+
+    public function testSingleLevelLadderIsImmediatelyAtMax(): void
+    {
+        $this->e->open('t1', 1);
+        $this->assertTrue($this->e->atMaxLevel('t1'));
+        $this->assertFalse($this->e->escalate('t1')); // nowhere to go
+    }
+
+    public function testActiveCasesOrderedByLevelDesc(): void
+    {
+        $this->e->open('low', 3);
+        $this->e->open('high', 3);
+        $this->e->escalate('high');
+        $this->e->escalate('high'); // high at L3
+        $this->e->open('done', 3);
+        $this->e->resolve('done');  // excluded
+        $active = $this->e->activeCases();
+        $this->assertCount(2, $active);
+        $this->assertSame('high', $active[0]['reference']);
+        $this->assertSame(3, $active[0]['level']);
+        $this->assertSame('low', $active[1]['reference']);
+    }
+
+    public function testCountAtLevel(): void
+    {
+        $this->e->open('a', 3);
+        $this->e->open('b', 3);
+        $this->e->open('c', 3);
+        $this->e->escalate('b'); // b → L2
+        $this->assertSame(2, $this->e->countAtLevel(1)); // a, c
+        $this->assertSame(1, $this->e->countAtLevel(2)); // b
+        $this->e->resolve('a');
+        $this->assertSame(1, $this->e->countAtLevel(1)); // only c now
+    }
+
+    public function testUnknownReferenceReadsAreSafe(): void
+    {
+        $this->assertNull($this->e->level('ghost'));
+        $this->assertFalse($this->e->isResolved('ghost'));
+        $this->assertFalse($this->e->atMaxLevel('ghost'));
+        $this->assertFalse($this->e->escalate('ghost'));
+        $this->assertFalse($this->e->resolve('ghost'));
+    }
+
+    public function testOpenDuplicateThrows(): void
+    {
+        $this->e->open('t1', 3);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->e->open('t1', 3);
+    }
+
+    public function testOpenRejectsZeroMaxLevel(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->e->open('t1', 0);
+    }
+
+    public function testOpenRejectsEmptyReference(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->e->open('   ', 3);
+    }
+}


### PR DESCRIPTION
## Summary

Field Trial **FT316** — `Nene\Kit\Escalation`: an L1→L2→…→Lmax escalation ladder. Distinct from `IncidentLog` (severity/lifecycle) and `SlaTracker` (breach detection).

| Method | Description |
| --- | --- |
| `open(reference, maxLevel=3): int` | Open at L1. |
| `escalate(reference): bool` | +1 if open and below ceiling. |
| `resolve(reference): bool` | Close. |
| `level / isResolved / atMaxLevel / activeCases / countAtLevel` | Reads. |

- Guarded ladder: `UPDATE … SET level = level + 1 WHERE status='open' AND level < max_level` — never overshoots, no-op on resolved/unknown.

## F-N findings
- **F-1** — none (clean trial).

> Closes the **FT307–FT316 batch-5 wave** — 50 trials in the `Nene\Kit` run.

## Test plan
- [x] 11 tests / 34 assertions (L1 start, ladder+cap, resolve stops, no double-resolve, single-level at-max, activeCases ordering/exclusion, countAtLevel, safe unknown reads, duplicate-open throw, validation)
- [x] `composer precommit` green (format → Phan → 5203 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)