### PR TITLE
docs(site): MkDocs Material documentation site for GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: docs
+
+# Build the MkDocs documentation site and publish it to GitHub Pages.
+# Requires Pages to be enabled with "Source: GitHub Actions" (Settings → Pages),
+# and a DNS CNAME record: docs.nene-php.com → hideyukimori.github.io.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: pip
+      - run: pip install -r requirements-docs.txt
+      - run: mkdocs build --clean
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    # Publish only on pushes to main; PRs run the build job for validation only.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           python-version: '3.x'
           cache: pip
+          cache-dependency-path: requirements-docs.txt
       - run: pip install -r requirements-docs.txt
       - run: mkdocs build --clean
       - uses: actions/upload-pages-artifact@v3

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,0 +1,5 @@
+nav:
+  - Home: index.md
+  - Overview: project.md
+  - tutorials
+  - development

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.nene-php.com

--- a/docs/development/.pages
+++ b/docs/development/.pages
@@ -1,0 +1,2 @@
+title: How-to Guides
+order: asc

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,65 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+# NeNe Documentation
+
+**NeNe** is a tiny renovated legacy-style PHP framework for *reviewable* small
+services. It keeps visible URL routing, controller actions, Smarty pages,
+lightweight mappers, REST endpoints, OpenAPI, Docker, tests, and explicit
+security boundaries — small enough to read end-to-end.
+
+This site collects the **how-to guides**, the **getting-started tutorial**, and
+a **project overview**. Source and issues live on
+[GitHub](https://github.com/hideyukiMORI/NeNe); a live instance runs at
+[nene-php.com](https://nene-php.com/).
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch: **Getting Started**
+
+    ---
+
+    Build a small NeNe service end-to-end: pages, REST endpoints, a
+    database-backed feature, OpenAPI, and tests.
+
+    [:octicons-arrow-right-24: Building a service](tutorials/building-a-service.md)
+
+-   :material-book-open-variant: **How-to Guides**
+
+    ---
+
+    ~80 focused, single-topic guides — rate limiting, money handling, RBAC,
+    state machines, signed URLs, pagination, full-text search, and more.
+
+    [:octicons-arrow-right-24: Browse the guides](development/coding-standards.md)
+
+-   :material-map: **Overview**
+
+    ---
+
+    What NeNe is (and is not), the routing convention, and the
+    `Nene\Xion` core vs. `Nene\Kit` helper-catalogue layout (ADR-0014).
+
+    [:octicons-arrow-right-24: Project overview](project.md)
+
+-   :material-github: **Source & Releases**
+
+    ---
+
+    Clone, read the conventions, and follow the release notes.
+
+    [:octicons-arrow-right-24: GitHub repository](https://github.com/hideyukiMORI/NeNe)
+
+</div>
+
+---
+
+NeNe is intentionally much smaller than full-stack frameworks. Its visible
+conventions stay readable by both humans and AI agents, so code generated or
+edited with AI assistance follows the same shape a developer would normally
+review. The goal is to lower review cost for small services by keeping HTTP
+input, controller actions, service rules, mapper SQL, OpenAPI, and tests in
+predictable places.

--- a/docs/tutorials/.pages
+++ b/docs/tutorials/.pages
@@ -1,0 +1,1 @@
+title: Getting Started

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,93 @@
+site_name: NeNe Documentation
+site_description: >-
+  HOW-TO guides, tutorial, and overview for NeNe — a tiny renovated
+  legacy-style PHP framework for reviewable small services.
+site_url: https://docs.nene-php.com/
+site_author: hideyukiMORI
+
+repo_url: https://github.com/hideyukiMORI/NeNe
+repo_name: hideyukiMORI/NeNe
+edit_uri: edit/main/docs/
+
+# The repository's docs/ folder is the source. Pages are built from it as-is;
+# navigation scope is curated in docs/.pages (awesome-pages plugin).
+docs_dir: docs
+
+# index.md is the site landing page; the in-repo folder index (docs/README.md,
+# meant for browsing the folder on GitHub) is not part of the site to avoid an
+# index/README URL collision. Nothing links to the top-level README.
+exclude_docs: |
+  /README.md
+
+theme:
+  name: material
+  language: en
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+
+plugins:
+  - search
+  - awesome-pages
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/hideyukiMORI/NeNe
+    - icon: material/web
+      link: https://nene-php.com/
+      name: Live demo
+
+# Unlisted pages (ADR, roadmap, field-trials, …) are still built so that
+# cross-links from the curated pages keep resolving; they just don't appear
+# in the navigation. Suppress the "not in nav" warning to keep CI clean.
+validation:
+  nav:
+    omitted_files: ignore
+  not_found: warn

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.5
+mkdocs-awesome-pages-plugin>=2.9


### PR DESCRIPTION
## Summary

Stands up a browsable, searchable **documentation site** (MkDocs Material) for publishing to **GitHub Pages at `docs.nene-php.com`**. Directly targets the #1 gap named in `docs/publication-strategy.md` — *"The main gap is not implementation depth. The main gap is discovery."* — by surfacing the ~80 how-to guides that currently only exist as raw `.md` in `docs/development/`.

`nene-php.com` stays the **live demo app**; the docs site is a separate subdomain.

## What's included
- **`mkdocs.yml`** — Material theme (light/dark toggle, search, code copy, GitHub edit links), `docs/` as the source.
- **Curated nav** via `awesome-pages` (`docs/.pages`): **Home → Overview → Getting Started → How-to Guides**. Unlisted pages (ADR, roadmap, field-trials, …) are still built so cross-links keep resolving — they're just omitted from the navigation (`validation.nav.omitted_files: ignore`).
- **`docs/index.md`** — a landing page with cards. The in-repo `docs/README.md` is excluded from the build to avoid an index/README URL collision (nothing links to the top-level README).
- **`docs/CNAME`** — `docs.nene-php.com`.
- **`.github/workflows/docs.yml`** — builds on **PR** (validation only) and on **push to main**, deploys to Pages via `actions/deploy-pages` on main only.
- **`requirements-docs.txt`** — `mkdocs-material`, `mkdocs-awesome-pages-plugin`.

## Scope (as agreed)
How-to guides (`docs/development`) + tutorial (`building-a-service`) + overview (`project.md`). Easy to widen later (deployment/api/frontend) by editing `docs/.pages`.

## Manual steps after merge (owner)
1. **Settings → Pages → Source: GitHub Actions** (enables the deploy).
2. **DNS**: add `CNAME docs.nene-php.com → hideyukimori.github.io`.

Until step 1, the `build` job passes but `deploy` has nothing to publish to.

## Test plan
- [x] YAML syntax validated locally (mkdocs.yml, workflow, all `.pages`).
- [ ] **CI `build` job on this PR** confirms `mkdocs build` succeeds (couldn't run mkdocs in the dev sandbox — no pip).
- [ ] Post-merge: site renders at the Pages URL, then at `docs.nene-php.com` once DNS propagates.

> Note: the two file pairs I earlier flagged as possible duplicates (`cors.md`/`cors-and-csrf.md`, `invitation-token.md`/`invitation-tokens.md`) turned out to be **distinct** (class guide vs. concept/pattern guide) — no cleanup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)