### PR TITLE
docs: refresh stale post-v0.3.0 / post-ADR-0014 references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ composer test                        # PHPUnit unit suite
 ## Scaffolding a New Helper (`Nene\Kit`) — the common case
 
 Per **ADR-0014**, framework core lives in `Nene\Xion` (`class/xion/`, ~55 classes)
-and the opt-in helper catalogue lives in `Nene\Kit` (`class/kit/`, ~227 classes).
+and the opt-in helper catalogue lives in `Nene\Kit` (`class/kit/`, ~255 classes).
 **Field-trial helpers go in `Nene\Kit`:**
 
 ```bash
@@ -136,7 +136,7 @@ Never use a date that is only "near" the boundary and hope it works.
 
 ## Class Indexes (consult before starting — avoid duplicates)
 
-- `class/kit/INDEX.md` — the ~227 `Nene\Kit` helper classes grouped by domain.
+- `class/kit/INDEX.md` — the ~255 `Nene\Kit` helper classes grouped by domain.
 - `class/xion/INDEX.md` — the ~55 `Nene\Xion` framework-core classes.
 
 **Concept-scan, not just name-scan**, before adding a helper — grep the INDEX

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Tiny renovated legacy-style PHP framework for reviewable small services.
 
 - Demo: <https://nene-php.com/>
-- Latest release: [`v0.2.0`](https://github.com/hideyukiMORI/NeNe/releases/tag/v0.2.0)
+- Latest release: [`v0.3.0`](https://github.com/hideyukiMORI/NeNe/releases/tag/v0.3.0)
 - License: MIT
 - Service tutorial: `docs/tutorials/building-a-service.md`
 - AI self-review checklists: `docs/ai/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ This directory contains project documentation for humans and AI agents.
 - `todo/current.md`: Current TODO summary.
 - `milestones/README.md`: Milestone management.
 - `adr/README.md`: Architecture decision records.
+- `../class/xion/INDEX.md`: Framework-core class catalogue (`Nene\Xion`).
+- `../class/kit/INDEX.md`: Opt-in helper class catalogue (`Nene\Kit`, see ADR-0014).
 - `api/README.md`: OpenAPI and API documentation policy.
 - `field-trials/README.md`: Field trial methodology and clone-based trial layout under `../NeNe-FT/`.
 - `templates/field-trial-report.md`: Report skeleton copied for each new trial.

--- a/docs/project.md
+++ b/docs/project.md
@@ -77,7 +77,7 @@ Do not treat legacy style as a defect by itself. In NeNe, some legacy shape is i
 NeNe keeps framework core and the bundled sample/application code in the same repository, but they have different responsibilities:
 
 - `class/xion/` (`Nene\Xion`) is framework core. It contains dispatching, controller base behavior, request/session helpers, response helpers, database base classes, logging, and transaction boundaries. Kept small (~55 classes) so it can be read end-to-end.
-- `class/kit/` (`Nene\Kit`) is an opt-in helper catalogue: ~227 small, single-purpose, DB-backed feature building blocks (commerce, content, analytics, notifications, …) produced by the field-trial loop. None is required for the framework to boot — see ADR-0014 for the core-vs-helper boundary and the "boot test". New helpers scaffold here via `composer make:kit`.
+- `class/kit/` (`Nene\Kit`) is an opt-in helper catalogue: ~255 small, single-purpose, DB-backed feature building blocks (commerce, content, analytics, notifications, …) produced by the field-trial loop. None is required for the framework to boot — see ADR-0014 for the core-vs-helper boundary and the "boot test". New helpers scaffold here via `composer make:kit`.
 - `class/controller/`, `class/db/`, `class/model/`, and `class/func/` are the current sample/application-side namespaces. The bundled TODO, session, health, and documentation pages live here to show how a small NeNe service is built.
 - `view/source/`, `htdocs/css/`, and `htdocs/js/` are application-facing presentation assets discovered by convention.
 - `docs/api/`, `config/error_codes.php`, database setup scripts, and tests are part of the application contract whenever a sample or real service exposes public behavior.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -55,11 +55,11 @@ breaking changes to the public routing, controller, or REST conventions.
 
 ### Known follow-ups
 
-- The `class/xion/` namespace has grown large and now mixes framework-core
-  concerns with application-domain helpers. A post-`v0.3.0` review of the folder
-  structure and the framework-core vs. helper-library boundary is planned (see
-  `docs/`), and may lead to splitting the helpers into a separate package or an
-  explicitly-separated namespace before `v1.0.0`.
+- The `class/xion/` namespace had grown large and mixed framework-core concerns
+  with application-domain helpers. This was resolved immediately after `v0.3.0`
+  by **ADR-0014**, which split the helpers into the opt-in `Nene\Kit` catalogue
+  (`class/kit/`), leaving `Nene\Xion` as the small framework core. See
+  `docs/adr/0014-xion-core-vs-kit-helper-boundary.md`.
 
 ## v0.2.0
 


### PR DESCRIPTION
## Summary

Documentation freshness pass — fixes references that went stale after the v0.3.0 release and the ADR-0014 `Nene\Xion` → `Nene\Kit` split.

| File | Fix |
| --- | --- |
| `README.md` | Latest release `v0.2.0` → `v0.3.0` |
| `docs/project.md`, `CLAUDE.md` | `Nene\Kit` helper count `~227` → `~255` (actual 256) |
| `docs/README.md` | Add pointers to `class/xion/INDEX.md` and `class/kit/INDEX.md` (ADR-0014) |
| `docs/releases.md` | v0.3.0 "Known follow-ups" said a folder-structure review *is planned*; it was carried out by ADR-0014 — reworded to reflect completion |

**Left intentionally untouched:** the ADR-0014 body and its index entry keep the pre-split estimates (~75 core / ~200 helpers) — those are a frozen record of the situation at decision time, not a current-state claim. Historical `v0.2.0` comparisons in the release notes are also correct as-is.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)