### PR TITLE
docs(journal): add 2026-05-30 daily report

### DIFF
--- a/docs/journal/2026-05-30.md
+++ b/docs/journal/2026-05-30.md
@@ -1,0 +1,97 @@
+# 日報 2026-05-30
+
+## 作業範囲
+
+NeNe フレームワーク改修。前セッションから継続していた自走 `Nene\Kit` フィールドトライアル wave を **50/50 で完走**（batch 5 = FT307–316）、続けてドキュメントの情報不整合を点検・修正し、最後に **MkDocs 製ドキュメントサイトを `https://docs.nene-php.com/` に新規公開**した。マージ PR は **#773〜#786 の計 14 件**（コード10 + ドキュメント4）。
+
+---
+
+## 完了タスク
+
+### 1. Batch 5 — FT307〜FT316（`Nene\Kit` ヘルパー 10 本）
+
+| FT | クラス | 内容 | PR |
+|---|---|---|---|
+| 307 | `LeaveRequest` | 従業員の休暇申請（承認ワークフロー） | #773 |
+| 308 | `ExpenseClaim` | 経費精算（明細＋承認） | #774 |
+| 309 | `Kudos` | ユーザー間のピア・リコグニション | #775 |
+| 310 | `Tournament` | シングルエリミネーション（試合記録で敗者除外） | #776 |
+| 311 | `Dispute` | 取引ディスピュート／チャージバックの状態機械（cents） | #777 |
+| 312 | `PledgeDrive` | クラウドファンディング（目標額＋支援） | #778 |
+| 313 | `ShiftRoster` | スタッフのシフト編成＋充足管理 | #779 |
+| 314 | `SpaceOccupancy` | 容量制限つきの実空間ライブ人数カウンタ | #780 |
+| 315 | `SeatMap` | 固定会場の指定席予約 | #781 |
+| 316 | `Escalation` | L1→L2→L3 エスカレーションの階段状態機械 | #782 |
+
+- 各 FT は単一目的・全テスト付き。ガード付き単一 SQL／integer cents／PDO 注入の規約を踏襲。
+- **FT314 はピボット**：当初 `PunchCard` を予定したが、概念スキャンで既存 `TimeEntry`（start/stop/duration）の重複と判明（FT281 の教訓）→ 重複のない `SpaceOccupancy` に差し替え。
+
+### 2. ドキュメント wave — FT1〜FT316 完了マーク（#783）
+
+`composer ft:done` を FT307–316 の 10 件分まとめて実行。`docs/todo/current.md` ・ `docs/roadmap.md` の完了マーカーを **FT1–FT306 → FT1–FT316** に前進、`candidates.md` にアーカイブ追記。これで自走 wave（FT267–316, 50 本）が完結。
+
+### 3. セッション・チェックポイント（#784）
+
+`.claude/session-state.md` を更新（wave 完了・進行中タスクなしを明記、FT ワークフローを `make:kit` 系に刷新）。
+
+### 4. ドキュメント整合性の点検・修正（#785）
+
+リリース／ADR-0014 後に古くなった living docs を修正：
+
+| ファイル | 修正 |
+|---|---|
+| `README.md` | Latest release `v0.2.0` → `v0.3.0` |
+| `docs/project.md` / `CLAUDE.md` | `Nene\Kit` ヘルパー数 `~227` → `~255`（実 256） |
+| `docs/README.md` | クラスカタログ（`class/xion/INDEX.md` / `class/kit/INDEX.md`）への導線を追加 |
+| `docs/releases.md` | v0.3.0 の Known follow-ups「フォルダ構成レビューは予定」→ ADR-0014 で実施済みに書き換え |
+
+- ADR-0014 本文・索引の「~75 core / ~200 helpers」は**意思決定時点の凍結記録**として意図的に温存。
+
+### 5. ドキュメントサイトを新規公開（#786 ＋ インフラ設定）
+
+`docs/` の HOWTO（約80本）・チュートリアル・概要を、検索可能なサイトとして公開。
+
+- **`mkdocs.yml`** — Material テーマ（ライト/ダーク・検索・コードコピー・GitHub 編集リンク）、`docs/` をソースに。
+- **ナビ選定** — `awesome-pages`（`docs/.pages`）で Home → Overview → Getting Started → How-to Guides に限定。**非掲載ページもビルドはする**（除外ページへのクロスリンクが切れない）方式。
+- **`docs/index.md`** — カード UI のランディング。トップ `docs/README.md` はビルド除外（index/README の URL 衝突回避）。
+- **`.github/workflows/docs.yml`** — PR でビルド検証、main push でビルド→ Pages デプロイ。
+- **インフラ**：GitHub Pages を Actions ソースで有効化 → カスタムドメイン `docs.nene-php.com` 設定 → DNS（CNAME → hideyukimori.github.io）伝播確認 → Let's Encrypt 証明書発行 → **HTTPS 強制 ON**。トップ・HOWTO 個別ページとも HTTP 200 を確認。
+
+---
+
+## 数字まとめ
+
+| 指標 | 値 |
+|---|---|
+| マージ PR | 14 件（#773–#786） |
+| 新規 `Nene\Kit` クラス | 10（FT307–316） |
+| `Nene\Kit` 総数 | 256 |
+| 自走 wave 累計 | FT267–316 = 50/50 完了 |
+| 全ユニットテスト（FT316 時点） | 5203 / 5203 ✅ |
+| Phan | 0 エラー ✅ |
+| 新規公開サイト | https://docs.nene-php.com/（HTTPS 強制） |
+
+---
+
+## 主な技術的知見
+
+1. **`DbUpsert` は `Nene\Xion`、`make:kit` の雛形は未 import**（FT313）。`Nene\Kit` ヘルパーで `DbUpsert` を使うと無 import で `Nene\Kit\DbUpsert`（未定義）に解決され、Phan＋テストで即検出。`use Nene\Xion\DbUpsert;` を明示。
+
+2. **名前スキャンだけでは概念重複を見逃す**（FT314 / FT281 再確認）。`PunchCard` ≈ 既存 `TimeEntry`。着手前に `class/kit/INDEX.md` の **説明文を grep** するのが必須。
+
+3. **MkDocs の "build はするが nav に載せない"** を使うとリンク整合とスコープ提示を両立できる。`validation.nav.omitted_files: ignore` で CI 警告も抑制。
+
+4. **`docs/README.md` と `index.md` は URL 衝突**する。`exclude_docs: /README.md` でトップ README だけビルド除外（サブディレクトリの README は温存）。
+
+5. **`setup-python` の `cache: pip`** は既定で `requirements.txt`／`pyproject.toml` を探す。ファイル名が違う場合は `cache-dependency-path` を明示（初回 CI が 6 秒で失敗 → 修正）。
+
+6. **Actions ソースの Pages はアーティファクト内 CNAME でドメイン自動設定されない**。`gh api -X PUT .../pages -f cname=...` で明示設定し、DNS 整備後に HTTPS 強制を有効化する順序。
+
+---
+
+## 残タスク / 繰り越し
+
+- **表サイト（`nene-php.com` のデモアプリ）の整備** — 後日実施予定（ユーザー表明）。`htdocs/` 周辺。
+- **`README.md` にドキュメントサイトへの導線**（`- Documentation: https://docs.nene-php.com/`）追加 — 任意の仕上げとして提案済み、未着手。
+- `candidates.md` のアクティブ候補はトリガー待ちのみ（Background jobs / Multi-tenancy / OpenTelemetry / 制約変更 ADR）。先行実装しない。
+- Node.js 20 actions 非推奨警告（2026/6 強制移行）— `tests.yml` / `docs.yml` 共通。実害は当面なし、必要なら一括バージョン更新。


### PR DESCRIPTION
Daily report for 2026-05-30. Covers:

- **Batch 5 (FT307–316)** — 10 `Nene\Kit` helpers; wave finished **50/50**.
- **Docs wave #783** — markers advanced to FT1–FT316 complete.
- **Docs refresh #785** — fixed post-v0.3.0 / post-ADR-0014 stale references.
- **Docs site #786** — MkDocs Material site live at `docs.nene-php.com` (HTTPS enforced).

Follows the existing `docs/journal/` convention. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)