### PR TITLE
docs(ft): mark FT307–FT316 complete (batch-5 Nene\Kit wave)

### DIFF
--- a/docs/field-trials/candidates.md
+++ b/docs/field-trials/candidates.md
@@ -54,6 +54,16 @@ The Xion helper wave (FT78–FT264) is ongoing as of 2026-05-28. Trigger-based a
 
 When a candidate becomes a trial, move it to this section briefly so we can see the recent flow.
 
+- **FT316 — Escalation** (2026-05-29): `Nene\Xion\Escalation` — tiered escalation ladder for a work item.. PR #782.
+- **FT315 — SeatMap** (2026-05-29): `Nene\Xion\SeatMap` — named-seat reservation for a fixed venue layout.. PR #781.
+- **FT314 — SpaceOccupancy** (2026-05-29): `Nene\Xion\SpaceOccupancy` — live headcount for a capacity-limited physical space.. PR #780.
+- **FT313 — ShiftRoster** (2026-05-29): `Nene\Xion\ShiftRoster` — staff shift scheduling with coverage tracking.. PR #779.
+- **FT312 — PledgeDrive** (2026-05-29): `Nene\Xion\PledgeDrive` — crowdfunding / fundraising drive with monetary pledges.. PR #778.
+- **FT311 — Dispute** (2026-05-29): `Nene\Xion\Dispute` — transaction dispute / chargeback workflow.. PR #777.
+- **FT310 — Tournament** (2026-05-29): `Nene\Xion\Tournament` — single-elimination entrant tracking with match recording.. PR #776.
+- **FT309 — Kudos** (2026-05-29): `Nene\Xion\Kudos` — peer recognition / shout-outs between users.. PR #775.
+- **FT308 — ExpenseClaim** (2026-05-29): `Nene\Xion\ExpenseClaim` — expense reimbursement claims with line items and approval.. PR #774.
+- **FT307 — LeaveRequest** (2026-05-29): `Nene\Xion\LeaveRequest` — employee time-off requests with an approval workflow.. PR #773.
 - **FT306 — GiftRegistry** (2026-05-29): `Nene\Xion\GiftRegistry` — claimable gift registry with claimed-vs-desired accounting; addItem/claim (guarded)/unclaim/isFulfilled; distinct from Wishlist. PR #771.
 - **FT305 — Annotation** (2026-05-29): `Nene\Xion\Annotation` — per-user text highlights/notes over [start,end) ranges; add/forDocument/forUser/updateNote; distinct from EntityComment. PR #770.
 - **FT304 — QueueTicket** (2026-05-29): `Nene\Xion\QueueTicket` — take-a-number service queue; issue/callNext (advance now-serving)/position (1-based)/skip; distinct from JobQueue. PR #769.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,7 +186,7 @@ Future candidates:
 
 ## 7. Field Trials
 
-Status: methodology adopted (ADR 0002). FT1–FT306 complete as of 2026-05-29 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
+Status: methodology adopted (ADR 0002). FT1–FT316 complete as of 2026-05-29 (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61).
 
 Goal:
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,7 +6,7 @@ This file summarizes short-term work for humans and AI agents. GitHub Issues rem
 
 No open Issues. Promotion articles (#178 Qiita / #179 DEV Community / #180 Reddit・HN) are closed — outreach is managed in a separate repository.
 
-The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-29: all non-promotion Issues are closed; FT1–FT306 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
+The Phase 6 (reviewable small-service delivery) and Phase 7 (field trials) loops have been running continuously. As of 2026-05-29: all non-promotion Issues are closed; FT1–FT316 are complete (FT36 deferred as ADR-class; FT112 closed as conflicting with FT61); ADR-0001–0013 are in place. The Xion helper wave is ongoing — see **Field Trials** for the full log and **Backlog Candidates** for trigger-based future work.
 
 ## Recently Completed
 


### PR DESCRIPTION
## Summary

Batches the `composer ft:done` doc updates for the final 10 field trials, advancing the completion markers **FT1–FT306 → FT1–FT316** and archiving each into `candidates.md`.

| FT | Class | PR |
| --- | --- | --- |
| 307 | LeaveRequest | #773 |
| 308 | ExpenseClaim | #774 |
| 309 | Kudos | #775 |
| 310 | Tournament | #776 |
| 311 | Dispute | #777 |
| 312 | PledgeDrive | #778 |
| 313 | ShiftRoster | #779 |
| 314 | SpaceOccupancy | #780 |
| 315 | SeatMap | #781 |
| 316 | Escalation | #782 |

Closes the 50-trial `Nene\Kit` run. Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)